### PR TITLE
chore: add temporary limitation for number of model and destination

### DIFF
--- a/integration-test/grpc.js
+++ b/integration-test/grpc.js
@@ -235,12 +235,15 @@ export default function (data) {
 
   triggerSync.CheckTriggerSyncSingleImageSingleModel()
   triggerSync.CheckTriggerSyncMultiImageSingleModel()
-  triggerSync.CheckTriggerSyncMultiImageMultiModel()
+  // Don't support this temporarily
+  // triggerSync.CheckTriggerSyncMultiImageMultiModel()
 
   triggerAsync.CheckTriggerAsyncSingleImageSingleModel()
   triggerAsync.CheckTriggerAsyncMultiImageSingleModel()
-  triggerAsync.CheckTriggerAsyncMultiImageMultiModel()
-  triggerAsync.CheckTriggerAsyncMultiImageMultiModelMultipleDestination()
+
+  // Don't support this temporarily
+  // triggerAsync.CheckTriggerAsyncMultiImageMultiModel()
+  // triggerAsync.CheckTriggerAsyncMultiImageMultiModelMultipleDestination()
 
   if (!constant.apiGatewayMode) {
     pipelinePrivate.CheckList()

--- a/integration-test/rest.js
+++ b/integration-test/rest.js
@@ -238,12 +238,15 @@ export default function (data) {
 
   triggerSync.CheckTriggerSyncSingleImageSingleModel()
   triggerSync.CheckTriggerSyncMultiImageSingleModel()
-  triggerSync.CheckTriggerSyncMultiImageMultiModel()
+  // Don't support this temporarily
+  // triggerSync.CheckTriggerSyncMultiImageMultiModel()
 
   triggerAsync.CheckTriggerAsyncSingleImageSingleModel()
   triggerAsync.CheckTriggerAsyncMultiImageSingleModel()
-  triggerAsync.CheckTriggerAsyncMultiImageMultiModel()
-  triggerAsync.CheckTriggerAsyncMultiImageMultiModelMultipleDestination()
+
+  // Don't support this temporarily
+  // triggerAsync.CheckTriggerAsyncMultiImageMultiModel()
+  // triggerAsync.CheckTriggerAsyncMultiImageMultiModelMultipleDestination()
 
 }
 

--- a/pkg/service/mode.go
+++ b/pkg/service/mode.go
@@ -38,6 +38,8 @@ func (s *service) checkRecipe(owner *mgmtPB.User, recipeRscName *datamodel.Recip
 	dstHasHttp := false
 	dstHasGrpc := false
 
+	modelCnt := 0
+
 	componentIdSet := make(map[string]bool)
 	exp := "^[A-Za-z0-9]([A-Za-z0-9-_]{0,62}[A-Za-z0-9])?$"
 	r, _ := regexp.Compile(exp)
@@ -122,7 +124,20 @@ func (s *service) checkRecipe(owner *mgmtPB.User, recipeRscName *datamodel.Recip
 			if strings.Contains(dstConnDefID, "grpc") {
 				dstHasGrpc = true
 			}
+		case utils.Model:
+			modelCnt += 1
 		}
+	}
+
+	// Temporary Constraint
+	if modelCnt != 1 {
+		return datamodel.PipelineMode(pipelinePB.Pipeline_MODE_UNSPECIFIED),
+			status.Errorf(codes.InvalidArgument, "[pipeline-backend] Need to have exactly one model")
+	}
+	// Temporary Constraint
+	if len(dstConnDefIDs) != 1 {
+		return datamodel.PipelineMode(pipelinePB.Pipeline_MODE_UNSPECIFIED),
+			status.Errorf(codes.InvalidArgument, "[pipeline-backend] Need to have exactly one destination connector")
 	}
 
 	if srcCnt == 0 {

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -45,6 +45,10 @@ func TestCreatePipeline(t *testing.T) {
 						ResourceName: "source-connectors/source-http",
 					},
 					{
+						Id:           "m01",
+						ResourceName: "models/model01",
+					},
+					{
 						Id:           "d01",
 						ResourceName: "destination-connectors/destination-http",
 					},
@@ -79,6 +83,7 @@ func TestCreatePipeline(t *testing.T) {
 
 		mockModelPublicServiceClient := NewMockModelPublicServiceClient(ctrl)
 		mockModelPrivateServiceClient := NewMockModelPrivateServiceClient(ctrl)
+		mockModelPublicServiceClient.EXPECT().GetModel(gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
 
 		mockControllerPrivateServiceClient := NewMockControllerPrivateServiceClient(ctrl)
 		// mockRedisClient := NewMockRes


### PR DESCRIPTION
Because

- multiple models and destinations are not supported in console yet

This commit

- add limitation for the number of model and destination
