### PR TITLE
refactor: update default user id

### DIFF
--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -21,6 +21,6 @@ const DefaultOutputLen int = 100
 const DefaultTopK int = 40
 
 // Constants for resource owner
-const DefaultOwnerID string = "local-user"
+const DefaultOwnerID string = "instill-ai"
 const HeaderOwnerUIDKey = "jwt-sub"
 const HeaderOwnerIDKey = "owner-id"

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -28,13 +28,13 @@ func TestCreatePipeline(t *testing.T) {
 		uid := uuid.New()
 		uidstr := uid.String()
 		owner := mgmtPB.User{
-			Name: "users/local-user",
+			Name: "users/instill-ai",
 			Uid:  &uidstr,
 		}
 
 		normalPipeline := datamodel.Pipeline{
 			ID:    "awesome",
-			Owner: "users/local-user",
+			Owner: "users/instill-ai",
 
 			Recipe: &datamodel.Recipe{
 				Source:      "source-connectors/source-http",


### PR DESCRIPTION
Because

- we use a more representative user ID

This commit

- update the default user id
