### PR TITLE
chore: refactor integration test mode

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -121,7 +121,7 @@ jobs:
 
       - name: Run integration-test
         run: |
-          make integration-test MODE=localhost
+          make integration-test API_GATEWAY_HOST=localhost API_GATEWAY_PORT=8080
 
       - name: Checkout (connector)
         uses: actions/checkout@v3
@@ -135,7 +135,7 @@ jobs:
 
       - name: Run integration-test
         run: |
-          make integration-test MODE=localhost
+          make integration-test API_GATEWAY_HOST=localhost API_GATEWAY_PORT=8080
 
       - name: Checkout (model)
         uses: actions/checkout@v3
@@ -149,7 +149,7 @@ jobs:
 
       - name: Run integration-test
         run: |
-          make integration-test MODE=localhost
+          make integration-test API_GATEWAY_HOST=localhost API_GATEWAY_PORT=8080
 
       - name: Checkout (mgmt)
         uses: actions/checkout@v3
@@ -163,4 +163,4 @@ jobs:
 
       - name: Run integration-test
         run: |
-          make integration-test MODE=localhost
+          make integration-test API_GATEWAY_HOST=localhost API_GATEWAY_PORT=8080

--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,12 @@ unit-test:       				## Run unit test
 
 .PHONY: integration-test
 integration-test:				## Run integration test
-	@TEST_FOLDER_ABS_PATH=${PWD} k6 run -e MODE=$(MODE) integration-test/grpc.js --no-usage-report --quiet
-	@TEST_FOLDER_ABS_PATH=${PWD} k6 run -e MODE=$(MODE) integration-test/rest.js --no-usage-report --quiet
+	@TEST_FOLDER_ABS_PATH=${PWD} k6 run \
+		-e API_GATEWAY_PROTOCOL=${API_GATEWAY_PROTOCOL} -e API_GATEWAY_HOST=${API_GATEWAY_HOST} -e API_GATEWAY_PORT=${API_GATEWAY_PORT} \
+		integration-test/grpc.js --no-usage-report --quiet
+	@TEST_FOLDER_ABS_PATH=${PWD} k6 run \
+		-e API_GATEWAY_PROTOCOL=${API_GATEWAY_PROTOCOL} -e API_GATEWAY_HOST=${API_GATEWAY_HOST} -e API_GATEWAY_PORT=${API_GATEWAY_PORT} \
+		integration-test/rest.js --no-usage-report --quiet
 
 .PHONY: help
 help:       	 				## Show this help

--- a/integration-test/const.js
+++ b/integration-test/const.js
@@ -4,27 +4,28 @@ let proto
 let pHost, cHost, mHost
 let pPrivatePort, pPublicPort, cPublicPort, mPublicPort
 
-if (__ENV.MODE == "api-gateway") {
-  // api-gateway mode for accessing api-gateway directly
+if (__ENV.API_GATEWAY_HOST && !__ENV.API_GATEWAY_PORT || !__ENV.API_GATEWAY_HOST && __ENV.API_GATEWAY_PORT) {
+  fail("both API_GATEWAY_HOST and API_GATEWAY_PORT should be properly configured.")
+}
+
+export const apiGatewayMode = (__ENV.API_GATEWAY_HOST && __ENV.API_GATEWAY_PORT);
+
+if (__ENV.API_GATEWAY_PROTOCOL) {
+  if (__ENV.API_GATEWAY_PROTOCOL !== "http" && __ENV.API_GATEWAY_PROTOCOL != "https") {
+    fail("only allow `http` or `https` for API_GATEWAY_PROTOCOL")
+  }
+  proto = __ENV.API_GATEWAY_PROTOCOL
+} else {
   proto = "http"
-  pHost = cHost = mHost = "api-gateway"
-  pPrivatePort = 3081
-  pPublicPort = cPublicPort = mPublicPort = 8080
-} else if (__ENV.MODE == "localhost") {
-  // localhost mode for accessing api-gateway from localhost
-  proto = "http"
-  pHost = cHost = mHost = "localhost"
-  pPrivatePort = 3081
-  pPublicPort = cPublicPort = mPublicPort = 8080
-} else if (__ENV.MODE == "internal") {
+}
+
+if (apiGatewayMode) {
   // internal mode for accessing api-gateway from container
-  proto = "http"
-  pHost = cHost = mHost = "host.docker.internal"
+  pHost = cHost = mHost = __ENV.API_GATEWAY_HOST
   pPrivatePort = 3081
-  pPublicPort = cPublicPort = mPublicPort = 8080
+  pPublicPort = cPublicPort = mPublicPort = __ENV.API_GATEWAY_PORT
 } else {
   // direct microservice mode
-  proto = "http"
   pHost = "pipeline-backend"
   cHost = "connector-backend"
   mHost = "model-backend"

--- a/integration-test/grpc.js
+++ b/integration-test/grpc.js
@@ -232,7 +232,7 @@ export default function (data) {
   triggerAsync.CheckTriggerAsyncMultiImageSingleModel()
   triggerAsync.CheckTriggerAsyncMultiImageMultiModel()
 
-  if (__ENV.MODE != "api-gateway" && __ENV.MODE != "localhost" && __ENV.MODE != "internal") {
+  if (!constant.apiGatewayMode) {
     pipelinePrivate.CheckList()
     pipelinePrivate.CheckGet()
     pipelinePrivate.CheckLookUp()

--- a/integration-test/rest.js
+++ b/integration-test/rest.js
@@ -206,7 +206,7 @@ export default function (data) {
     });
   }
 
-  if (__ENV.MODE != "api-gateway" && __ENV.MODE != "localhost" && __ENV.MODE != "internal") {
+  if (!constant.apiGatewayMode) {
     pipelinePrivate.CheckList()
     pipelinePrivate.CheckGet()
     pipelinePrivate.CheckLookUp()


### PR DESCRIPTION
Because

- Need to simplify the integration test mode

This commit

- Add `API_GATEWAY_HOST`, `API_GATEWAY_PORT` and `API_GATEWAY_PROTOCOL` var. to simplify the integration test setting
