### PR TITLE
chore: use instill-ai/x module for zapadapter

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - uses: actions/setup-go@v1
+      - uses: actions/setup-go@v3
         with:
           go-version: 1.17
 
@@ -17,6 +17,7 @@ jobs:
 
       - name: Generate coverage report
         run: |
+          go mod tidy
           go test -race ./... -coverprofile=coverage.txt -covermode=atomic
 
       - name: Upload coverage report

--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,11 @@ mysql-persistence/
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+
+# built binary
+pipeline-backend
+
+# air related files and folders
+.air.toml
+tmp

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Pipeline-backend
+# pipeline-backend
 
-The pipeline-backend manages all pipeline resources and talks to [Visual Data Preparation (VDP)](https://github.com/instill-ai/vdp) for pipeline orchestration.
+The pipeline-backend manages all pipeline resources working with [Visual Data Preparation (VDP)](https://github.com/instill-ai/vdp).
 
 ## Development
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/instill-ai/pipeline-backend
 go 1.17
 
 require (
-	github.com/bochengyang/zapadapter v0.0.0-20220121170652-8b0c7573d884
 	github.com/go-redis/redis/v8 v8.11.4
 	github.com/gogo/status v1.1.0
 	github.com/golang-migrate/migrate/v4 v4.15.1
@@ -12,6 +11,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.3
 	github.com/instill-ai/protogen-go v0.1.1-alpha
 	github.com/instill-ai/vdp v0.1.2-alpha
+	github.com/instill-ai/x v0.1.0-alpha
 	github.com/knadh/koanf v1.4.0
 	github.com/stretchr/testify v1.7.0
 	go.temporal.io/sdk v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -148,7 +148,6 @@ github.com/bkaradzic/go-lz4 v1.0.0/go.mod h1:0YdlkowM3VswSROI7qDxhRvJ3sLhlFrRRwj
 github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
-github.com/bochengyang/zapadapter v0.0.0-20220121170652-8b0c7573d884 h1:rxlcnMJ0eukNpiEj9Ir13YtiBVfma39RBlwvoJrrPyw=
 github.com/bochengyang/zapadapter v0.0.0-20220121170652-8b0c7573d884/go.mod h1:55wu0OmeRZUmJp4REDpXw+7V7KM0qSjA4YrNho3g/rc=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/bshuster-repo/logrus-logstash-hook v0.4.1/go.mod h1:zsTqEiSzDgAa/8GZR7E1qaXrhYNDKBYy5/dWPTIflbk=
@@ -601,6 +600,8 @@ github.com/instill-ai/protogen-go v0.1.1-alpha h1:rZ/mGWOi8sbSfub840WBDB/AmaClgk
 github.com/instill-ai/protogen-go v0.1.1-alpha/go.mod h1:q2Pq4P0AY/59RGibT4nSDnOsA4wD4XhLueFRoGYNBjk=
 github.com/instill-ai/vdp v0.1.2-alpha h1:+R0TEb/Igo1JE/UrH9ZzeO/kUuv1ZZSGLl2ypTVabxw=
 github.com/instill-ai/vdp v0.1.2-alpha/go.mod h1:lEhCVtzWPBU8dr/hpaiVKpwbByiYYpwtXMDQy6OJ+Po=
+github.com/instill-ai/x v0.1.0-alpha h1:cXzOGkHr+u1XdB8Pn6VHYb+hZX621mvlz7qBxZ29S5Y=
+github.com/instill-ai/x v0.1.0-alpha/go.mod h1:MzD0v46c0h0t5tvE8Fmqa44rxrI75Ew5JK2iWqqZV2g=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
 github.com/jackc/chunkreader v1.0.0 h1:4s39bBR8ByfqH+DKm8rQA3E1LHZWB9XWcrz8fqaZbe0=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
@@ -1034,8 +1035,9 @@ go.temporal.io/api v1.6.1-0.20211110205628-60c98e9cbfe2/go.mod h1:IlUgOTGfmJuOkG
 go.temporal.io/api v1.7.0 h1:fMaxrk8u12zPPOKgN6HCHyJjQQX6HcCxtMQTjck1rGE=
 go.temporal.io/api v1.7.0/go.mod h1:Bjxr81kDTMY0IYxbosWleAVOFE+Pnp4SRk87oWchYv8=
 go.temporal.io/sdk v1.12.0/go.mod h1:lSp3lH1lI0TyOsus0arnO3FYvjVXBZGi/G7DjnAnm6o=
-go.temporal.io/sdk v1.13.0 h1:8PW27o/uYAf1C1u8WUd6LNa6He2nYkBhdUX3c5gif5o=
 go.temporal.io/sdk v1.13.0/go.mod h1:TCof7U/xas2FyDnx/UUEv4c/O/S41Lnhva+6JVer+Jo=
+go.temporal.io/sdk v1.13.1 h1:4LRIe1WLM+m2pN6sNod4sMV+0bV8WTscVfRsipOP8N8=
+go.temporal.io/sdk v1.13.1/go.mod h1:TCof7U/xas2FyDnx/UUEv4c/O/S41Lnhva+6JVer+Jo=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=

--- a/internal/temporal/temporal.go
+++ b/internal/temporal/temporal.go
@@ -6,12 +6,12 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/bochengyang/zapadapter"
 	"github.com/instill-ai/pipeline-backend/configs"
 	"github.com/instill-ai/pipeline-backend/internal/definition"
 	"github.com/instill-ai/pipeline-backend/internal/logger"
 	"github.com/instill-ai/pipeline-backend/pkg/model"
 	worker "github.com/instill-ai/vdp/pkg/temporal"
+	"github.com/instill-ai/x/zapadapter"
 	"go.temporal.io/sdk/client"
 )
 


### PR DESCRIPTION
Because

- we now have module `instill-ai/x` to share common package

This commit

- adopt `instill-ai/x/zapadapter` pacakge
- update `README.md`
- update `.gitignore`
- update codecov job