### PR TITLE
chore: add config for max image file size

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -41,6 +41,7 @@ type ServerConfig struct {
 	Edition      string   `koanf:"edition"`
 	DisableUsage bool     `koanf:"disableusage"`
 	Debug        bool     `koanf:"debug"`
+	MaxImageSize int      `koanf:"maximagesize"`
 }
 
 // DatabaseConfig related to database

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -10,6 +10,7 @@ server:
   edition: local-ce:dev
   disableusage: false
   debug: true
+  maximagesize: 12 # MB in unit
 database:
   username: postgres
   password: password

--- a/internal/constant/constant.go
+++ b/internal/constant/constant.go
@@ -9,4 +9,3 @@ const (
 )
 
 const MaxBatchSize int = 32
-const MaxImageSizeBytes int = 4 * MB

--- a/pkg/handler/handlercustom.go
+++ b/pkg/handler/handlercustom.go
@@ -157,11 +157,10 @@ func parseImageFormDataInputsToBytes(req *http.Request) (content []byte, fileNam
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("Unable to read content body from image")
 		}
-
-		if numBytes > int64(constant.MaxImageSizeBytes) {
+		if numBytes > int64(config.Config.Server.MaxImageSize*constant.MB) {
 			return nil, nil, nil, fmt.Errorf(
 				"Image size must be smaller than %vMB. Got %vMB",
-				float32(constant.MaxImageSizeBytes)/float32(constant.MB),
+				float32(config.Config.Server.MaxImageSize*constant.MB)/float32(constant.MB),
 				float32(numBytes)/float32(constant.MB),
 			)
 		}

--- a/pkg/handler/handlercustom.go
+++ b/pkg/handler/handlercustom.go
@@ -160,7 +160,7 @@ func parseImageFormDataInputsToBytes(req *http.Request) (content []byte, fileNam
 		if numBytes > int64(config.Config.Server.MaxImageSize*constant.MB) {
 			return nil, nil, nil, fmt.Errorf(
 				"Image size must be smaller than %vMB. Got %vMB",
-				float32(config.Config.Server.MaxImageSize*constant.MB)/float32(constant.MB),
+				config.Config.Server.MaxImageSize,
 				float32(numBytes)/float32(constant.MB),
 			)
 		}


### PR DESCRIPTION
Because

- max image file size should be configurable

This commit

- add `maximagesize` in server config
