### PR TITLE
test: update integration tests for requests with `jwt-sub` header

### DIFF
--- a/integration-test/const.js
+++ b/integration-test/const.js
@@ -1,3 +1,5 @@
+import { uuidv4 } from 'https://jslib.k6.io/k6-utils/1.4.0/index.js';
+
 let proto
 let pHost, cHost, mHost
 let pPrivatePort, pPublicPort, cPublicPort, mPublicPort
@@ -49,6 +51,14 @@ export const params = {
     "Content-Type": "application/json",
   },
 };
+
+const randomUUID = uuidv4();
+export const paramsWithJwt = {
+  headers: {
+    "Content-Type": "application/json",
+    "Jwt-Sub": randomUUID,
+  },
+}
 
 export const detSyncHTTPSingleModelInstRecipe = {
   recipe: {

--- a/integration-test/grpc-pipeline-public-with-jwt.js
+++ b/integration-test/grpc-pipeline-public-with-jwt.js
@@ -1,0 +1,279 @@
+import grpc from 'k6/net/grpc';
+import {
+  check,
+  group
+} from "k6";
+import {
+  randomString
+} from "https://jslib.k6.io/k6-utils/1.1.0/index.js";
+
+import * as constant from "./const.js"
+
+const client = new grpc.Client();
+client.load(['proto/vdp/pipeline/v1alpha'], 'pipeline_public_service.proto');
+
+export function CheckCreate() {
+
+  group(`Pipelines API: Create a pipeline [with random "jwt-sub" header]`, () => {
+
+    client.connect(constant.pipelineGRPCPublicHost, {
+      plaintext: true
+    });
+
+    var reqBody = Object.assign({
+      id: randomString(63),
+      description: randomString(50),
+    },
+      constant.detSyncHTTPSingleModelInstRecipe
+    )
+
+    // Cannot create a pipeline of a non-exist user
+    check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline', {
+      pipeline: reqBody
+    }, constant.paramsWithJwt), {
+      [`[with random "jwt-sub" header] vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+    })
+
+    client.close();
+  });
+}
+
+export function CheckList() {
+
+  group(`Pipelines API: List pipelines [with random "jwt-sub" header]`, () => {
+
+    client.connect(constant.pipelineGRPCPublicHost, {
+      plaintext: true
+    });
+
+    // Cannot list pipelines of a non-exist user
+    check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/ListPipelines', {}, constant.paramsWithJwt), {
+      [`[with random "jwt-sub" header] vdp.pipeline.v1alpha.PipelinePublicService/ListPipelines response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+    })
+
+    client.close();
+  });
+}
+
+export function CheckGet() {
+
+  group(`Pipelines API: Get a pipeline [with random "jwt-sub" header]`, () => {
+
+    client.connect(constant.pipelineGRPCPublicHost, {
+      plaintext: true
+    });
+
+    var reqBody = Object.assign({
+      id: randomString(10),
+      description: randomString(50),
+    },
+      constant.detSyncHTTPSingleModelInstRecipe
+    )
+
+    check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline', {
+      pipeline: reqBody
+    }), {
+      [`vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline response StatusOK`]: (r) => r.status === grpc.StatusOK,
+    });
+
+    // Cannot get a pipeline of a non-exist user
+    check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/GetPipeline', {
+      name: `pipelines/${reqBody.id}`
+    }, constant.paramsWithJwt), {
+      [`[with random "jwt-sub" header] vdp.pipeline.v1alpha.PipelinePublicService/GetPipeline response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+    })
+
+    // Delete the pipeline
+    check(client.invoke(`vdp.pipeline.v1alpha.PipelinePublicService/DeletePipeline`, {
+      name: `pipelines/${reqBody.id}`
+    }), {
+      [`vdp.pipeline.v1alpha.PipelinePublicService/DeletePipeline response StatusOK`]: (r) => r.status === grpc.StatusOK,
+    });
+
+    client.close();
+  });
+}
+
+export function CheckUpdate() {
+
+  group(`Pipelines API: Update a pipeline [with random "jwt-sub" header]`, () => {
+
+    client.connect(constant.pipelineGRPCPublicHost, {
+      plaintext: true
+    });
+
+    var reqBody = Object.assign({
+      id: randomString(10),
+    },
+      constant.detSyncHTTPSingleModelInstRecipe
+    )
+
+    // Create a pipeline
+    var resOrigin = client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline', {
+      pipeline: reqBody
+    })
+
+    check(resOrigin, {
+      [`vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline response StatusOK`]: (r) => r.status === grpc.StatusOK,
+    });
+
+    var reqBodyUpdate = Object.assign({
+      id: reqBody.id,
+      name: `pipelines/${reqBody.id}`,
+      uid: "output-only-to-be-ignored",
+      mode: "MODE_ASYNC",
+      description: randomString(50),
+    },)
+
+    // Cannot update a pipeline of a non-exist user
+    check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/UpdatePipeline', {
+      pipeline: reqBodyUpdate,
+      update_mask: "description"
+    }, constant.paramsWithJwt), {
+      [`[with random "jwt-sub" header] vdp.pipeline.v1alpha.PipelinePublicService/UpdatePipeline response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+    })
+
+    // Delete the pipeline
+    check(client.invoke(`vdp.pipeline.v1alpha.PipelinePublicService/DeletePipeline`, {
+      name: `pipelines/${reqBody.id}`
+    }), {
+      [`vdp.pipeline.v1alpha.PipelinePublicService/DeletePipeline response StatusOK`]: (r) => r.status === grpc.StatusOK,
+    });
+
+    client.close()
+  });
+}
+
+export function CheckUpdateState() {
+
+  group(`Pipelines API: Update a pipeline state [with random "jwt-sub" header]`, () => {
+
+    client.connect(constant.pipelineGRPCPublicHost, {
+      plaintext: true
+    });
+
+    var reqBodySync = Object.assign({
+      id: randomString(10),
+    },
+      constant.detSyncHTTPSingleModelInstRecipe
+    )
+
+    check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline', {
+      pipeline: reqBodySync
+    }), {
+      [`vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline Sync response StatusOK`]: (r) => r.status === grpc.StatusOK,
+      [`vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline Sync response pipeline state ACTIVE`]: (r) => r.message.pipeline.state === "STATE_ACTIVE",
+    })
+
+    // Cannot activate a pipeline of a non-exist user
+    check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/ActivatePipeline', {
+      name: `pipelines/${reqBodySync.id}`
+    }, constant.paramsWithJwt), {
+      [`[with random "jwt-sub" header] vdp.pipeline.v1alpha.PipelinePublicService/ActivatePipeline response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+    })
+
+    // Cannot deactivate a pipeline of a non-exist user
+    check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/DeactivatePipeline', {
+      name: `pipelines/${reqBodySync.id}`
+    }, constant.paramsWithJwt), {
+      [`[with random "jwt-sub" header] vdp.pipeline.v1alpha.PipelinePublicService/DeactivatePipeline response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+    })
+
+    // Delete the pipeline
+    check(client.invoke(`vdp.pipeline.v1alpha.PipelinePublicService/DeletePipeline`, {
+      name: `pipelines/${reqBodySync.id}`
+    }), {
+      [`vdp.pipeline.v1alpha.PipelinePublicService/DeletePipeline response StatusOK`]: (r) => r.status === grpc.StatusOK,
+    });
+
+    client.close()
+  });
+}
+
+export function CheckRename() {
+
+  group(`Pipelines API: Rename a pipeline [with random "jwt-sub" header]`, () => {
+
+    client.connect(constant.pipelineGRPCPublicHost, {
+      plaintext: true
+    });
+
+    var reqBody = Object.assign({
+      id: randomString(10),
+    },
+      constant.detSyncHTTPSingleModelInstRecipe
+    )
+
+    // Create a pipeline
+    var res = client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline', {
+      pipeline: reqBody
+    })
+
+    check(res, {
+      [`vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline response StatusOK`]: (r) => r.status === grpc.StatusOK,
+      [`vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline response pipeline name`]: (r) => r.message.pipeline.name === `pipelines/${reqBody.id}`,
+    });
+
+    var new_pipeline_id = randomString(10)
+
+    // Cannot rename a pipeline of a non-exist user
+    check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/RenamePipeline', {
+      name: `pipelines/${reqBody.id}`,
+      new_pipeline_id: new_pipeline_id
+    }, constant.paramsWithJwt), {
+      [`[with random "jwt-sub" header] vdp.pipeline.v1alpha.PipelinePublicService/RenamePipeline response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+    })
+
+    // Delete the pipeline
+    check(client.invoke(`vdp.pipeline.v1alpha.PipelinePublicService/DeletePipeline`, {
+      name: `pipelines/${reqBody.id}`
+    }), {
+      [`vdp.pipeline.v1alpha.PipelinePublicService/DeletePipeline response StatusOK`]: (r) => r.status === grpc.StatusOK,
+    });
+
+    client.close()
+  });
+
+}
+
+export function CheckLookUp() {
+
+  group(`Pipelines API: Look up a pipeline by uid [with random "jwt-sub" header]`, () => {
+
+    client.connect(constant.pipelineGRPCPublicHost, {
+      plaintext: true
+    });
+
+    var reqBody = Object.assign({
+      id: randomString(10),
+    },
+      constant.detSyncHTTPSingleModelInstRecipe
+    )
+
+    // Create a pipeline
+    var res = client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline', {
+      pipeline: reqBody
+    })
+
+    check(res, {
+      [`vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline response StatusOK`]: (r) => r.status === grpc.StatusOK,
+    });
+
+    // Cannot look up a pipeline of a non-exist user
+    check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/LookUpPipeline', {
+      permalink: `pipelines/${res.message.pipeline.uid}`
+    }, constant.paramsWithJwt), {
+      [`[with random "jwt-sub" header] vdp.pipeline.v1alpha.PipelinePublicService/LookUpPipeline response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+    })
+
+    // Delete the pipeline
+    check(client.invoke(`vdp.pipeline.v1alpha.PipelinePublicService/DeletePipeline`, {
+      name: `pipelines/${reqBody.id}`
+    }), {
+      [`vdp.pipeline.v1alpha.PipelinePublicService/DeletePipeline response StatusOK`]: (r) => r.status === grpc.StatusOK,
+    });
+
+    client.close()
+  });
+
+}

