### PR TITLE
fix: add support URL/base64 endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,8 @@ require (
 	github.com/golang-migrate/migrate/v4 v4.15.1
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.3
-	github.com/instill-ai/protogen-go v0.0.0-20220219173653-3c0c45e11858
-	github.com/instill-ai/vdp v0.1.1-alpha
+	github.com/instill-ai/protogen-go v0.1.1-alpha
+	github.com/instill-ai/vdp v0.1.2-alpha
 	github.com/knadh/koanf v1.4.0
 	go.temporal.io/sdk v1.13.0
 	go.uber.org/zap v1.21.0

--- a/go.sum
+++ b/go.sum
@@ -596,11 +596,11 @@ github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/instill-ai/protogen-go v0.0.0-20220121071429-f56fdeee9a34/go.mod h1:q2Pq4P0AY/59RGibT4nSDnOsA4wD4XhLueFRoGYNBjk=
-github.com/instill-ai/protogen-go v0.0.0-20220219173653-3c0c45e11858 h1:2lolSo+ykanKXKMwuBEBw4FoxXmjh868gDjkOUuHPts=
 github.com/instill-ai/protogen-go v0.0.0-20220219173653-3c0c45e11858/go.mod h1:q2Pq4P0AY/59RGibT4nSDnOsA4wD4XhLueFRoGYNBjk=
-github.com/instill-ai/vdp v0.1.1-alpha h1:ixG1xoimp60q2E3SC/5sqW/PiYGb2GYG+/e7qTLgLb4=
-github.com/instill-ai/vdp v0.1.1-alpha/go.mod h1:OcW7cT58iSmvAoHmTMYxkBj/oEvxYy04BVqakzEO6jA=
+github.com/instill-ai/protogen-go v0.1.1-alpha h1:rZ/mGWOi8sbSfub840WBDB/AmaClgkRjGT/8sDvCveo=
+github.com/instill-ai/protogen-go v0.1.1-alpha/go.mod h1:q2Pq4P0AY/59RGibT4nSDnOsA4wD4XhLueFRoGYNBjk=
+github.com/instill-ai/vdp v0.1.2-alpha h1:+R0TEb/Igo1JE/UrH9ZzeO/kUuv1ZZSGLl2ypTVabxw=
+github.com/instill-ai/vdp v0.1.2-alpha/go.mod h1:lEhCVtzWPBU8dr/hpaiVKpwbByiYYpwtXMDQy6OJ+Po=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
 github.com/jackc/chunkreader v1.0.0 h1:4s39bBR8ByfqH+DKm8rQA3E1LHZWB9XWcrz8fqaZbe0=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -15,6 +15,7 @@ import (
 	model "github.com/instill-ai/pipeline-backend/pkg/model"
 	"github.com/instill-ai/pipeline-backend/pkg/repository"
 	modelPB "github.com/instill-ai/protogen-go/model"
+	pipelinePB "github.com/instill-ai/protogen-go/pipeline"
 	"google.golang.org/grpc/codes"
 )
 
@@ -24,6 +25,7 @@ type Services interface {
 	GetPipelineByName(namespace string, pipelineName string) (model.Pipeline, error)
 	UpdatePipeline(pipeline model.Pipeline) (model.Pipeline, error)
 	DeletePipeline(namespace string, pipelineName string) error
+	TriggerPipeline(namespace string, trigger pipelinePB.TriggerPipelineRequest, pipeline model.Pipeline) (interface{}, error)
 	ValidateTriggerPipeline(namespace string, pipelineName string, pipeline model.Pipeline) error
 	TriggerPipelineByUpload(namespace string, buf bytes.Buffer, pipeline model.Pipeline) (interface{}, error)
 	ValidateModel(namespace string, selectedModel []*model.Model) error
@@ -43,23 +45,29 @@ func NewPipelineService(r repository.Operations, modelServiceClient modelPB.Mode
 
 func (p *PipelineService) CreatePipeline(pipeline model.Pipeline) (model.Pipeline, error) {
 
+	// TODO: more validation
+	if pipeline.Name == "" {
+		return model.Pipeline{}, status.Error(codes.FailedPrecondition, "The required field name not specify")
+	}
+
 	// Validate the naming rule of pipeline
 	if match, _ := regexp.MatchString("^[A-Za-z0-9][a-zA-Z0-9_.-]*$", pipeline.Name); !match {
 		return model.Pipeline{}, status.Error(codes.FailedPrecondition, "The name of pipeline is invalid")
 	}
 
-	// TODO: validation
-	if pipeline.Name == "" {
-		return model.Pipeline{}, status.Error(codes.FailedPrecondition, "The required field name not specify")
+	if len(pipeline.Name) > 100 {
+		return model.Pipeline{}, status.Error(codes.FailedPrecondition, "The length of the name is greater than 38")
 	}
 
 	if existingPipeline, _ := p.GetPipelineByName(pipeline.Namespace, pipeline.Name); existingPipeline.Name != "" {
 		return model.Pipeline{}, status.Errorf(codes.FailedPrecondition, "The name %s is existing in your namespace", pipeline.Name)
 	}
 
-	err := p.ValidateModel(pipeline.Namespace, pipeline.Recipe.Model)
-	if err != nil {
-		return model.Pipeline{}, err
+	if pipeline.Recipe != nil && pipeline.Recipe.Model != nil && len(pipeline.Recipe.Model) > 0 {
+		err := p.ValidateModel(pipeline.Namespace, pipeline.Recipe.Model)
+		if err != nil {
+			return model.Pipeline{}, err
+		}
 	}
 
 	if err := p.PipelineRepository.CreatePipeline(pipeline); err != nil {
@@ -136,6 +144,41 @@ func (p *PipelineService) ValidateTriggerPipeline(namespace string, pipelineName
 	return nil
 }
 
+func (p *PipelineService) TriggerPipeline(namespace string, trigger pipelinePB.TriggerPipelineRequest, pipeline model.Pipeline) (interface{}, error) {
+
+	// TODO: The model that pipeline used is offline
+
+	if temporal.IsDirect(pipeline.Recipe) {
+
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+
+		vdo := pipeline.Recipe.Model[0]
+
+		var contents []*modelPB.ImageRequest
+		for _, content := range trigger.Contents {
+			contents = append(contents, &modelPB.ImageRequest{
+				Url:    content.Url,
+				Base64: content.Base64,
+			})
+		}
+
+		ret, err := p.ModelServiceClient.PredictModel(ctx, &modelPB.PredictModelImageRequest{
+			Name:     vdo.Name,
+			Version:  vdo.Version,
+			Contents: contents,
+		})
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "cannot make inference: %s", err.Error())
+		}
+
+		fmt.Printf("%+v\n", ret)
+
+		return ret, nil
+	} else {
+		return nil, nil
+	}
+}
 
 func (p *PipelineService) TriggerPipelineByUpload(namespace string, image bytes.Buffer, pipeline model.Pipeline) (interface{}, error) {
 

--- a/rpc/pipeline.go
+++ b/rpc/pipeline.go
@@ -199,6 +199,29 @@ func (s *pipelineServiceHandlers) DeletePipeline(ctx context.Context, in *pipeli
 	return &emptypb.Empty{}, nil
 }
 
+func (s *pipelineServiceHandlers) TriggerPipeline(ctx context.Context, in *pipelinePB.TriggerPipelineRequest) (*structpb.Struct, error) {
+
+	username, err := getUsername(ctx)
+	if err != nil {
+		return &structpb.Struct{}, err
+	}
+
+	pipeline, err := s.pipelineService.GetPipelineByName(username, in.Name)
+	if err != nil {
+		return &structpb.Struct{}, err
+	}
+
+	if err := s.pipelineService.ValidateTriggerPipeline(username, in.Name, pipeline); err != nil {
+		return &structpb.Struct{}, err
+	}
+
+	if obj, err := s.pipelineService.TriggerPipeline(username, *in, pipeline); err != nil {
+		return &structpb.Struct{}, err
+	} else {
+		return obj.(*structpb.Struct), nil
+	}
+}
+
 func (s *pipelineServiceHandlers) TriggerPipelineByUpload(stream pipelinePB.Pipeline_TriggerPipelineByUploadServer) error {
 
 	username, err := getUsername(stream.Context())

--- a/rpc/unmarshal.go
+++ b/rpc/unmarshal.go
@@ -58,6 +58,5 @@ func unmarshalPipelineTriggerContent(content *pb.TriggerPipelineContent) *model.
 	return &model.TriggerPipelineContent{
 		Url:    content.Url,
 		Base64: content.Base64,
-		Chunk:  content.Chunk,
 	}
 }


### PR DESCRIPTION
Because

- `model-backend` now support endpoint for URL/base64 request, so `pipeline-backend` also need to support this

This commit

- add support URL/base64 endpoint
- close #22 
