### PR TITLE
chore: add integration test for watch endpoint

### DIFF
--- a/integration-test/grpc.js
+++ b/integration-test/grpc.js
@@ -223,6 +223,7 @@ export default function (data) {
   pipeline.CheckUpdateState()
   pipeline.CheckRename()
   pipeline.CheckLookUp()
+  pipeline.CheckWatch()
 
   triggerSync.CheckTriggerSyncSingleImageSingleModel()
   triggerSync.CheckTriggerSyncMultiImageSingleModel()

--- a/integration-test/rest.js
+++ b/integration-test/rest.js
@@ -227,6 +227,7 @@ export default function (data) {
   pipelinePublic.CheckUpdateState()
   pipelinePublic.CheckRename()
   pipelinePublic.CheckLookUp()
+  pipelinePublic.CheckWatch()
 
   triggerSync.CheckTriggerSyncSingleImageSingleModel()
   triggerSync.CheckTriggerSyncMultiImageSingleModel()


### PR DESCRIPTION
Because

- the integration tests didn't detect connector/model private port problem

This commit

- add integration tests for watch endpoint
