### PR TITLE
chore: remove redundant grpc and repository client instance

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -215,7 +215,7 @@ func main() {
 	)
 
 	// Register custom route for POST multipart form data
-	if err := publicServeMux.HandlePath("POST", "/v1alpha/pipelines/{id}/trigger-multipart", middleware.AppendCustomHeaderMiddleware(handler.HandleTriggerPipelineBinaryFileUpload)); err != nil {
+	if err := publicServeMux.HandlePath("POST", "/v1alpha/pipelines/{id}/trigger-multipart", middleware.AppendCustomHeaderMiddleware(service, handler.HandleTriggerPipelineBinaryFileUpload)); err != nil {
 		logger.Fatal(err.Error())
 	}
 

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -6,12 +6,15 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 
 	"github.com/instill-ai/pipeline-backend/pkg/constant"
+	"github.com/instill-ai/pipeline-backend/pkg/service"
 )
 
+type fn func(service.Service, http.ResponseWriter, *http.Request, map[string]string)
+
 // AppendCustomHeaderMiddleware appends custom headers
-func AppendCustomHeaderMiddleware(next runtime.HandlerFunc) runtime.HandlerFunc {
+func AppendCustomHeaderMiddleware(s service.Service, next fn) runtime.HandlerFunc {
 	return runtime.HandlerFunc(func(w http.ResponseWriter, r *http.Request, pathParams map[string]string) {
 		r.Header.Add(constant.HeaderOwnerIDKey, constant.DefaultOwnerID)
-		next(w, r, pathParams)
+		next(s, w, r, pathParams)
 	})
 }


### PR DESCRIPTION
Because

- We create new client instance every time for `/v1alpha/pipelines/{id}/trigger-multipart` endpoint

This commit

- share the client instance with main service
