### PR TITLE
fix: fix response in snake case

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -2,5 +2,7 @@ coverage:
   status:
     project:
       default:
-        target: auto
-        threshold: 50%
+        informational: true
+    patch:
+      default:
+        informational: true

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -132,7 +132,9 @@ func main() {
 		runtime.WithIncomingHeaderMatcher(customMatcher),
 		runtime.WithMarshalerOption(runtime.MIMEWildcard, &runtime.JSONPb{
 			MarshalOptions: protojson.MarshalOptions{
+				UseProtoNames:   true,
 				EmitUnpopulated: true,
+				UseEnumNumbers:  false,
 			},
 			UnmarshalOptions: protojson.UnmarshalOptions{
 				DiscardUnknown: true,

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.3
-	github.com/instill-ai/protogen-go v0.1.4-alpha
+	github.com/instill-ai/protogen-go v0.1.5-alpha
 	github.com/instill-ai/vdp v0.1.3-alpha.0.20220320033117-c3e0db375b45
 	github.com/instill-ai/x v0.1.0-alpha
 	github.com/knadh/koanf v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -596,8 +596,8 @@ github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/instill-ai/protogen-go v0.1.3-alpha/go.mod h1:q2Pq4P0AY/59RGibT4nSDnOsA4wD4XhLueFRoGYNBjk=
-github.com/instill-ai/protogen-go v0.1.4-alpha h1:Je7QW9/4S1nWgAGwEtEZb0cUl0n/Fbilp/bkl99KN2o=
-github.com/instill-ai/protogen-go v0.1.4-alpha/go.mod h1:q2Pq4P0AY/59RGibT4nSDnOsA4wD4XhLueFRoGYNBjk=
+github.com/instill-ai/protogen-go v0.1.5-alpha h1:rmovaQhNaTFGuZxXPWLpYX5E6jqS/akWWaJ+3yAx0Xo=
+github.com/instill-ai/protogen-go v0.1.5-alpha/go.mod h1:q2Pq4P0AY/59RGibT4nSDnOsA4wD4XhLueFRoGYNBjk=
 github.com/instill-ai/vdp v0.1.3-alpha.0.20220320033117-c3e0db375b45 h1:MureMU/JCh3C0QwBVVgv1HsIPRcCN+wxqpg9vnvfutU=
 github.com/instill-ai/vdp v0.1.3-alpha.0.20220320033117-c3e0db375b45/go.mod h1:xcFgWKOHkqqkKMUkc5ftoD/5/hMSVR3qNhnnHxWzxYQ=
 github.com/instill-ai/x v0.1.0-alpha h1:cXzOGkHr+u1XdB8Pn6VHYb+hZX621mvlz7qBxZ29S5Y=

--- a/rpc/pipeline.go
+++ b/rpc/pipeline.go
@@ -259,11 +259,11 @@ func (s *pipelineServiceHandlers) TriggerPipelineBinaryFileUpload(stream pipelin
 			return status.Errorf(codes.Internal, "failed unexpectedly while reading chunks from stream: %s", err.Error())
 		}
 
-		if data.Chunk == nil {
+		if data.Bytes == nil {
 			continue
 		}
 
-		if _, err := buf.Write(data.Chunk); err != nil {
+		if _, err := buf.Write(data.Bytes); err != nil {
 			return status.Errorf(codes.Internal, "failed unexpectedly while reading chunks from stream: %s", err.Error())
 		}
 	}


### PR DESCRIPTION
Because

- response output standard follows snake_case to disambiguate REST and gRPC naming convention

This commit

- adopt protobuf@v0.1.5-alpha
- make codecov.yml unblock mode
- configure grpc-gateway to use snake_case
