### PR TITLE
chore: change owner from using id to uuid

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.3
 	github.com/iancoleman/strcase v0.2.0
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230402125221-c8f1a70b6b8b
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230419012951-e41ce4bf9d1f
 	github.com/instill-ai/usage-client v0.2.3-alpha
 	github.com/instill-ai/x v0.2.0-alpha
 	github.com/knadh/koanf v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -728,8 +728,8 @@ github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230402125221-c8f1a70b6b8b h1:BI97L8e4pkbQVcqRyQsR9/Q1/4pXB+zFGUWOEL/hZ6U=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230402125221-c8f1a70b6b8b/go.mod h1:7/Jj3ATVozPwB0WmKRM612o/k5UJF8K9oRCNKYH8iy0=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230419012951-e41ce4bf9d1f h1:jEIJNyInj40CKphLzOM+/F+XLhudSHQgF6X02CivDvo=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230419012951-e41ce4bf9d1f/go.mod h1:7/Jj3ATVozPwB0WmKRM612o/k5UJF8K9oRCNKYH8iy0=
 github.com/instill-ai/usage-client v0.2.3-alpha h1:jdbCH6WJ7eUVudGtuDWaEsWmGX09ZFUnAHx+8S2MnDY=
 github.com/instill-ai/usage-client v0.2.3-alpha/go.mod h1:G0bnSyJw3ul8iNTpAGNslB18Qux0aMZF08h+CRICumw=
 github.com/instill-ai/x v0.2.0-alpha h1:8yszKP9DE8bvSRAtEpOwqhG2wwqU3olhTqhwoiLrHfc=

