### PR TITLE
chore: return 404 for non-exist user and 401 for non-existent headers

### DIFF
--- a/integration-test/grpc-pipeline-public-with-jwt.js
+++ b/integration-test/grpc-pipeline-public-with-jwt.js
@@ -31,7 +31,7 @@ export function CheckCreate() {
     check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline', {
       pipeline: reqBody
     }, constant.paramsGRPCWithJwt), {
-      [`[with random "jwt-sub" header] vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+      [`[with random "jwt-sub" header] vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline response StatusNotFound`]: (r) => r.status === grpc.StatusNotFound,
     })
 
     client.close();
@@ -48,7 +48,7 @@ export function CheckList() {
 
     // Cannot list pipelines of a non-exist user
     check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/ListPipelines', {}, constant.paramsGRPCWithJwt), {
-      [`[with random "jwt-sub" header] vdp.pipeline.v1alpha.PipelinePublicService/ListPipelines response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+      [`[with random "jwt-sub" header] vdp.pipeline.v1alpha.PipelinePublicService/ListPipelines response StatusNotFound`]: (r) => r.status === grpc.StatusNotFound,
     })
 
     client.close();
@@ -80,7 +80,7 @@ export function CheckGet() {
     check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/GetPipeline', {
       name: `pipelines/${reqBody.id}`
     }, constant.paramsGRPCWithJwt), {
-      [`[with random "jwt-sub" header] vdp.pipeline.v1alpha.PipelinePublicService/GetPipeline response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+      [`[with random "jwt-sub" header] vdp.pipeline.v1alpha.PipelinePublicService/GetPipeline response StatusNotFound`]: (r) => r.status === grpc.StatusNotFound,
     })
 
     // Delete the pipeline
@@ -130,7 +130,7 @@ export function CheckUpdate() {
       pipeline: reqBodyUpdate,
       update_mask: "description"
     }, constant.paramsGRPCWithJwt), {
-      [`[with random "jwt-sub" header] vdp.pipeline.v1alpha.PipelinePublicService/UpdatePipeline response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+      [`[with random "jwt-sub" header] vdp.pipeline.v1alpha.PipelinePublicService/UpdatePipeline response StatusNotFound`]: (r) => r.status === grpc.StatusNotFound,
     })
 
     // Delete the pipeline
@@ -176,14 +176,14 @@ export function CheckUpdateState() {
     check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/ActivatePipeline', {
       name: `pipelines/${reqBodySync.id}`
     }, constant.paramsGRPCWithJwt), {
-      [`[with random "jwt-sub" header] vdp.pipeline.v1alpha.PipelinePublicService/ActivatePipeline response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+      [`[with random "jwt-sub" header] vdp.pipeline.v1alpha.PipelinePublicService/ActivatePipeline response StatusNotFound`]: (r) => r.status === grpc.StatusNotFound,
     })
 
     // Cannot deactivate a pipeline of a non-exist user
     check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/DeactivatePipeline', {
       name: `pipelines/${reqBodySync.id}`
     }, constant.paramsGRPCWithJwt), {
-      [`[with random "jwt-sub" header] vdp.pipeline.v1alpha.PipelinePublicService/DeactivatePipeline response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+      [`[with random "jwt-sub" header] vdp.pipeline.v1alpha.PipelinePublicService/DeactivatePipeline response StatusNotFound`]: (r) => r.status === grpc.StatusNotFound,
     })
 
     // Delete the pipeline
@@ -228,7 +228,7 @@ export function CheckRename() {
       name: `pipelines/${reqBody.id}`,
       new_pipeline_id: new_pipeline_id
     }, constant.paramsGRPCWithJwt), {
-      [`[with random "jwt-sub" header] vdp.pipeline.v1alpha.PipelinePublicService/RenamePipeline response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+      [`[with random "jwt-sub" header] vdp.pipeline.v1alpha.PipelinePublicService/RenamePipeline response StatusNotFound`]: (r) => r.status === grpc.StatusNotFound,
     })
 
     // Delete the pipeline
@@ -270,7 +270,7 @@ export function CheckLookUp() {
     check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/LookUpPipeline', {
       permalink: `pipelines/${res.message.pipeline.uid}`
     }, constant.paramsGRPCWithJwt), {
-      [`[with random "jwt-sub" header] vdp.pipeline.v1alpha.PipelinePublicService/LookUpPipeline response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+      [`[with random "jwt-sub" header] vdp.pipeline.v1alpha.PipelinePublicService/LookUpPipeline response StatusNotFound`]: (r) => r.status === grpc.StatusNotFound,
     })
 
     // Delete the pipeline

