### PR TITLE
fix: expose all structs inside pkg folder

### DIFF
--- a/pkg/repository/pipeline.go
+++ b/pkg/repository/pipeline.go
@@ -11,7 +11,7 @@ import (
 	"gorm.io/gorm"
 )
 
-type PipelineRepository interface {
+type Operations interface {
 	CreatePipeline(pipeline model.Pipeline) error
 	ListPipelines(query model.ListPipelineQuery) ([]model.Pipeline, uint64, uint64, error)
 	GetPipelineByName(namespace string, pipelineName string) (model.Pipeline, error)
@@ -19,12 +19,12 @@ type PipelineRepository interface {
 	DeletePipeline(namespace string, pipelineName string) error
 }
 
-type pipelineRepository struct {
+type PipelineRepository struct {
 	DB *gorm.DB
 }
 
-func NewPipelineRepository(db *gorm.DB) PipelineRepository {
-	return &pipelineRepository{
+func NewPipelineRepository(db *gorm.DB) Operations {
+	return &PipelineRepository{
 		DB: db,
 	}
 }
@@ -52,7 +52,7 @@ var GetPipelineWithRecipeSelectField = []string{
 	`CONCAT(namespace, '/', name) as full_name`,
 }
 
-func (r *pipelineRepository) CreatePipeline(pipeline model.Pipeline) error {
+func (r *PipelineRepository) CreatePipeline(pipeline model.Pipeline) error {
 	l, _ := logger.GetZapLogger()
 
 	// We ignore the full_name column since it's a virtual column
@@ -66,7 +66,7 @@ func (r *pipelineRepository) CreatePipeline(pipeline model.Pipeline) error {
 	return nil
 }
 
-func (r *pipelineRepository) ListPipelines(query model.ListPipelineQuery) ([]model.Pipeline, uint64, uint64, error) {
+func (r *PipelineRepository) ListPipelines(query model.ListPipelineQuery) ([]model.Pipeline, uint64, uint64, error) {
 	var pipelines []model.Pipeline
 
 	var count int64
@@ -116,7 +116,7 @@ func (r *pipelineRepository) ListPipelines(query model.ListPipelineQuery) ([]mod
 	return pipelines, max, min, nil
 }
 
-func (r *pipelineRepository) GetPipelineByName(namespace string, pipelineName string) (model.Pipeline, error) {
+func (r *PipelineRepository) GetPipelineByName(namespace string, pipelineName string) (model.Pipeline, error) {
 	var pipeline model.Pipeline
 	if result := r.DB.Model(&model.Pipeline{}).
 		Select(GetPipelineWithRecipeSelectField).
@@ -128,7 +128,7 @@ func (r *pipelineRepository) GetPipelineByName(namespace string, pipelineName st
 	return pipeline, nil
 }
 
-func (r *pipelineRepository) UpdatePipeline(pipeline model.Pipeline) error {
+func (r *PipelineRepository) UpdatePipeline(pipeline model.Pipeline) error {
 	l, _ := logger.GetZapLogger()
 
 	// We ignore the name column since it can not be updated
@@ -142,7 +142,7 @@ func (r *pipelineRepository) UpdatePipeline(pipeline model.Pipeline) error {
 	return nil
 }
 
-func (r *pipelineRepository) DeletePipeline(namespace string, pipelineName string) error {
+func (r *PipelineRepository) DeletePipeline(namespace string, pipelineName string) error {
 	l, _ := logger.GetZapLogger()
 
 	if result := r.DB.Model(&model.Pipeline{}).

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -30,14 +30,14 @@ type Services interface {
 }
 
 type PipelineService struct {
-	pipelineRepository repository.PipelineRepository
-	modelServiceClient modelPB.ModelClient
+	PipelineRepository repository.Operations
+	ModelServiceClient modelPB.ModelClient
 }
 
-func NewPipelineService(r repository.PipelineRepository, modelServiceClient modelPB.ModelClient) Services {
+func NewPipelineService(r repository.Operations, modelServiceClient modelPB.ModelClient) Services {
 	return &PipelineService{
-		pipelineRepository: r,
-		modelServiceClient: modelServiceClient,
+		PipelineRepository: r,
+		ModelServiceClient: modelServiceClient,
 	}
 }
 
@@ -62,7 +62,7 @@ func (p *PipelineService) CreatePipeline(pipeline model.Pipeline) (model.Pipelin
 		return model.Pipeline{}, err
 	}
 
-	if err := p.pipelineRepository.CreatePipeline(pipeline); err != nil {
+	if err := p.PipelineRepository.CreatePipeline(pipeline); err != nil {
 		return model.Pipeline{}, err
 	}
 
@@ -74,11 +74,11 @@ func (p *PipelineService) CreatePipeline(pipeline model.Pipeline) (model.Pipelin
 }
 
 func (p *PipelineService) ListPipelines(query model.ListPipelineQuery) ([]model.Pipeline, uint64, uint64, error) {
-	return p.pipelineRepository.ListPipelines(query)
+	return p.PipelineRepository.ListPipelines(query)
 }
 
 func (p *PipelineService) GetPipelineByName(namespace string, pipelineName string) (model.Pipeline, error) {
-	return p.pipelineRepository.GetPipelineByName(namespace, pipelineName)
+	return p.PipelineRepository.GetPipelineByName(namespace, pipelineName)
 }
 
 func (p *PipelineService) UpdatePipeline(pipeline model.Pipeline) (model.Pipeline, error) {
@@ -99,7 +99,7 @@ func (p *PipelineService) UpdatePipeline(pipeline model.Pipeline) (model.Pipelin
 		}
 	}
 
-	if err := p.pipelineRepository.UpdatePipeline(pipeline); err != nil {
+	if err := p.PipelineRepository.UpdatePipeline(pipeline); err != nil {
 		return model.Pipeline{}, err
 	}
 
@@ -111,7 +111,7 @@ func (p *PipelineService) UpdatePipeline(pipeline model.Pipeline) (model.Pipelin
 }
 
 func (p *PipelineService) DeletePipeline(namespace string, pipelineName string) error {
-	return p.pipelineRepository.DeletePipeline(namespace, pipelineName)
+	return p.PipelineRepository.DeletePipeline(namespace, pipelineName)
 }
 
 func (p *PipelineService) ValidateTriggerPipeline(namespace string, pipelineName string, pipeline model.Pipeline) error {
@@ -143,7 +143,7 @@ func (p *PipelineService) TriggerPipelineByUpload(namespace string, image bytes.
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 
-		stream, err := p.modelServiceClient.PredictModelByUpload(ctx)
+		stream, err := p.ModelServiceClient.PredictModelByUpload(ctx)
 		defer stream.CloseSend()
 		if err != nil {
 			return nil, err
@@ -191,7 +191,7 @@ func (p *PipelineService) ValidateModel(namespace string, selectedModels []*mode
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	supportModelResp, err := p.modelServiceClient.ListModels(ctx, &modelPB.ListModelRequest{})
+	supportModelResp, err := p.ModelServiceClient.ListModels(ctx, &modelPB.ListModelRequest{})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Because

- all structs in pkg folder should be public

This commit

- expose all structs inside pkg folder