--- a/integration-test/grpc-pipeline-private.js
+++ b/integration-test/grpc-pipeline-private.js
@@ -195,6 +195,7 @@ export function CheckGet() {
       [`vdp.pipeline.v1alpha.PipelinePrivateService/GetPipelineAdmin name: pipelines/${reqBody.id} response pipeline id`]: (r) => r.message.pipeline.id === reqBody.id,
       [`vdp.pipeline.v1alpha.PipelinePrivateService/GetPipelineAdmin name: pipelines/${reqBody.id} response pipeline description`]: (r) => r.message.pipeline.description === reqBody.description,
       [`vdp.pipeline.v1alpha.PipelinePrivateService/GetPipelineAdmin name: pipelines/${reqBody.id} response pipeline recipe is null`]: (r) => r.message.pipeline.recipe === null,
+      [`vdp.pipeline.v1alpha.PipelinePrivateService/GetPipelineAdmin name: pipelines/${reqBody.id} response pipeline owner is UUID`]: (r) => helper.isValidOwner(r.message.pipeline.user),
     });
 
     check(clientPrivate.invoke('vdp.pipeline.v1alpha.PipelinePrivateService/GetPipelineAdmin', {
@@ -203,6 +204,7 @@ export function CheckGet() {
     }, {}), {
       [`vdp.pipeline.v1alpha.PipelinePrivateService/GetPipelineAdmin name: pipelines/${reqBody.id} view: "VIEW_FULL" response StatusOK`]: (r) => r.status === grpc.StatusOK,
       [`vdp.pipeline.v1alpha.PipelinePrivateService/GetPipelineAdmin name: pipelines/${reqBody.id} view: "VIEW_FULL" response pipeline recipe is null`]: (r) => r.message.pipeline.recipe !== null,
+      [`vdp.pipeline.v1alpha.PipelinePrivateService/GetPipelineAdmin name: pipelines/${reqBody.id} view: "VIEW_FULL" response pipeline owner is UUID`]: (r) => helper.isValidOwner(r.message.pipeline.user),
     });
 
     check(clientPrivate.invoke('vdp.pipeline.v1alpha.PipelinePrivateService/GetPipelineAdmin', {

--- a/integration-test/grpc-pipeline-public.js
+++ b/integration-test/grpc-pipeline-public.js
@@ -40,6 +40,7 @@ export function CheckCreate() {
       "vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline response pipeline id": (r) => r.message.pipeline.id === reqBody.id,
       "vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline response pipeline description": (r) => r.message.pipeline.description === reqBody.description,
       "vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline response pipeline recipe is valid": (r) => helper.validateRecipeGRPC(r.message.pipeline.recipe),
+      "vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline response pipeline owner is UUID": (r) => helper.isValidOwner(r.message.pipeline.user),
       "vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline response pipeline state ACTIVE": (r) => r.message.pipeline.state === "STATE_ACTIVE",
       "vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline response pipeline mode": (r) => r.message.pipeline.mode == "MODE_SYNC",
       "vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline response pipeline create_time": (r) => new Date(r.message.pipeline.createTime).getTime() > new Date().setTime(0),
@@ -287,6 +288,7 @@ export function CheckGet() {
       [`vdp.pipeline.v1alpha.PipelinePublicService/GetPipeline name: pipelines/${reqBody.id} response pipeline id`]: (r) => r.message.pipeline.id === reqBody.id,
       [`vdp.pipeline.v1alpha.PipelinePublicService/GetPipeline name: pipelines/${reqBody.id} response pipeline description`]: (r) => r.message.pipeline.description === reqBody.description,
       [`vdp.pipeline.v1alpha.PipelinePublicService/GetPipeline name: pipelines/${reqBody.id} response pipeline recipe is null`]: (r) => r.message.pipeline.recipe === null,
+      [`vdp.pipeline.v1alpha.PipelinePublicService/GetPipeline name: pipelines/${reqBody.id} response pipeline owner is UUID`]: (r) => helper.isValidOwner(r.message.pipeline.user),
     });
 
     check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/GetPipeline', {
@@ -295,6 +297,7 @@ export function CheckGet() {
     }, {}), {
       [`vdp.pipeline.v1alpha.PipelinePublicService/GetPipeline name: pipelines/${reqBody.id} view: "VIEW_FULL" response StatusOK`]: (r) => r.status === grpc.StatusOK,
       [`vdp.pipeline.v1alpha.PipelinePublicService/GetPipeline name: pipelines/${reqBody.id} view: "VIEW_FULL" response pipeline recipe is null`]: (r) => r.message.pipeline.recipe !== null,
+      [`vdp.pipeline.v1alpha.PipelinePublicService/GetPipeline name: pipelines/${reqBody.id} view: "VIEW_FULL" response pipeline owner is UUID`]: (r) => helper.isValidOwner(r.message.pipeline.user),
     });
 
     check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/GetPipeline', {

--- a/integration-test/helper.js
+++ b/integration-test/helper.js
@@ -11,6 +11,10 @@ export function isUUID(uuid) {
   return regexExp.test(uuid)
 }
 
+export function isValidOwner(user) {
+  return isUUID(user.replace("users/", ""));
+}
+
 export function validateRecipe(recipe) {
   if (!('source' in recipe)) {
     console.log("Recipe has no source field")

--- a/integration-test/proto/vdp/connector/v1alpha/connector.proto
+++ b/integration-test/proto/vdp/connector/v1alpha/connector.proto
@@ -748,17 +748,3 @@ message CheckDestinationConnectorResponse {
   // Retrieved longrunning workflow id
   string workflow_id = 1;
 }
-
-// GetConnectorOperationRequest represents a request to query a longrunning operation
-message GetConnectorOperationRequest {
-  // The name of the operation resource.
-  string name = 1 [ (google.api.field_behavior) = REQUIRED ];
-  // SourceConnector view (default is VIEW_BASIC)
-  optional View view = 2 [ (google.api.field_behavior) = OPTIONAL ];
-}
-
-// GetConnectorOperationResponse represents a response for a longrunning operation
-message GetConnectorOperationResponse {
-  // The retrieved longrunning operation
-  google.longrunning.Operation operation = 1;
-}

--- a/integration-test/proto/vdp/connector/v1alpha/connector_public_service.proto
+++ b/integration-test/proto/vdp/connector/v1alpha/connector_public_service.proto
@@ -337,16 +337,4 @@ service ConnectorPublicService {
     option (google.api.method_signature) = "name";
   }
 
-  // *Longrunning operation methods
-
-  // GetConnectorOperation method receives a
-  // GetConnectorOperationRequest message and returns a
-  // GetConnectorOperationResponse message.
-  rpc GetConnectorOperation(GetConnectorOperationRequest)
-      returns (GetConnectorOperationResponse) {
-    option (google.api.http) = {
-      get : "/v1alpha/{name=operations/*}"
-    };
-    option (google.api.method_signature) = "name";
-  }
 }

--- a/integration-test/proto/vdp/model/v1alpha/model.proto
+++ b/integration-test/proto/vdp/model/v1alpha/model.proto
@@ -591,45 +591,6 @@ message GetModelOperationResponse {
   google.longrunning.Operation operation = 1;
 }
 
-// ListModelOperationsRequest represents a request to list all model operations
-// including deploy and undeploy
-message ListModelOperationsRequest {
-  // Page size: the maximum number of resources to return. The service may
-  // return fewer than this value. If unspecified, at most 10 operations will be
-  // returned. The maximum value is 100; values above 100 will be coereced to
-  // 100.
-  optional int64 page_size = 1 [ (google.api.field_behavior) = OPTIONAL ];
-  // Page token
-  string page_token = 2;
-  // Filter expression to list operations
-  optional string filter = 3 [ (google.api.field_behavior) = OPTIONAL ];
-  // View (default is VIEW_BASIC)
-  // VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`,
-  // `Model.configuration` VIEW_FULL: show full information
-  optional View view = 4 [ (google.api.field_behavior) = OPTIONAL ];
-}
-
-// ListModelOperationsResponse represents a response for a list of model
-// operations including deploy and undeploy
-message ListModelOperationsResponse {
-  // a list of model operations
-  repeated google.longrunning.Operation operations = 1;
-  // Next page token
-  string next_page_token = 2;
-  // Total count of operations
-  int64 total_size = 3;
-}
-
-// CancelModelOperationRequest represents a request to cancel a model operation
-message CancelModelOperationRequest {
-  // The name of the operation resource.
-  string name = 1 [ (google.api.field_behavior) = REQUIRED ];
-}
-
-// CancelModelOperationResponse represents a response for canceling a model
-// operation
-message CancelModelOperationResponse {}
-
 // ========== Private endpoints
 
 // ListModelsAdminRequest represents a request to list all models from all users by admin

--- a/integration-test/proto/vdp/model/v1alpha/model_public_service.proto
+++ b/integration-test/proto/vdp/model/v1alpha/model_public_service.proto
@@ -244,22 +244,4 @@ service ModelPublicService {
     option (google.api.method_signature) = "name";
   }
 
-  // ListModelOperations method receives a ListModelOperationsRequest message
-  // and returns a ListModelOperationsResponse
-  rpc ListModelOperations(ListModelOperationsRequest) returns (ListModelOperationsResponse) {
-    option (google.api.http) = {
-      get : "/v1alpha/operations"
-    };
-  }
-
-  // CancelModelOperation method receives a CancelModelOperationRequest message
-  // and returns a CancelModelOperationResponse
-  rpc CancelModelOperation(CancelModelOperationRequest)
-      returns (CancelModelOperationResponse) {
-    option (google.api.http) = {
-      post : "/v1alpha/{name=operations/*}/cancel"
-      body : "*"
-    };
-    option (google.api.method_signature) = "name";
-  }
 }

--- a/integration-test/rest-pipeline-private.js
+++ b/integration-test/rest-pipeline-private.js
@@ -140,11 +140,13 @@ export function CheckGet() {
       [`GET /v1alpha/admin/pipelines/${reqBody.id} response pipeline id`]: (r) => r.json().pipeline.id === reqBody.id,
       [`GET /v1alpha/admin/pipelines/${reqBody.id} response pipeline description`]: (r) => r.json().pipeline.description === reqBody.description,
       [`GET /v1alpha/admin/pipelines/${reqBody.id} response pipeline recipe is null`]: (r) => r.json().pipeline.recipe === null,
+      [`GET /v1alpha/admin/pipelines/${reqBody.id} response pipeline owner is UUID`]: (r) => helper.isValidOwner(r.json().pipeline.user),
     });
 
     check(http.request("GET", `${pipelinePrivateHost}/v1alpha/admin/pipelines/${reqBody.id}?view=VIEW_FULL`, null, constant.params), {
       [`GET /v1alpha/admin/pipelines/${reqBody.id} response status is 200`]: (r) => r.status === 200,
       [`GET /v1alpha/admin/pipelines/${reqBody.id} response pipeline recipe is not null`]: (r) => r.json().pipeline.recipe !== null,
+      [`GET /v1alpha/admin/pipelines/${reqBody.id} response pipeline owner is UUID`]: (r) => helper.isValidOwner(r.json().pipeline.user),
     });
 
     check(http.request("GET", `${pipelinePrivateHost}/v1alpha/admin/pipelines/this-id-does-not-exist`, null, constant.params), {

--- a/integration-test/rest-pipeline-public.js
+++ b/integration-test/rest-pipeline-public.js
@@ -28,6 +28,7 @@ export function CheckCreate() {
       "POST /v1alpha/pipelines response pipeline id": (r) => r.json().pipeline.id === reqBody.id,
       "POST /v1alpha/pipelines response pipeline description": (r) => r.json().pipeline.description === reqBody.description,
       "POST /v1alpha/pipelines response pipeline recipe is valid": (r) => helper.validateRecipe(r.json().pipeline.recipe),
+      "POST /v1alpha/pipelines response pipeline user is UUID": (r) => helper.isValidOwner(r.json().pipeline.user),
       "POST /v1alpha/pipelines response pipeline state ACTIVE": (r) => r.json().pipeline.state === "STATE_ACTIVE",
       "POST /v1alpha/pipelines response pipeline mode": (r) => r.json().pipeline.mode === "MODE_SYNC",
       "POST /v1alpha/pipelines response pipeline create_time": (r) => new Date(r.json().pipeline.create_time).getTime() > new Date().setTime(0),
@@ -224,11 +225,13 @@ export function CheckGet() {
       [`GET /v1alpha/pipelines/${reqBody.id} response pipeline id`]: (r) => r.json().pipeline.id === reqBody.id,
       [`GET /v1alpha/pipelines/${reqBody.id} response pipeline description`]: (r) => r.json().pipeline.description === reqBody.description,
       [`GET /v1alpha/pipelines/${reqBody.id} response pipeline recipe is null`]: (r) => r.json().pipeline.recipe === null,
+      [`GET /v1alpha/pipelines/${reqBody.id} response pipeline user is UUID`]: (r) => helper.isValidOwner(r.json().pipeline.user),
     });
 
     check(http.request("GET", `${pipelinePublicHost}/v1alpha/pipelines/${reqBody.id}?view=VIEW_FULL`, null, constant.params), {
       [`GET /v1alpha/pipelines/${reqBody.id} response status is 200`]: (r) => r.status === 200,
       [`GET /v1alpha/pipelines/${reqBody.id} response pipeline recipe is not null`]: (r) => r.json().pipeline.recipe !== null,
+      [`GET /v1alpha/pipelines/${reqBody.id} response pipeline user is UUID`]: (r) => helper.isValidOwner(r.json().pipeline.user),
     });
 
     check(http.request("GET", `${pipelinePublicHost}/v1alpha/pipelines/this-id-does-not-exist`, null, constant.params), {
@@ -279,6 +282,7 @@ export function CheckUpdate() {
       [`PATCH /v1alpha/pipelines/${reqBody.id} response pipeline state (OUTPUT_ONLY)`]: (r) => r.json().pipeline.state === resOrigin.json().pipeline.state,
       [`PATCH /v1alpha/pipelines/${reqBody.id} response pipeline description (OPTIONAL)`]: (r) => r.json().pipeline.description === reqBodyUpdate.description,
       [`PATCH /v1alpha/pipelines/${reqBody.id} response pipeline recipe (IMMUTABLE)`]: (r) => helper.deepEqual(r.json().pipeline.recipe, reqBody.recipe),
+      [`PATCH /v1alpha/pipelines/${reqBody.id} response pipeline user is UUID`]: (r) => helper.isValidOwner(r.json().pipeline.user),
       [`PATCH /v1alpha/pipelines/${reqBody.id} response pipeline create_time (OUTPUT_ONLY)`]: (r) => new Date(r.json().pipeline.create_time).getTime() > new Date().setTime(0),
       [`PATCH /v1alpha/pipelines/${reqBody.id} response pipeline update_time (OUTPUT_ONLY)`]: (r) => new Date(r.json().pipeline.update_time).getTime() > new Date().setTime(0),
       [`PATCH /v1alpha/pipelines/${reqBody.id} response pipeline update_time > create_time`]: (r) => new Date(r.json().pipeline.update_time).getTime() > new Date(r.json().pipeline.create_time).getTime()

--- a/pkg/service/mock_connector_grpc_test.go
+++ b/pkg/service/mock_connector_grpc_test.go
@@ -196,26 +196,6 @@ func (mr *MockConnectorPublicServiceClientMockRecorder) DisconnectSourceConnecto
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisconnectSourceConnector", reflect.TypeOf((*MockConnectorPublicServiceClient)(nil).DisconnectSourceConnector), varargs...)
 }
 
-// GetConnectorOperation mocks base method.
-func (m *MockConnectorPublicServiceClient) GetConnectorOperation(arg0 context.Context, arg1 *connectorv1alpha.GetConnectorOperationRequest, arg2 ...grpc.CallOption) (*connectorv1alpha.GetConnectorOperationResponse, error) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
-	for _, a := range arg2 {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "GetConnectorOperation", varargs...)
-	ret0, _ := ret[0].(*connectorv1alpha.GetConnectorOperationResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetConnectorOperation indicates an expected call of GetConnectorOperation.
-func (mr *MockConnectorPublicServiceClientMockRecorder) GetConnectorOperation(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConnectorOperation", reflect.TypeOf((*MockConnectorPublicServiceClient)(nil).GetConnectorOperation), varargs...)
-}
-
 // GetDestinationConnector mocks base method.
 func (m *MockConnectorPublicServiceClient) GetDestinationConnector(arg0 context.Context, arg1 *connectorv1alpha.GetDestinationConnectorRequest, arg2 ...grpc.CallOption) (*connectorv1alpha.GetDestinationConnectorResponse, error) {
 	m.ctrl.T.Helper()

--- a/pkg/service/mock_model_grpc_test.go
+++ b/pkg/service/mock_model_grpc_test.go
@@ -36,26 +36,6 @@ func (m *MockModelPublicServiceClient) EXPECT() *MockModelPublicServiceClientMoc
 	return m.recorder
 }
 
-// CancelModelOperation mocks base method.
-func (m *MockModelPublicServiceClient) CancelModelOperation(arg0 context.Context, arg1 *modelv1alpha.CancelModelOperationRequest, arg2 ...grpc.CallOption) (*modelv1alpha.CancelModelOperationResponse, error) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
-	for _, a := range arg2 {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "CancelModelOperation", varargs...)
-	ret0, _ := ret[0].(*modelv1alpha.CancelModelOperationResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CancelModelOperation indicates an expected call of CancelModelOperation.
-func (mr *MockModelPublicServiceClientMockRecorder) CancelModelOperation(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelModelOperation", reflect.TypeOf((*MockModelPublicServiceClient)(nil).CancelModelOperation), varargs...)
-}
-
 // CreateModel mocks base method.
 func (m *MockModelPublicServiceClient) CreateModel(arg0 context.Context, arg1 *modelv1alpha.CreateModelRequest, arg2 ...grpc.CallOption) (*modelv1alpha.CreateModelResponse, error) {
 	m.ctrl.T.Helper()
@@ -234,26 +214,6 @@ func (mr *MockModelPublicServiceClientMockRecorder) ListModelDefinitions(arg0, a
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListModelDefinitions", reflect.TypeOf((*MockModelPublicServiceClient)(nil).ListModelDefinitions), varargs...)
-}
-
-// ListModelOperations mocks base method.
-func (m *MockModelPublicServiceClient) ListModelOperations(arg0 context.Context, arg1 *modelv1alpha.ListModelOperationsRequest, arg2 ...grpc.CallOption) (*modelv1alpha.ListModelOperationsResponse, error) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
-	for _, a := range arg2 {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "ListModelOperations", varargs...)
-	ret0, _ := ret[0].(*modelv1alpha.ListModelOperationsResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListModelOperations indicates an expected call of ListModelOperations.
-func (mr *MockModelPublicServiceClientMockRecorder) ListModelOperations(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListModelOperations", reflect.TypeOf((*MockModelPublicServiceClient)(nil).ListModelOperations), varargs...)
 }
 
 // ListModels mocks base method.

--- a/pkg/service/utils.go
+++ b/pkg/service/utils.go
@@ -1,0 +1,7 @@
+package service
+
+import mgmtPB "github.com/instill-ai/protogen-go/vdp/mgmt/v1alpha"
+
+func GenOwnerPermalink(owner *mgmtPB.User) string {
+	return "users/" + owner.GetUid()
+}


### PR DESCRIPTION
Because

- The user ID can be changed now (in Instill Cloud), so using the owner ID is not reliable

This commit

- refactor owner of a pipeline to use the UUID, not the ID
- update protogen-go dependency
