### PR TITLE
fix: use direct instead of http for DS/DD in recipe

### DIFF
--- a/internal/definition/recipe.go
+++ b/internal/definition/recipe.go
@@ -1,6 +1,6 @@
 package definition
 
 const (
-	DataSourceKindHTTP      = "http"
-	DataDestinationKindHTTP = "http"
+	DataSourceKindDirect      = "direct"
+	DataDestinationKindDirect = "direct"
 )

--- a/internal/temporal/temporal.go
+++ b/internal/temporal/temporal.go
@@ -72,8 +72,8 @@ func TriggerTemporalWorkflow(pipelineName string, recipe *model.Recipe, uid stri
 // NOTE: Before migrate inference-backend into pipeline-backend, there is one more criteria is only 1 VDO
 func IsDirect(recipe *model.Recipe) bool {
 
-	return (strings.ToLower(recipe.Source.Type) == definition.DataSourceKindHTTP &&
-		strings.ToLower(recipe.Destination.Type) == definition.DataDestinationKindHTTP &&
+	return (strings.ToLower(recipe.Source.Type) == definition.DataSourceKindDirect &&
+		strings.ToLower(recipe.Destination.Type) == definition.DataDestinationKindDirect &&
 		len(recipe.Model) == 1 &&
 		(recipe.LogicOperator == nil || len(recipe.LogicOperator) == 0))
 }


### PR DESCRIPTION
Because

- we align the new term in the type of recipe if the trigger is from HTTP/gRPC

This commit

- use direct instead of http for DS/DD in recipe
