### PR TITLE
chore: update integration test to support new connector definition

### DIFF
--- a/integration-test/grpc.js
+++ b/integration-test/grpc.js
@@ -117,7 +117,7 @@ export function setup() {
     check(client.invoke('vdp.connector.v1alpha.ConnectorPublicService/CreateDestinationConnector', {
       destination_connector: {
         "id": constant.dstCSVConnID1,
-        "destination_connector_definition": "destination-connector-definitions/destination-csv",
+        "destination_connector_definition": "destination-connector-definitions/airbyte-destination-csv",
         "connector": {
           "configuration": {
             "destination_path": "/local/pipeline-backend-test-1"
@@ -134,7 +134,7 @@ export function setup() {
     check(client.invoke('vdp.connector.v1alpha.ConnectorPublicService/CreateDestinationConnector', {
       destination_connector: {
         "id": constant.dstCSVConnID2,
-        "destination_connector_definition": "destination-connector-definitions/destination-csv",
+        "destination_connector_definition": "destination-connector-definitions/airbyte-destination-csv",
         "connector": {
           "configuration": {
             "destination_path": "/local/pipeline-backend-test-2"

--- a/integration-test/rest.js
+++ b/integration-test/rest.js
@@ -111,7 +111,7 @@ export function setup() {
     var res = http.request("POST", `${connectorPublicHost}/v1alpha/destination-connectors`,
       JSON.stringify({
         "id": constant.dstCSVConnID1,
-        "destination_connector_definition": "destination-connector-definitions/destination-csv",
+        "destination_connector_definition": "destination-connector-definitions/airbyte-destination-csv",
         "connector": {
           "configuration": {
             "destination_path": "/local/pipeline-backend-test-1"
@@ -130,7 +130,7 @@ export function setup() {
     var res = http.request("POST", `${connectorPublicHost}/v1alpha/destination-connectors`,
       JSON.stringify({
         "id": constant.dstCSVConnID2,
-        "destination_connector_definition": "destination-connector-definitions/destination-csv",
+        "destination_connector_definition": "destination-connector-definitions/airbyte-destination-csv",
         "connector": {
           "configuration": {
             "destination_path": "/local/pipeline-backend-test-2"


### PR DESCRIPTION
Because

- the connector-definition in connector-backend have been updated

This commit

- update the integration-test to adopt this change