--- a/integration-test/grpc-pipeline-public.js
+++ b/integration-test/grpc-pipeline-public.js
@@ -29,6 +29,13 @@ export function CheckCreate() {
       constant.detSyncHTTPSingleModelInstRecipe
     )
 
+    // Cannot create a pipeline of a non-exist user
+    check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline', {
+      pipeline: reqBody
+    }, constant.paramsWithJwt), {
+      [`[with random "jwt-sub" header] vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+    })
+
     // Create a pipeline
     var resOrigin = client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline', {
       pipeline: reqBody
@@ -63,7 +70,7 @@ export function CheckCreate() {
     check(client.invoke(`vdp.pipeline.v1alpha.PipelinePublicService/DeletePipeline`, {
       name: `pipelines/${reqBody.id}`
     }), {
-      [`vdp.connector.v1alpha.ConnectorPublicService/DeleteDestinationConnector ${reqBody.id} response StatusOK`]: (r) => r.status === grpc.StatusOK,
+      [`vdp.pipeline.v1alpha.ConnectorPublicService/DeletePipeline ${reqBody.id} response StatusOK`]: (r) => r.status === grpc.StatusOK,
     });
 
     check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline', {
@@ -118,6 +125,11 @@ export function CheckList() {
     client.connect(constant.pipelineGRPCPublicHost, {
       plaintext: true
     });
+
+    // Cannot list pipelines of a non-exist user
+    check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/ListPipelines', {}, constant.paramsWithJwt), {
+      [`[with random "jwt-sub" header] vdp.pipeline.v1alpha.PipelinePublicService/ListPipelines response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+    })
 
     check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/ListPipelines', {}, {}), {
       [`vdp.pipeline.v1alpha.PipelinePublicService/ListPipelines response StatusOK`]: (r) => r.status === grpc.StatusOK,
