### PR TITLE
chore: resilient with non-working usage service

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -170,7 +170,9 @@ func main() {
 		usageServiceClient, usageServiceClientConn := external.InitUsageServiceClient()
 		defer usageServiceClientConn.Close()
 		usg = usage.NewUsage(ctx, repository, userServiceClient, redisClient, usageServiceClient)
-		usg.StartReporter(ctx)
+		if usg != nil {
+			usg.StartReporter(ctx)
+		}
 	}
 
 	// Start gRPC server
@@ -217,7 +219,7 @@ func main() {
 	case err := <-errSig:
 		logger.Error(fmt.Sprintf("Fatal error: %v\n", err))
 	case <-quitSig:
-		if !config.Config.Server.DisableUsage {
+		if !config.Config.Server.DisableUsage && usg != nil {
 			usg.TriggerSingleReporter(ctx)
 		}
 		logger.Info("Shutting down server...")

--- a/pkg/usage/usage.go
+++ b/pkg/usage/usage.go
@@ -42,12 +42,14 @@ func NewUsage(ctx context.Context, r repository.Repository, mu mgmtPB.UserServic
 
 	version, err := repo.ReadReleaseManifest("release-please/manifest.json")
 	if err != nil {
-		logger.Fatal(err.Error())
+		logger.Error(err.Error())
+		return nil
 	}
 
 	reporter, err := usageClient.InitReporter(ctx, usc, usagePB.Session_SERVICE_PIPELINE, config.Config.Server.Edition, version)
 	if err != nil {
-		logger.Fatal(err.Error())
+		logger.Error(err.Error())
+		return nil
 	}
 
 	return &usage{


### PR DESCRIPTION
Because

- usage service could be not available and the mgmt server should be resilient with this situation.

This commit

- check the connection to the usage service then report only have a connection
