### PR TITLE
chore: update protobuf message

### DIFF
--- a/pkg/handler/fieldannotation.go
+++ b/pkg/handler/fieldannotation.go
@@ -7,7 +7,7 @@ var activateRequiredFields = []string{"name"}
 var deactivateRequiredFields = []string{"name"}
 var renameRequiredFields = []string{"name", "new_pipeline_id"}
 var triggerRequiredFields = []string{"name", "inputs"}
-var triggerBinaryRequiredFields = []string{"name", "file_lengths", "bytes"}
+var triggerBinaryRequiredFields = []string{"name", "file_lengths", "content"}
 
 // immutableFields are Protobuf message fields with IMMUTABLE field_behavior annotation
 var immutableFields = []string{"id", "recipe", "recipe.source", "recipe.model_instances", "recipe.destination"}


### PR DESCRIPTION
Because

- protobuf message change bytes to content
- error when trigger a pipeline with grpc stream method

This commit

- update required fields
- fix read file length when trigger a pipeline
