### PR TITLE
fix: replace fatal logs with error logs

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -120,13 +120,19 @@ func main() {
 	defer cancel()
 
 	mgmtAdminServiceClient, mgmtAdminServiceClientConn := external.InitMgmtAdminServiceClient()
-	defer mgmtAdminServiceClientConn.Close()
+	if mgmtAdminServiceClientConn != nil {
+		defer mgmtAdminServiceClientConn.Close()
+	}
 
 	connectorServiceClient, connectorServiceClientConn := external.InitConnectorServiceClient()
-	defer connectorServiceClientConn.Close()
+	if connectorServiceClientConn != nil {
+		defer connectorServiceClientConn.Close()
+	}
 
 	modelServiceClient, modelServiceClientConn := external.InitModelServiceClient()
-	defer modelServiceClientConn.Close()
+	if modelServiceClientConn != nil {
+		defer modelServiceClientConn.Close()
+	}
 
 	redisClient := redis.NewClient(&config.Config.Cache.Redis.RedisOptions)
 	defer redisClient.Close()
@@ -174,10 +180,12 @@ func main() {
 	var usg usage.Usage
 	if !config.Config.Server.DisableUsage {
 		usageServiceClient, usageServiceClientConn := external.InitUsageServiceClient()
-		defer usageServiceClientConn.Close()
-		usg = usage.NewUsage(ctx, repository, mgmtAdminServiceClient, redisClient, usageServiceClient)
-		if usg != nil {
-			usg.StartReporter(ctx)
+		if usageServiceClientConn != nil {
+			defer usageServiceClientConn.Close()
+			usg = usage.NewUsage(ctx, repository, mgmtAdminServiceClient, redisClient, usageServiceClient)
+			if usg != nil {
+				usg.StartReporter(ctx)
+			}
 		}
 	}
 

--- a/internal/external/external.go
+++ b/internal/external/external.go
@@ -34,7 +34,8 @@ func InitConnectorServiceClient() (connectorPB.ConnectorServiceClient, *grpc.Cli
 
 	clientConn, err := grpc.Dial(fmt.Sprintf("%v:%v", config.Config.ConnectorBackend.Host, config.Config.ConnectorBackend.Port), clientDialOpts)
 	if err != nil {
-		logger.Fatal(err.Error())
+		logger.Error(err.Error())
+		return nil, nil
 	}
 
 	return connectorPB.NewConnectorServiceClient(clientConn), clientConn
@@ -57,7 +58,8 @@ func InitModelServiceClient() (modelPB.ModelServiceClient, *grpc.ClientConn) {
 
 	clientConn, err := grpc.Dial(fmt.Sprintf("%v:%v", config.Config.ModelBackend.Host, config.Config.ModelBackend.Port), clientDialOpts)
 	if err != nil {
-		logger.Fatal(err.Error())
+		logger.Error(err.Error())
+		return nil, nil
 	}
 
 	return modelPB.NewModelServiceClient(clientConn), clientConn
@@ -80,7 +82,8 @@ func InitMgmtAdminServiceClient() (mgmtPB.MgmtAdminServiceClient, *grpc.ClientCo
 
 	clientConn, err := grpc.Dial(fmt.Sprintf("%v:%v", config.Config.MgmtBackend.Host, config.Config.MgmtBackend.AdminPort), clientDialOpts)
 	if err != nil {
-		logger.Fatal(err.Error())
+		logger.Error(err.Error())
+		return nil, nil
 	}
 
 	return mgmtPB.NewMgmtAdminServiceClient(clientConn), clientConn
@@ -101,7 +104,8 @@ func InitUsageServiceClient() (usagePB.UsageServiceClient, *grpc.ClientConn) {
 
 	clientConn, err := grpc.Dial(fmt.Sprintf("%v:%v", config.Config.UsageServer.Host, config.Config.UsageServer.Port), clientDialOpts)
 	if err != nil {
-		logger.Fatal(err.Error())
+		logger.Error(err.Error())
+		return nil, nil
 	}
 
 	return usagePB.NewUsageServiceClient(clientConn), clientConn

--- a/pkg/handler/handlercustom.go
+++ b/pkg/handler/handlercustom.go
@@ -51,13 +51,19 @@ func HandleTriggerPipelineBinaryFileUpload(w http.ResponseWriter, req *http.Requ
 	if strings.Contains(contentType, "multipart/form-data") {
 
 		mgmtAdminServiceClient, mgmtAdminServiceClientConn := external.InitMgmtAdminServiceClient()
-		defer mgmtAdminServiceClientConn.Close()
+		if mgmtAdminServiceClientConn != nil {
+			defer mgmtAdminServiceClientConn.Close()
+		}
 
 		connectorServiceClient, connectorServiceClientConn := external.InitConnectorServiceClient()
-		defer connectorServiceClientConn.Close()
+		if connectorServiceClientConn != nil {
+			defer connectorServiceClientConn.Close()
+		}
 
 		modelServiceClient, modelServiceClientConn := external.InitModelServiceClient()
-		defer modelServiceClientConn.Close()
+		if modelServiceClientConn != nil {
+			defer modelServiceClientConn.Close()
+		}
 
 		redisClient := redis.NewClient(&config.Config.Cache.Redis.RedisOptions)
 		defer redisClient.Close()

--- a/pkg/usage/usage.go
+++ b/pkg/usage/usage.go
@@ -174,6 +174,6 @@ func (u *usage) TriggerSingleReporter(ctx context.Context) {
 	logger, _ := logger.GetZapLogger()
 	err := usageClient.SingleReporter(ctx, u.reporter, usagePB.Session_SERVICE_PIPELINE, config.Config.Server.Edition, u.version, u.RetrieveUsageData())
 	if err != nil {
-		logger.Fatal(err.Error())
+		logger.Error(fmt.Sprintf("unable to trigger single reporter: %v\n", err))
 	}
 }


### PR DESCRIPTION
Because

- backend service should not be terminated because of connection to other services

This commit

- replace fatal logs with error logs