@@ -272,6 +284,13 @@ export function CheckGet() {
       [`vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline response StatusOK`]: (r) => r.status === grpc.StatusOK,
     });
 
+    // Cannot get a pipeline of a non-exist user
+    check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/GetPipeline', {
+      name: `pipelines/${reqBody.id}`
+    }, constant.paramsWithJwt), {
+      [`[with random "jwt-sub" header] vdp.pipeline.v1alpha.PipelinePublicService/GetPipeline response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+    })
+
     check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/GetPipeline', {
       name: `pipelines/${reqBody.id}`
     }, {}), {
@@ -338,6 +357,14 @@ export function CheckUpdate() {
       mode: "MODE_ASYNC",
       description: randomString(50),
     },)
+
+     // Cannot update a pipeline of a non-exist user
+     check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/UpdatePipeline', {
+      pipeline: reqBodyUpdate,
+      update_mask: "description"
+    }, constant.paramsWithJwt), {
+      [`[with random "jwt-sub" header] vdp.pipeline.v1alpha.PipelinePublicService/UpdatePipeline response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+    })
 
     check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/UpdatePipeline', {
       pipeline: reqBodyUpdate,
@@ -446,12 +473,27 @@ export function CheckUpdateState() {
       [`vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline async response pipeline state ACTIVE`]: (r) => r.message.pipeline.state === "STATE_ACTIVE",
     });
 
+    // Cannot activate a pipeline of a non-exist user
+    check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/ActivatePipeline', {
+      name: `pipelines/${reqBodySync.id}`
+    }, constant.paramsWithJwt), {
+      [`[with random "jwt-sub" header] vdp.pipeline.v1alpha.PipelinePublicService/ActivatePipeline response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+    })
+
+
     check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/ActivatePipeline', {
       name: `pipelines/${reqBodyAsync.id}`
     }), {
       [`vdp.pipeline.v1alpha.PipelinePublicService/ActivatePipeline ${reqBodyAsync.id} response status is StatusOK for async pipeline`]: (r) => r.status === grpc.StatusOK,
       [`vdp.pipeline.v1alpha.PipelinePublicService/ActivatePipeline ${reqBodyAsync.id} response pipeline state ACTIVE`]: (r) => r.message.pipeline.state === "STATE_ACTIVE",
     });
+
+    // Cannot deactivate a pipeline of a non-exist user
+    check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/DeactivatePipeline', {
+      name: `pipelines/${reqBodySync.id}`
+    }, constant.paramsWithJwt), {
+      [`[with random "jwt-sub" header] vdp.pipeline.v1alpha.PipelinePublicService/DeactivatePipeline response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+    })
 
     check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/DeactivatePipeline', {
       name: `pipelines/${reqBodyAsync.id}`
@@ -502,6 +544,15 @@ export function CheckRename() {
     });
 
     reqBody.new_pipeline_id = randomString(10)
+
+    // Cannot rename a pipeline of a non-exist user
+    check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/RenamePipeline', {
+      name: `pipelines/${reqBody.id}`,
+      new_pipeline_id: reqBody.new_pipeline_id
+    }, constant.paramsWithJwt), {
+      [`[with random "jwt-sub" header] vdp.pipeline.v1alpha.PipelinePublicService/RenamePipeline response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+    })
+
     check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/RenamePipeline', {
       name: `pipelines/${reqBody.id}`,
       new_pipeline_id: reqBody.new_pipeline_id
@@ -545,6 +596,13 @@ export function CheckLookUp() {
     check(res, {
       [`vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline response StatusOK`]: (r) => r.status === grpc.StatusOK,
     });
+
+    // Cannot look up a pipeline of a non-exist user
+    check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/LookUpPipeline', {
+      permalink: `pipelines/${res.message.pipeline.uid}`
+    }, constant.paramsWithJwt), {
+      [`[with random "jwt-sub" header] vdp.pipeline.v1alpha.PipelinePublicService/LookUpPipeline response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+    })
 
     check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/LookUpPipeline', {
       permalink: `pipelines/${res.message.pipeline.uid}`

--- a/integration-test/grpc-pipeline-public.js
+++ b/integration-test/grpc-pipeline-public.js
@@ -29,13 +29,6 @@ export function CheckCreate() {
       constant.detSyncHTTPSingleModelInstRecipe
     )
 
-    // Cannot create a pipeline of a non-exist user
-    check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline', {
-      pipeline: reqBody
-    }, constant.paramsWithJwt), {
-      [`[with random "jwt-sub" header] vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
-    })
-
     // Create a pipeline
     var resOrigin = client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline', {
       pipeline: reqBody
@@ -125,11 +118,6 @@ export function CheckList() {
     client.connect(constant.pipelineGRPCPublicHost, {
       plaintext: true
     });
-
-    // Cannot list pipelines of a non-exist user
-    check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/ListPipelines', {}, constant.paramsWithJwt), {
-      [`[with random "jwt-sub" header] vdp.pipeline.v1alpha.PipelinePublicService/ListPipelines response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
-    })
 
     check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/ListPipelines', {}, {}), {
       [`vdp.pipeline.v1alpha.PipelinePublicService/ListPipelines response StatusOK`]: (r) => r.status === grpc.StatusOK,
@@ -284,13 +272,6 @@ export function CheckGet() {
       [`vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline response StatusOK`]: (r) => r.status === grpc.StatusOK,
     });
 
