### PR TITLE
ci: add rc workflows

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - rc
   release:
     types: [published]
 
@@ -31,6 +32,7 @@ jobs:
           password: ${{ secrets.botDockerHubPassword }}
 
       - name: Build and push (latest)
+        if: github.ref == 'refs/heads/main'
         uses: docker/build-push-action@v3
         with:
           platforms: linux/amd64,linux/arm64
@@ -40,6 +42,20 @@ jobs:
             SERVICE_NAME=pipeline-backend
             GOLANG_VERSION=${{ env.GOLANG_VERSION }}
           tags: instill/pipeline-backend:latest
+          cache-from: type=registry,ref=instill/pipeline-backend:buildcache
+          cache-to: type=registry,ref=instill/pipeline-backend:buildcache,mode=max
+
+      - name: Build and push (rc)
+        if: github.ref == 'refs/heads/rc'
+        uses: docker/build-push-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+          context: .
+          push: true
+          build-args: |
+            SERVICE_NAME=pipeline-backend
+            GOLANG_VERSION=${{ env.GOLANG_VERSION }}
+          tags: instill/pipeline-backend:rc
           cache-from: type=registry,ref=instill/pipeline-backend:buildcache
           cache-to: type=registry,ref=instill/pipeline-backend:buildcache,mode=max
 

--- a/.github/workflows/integration-test-latest.yml
+++ b/.github/workflows/integration-test-latest.yml
@@ -1,0 +1,20 @@
+name: Integration Test (latest) # for PR merged into rc branch
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+    branches:
+      - rc
+
+jobs:
+  backend:
+    strategy:
+      fail-fast: false
+      matrix:
+        component: [pipeline]
+    uses: instill-ai/vdp/.github/workflows/integration-test-backend.yml@main
+    with:
+      component: ${{ matrix.component }}
+      target: latest

--- a/.github/workflows/integration-test-rc.yml
+++ b/.github/workflows/integration-test-rc.yml
@@ -1,0 +1,21 @@
+name: Integration Test (release) # for release-please PR
+
+on:
+  push:
+    branches:
+      - release-please--branches--rc
+
+jobs:
+  backend:
+    strategy:
+      fail-fast: false
+      matrix:
+        component: [pipeline, connector, model, mgmt]
+    uses: instill-ai/vdp/.github/workflows/integration-test-backend.yml@main
+    with:
+      component: ${{ matrix.component }}
+      target: rc
+  console:
+    uses: instill-ai/vdp/.github/workflows/integration-test-console.yml@main
+    with:
+      target: rc

--- a/.github/workflows/pr-rc-check.yml
+++ b/.github/workflows/pr-rc-check.yml
@@ -1,0 +1,23 @@
+name: PR for rc Branch Check
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+    branches:
+      - rc
+
+jobs:
+  head-branch-check:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check head branch
+      run: |
+        HEAD_BRANCH="${{ github.event.pull_request.head.ref }}"
+        ALLOWED_HEAD_BRANCH="main"
+        if [[ "$HEAD_BRANCH" != "$ALLOWED_HRAD_BRANCH" ]]; then
+          echo "Invalid head branch: $HEAD_BRANCH. It must be: $ALLOWED_HEAD_BRANCH"
+          exit 1
+        fi
+        echo "Head branch check passed"

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -3,7 +3,7 @@ name: Release Please
 on:
   push:
     branches:
-      - main
+      - rc
 
 jobs:
   release-please:
@@ -22,9 +22,11 @@ jobs:
           config-file: release-please/config.json
           manifest-file: release-please/manifest.json
       - uses: actions/checkout@v3
+        if: ${{ steps.release.outputs.release_created }}
         with:
           token: ${{ secrets.botGitHubToken }}
       - name: Import GPG Key
+        if: ${{ steps.release.outputs.release_created }}
         uses: crazy-max/ghaction-import-gpg@v5
         with:
           gpg_private_key: ${{ secrets.botGPGPrivateKey }}


### PR DESCRIPTION
Because

- we are introducing the rc branch to make the ci/cd flow more robust 

This commit

- add corresponding GitHub actions 
