### PR TITLE
ci: add codecov action

### DIFF
--- a/.github/workflows/add-issue-to-prj.yml
+++ b/.github/workflows/add-issue-to-prj.yml
@@ -1,4 +1,4 @@
-name: Add Issue to project
+name: Add Issue to Project
 
 on:
   issues:

--- a/.github/workflows/add-pr-to-prj.yml
+++ b/.github/workflows/add-pr-to-prj.yml
@@ -1,4 +1,4 @@
-name: Add PR to project
+name: Add PR to Project
 
 on:
   pull_request:
@@ -14,7 +14,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.botGitHubToken }}
           ORGANIZATION: instill-ai
-          PROJECT_NUMBER: 5  # Visual Datat Preparation (VDP) project
+          PROJECT_NUMBER: 5  # Visual Data Preparation (VDP) project
         run: |
           gh api graphql -f query='
             query($org: String!, $number: Int!) {

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,27 @@
+name: Coverage
+
+on: [push, pull_request]
+
+jobs:
+
+  codecov:
+    name: codecov
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/setup-go@v1
+        with:
+          go-version: 1.17
+
+      - uses: actions/checkout@v2
+
+      - name: Generate coverage report
+        run: |
+          go test -race ./... -coverprofile=coverage.txt -covermode=atomic
+
+      - name: Upload coverage report
+        uses: codecov/codecov-action@v2
+        with:
+          file: ./coverage.txt
+          flags: unittests
+          name: codecov-umbrella

--- a/pkg/repository/pipeline.go
+++ b/pkg/repository/pipeline.go
@@ -81,7 +81,7 @@ func (r *PipelineRepository) ListPipelines(query model.ListPipelineQuery) ([]mod
 			Rows()
 		if err != nil {
 			rows.Close()
-			return nil, 0, 0, status.Errorf(codes.Internal, "Error when query min & max value", err.Error())
+			return nil, 0, 0, status.Errorf(codes.Internal, "Error when query min & max value: %s", err.Error())
 		}
 		if rows.Next() {
 			if err := rows.Scan(&min, &max); err != nil {


### PR DESCRIPTION
Because

- we would like to regularly check test coverage of the codebase

This commit

- set up codecov action
- make GitHub Actions workflow name consistent