### PR TITLE
chore: update Visual Data Preparation to Versatile Data Pipeline

### DIFF
--- a/.github/workflows/add-issue-to-prj.yml
+++ b/.github/workflows/add-issue-to-prj.yml
@@ -9,6 +9,6 @@ jobs:
   track_issue:
     uses: instill-ai/meta/.github/workflows/add-issue-to-prj.yml@main
     with:
-      project_number: 5 # Visual Data Preparation (VDP) project
+      project_number: 5 # Versatile Data Pipeline (VDP) project
     secrets:
       botGitHubToken: ${{ secrets.botGitHubToken }}

--- a/.github/workflows/add-pr-to-prj.yml
+++ b/.github/workflows/add-pr-to-prj.yml
@@ -9,6 +9,6 @@ jobs:
   track_pr:
     uses: instill-ai/meta/.github/workflows/add-pr-to-prj.yml@main
     with:
-      project_number: 5 # Visual Data Preparation (VDP) project
+      project_number: 5 # Versatile Data Pipeline (VDP) project
     secrets:
       botGitHubToken: ${{ secrets.botGitHubToken }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pipeline-backend
 
-`pipeline-backend` manages all pipeline resources within [Visual Data Preparation (VDP)](https://github.com/instill-ai/vdp) to streamline data from a source connector to models, and to a destination connector at the end.
+`pipeline-backend` manages all pipeline resources within [Versatile Data Pipeline (VDP)](https://github.com/instill-ai/vdp) to streamline data from a source connector to models, and to a destination connector at the end.
 
 ## Local dev
 

--- a/pkg/service/convert.go
+++ b/pkg/service/convert.go
@@ -245,7 +245,7 @@ func cvtModelTaskOutputToPipelineTaskOutput(modelTaskOutputs []*modelPB.TaskOutp
 				},
 			})
 		default:
-			logger.Error("CV Task type is not defined")
+			logger.Error("AI task type is not defined")
 		}
 	}
 


### PR DESCRIPTION
Because

- instead of Visual Data Preparation, VDP is Versatile Data Pipeline now. We realise that as a general ETL infrastructure, VDP is capable of processing all kinds of unstructured data, and we should not limit its usage to only visual data. That's why we replace the word Visual with Versatile. Besides, the term Data Preparation is a bit misleading, users often think it has something to do with data labelling or cleaning. The term Data Pipeline is definitely more precise to capture the core concept of VDP.
 
This commit

- update to Versatile Data Pipeline