--- a/integration-test/rest-pipeline-public-with-jwt.js
+++ b/integration-test/rest-pipeline-public-with-jwt.js
@@ -20,7 +20,7 @@ export function CheckCreate() {
 
     // Cannot create a pipeline of a non-exist user
     check(http.request("POST", `${pipelinePublicHost}/v1alpha/pipelines`, JSON.stringify(reqBody), constant.paramsHTTPWithJwt), {
-      [`[with random "jwt-sub" header] POST /v1alpha/pipelines response status is 500`]: (r) => r.status === 500
+      [`[with random "jwt-sub" header] POST /v1alpha/pipelines response status is 404`]: (r) => r.status === 404
     });
 
   });
@@ -32,7 +32,7 @@ export function CheckList() {
 
     // Cannot list pipelines of a non-exist user
     check(http.request("GET", `${pipelinePublicHost}/v1alpha/pipelines`, null, constant.paramsHTTPWithJwt), {
-      [`[with random "jwt-sub" header] GET /v1alpha/pipelines response status is 500`]: (r) => r.status === 500
+      [`[with random "jwt-sub" header] GET /v1alpha/pipelines response status is 404`]: (r) => r.status === 404
     });
   });
 }
@@ -56,7 +56,7 @@ export function CheckGet() {
 
     // Cannot get a pipeline of a non-exist user
     check(http.request("GET", `${pipelinePublicHost}/v1alpha/pipelines/${reqBody.id}`, null, constant.paramsHTTPWithJwt), {
-      [`[with random "jwt-sub" header] GET /v1alpha/pipelines/${reqBody.id} response status is 500`]: (r) => r.status === 500
+      [`[with random "jwt-sub" header] GET /v1alpha/pipelines/${reqBody.id} response status is 404`]: (r) => r.status === 404
     });
 
     // Delete the pipeline
@@ -96,7 +96,7 @@ export function CheckUpdate() {
 
     // Cannot update a pipeline of a non-exist user
     check(http.request("PATCH", `${pipelinePublicHost}/v1alpha/pipelines/${reqBody.id}`, JSON.stringify(reqBodyUpdate), constant.paramsHTTPWithJwt), {
-      [`[with random "jwt-sub" header] PATCH /v1alpha/pipelines/${reqBody.id} response status is 500`]: (r) => r.status === 500
+      [`[with random "jwt-sub" header] PATCH /v1alpha/pipelines/${reqBody.id} response status is 404`]: (r) => r.status === 404
     });
 
     // Delete the pipeline
@@ -130,12 +130,12 @@ export function CheckUpdateState() {
 
     // Cannot activate a pipeline of a non-exist user
     check(http.request("POST", `${pipelinePublicHost}/v1alpha/pipelines/${reqBodySync.id}/activate`, null, constant.paramsHTTPWithJwt), {
-      [`[with random "jwt-sub" header] POST /v1alpha/pipelines/${reqBodySync.id}/activate response status is 500 for sync pipeline`]: (r) => r.status === 500
+      [`[with random "jwt-sub" header] POST /v1alpha/pipelines/${reqBodySync.id}/activate response status is 404 for sync pipeline`]: (r) => r.status === 404
     });
 
     // Cannot deactivate a pipeline of a non-exist user
     check(http.request("POST", `${pipelinePublicHost}/v1alpha/pipelines/${reqBodySync.id}/deactivate`, null, constant.paramsHTTPWithJwt), {
-      [`[with random "jwt-sub" header] POST /v1alpha/pipelines/${reqBodySync.id}/deactivate response status is 500 for sync pipeline`]: (r) => r.status === 500
+      [`[with random "jwt-sub" header] POST /v1alpha/pipelines/${reqBodySync.id}/deactivate response status is 404 for sync pipeline`]: (r) => r.status === 404
     });
 
     // Delete the pipelines
@@ -170,7 +170,7 @@ export function CheckRename() {
 
     // Cannot rename a pipeline of a non-exist user
     check(http.request("POST", `${pipelinePublicHost}/v1alpha/pipelines/${res.json().pipeline.id}/rename`, JSON.stringify(reqBody), constant.paramsHTTPWithJwt), {
-      [`[with random "jwt-sub" header] POST /v1alpha/pipelines/${res.json().pipeline.id}/rename response status is 500`]: (r) => r.status === 500
+      [`[with random "jwt-sub" header] POST /v1alpha/pipelines/${res.json().pipeline.id}/rename response status is 404`]: (r) => r.status === 404
     });
 
     // Delete the pipeline
@@ -202,7 +202,7 @@ export function CheckLookUp() {
 
     // Cannot look up a pipeline of a non-exist user
     check(http.request("GET", `${pipelinePublicHost}/v1alpha/pipelines/${res.json().pipeline.id}/lookUp`, null, constant.paramsHTTPWithJwt), {
-      [`[with random "jwt-sub" header] POST /v1alpha/pipelines/${res.json().pipeline.id}/lookUp response status is 500`]: (r) => r.status === 500
+      [`[with random "jwt-sub" header] POST /v1alpha/pipelines/${res.json().pipeline.id}/lookUp response status is 404`]: (r) => r.status === 404
     });
 
     // Delete the pipeline

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -2,7 +2,6 @@ package resource
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
@@ -71,7 +70,7 @@ func GetOwner(ctx context.Context, client mgmtPB.MgmtPrivateServiceClient) (*mgm
 	if headerOwnerUId != "" {
 		_, err := uuid.FromString(headerOwnerUId)
 		if err != nil {
-			return nil, status.Errorf(codes.Unauthenticated, "Unauthenticated request")
+			return nil, status.Errorf(codes.Unauthenticated, "Unauthorized")
 		}
 		ownerPermalink := "users/" + headerOwnerUId
 
@@ -79,7 +78,7 @@ func GetOwner(ctx context.Context, client mgmtPB.MgmtPrivateServiceClient) (*mgm
 		defer cancel()
 		resp, err := client.LookUpUserAdmin(ctx, &mgmtPB.LookUpUserAdminRequest{Permalink: ownerPermalink})
 		if err != nil {
-			return nil, fmt.Errorf("[mgmt-backend] %s", err)
+			return nil, status.Errorf(codes.NotFound, "Not found")
 		}
 
 		return resp.User, nil
@@ -88,14 +87,14 @@ func GetOwner(ctx context.Context, client mgmtPB.MgmtPrivateServiceClient) (*mgm
 	// Verify "owner-id" in the header if there is no "jwt-sub"
 	headerOwnerId := GetRequestSingleHeader(ctx, constant.HeaderOwnerIDKey)
 	if headerOwnerId != constant.DefaultOwnerID {
-		return nil, status.Error(codes.Unauthenticated, "Unauthenticated request")
+		return nil, status.Error(codes.Unauthenticated, "Unauthorized")
 	} else {
 		// Get the permalink from management backend from resource name
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		resp, err := client.GetUserAdmin(ctx, &mgmtPB.GetUserAdminRequest{Name: "users/" + headerOwnerId})
 		if err != nil {
-			return nil, fmt.Errorf("[mgmt-backend] %s", err)
+			return nil, status.Errorf(codes.NotFound, "Not found")
 		}
 		return resp.User, nil
 	}

--- a/pkg/handler/handlercustom.go
+++ b/pkg/handler/handlercustom.go
@@ -120,16 +120,17 @@ func HandleTriggerPipelineBinaryFileUpload(w http.ResponseWriter, req *http.Requ
 	if headerOwnerUId != "" {
 		_, err := uuid.FromString(headerOwnerUId)
 		if err != nil {
-			st, err := sterr.CreateErrorResourceInfo(
-				codes.Unauthenticated,
-				"[handler] unauthenticated request",
-				"pipelines",
-				fmt.Sprintf("id %s", id),
-				headerOwnerUId,
+			logger.Error(err.Error())
+			st, e := sterr.CreateErrorResourceInfo(
+				codes.NotFound,
+				"Not found",
+				"user",
+				fmt.Sprintf("uid %s", headerOwnerUId),
+				"",
 				err.Error(),
 			)
-			if err != nil {
-				logger.Error(err.Error())
+			if e != nil {
+				logger.Error(e.Error())
 			}
 			errorResponse(w, st)
 			logger.Error(st.String())
@@ -139,16 +140,17 @@ func HandleTriggerPipelineBinaryFileUpload(w http.ResponseWriter, req *http.Requ
 		ownerPermalink := "users/" + headerOwnerUId
 		resp, err := service.GetMgmtPrivateServiceClient().LookUpUserAdmin(req.Context(), &mgmtPB.LookUpUserAdminRequest{Permalink: ownerPermalink})
 		if err != nil {
-			st, err := sterr.CreateErrorResourceInfo(
-				codes.Unauthenticated,
-				"[handler] unauthenticated request",
-				"pipelines",
-				fmt.Sprintf("id %s", id),
-				ownerPermalink,
+			logger.Error(err.Error())
+			st, e := sterr.CreateErrorResourceInfo(
+				codes.NotFound,
+				"Not found",
+				"user",
+				fmt.Sprintf("uid %s", headerOwnerUId),
+				"",
 				err.Error(),
 			)
-			if err != nil {
-				logger.Error(err.Error())
+			if e != nil {
+				logger.Error(e.Error())
 			}
 			errorResponse(w, st)
 			logger.Error(st.String())
@@ -160,13 +162,14 @@ func HandleTriggerPipelineBinaryFileUpload(w http.ResponseWriter, req *http.Requ
 		// Verify "owner-id" in the header if there is no "jwt-sub"
 		headerOwnerId := req.Header.Get(constant.HeaderOwnerIDKey)
 		if headerOwnerId == "" {
-			st, err := sterr.CreateErrorBadRequest("[handler] invalid owner field",
-				[]*errdetails.BadRequest_FieldViolation{
-					{
-						Field:       "owner",
-						Description: "required parameter Jwt-Sub not found in the header",
-					},
-				})
+			st, err := sterr.CreateErrorResourceInfo(
+				codes.Unauthenticated,
+				"Unauthorized",
+				"pipeline",
+				fmt.Sprintf("id %s", id),
+				"",
+				"",
+			)
 			if err != nil {
 				logger.Error(err.Error())
 			}
@@ -178,16 +181,17 @@ func HandleTriggerPipelineBinaryFileUpload(w http.ResponseWriter, req *http.Requ
 		ownerName := "users/" + headerOwnerId
 		resp, err := service.GetMgmtPrivateServiceClient().GetUserAdmin(req.Context(), &mgmtPB.GetUserAdminRequest{Name: ownerName})
 		if err != nil {
-			st, err := sterr.CreateErrorResourceInfo(
-				codes.Unauthenticated,
-				"[handler] unauthenticated request",
-				"pipelines",
-				fmt.Sprintf("id %s", id),
-				ownerName,
+			logger.Error(err.Error())
+			st, e := sterr.CreateErrorResourceInfo(
+				codes.NotFound,
+				"Not found",
+				"user",
+				fmt.Sprintf("id %s", headerOwnerId),
+				"",
 				err.Error(),
 			)
-			if err != nil {
-				logger.Error(err.Error())
+			if e != nil {
+				logger.Error(e.Error())
 			}
 			errorResponse(w, st)
 			logger.Error(st.String())


### PR DESCRIPTION
Because

- currently, if a user does not exist in mgmt-backend, returns 500 status error

This commit

- return 404 when a user does not exist
- return 401 when both `jwt-sub` and `owner-id` does not exist in the header 
- update tests
