### PR TITLE
refactor: update custom matcher

### DIFF
--- a/pkg/middleware/misc.go
+++ b/pkg/middleware/misc.go
@@ -145,6 +145,8 @@ func CustomMatcher(key string) (string, bool) {
 	}
 
 	switch key {
+	case "request-id":
+		return key, true
 	case constant.HeaderOwnerIDKey:
 		return key, true
 	default:


### PR DESCRIPTION
Because

- we want to pass headers "request-id" to the backend

This commit

- update custom header