-    // Cannot get a pipeline of a non-exist user
-    check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/GetPipeline', {
-      name: `pipelines/${reqBody.id}`
-    }, constant.paramsWithJwt), {
-      [`[with random "jwt-sub" header] vdp.pipeline.v1alpha.PipelinePublicService/GetPipeline response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
-    })
-
     check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/GetPipeline', {
       name: `pipelines/${reqBody.id}`
     }, {}), {
@@ -357,14 +338,6 @@ export function CheckUpdate() {
       mode: "MODE_ASYNC",
       description: randomString(50),
     },)
-
-     // Cannot update a pipeline of a non-exist user
-     check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/UpdatePipeline', {
-      pipeline: reqBodyUpdate,
-      update_mask: "description"
-    }, constant.paramsWithJwt), {
-      [`[with random "jwt-sub" header] vdp.pipeline.v1alpha.PipelinePublicService/UpdatePipeline response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
-    })
 
     check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/UpdatePipeline', {
       pipeline: reqBodyUpdate,
@@ -473,27 +446,12 @@ export function CheckUpdateState() {
       [`vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline async response pipeline state ACTIVE`]: (r) => r.message.pipeline.state === "STATE_ACTIVE",
     });
 
-    // Cannot activate a pipeline of a non-exist user
-    check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/ActivatePipeline', {
-      name: `pipelines/${reqBodySync.id}`
-    }, constant.paramsWithJwt), {
-      [`[with random "jwt-sub" header] vdp.pipeline.v1alpha.PipelinePublicService/ActivatePipeline response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
-    })
-
-
     check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/ActivatePipeline', {
       name: `pipelines/${reqBodyAsync.id}`
     }), {
       [`vdp.pipeline.v1alpha.PipelinePublicService/ActivatePipeline ${reqBodyAsync.id} response status is StatusOK for async pipeline`]: (r) => r.status === grpc.StatusOK,
       [`vdp.pipeline.v1alpha.PipelinePublicService/ActivatePipeline ${reqBodyAsync.id} response pipeline state ACTIVE`]: (r) => r.message.pipeline.state === "STATE_ACTIVE",
     });
-
-    // Cannot deactivate a pipeline of a non-exist user
-    check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/DeactivatePipeline', {
-      name: `pipelines/${reqBodySync.id}`
-    }, constant.paramsWithJwt), {
-      [`[with random "jwt-sub" header] vdp.pipeline.v1alpha.PipelinePublicService/DeactivatePipeline response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
-    })
 
     check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/DeactivatePipeline', {
       name: `pipelines/${reqBodyAsync.id}`
@@ -545,14 +503,6 @@ export function CheckRename() {
 
     reqBody.new_pipeline_id = randomString(10)
 
-    // Cannot rename a pipeline of a non-exist user
-    check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/RenamePipeline', {
-      name: `pipelines/${reqBody.id}`,
-      new_pipeline_id: reqBody.new_pipeline_id
-    }, constant.paramsWithJwt), {
-      [`[with random "jwt-sub" header] vdp.pipeline.v1alpha.PipelinePublicService/RenamePipeline response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
-    })
-
     check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/RenamePipeline', {
       name: `pipelines/${reqBody.id}`,
       new_pipeline_id: reqBody.new_pipeline_id
@@ -596,13 +546,6 @@ export function CheckLookUp() {
     check(res, {
       [`vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline response StatusOK`]: (r) => r.status === grpc.StatusOK,
     });
-
-    // Cannot look up a pipeline of a non-exist user
-    check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/LookUpPipeline', {
-      permalink: `pipelines/${res.message.pipeline.uid}`
-    }, constant.paramsWithJwt), {
-      [`[with random "jwt-sub" header] vdp.pipeline.v1alpha.PipelinePublicService/LookUpPipeline response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
-    })
 
     check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/LookUpPipeline', {
       permalink: `pipelines/${res.message.pipeline.uid}`

--- a/integration-test/grpc.js
+++ b/integration-test/grpc.js
@@ -14,6 +14,7 @@ import {
 } from "https://jslib.k6.io/k6-utils/1.1.0/index.js";
 
 import * as pipeline from './grpc-pipeline-public.js';
+import * as pipelineWithJwt from './grpc-pipeline-public-with-jwt.js';
 import * as pipelinePrivate from './grpc-pipeline-private.js';
 import * as triggerSync from './grpc-trigger-sync.js';
 import * as triggerAsync from './grpc-trigger-async.js';
@@ -227,6 +228,14 @@ export default function (data) {
     pipelinePrivate.CheckList()
     pipelinePrivate.CheckGet()
     pipelinePrivate.CheckLookUp()
+
+    pipelineWithJwt.CheckCreate()
+    pipelineWithJwt.CheckList()
+    pipelineWithJwt.CheckGet()
+    pipelineWithJwt.CheckUpdate()
+    pipelineWithJwt.CheckUpdateState()
+    pipelineWithJwt.CheckRename()
+    pipelineWithJwt.CheckLookUp()
   }
 
 }

