### PR TITLE
refactor: update usage reporter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.10.3
 	github.com/iancoleman/strcase v0.2.0
 	github.com/instill-ai/protogen-go v0.3.1-alpha
-	github.com/instill-ai/usage-client v0.1.1-alpha
+	github.com/instill-ai/usage-client v0.1.2-alpha
 	github.com/instill-ai/x v0.2.0-alpha
 	github.com/knadh/koanf v1.4.1
 	github.com/mennanov/fieldmask-utils v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -696,8 +696,8 @@ github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/instill-ai/protogen-go v0.3.1-alpha h1:gejEAwadzpa41a09O/wTC9l9E/m5KCY9igGrHs4cLuI=
 github.com/instill-ai/protogen-go v0.3.1-alpha/go.mod h1:7/Jj3ATVozPwB0WmKRM612o/k5UJF8K9oRCNKYH8iy0=
-github.com/instill-ai/usage-client v0.1.1-alpha h1:TG1jH82GHjPqmjogQ4I1d8KFY5cBzrskBt9stoARWnU=
-github.com/instill-ai/usage-client v0.1.1-alpha/go.mod h1:Vi+RgL2YNT+hfztD33JzqFl/Y7/SsV+NpWGIjUgig3s=
+github.com/instill-ai/usage-client v0.1.2-alpha h1:aGZKqZSZu4FB4ov1lyaJVIuoD6MQ+zDBUFqSYWVauSE=
+github.com/instill-ai/usage-client v0.1.2-alpha/go.mod h1:Vi+RgL2YNT+hfztD33JzqFl/Y7/SsV+NpWGIjUgig3s=
 github.com/instill-ai/x v0.2.0-alpha h1:8yszKP9DE8bvSRAtEpOwqhG2wwqU3olhTqhwoiLrHfc=
 github.com/instill-ai/x v0.2.0-alpha/go.mod h1:/UEx/zFyMo7so2ctBY0pzjmIoJB9Qz5Y4gvwU2FoU74=
 github.com/intel/goresctrl v0.2.0/go.mod h1:+CZdzouYFn5EsxgqAQTEzMfwKwuc0fVdMrT9FCCAVRQ=

--- a/pkg/usage/usage.go
+++ b/pkg/usage/usage.go
@@ -3,36 +3,59 @@ package usage
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/go-redis/redis/v9"
 	"go.einride.tech/aip/filtering"
 
+	"github.com/instill-ai/pipeline-backend/config"
 	"github.com/instill-ai/pipeline-backend/internal/logger"
 	"github.com/instill-ai/pipeline-backend/pkg/datamodel"
 	"github.com/instill-ai/pipeline-backend/pkg/repository"
+	"github.com/instill-ai/x/repo"
 
 	mgmtPB "github.com/instill-ai/protogen-go/vdp/mgmt/v1alpha"
 	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1alpha"
 	usagePB "github.com/instill-ai/protogen-go/vdp/usage/v1alpha"
+	usageClient "github.com/instill-ai/usage-client/client"
+	usageReporter "github.com/instill-ai/usage-client/reporter"
 )
 
 // Usage interface
 type Usage interface {
 	RetrieveUsageData() interface{}
+	StartReporter(ctx context.Context)
+	TriggerSingleReporter(ctx context.Context)
 }
 
 type usage struct {
 	repository        repository.Repository
 	userServiceClient mgmtPB.UserServiceClient
 	redisClient       *redis.Client
+	reporter          usageReporter.Reporter
+	version           string
 }
 
 // NewUsage initiates a usage instance
-func NewUsage(r repository.Repository, mu mgmtPB.UserServiceClient, rc *redis.Client) Usage {
+func NewUsage(ctx context.Context, r repository.Repository, mu mgmtPB.UserServiceClient, rc *redis.Client, usc usagePB.UsageServiceClient) Usage {
+	logger, _ := logger.GetZapLogger()
+
+	version, err := repo.ReadReleaseManifest("release-please/manifest.json")
+	if err != nil {
+		logger.Fatal(err.Error())
+	}
+
+	reporter, err := usageClient.InitReporter(ctx, usc, usagePB.Session_SERVICE_MGMT, config.Config.Server.Edition, version)
+	if err != nil {
+		logger.Fatal(err.Error())
+	}
+
 	return &usage{
 		repository:        r,
 		userServiceClient: mu,
 		redisClient:       rc,
+		reporter:          reporter,
+		version:           version,
 	}
 }
 
@@ -123,5 +146,31 @@ func (u *usage) RetrieveUsageData() interface{} {
 		PipelineUsageData: &usagePB.PipelineUsageData{
 			Usages: pbPipelineUsageData,
 		},
+	}
+}
+
+func (u *usage) StartReporter(ctx context.Context) {
+	if u.reporter == nil {
+		return
+	}
+
+	logger, _ := logger.GetZapLogger()
+	go func() {
+		time.Sleep(5 * time.Second)
+		err := usageClient.StartReporter(ctx, u.reporter, usagePB.Session_SERVICE_MGMT, config.Config.Server.Edition, u.version, u.RetrieveUsageData)
+		if err != nil {
+			logger.Error(fmt.Sprintf("unable to start reporter: %v\n", err))
+		}
+	}()
+}
+
+func (u *usage) TriggerSingleReporter(ctx context.Context) {
+	if u.reporter == nil {
+		return
+	}
+	logger, _ := logger.GetZapLogger()
+	err := usageClient.SingleReporter(ctx, u.reporter, usagePB.Session_SERVICE_MGMT, config.Config.Server.Edition, u.version, u.RetrieveUsageData())
+	if err != nil {
+		logger.Fatal(err.Error())
 	}
 }


### PR DESCRIPTION
Because

- upgrade usage collection

This commit

- move usage-related code into the usage package
- trigger the reporter before shutting down the server