### PR TITLE
fix: pipeline trigger model hangout

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -454,6 +454,7 @@ func (s *service) TriggerPipeline(req *pipelinePB.TriggerPipelineRequest, dbPipe
 			for err := range errors {
 				if err != nil {
 					logger.Error(fmt.Sprintf("[connector-backend] Error trigger model instance got error %v", err.Error()))
+					return
 				}
 			}
 

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -453,7 +453,7 @@ func (s *service) TriggerPipeline(req *pipelinePB.TriggerPipelineRequest, dbPipe
 			}()
 			for err := range errors {
 				if err != nil {
-					logger.Error(fmt.Sprintf("[connector-backend] Error trigger model instance got error %v", err.Error()))
+					logger.Error(fmt.Sprintf("[model-backend] Error trigger model instance got error %v", err.Error()))
 					return
 				}
 			}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -384,7 +384,7 @@ func (s *service) TriggerPipeline(req *pipelinePB.TriggerPipelineRequest, dbPipe
 
 		for idx, modelInstance := range dbPipeline.Recipe.ModelInstances {
 
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
 			resp, err := s.modelServiceClient.TriggerModelInstance(ctx, &modelPB.TriggerModelInstanceRequest{
 				Name:   modelInstance,

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -430,7 +430,12 @@ func (s *service) TriggerPipeline(req *pipelinePB.TriggerPipelineRequest, dbPipe
 
 	for err := range errors {
 		if err != nil {
-			return nil, fmt.Errorf("error when trigger model instance %v", err.Error())
+			switch {
+			case strings.Contains(err.Error(), "code = DeadlineExceeded"):
+				return nil, status.Errorf(codes.DeadlineExceeded, "trigger model instance got timeout error")
+			default:
+				return nil, status.Errorf(codes.Internal, fmt.Sprintf("trigger model instance got error %v", err.Error()))
+			}
 		}
 	}
 


### PR DESCRIPTION
Because

- Trigger model timeout 5 seconds is not enough for making model inference
- Goroutines use sync.WaitGroup which does not decrease the counter due to exception errors

This commit

- Increase timeout to 30 seconds
- defer wg.Done() and end function when have any error
- close #79 
- close #77 