--- a/integration-test/rest-pipeline-public-with-jwt.js
+++ b/integration-test/rest-pipeline-public-with-jwt.js
@@ -1,0 +1,215 @@
+import http from "k6/http";
+import { check, group } from "k6";
+import { randomString } from "https://jslib.k6.io/k6-utils/1.1.0/index.js";
+
+import { pipelinePublicHost } from "./const.js";
+
+import * as constant from "./const.js"
+
+export function CheckCreate() {
+
+  group(`Pipelines API: Create a pipeline [with random "jwt-sub" header]`, () => {
+
+    var reqBody = Object.assign(
+      {
+        id: randomString(63),
+        description: randomString(50),
+      },
+      constant.detSyncHTTPSingleModelInstRecipe
+    )
+
+    // Cannot create a pipeline of a non-exist user
+    check(http.request("POST", `${pipelinePublicHost}/v1alpha/pipelines`, JSON.stringify(reqBody), constant.paramsWithJwt), {
+      [`[with random "jwt-sub" header] POST /v1alpha/pipelines response status is 500`]: (r) => r.status === 500
+    });
+
+  });
+}
+
+export function CheckList() {
+
+  group(`Pipelines API: List pipelines [with random "jwt-sub" header]`, () => {
+
+    // Cannot list pipelines of a non-exist user
+    check(http.request("GET", `${pipelinePublicHost}/v1alpha/pipelines`, null, constant.paramsWithJwt), {
+      [`[with random "jwt-sub" header] GET /v1alpha/pipelines response status is 500`]: (r) => r.status === 500
+    });
+  });
+}
+
+export function CheckGet() {
+
+  group(`Pipelines API: Get a pipeline [with random "jwt-sub" header]`, () => {
+
+    var reqBody = Object.assign(
+      {
+        id: randomString(10),
+        description: randomString(50),
+      },
+      constant.detSyncHTTPSingleModelInstRecipe
+    )
+
+    // Create a pipeline
+    check(http.request("POST", `${pipelinePublicHost}/v1alpha/pipelines`, JSON.stringify(reqBody), constant.params), {
+      "POST /v1alpha/pipelines response status is 201": (r) => r.status === 201,
+    });
+
+    // Cannot get a pipeline of a non-exist user
+    check(http.request("GET", `${pipelinePublicHost}/v1alpha/pipelines/${reqBody.id}`, null, constant.paramsWithJwt), {
+      [`[with random "jwt-sub" header] GET /v1alpha/pipelines/${reqBody.id} response status is 500`]: (r) => r.status === 500
+    });
+
+    // Delete the pipeline
+    check(http.request("DELETE", `${pipelinePublicHost}/v1alpha/pipelines/${reqBody.id}`, null, constant.params), {
+      [`DELETE /v1alpha/pipelines/${reqBody.id} response status 204`]: (r) => r.status === 204,
+    });
+
+  });
+}
+
+export function CheckUpdate() {
+
+  group(`Pipelines API: Update a pipeline [with random "jwt-sub" header]`, () => {
+
+    var reqBody = Object.assign(
+      {
+        id: randomString(10),
+      },
+      constant.detSyncHTTPSingleModelInstRecipe
+    )
+
+    // Create a pipeline
+    var resOrigin = http.request("POST", `${pipelinePublicHost}/v1alpha/pipelines`, JSON.stringify(reqBody), constant.params)
+
+    check(resOrigin, {
+      "POST /v1alpha/pipelines response status is 201": (r) => r.status === 201,
+    });
+
+    var reqBodyUpdate = Object.assign(
+      {
+        uid: "output-only-to-be-ignored",
+        mode: "MODE_ASYNC",
+        name: "pipelines/some-string-to-be-ignored",
+        description: randomString(50),
+      },
+    )
+
+    // Cannot update a pipeline of a non-exist user
+    check(http.request("PATCH", `${pipelinePublicHost}/v1alpha/pipelines/${reqBody.id}`, JSON.stringify(reqBodyUpdate), constant.paramsWithJwt), {
+      [`[with random "jwt-sub" header] PATCH /v1alpha/pipelines/${reqBody.id} response status is 500`]: (r) => r.status === 500
+    });
+
+    // Delete the pipeline
+    check(http.request("DELETE", `${pipelinePublicHost}/v1alpha/pipelines/${reqBody.id}`, null, constant.params), {
+      [`DELETE /v1alpha/pipelines/${reqBody.id} response status 204`]: (r) => r.status === 204,
+    });
+
+  });
+}
+
+export function CheckUpdateState() {
+
+  group(`Pipelines API: Update a pipeline state [with random "jwt-sub" header]`, () => {
+
+    var reqBodySync = Object.assign(
+      {
+        id: randomString(10),
+      },
+      constant.detSyncHTTPSingleModelInstRecipe
+    )
+
+    check(http.request("POST", `${pipelinePublicHost}/v1alpha/pipelines`, JSON.stringify(reqBodySync), constant.params), {
+      "POST /v1alpha/pipelines sync pipeline creation response status is 201": (r) => r.status === 201,
+      "POST /v1alpha/pipelines sync pipeline creation response pipeline state ACTIVE": (r) => r.json().pipeline.state === "STATE_ACTIVE",
+    });
+
+    check(http.request("POST", `${pipelinePublicHost}/v1alpha/pipelines`, JSON.stringify(reqBodyAsync), constant.params), {
+      "POST /v1alpha/pipelines async pipeline creation response status is 201": (r) => r.status === 201,
+      "POST /v1alpha/pipelines async pipeline creation response pipeline state ACTIVE": (r) => r.json().pipeline.state === "STATE_ACTIVE",
+    });
+
+    // Cannot activate a pipeline of a non-exist user
+    check(http.request("POST", `${pipelinePublicHost}/v1alpha/pipelines/${reqBodySync.id}/activate`, null, constant.paramsWithJwt), {
+      [`[with random "jwt-sub" header] POST /v1alpha/pipelines/${reqBodySync.id}/activate response status is 500 for sync pipeline`]: (r) => r.status === 500
+    });
+
+    // Cannot deactivate a pipeline of a non-exist user
+    check(http.request("POST", `${pipelinePublicHost}/v1alpha/pipelines/${reqBodySync.id}/deactivate`, null, constant.paramsWithJwt), {
+      [`[with random "jwt-sub" header] POST /v1alpha/pipelines/${reqBodySync.id}/deactivate response status is 500 for sync pipeline`]: (r) => r.status === 500
+    });
+
+    // Delete the pipelines
+    check(http.request("DELETE", `${pipelinePublicHost}/v1alpha/pipelines/${reqBodySync.id}`, null, constant.params), {
+      [`DELETE /v1alpha/pipelines/${reqBodySync.id} response status 204`]: (r) => r.status === 204,
+    });
+
+  });
+}
+
+export function CheckRename() {
+
+  group(`Pipelines API: Rename a pipeline [with random "jwt-sub" header]`, () => {
+
+    var id = randomString(10) 
+    var reqBody = Object.assign(
+      {
+        id: id,
+      },
+      constant.detSyncHTTPSingleModelInstRecipe
+    )
+
+    // Create a pipeline
+    var res = http.request("POST", `${pipelinePublicHost}/v1alpha/pipelines`, JSON.stringify(reqBody), constant.params)
+
+    check(res, {
+      "POST /v1alpha/pipelines response status is 201": (r) => r.status === 201,
+      "POST /v1alpha/pipelines response pipeline name": (r) => r.json().pipeline.name === `pipelines/${reqBody.id}`,
+    });
+
+    reqBody.new_pipeline_id = randomString(10)
+
+    // Cannot rename a pipeline of a non-exist user
+    check(http.request("POST", `${pipelinePublicHost}/v1alpha/pipelines/${res.json().pipeline.id}/rename`, JSON.stringify(reqBody), constant.paramsWithJwt), {
+      [`[with random "jwt-sub" header] POST /v1alpha/pipelines/${res.json().pipeline.id}/rename response status is 500`]: (r) => r.status === 500
+    });
+
+    // Delete the pipeline
+    check(http.request("DELETE", `${pipelinePublicHost}/v1alpha/pipelines/${id}`, null, constant.params), {
+      [`DELETE /v1alpha/pipelines/${id} response status 204`]: (r) => r.status === 204,
+    });
+
+  });
+
+}
+
+export function CheckLookUp() {
+
+  group(`Pipelines API: Look up a pipeline by uid [with random "jwt-sub" header]`, () => {
+
+    var reqBody = Object.assign(
+      {
+        id: randomString(10),
+      },
+      constant.detSyncHTTPSingleModelInstRecipe
+    )
+
+    // Create a pipeline
+    var res = http.request("POST", `${pipelinePublicHost}/v1alpha/pipelines`, JSON.stringify(reqBody), constant.params)
+
+    check(res, {
+      "POST /v1alpha/pipelines response status is 201": (r) => r.status === 201,
+    });
+
+    // Cannot look up a pipeline of a non-exist user
+    check(http.request("GET", `${pipelinePublicHost}/v1alpha/pipelines/${res.json().pipeline.id}/lookUp`, null, constant.paramsWithJwt), {
+      [`[with random "jwt-sub" header] POST /v1alpha/pipelines/${res.json().pipeline.id}/lookUp response status is 500`]: (r) => r.status === 500
+    });
+
+    // Delete the pipeline
+    check(http.request("DELETE", `${pipelinePublicHost}/v1alpha/pipelines/${reqBody.id}`, null, constant.params), {
+      [`DELETE /v1alpha/pipelines/${reqBody.id} response status 204`]: (r) => r.status === 204,
+    });
+
+  });
+
+}

--- a/integration-test/rest-pipeline-public.js
+++ b/integration-test/rest-pipeline-public.js
@@ -19,6 +19,11 @@ export function CheckCreate() {
       constant.detSyncHTTPSingleModelInstRecipe
     )
 
+    // Cannot create a pipeline of a non-exist user
+    check(http.request("POST", `${pipelinePublicHost}/v1alpha/pipelines`, JSON.stringify(reqBody), constant.paramsWithJwt), {
+      [`[with random "jwt-sub" header] POST /v1alpha/pipelines response status is 500`]: (r) => r.status === 500
+    });
+
     // Create a pipeline
     var resOrigin = http.request("POST", `${pipelinePublicHost}/v1alpha/pipelines`, JSON.stringify(reqBody), constant.params)
     check(resOrigin, {
@@ -114,6 +119,11 @@ export function CheckList() {
         [`POST /v1alpha/pipelines x${reqBodies.length} response status is 201`]: (r) => r.status === 201
       });
     }
+
+    // Cannot list pipelines of a non-exist user
+    check(http.request("GET", `${pipelinePublicHost}/v1alpha/pipelines`, null, constant.paramsWithJwt), {
+      [`[with random "jwt-sub" header] GET /v1alpha/pipelines response status is 500`]: (r) => r.status === 500
+    });
 
     check(http.request("GET", `${pipelinePublicHost}/v1alpha/pipelines`, null, constant.params), {
       [`GET /v1alpha/pipelines response status is 200`]: (r) => r.status === 200,
@@ -213,6 +223,11 @@ export function CheckGet() {
       "POST /v1alpha/pipelines response status is 201": (r) => r.status === 201,
     });
 
+    // Cannot get a pipeline of a non-exist user
+    check(http.request("GET", `${pipelinePublicHost}/v1alpha/pipelines/${reqBody.id}`, null, constant.paramsWithJwt), {
+      [`[with random "jwt-sub" header] GET /v1alpha/pipelines/${reqBody.id} response status is 500`]: (r) => r.status === 500
+    });
+
     check(http.request("GET", `${pipelinePublicHost}/v1alpha/pipelines/${reqBody.id}`, null, constant.params), {
       [`GET /v1alpha/pipelines/${reqBody.id} response status is 200`]: (r) => r.status === 200,
       [`GET /v1alpha/pipelines/${reqBody.id} response pipeline name`]: (r) => r.json().pipeline.name === `pipelines/${reqBody.id}`,
@@ -265,6 +280,11 @@ export function CheckUpdate() {
         description: randomString(50),
       },
     )
+
+    // Cannot update a pipeline of a non-exist user
+    check(http.request("PATCH", `${pipelinePublicHost}/v1alpha/pipelines/${reqBody.id}`, JSON.stringify(reqBodyUpdate), constant.paramsWithJwt), {
+      [`[with random "jwt-sub" header] PATCH /v1alpha/pipelines/${reqBody.id} response status is 500`]: (r) => r.status === 500
+    });
 
     check(http.request("PATCH", `${pipelinePublicHost}/v1alpha/pipelines/${reqBody.id}`, JSON.stringify(reqBodyUpdate), constant.params), {
       [`PATCH /v1alpha/pipelines/${reqBody.id} response status is 200`]: (r) => r.status === 200,
@@ -351,9 +371,19 @@ export function CheckUpdateState() {
       "POST /v1alpha/pipelines async pipeline creation response pipeline state ACTIVE": (r) => r.json().pipeline.state === "STATE_ACTIVE",
     });
 
+    // Cannot activate a pipeline of a non-exist user
+    check(http.request("POST", `${pipelinePublicHost}/v1alpha/pipelines/${reqBodyAsync.id}/activate`, null, constant.paramsWithJwt), {
+      [`[with random "jwt-sub" header] POST /v1alpha/pipelines/${reqBodyAsync.id}/activate response status is 500 for async pipeline`]: (r) => r.status === 500
+    });
+
     check(http.request("POST", `${pipelinePublicHost}/v1alpha/pipelines/${reqBodyAsync.id}/activate`, null, constant.params), {
       [`POST /v1alpha/pipelines/${reqBodyAsync.id}/activate response status is 200 for async pipeline`]: (r) => r.status === 200,
       [`POST /v1alpha/pipelines/${reqBodyAsync.id}/activate response pipeline state ACTIVE`]: (r) => r.json().pipeline.state === "STATE_ACTIVE",
+    });
+
+    // Cannot deactivate a pipeline of a non-exist user
+    check(http.request("POST", `${pipelinePublicHost}/v1alpha/pipelines/${reqBodyAsync.id}/deactivate`, null, constant.paramsWithJwt), {
+      [`[with random "jwt-sub" header] POST /v1alpha/pipelines/${reqBodyAsync.id}/deactivate response status is 500 for async pipeline`]: (r) => r.status === 500
     });
 
     check(http.request("POST", `${pipelinePublicHost}/v1alpha/pipelines/${reqBodyAsync.id}/deactivate`, null, constant.params), {
@@ -393,6 +423,12 @@ export function CheckRename() {
     });
 
     reqBody.new_pipeline_id = randomString(10)
+
+    // Cannot rename a pipeline of a non-exist user
+    check(http.request("POST", `${pipelinePublicHost}/v1alpha/pipelines/${res.json().pipeline.id}/rename`, JSON.stringify(reqBody), constant.paramsWithJwt), {
+      [`[with random "jwt-sub" header] POST /v1alpha/pipelines/${res.json().pipeline.id}/rename response status is 500`]: (r) => r.status === 500
+    });
+
     check(http.request("POST", `${pipelinePublicHost}/v1alpha/pipelines/${res.json().pipeline.id}/rename`, JSON.stringify(reqBody), constant.params), {
       [`POST /v1alpha/pipelines/${res.json().pipeline.id}/rename response status is 200"`]: (r) => r.status === 200,
       [`POST /v1alpha/pipelines/${res.json().pipeline.id}/rename response pipeline new name"`]: (r) => r.json().pipeline.name === `pipelines/${reqBody.new_pipeline_id}`,
@@ -424,6 +460,11 @@ export function CheckLookUp() {
 
     check(res, {
       "POST /v1alpha/pipelines response status is 201": (r) => r.status === 201,
+    });
+
+    // Cannot look up a pipeline of a non-exist user
+    check(http.request("GET", `${pipelinePublicHost}/v1alpha/pipelines/${res.json().pipeline.id}/lookUp`, null, constant.paramsWithJwt), {
+      [`[with random "jwt-sub" header] POST /v1alpha/pipelines/${res.json().pipeline.id}/lookUp response status is 500`]: (r) => r.status === 500
     });
 
     check(http.request("GET", `${pipelinePublicHost}/v1alpha/pipelines/${res.json().pipeline.uid}/lookUp`), {

--- a/integration-test/rest-pipeline-public.js
+++ b/integration-test/rest-pipeline-public.js
@@ -19,11 +19,6 @@ export function CheckCreate() {
       constant.detSyncHTTPSingleModelInstRecipe
     )
 
-    // Cannot create a pipeline of a non-exist user
-    check(http.request("POST", `${pipelinePublicHost}/v1alpha/pipelines`, JSON.stringify(reqBody), constant.paramsWithJwt), {
-      [`[with random "jwt-sub" header] POST /v1alpha/pipelines response status is 500`]: (r) => r.status === 500
-    });
-
     // Create a pipeline
     var resOrigin = http.request("POST", `${pipelinePublicHost}/v1alpha/pipelines`, JSON.stringify(reqBody), constant.params)
     check(resOrigin, {
@@ -119,11 +114,6 @@ export function CheckList() {
         [`POST /v1alpha/pipelines x${reqBodies.length} response status is 201`]: (r) => r.status === 201
       });
     }
-
-    // Cannot list pipelines of a non-exist user
-    check(http.request("GET", `${pipelinePublicHost}/v1alpha/pipelines`, null, constant.paramsWithJwt), {
-      [`[with random "jwt-sub" header] GET /v1alpha/pipelines response status is 500`]: (r) => r.status === 500
-    });
 
     check(http.request("GET", `${pipelinePublicHost}/v1alpha/pipelines`, null, constant.params), {
       [`GET /v1alpha/pipelines response status is 200`]: (r) => r.status === 200,
@@ -223,11 +213,6 @@ export function CheckGet() {
       "POST /v1alpha/pipelines response status is 201": (r) => r.status === 201,
     });
 
-    // Cannot get a pipeline of a non-exist user
-    check(http.request("GET", `${pipelinePublicHost}/v1alpha/pipelines/${reqBody.id}`, null, constant.paramsWithJwt), {
-      [`[with random "jwt-sub" header] GET /v1alpha/pipelines/${reqBody.id} response status is 500`]: (r) => r.status === 500
-    });
-
     check(http.request("GET", `${pipelinePublicHost}/v1alpha/pipelines/${reqBody.id}`, null, constant.params), {
       [`GET /v1alpha/pipelines/${reqBody.id} response status is 200`]: (r) => r.status === 200,
       [`GET /v1alpha/pipelines/${reqBody.id} response pipeline name`]: (r) => r.json().pipeline.name === `pipelines/${reqBody.id}`,
@@ -280,11 +265,6 @@ export function CheckUpdate() {
         description: randomString(50),
       },
     )
-
-    // Cannot update a pipeline of a non-exist user
-    check(http.request("PATCH", `${pipelinePublicHost}/v1alpha/pipelines/${reqBody.id}`, JSON.stringify(reqBodyUpdate), constant.paramsWithJwt), {
-      [`[with random "jwt-sub" header] PATCH /v1alpha/pipelines/${reqBody.id} response status is 500`]: (r) => r.status === 500
-    });
 
     check(http.request("PATCH", `${pipelinePublicHost}/v1alpha/pipelines/${reqBody.id}`, JSON.stringify(reqBodyUpdate), constant.params), {
       [`PATCH /v1alpha/pipelines/${reqBody.id} response status is 200`]: (r) => r.status === 200,
@@ -371,19 +351,9 @@ export function CheckUpdateState() {
       "POST /v1alpha/pipelines async pipeline creation response pipeline state ACTIVE": (r) => r.json().pipeline.state === "STATE_ACTIVE",
     });
 
-    // Cannot activate a pipeline of a non-exist user
-    check(http.request("POST", `${pipelinePublicHost}/v1alpha/pipelines/${reqBodyAsync.id}/activate`, null, constant.paramsWithJwt), {
-      [`[with random "jwt-sub" header] POST /v1alpha/pipelines/${reqBodyAsync.id}/activate response status is 500 for async pipeline`]: (r) => r.status === 500
-    });
-
     check(http.request("POST", `${pipelinePublicHost}/v1alpha/pipelines/${reqBodyAsync.id}/activate`, null, constant.params), {
       [`POST /v1alpha/pipelines/${reqBodyAsync.id}/activate response status is 200 for async pipeline`]: (r) => r.status === 200,
       [`POST /v1alpha/pipelines/${reqBodyAsync.id}/activate response pipeline state ACTIVE`]: (r) => r.json().pipeline.state === "STATE_ACTIVE",
-    });
-
-    // Cannot deactivate a pipeline of a non-exist user
-    check(http.request("POST", `${pipelinePublicHost}/v1alpha/pipelines/${reqBodyAsync.id}/deactivate`, null, constant.paramsWithJwt), {
-      [`[with random "jwt-sub" header] POST /v1alpha/pipelines/${reqBodyAsync.id}/deactivate response status is 500 for async pipeline`]: (r) => r.status === 500
     });
 
     check(http.request("POST", `${pipelinePublicHost}/v1alpha/pipelines/${reqBodyAsync.id}/deactivate`, null, constant.params), {
@@ -424,11 +394,6 @@ export function CheckRename() {
 
     reqBody.new_pipeline_id = randomString(10)
 
-    // Cannot rename a pipeline of a non-exist user
-    check(http.request("POST", `${pipelinePublicHost}/v1alpha/pipelines/${res.json().pipeline.id}/rename`, JSON.stringify(reqBody), constant.paramsWithJwt), {
-      [`[with random "jwt-sub" header] POST /v1alpha/pipelines/${res.json().pipeline.id}/rename response status is 500`]: (r) => r.status === 500
-    });
-
     check(http.request("POST", `${pipelinePublicHost}/v1alpha/pipelines/${res.json().pipeline.id}/rename`, JSON.stringify(reqBody), constant.params), {
       [`POST /v1alpha/pipelines/${res.json().pipeline.id}/rename response status is 200"`]: (r) => r.status === 200,
       [`POST /v1alpha/pipelines/${res.json().pipeline.id}/rename response pipeline new name"`]: (r) => r.json().pipeline.name === `pipelines/${reqBody.new_pipeline_id}`,
@@ -460,11 +425,6 @@ export function CheckLookUp() {
 
     check(res, {
       "POST /v1alpha/pipelines response status is 201": (r) => r.status === 201,
-    });
-
-    // Cannot look up a pipeline of a non-exist user
-    check(http.request("GET", `${pipelinePublicHost}/v1alpha/pipelines/${res.json().pipeline.id}/lookUp`, null, constant.paramsWithJwt), {
-      [`[with random "jwt-sub" header] POST /v1alpha/pipelines/${res.json().pipeline.id}/lookUp response status is 500`]: (r) => r.status === 500
     });
 
     check(http.request("GET", `${pipelinePublicHost}/v1alpha/pipelines/${res.json().pipeline.uid}/lookUp`), {

--- a/integration-test/rest.js
+++ b/integration-test/rest.js
@@ -21,6 +21,7 @@ import {
 
 import * as constant from "./const.js";
 import * as pipelinePublic from './rest-pipeline-public.js';
+import * as pipelinePublicWithJwt from './rest-pipeline-public-with-jwt.js';
 import * as pipelinePrivate from './rest-pipeline-private.js';
 import * as triggerSync from './rest-trigger-sync.js';
 import * as triggerAsync from './rest-trigger-async.js';
@@ -201,6 +202,14 @@ export default function (data) {
     pipelinePrivate.CheckList()
     pipelinePrivate.CheckGet()
     pipelinePrivate.CheckLookUp()
+
+    pipelinePublicWithJwt.CheckCreate()
+    pipelinePublicWithJwt.CheckList()
+    pipelinePublicWithJwt.CheckGet()
+    pipelinePublicWithJwt.CheckUpdate()
+    pipelinePublicWithJwt.CheckUpdateState()
+    pipelinePublicWithJwt.CheckRename()
+    pipelinePublicWithJwt.CheckLookUp()
   }
 
   pipelinePublic.CheckCreate()

--- a/pkg/middleware/misc.go
+++ b/pkg/middleware/misc.go
@@ -15,6 +15,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/instill-ai/pipeline-backend/pkg/constant"
 	"github.com/instill-ai/pipeline-backend/pkg/logger"
 )
 
@@ -144,7 +145,7 @@ func CustomMatcher(key string) (string, bool) {
 	}
 
 	switch key {
-	case "owner":
+	case constant.HeaderOwnerIDKey:
 		return key, true
 	default:
 		return runtime.DefaultHeaderMatcher(key)


### PR DESCRIPTION
Because

- we want to test whether `jwt-sub` is supported by pipeline backend

This commit

- add integration tests for requests with `jwt-sub` header, these tests only run in  direct microservice mode
