### PR TITLE
chore: allow unfinished pipeline

### DIFF
--- a/integration-test/grpc-pipeline-private.js
+++ b/integration-test/grpc-pipeline-private.js
@@ -40,18 +40,23 @@ export function CheckList() {
       reqBodies[i] = Object.assign({
         id: randomString(10),
         description: randomString(50),
+        mode: "MODE_SYNC",
       },
         constant.detSyncHTTPSingleModelRecipe
       )
     }
 
     // Create pipelines
-    for (const reqBody of reqBodies)
+    for (const reqBody of reqBodies){
       check(clientPublic.invoke('vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline', {
         pipeline: reqBody
       }), {
         [`vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline x${reqBodies.length} response StatusOK`]: (r) => r.status === grpc.StatusOK,
       });
+      clientPublic.invoke('vdp.pipeline.v1alpha.PipelinePublicService/ActivatePipeline', {
+        name: `pipelines/${reqBody.id}`
+      })
+    }
 
     check(clientPrivate.invoke('vdp.pipeline.v1alpha.PipelinePrivateService/ListPipelinesAdmin', {}, {}), {
       [`vdp.pipeline.v1alpha.PipelinePrivateService/ListPipelinesAdmin response StatusOK`]: (r) => r.status === grpc.StatusOK,

--- a/integration-test/grpc-pipeline-public-with-jwt.js
+++ b/integration-test/grpc-pipeline-public-with-jwt.js
@@ -23,6 +23,7 @@ export function CheckCreate() {
     var reqBody = Object.assign({
       id: randomString(63),
       description: randomString(50),
+      mode: "MODE_SYNC",
     },
       constant.detSyncHTTPSingleModelRecipe
     )
@@ -66,6 +67,7 @@ export function CheckGet() {
     var reqBody = Object.assign({
       id: randomString(10),
       description: randomString(50),
+      mode: "MODE_SYNC",
     },
       constant.detSyncHTTPSingleModelRecipe
     )
@@ -104,6 +106,7 @@ export function CheckUpdate() {
 
     var reqBody = Object.assign({
       id: randomString(10),
+      mode: "MODE_SYNC",
     },
       constant.detSyncHTTPSingleModelRecipe
     )
@@ -154,6 +157,7 @@ export function CheckUpdateState() {
 
     var reqBodySync = Object.assign({
       id: randomString(10),
+      mode: "MODE_SYNC",
     },
       constant.detSyncHTTPSingleModelRecipe
     )
@@ -162,7 +166,10 @@ export function CheckUpdateState() {
       pipeline: reqBodySync
     }), {
       [`vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline Sync response StatusOK`]: (r) => r.status === grpc.StatusOK,
-      [`vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline Sync response pipeline state ACTIVE`]: (r) => r.message.pipeline.state === "STATE_ACTIVE",
+    })
+
+    client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/ActivatePipeline', {
+      name: `pipelines/${reqBodySync.id}`
     })
 
     check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/WatchPipeline', {
@@ -207,6 +214,7 @@ export function CheckRename() {
 
     var reqBody = Object.assign({
       id: randomString(10),
+      mode: "MODE_SYNC",
     },
       constant.detSyncHTTPSingleModelRecipe
     )
@@ -253,6 +261,7 @@ export function CheckLookUp() {
 
     var reqBody = Object.assign({
       id: randomString(10),
+      mode: "MODE_SYNC",
     },
       constant.detSyncHTTPSingleModelRecipe
     )

--- a/integration-test/grpc-trigger-async.js
+++ b/integration-test/grpc-trigger-async.js
@@ -30,6 +30,7 @@ export function CheckTriggerAsyncSingleImageSingleModel() {
     var reqBody = Object.assign({
       id: randomString(10),
       description: randomString(50),
+      mode: "MODE_ASYNC",
     },
       constant.detAsyncSingleModelRecipe
     );
@@ -94,6 +95,7 @@ export function CheckTriggerAsyncMultiImageSingleModel() {
     var reqBody = Object.assign({
       id: randomString(10),
       description: randomString(50),
+      mode: "MODE_ASYNC",
     },
       constant.detAsyncSingleModelRecipe
     );
@@ -175,6 +177,7 @@ export function CheckTriggerAsyncMultiImageMultiModel() {
     var reqBody = Object.assign({
       id: randomString(10),
       description: randomString(50),
+      mode: "MODE_ASYNC",
     },
       constant.detAsyncMultiModelRecipe
     );
@@ -265,6 +268,7 @@ export function CheckTriggerAsyncMultiImageMultiModelMultipleDestination() {
     var reqBody = Object.assign({
       id: randomString(10),
       description: randomString(50),
+      mode: "MODE_ASYNC",
     },
       constant.detAsyncMultiModelMultipleDestinationRecipe
     );

--- a/integration-test/grpc-trigger-sync.js
+++ b/integration-test/grpc-trigger-sync.js
@@ -25,6 +25,7 @@ export function CheckTriggerSyncSingleImageSingleModel() {
     var reqGRPC = Object.assign({
       id: randomString(10),
       description: randomString(50),
+      mode: "MODE_SYNC",
     },
       constant.detSyncGRPCSingleModelRecipe
     );
@@ -92,6 +93,7 @@ export function CheckTriggerSyncSingleImageSingleModel() {
     var reqHTTP = Object.assign({
       id: randomString(10),
       description: randomString(50),
+      mode: "MODE_SYNC",
     },
       constant.detSyncHTTPSingleModelRecipe
     );
@@ -131,6 +133,7 @@ export function CheckTriggerSyncMultiImageSingleModel() {
     var reqGRPC = Object.assign({
       id: randomString(10),
       description: randomString(50),
+      mode: "MODE_SYNC",
     },
       constant.detSyncGRPCSingleModelRecipe
     );
@@ -232,6 +235,7 @@ export function CheckTriggerSyncMultiImageMultiModel() {
     var reqGRPC = Object.assign({
       id: randomString(10),
       description: randomString(50),
+      mode: "MODE_SYNC",
     },
       constant.detSynGRPCMultiModelRecipe
     );

--- a/integration-test/rest-pipeline-private.js
+++ b/integration-test/rest-pipeline-private.js
@@ -24,6 +24,7 @@ export function CheckList() {
         {
           id: randomString(10),
           description: randomString(50),
+          mode: "MODE_SYNC"
         },
         constant.detSyncHTTPSingleModelRecipe
       )
@@ -34,6 +35,7 @@ export function CheckList() {
       check(http.request("POST", `${pipelinePublicHost}/v1alpha/pipelines`, JSON.stringify(reqBody), constant.params), {
         [`POST /v1alpha/pipelines x${reqBodies.length} response status is 201`]: (r) => r.status === 201
       });
+      http.request("POST", `${pipelinePublicHost}/v1alpha/pipelines/${reqBody.id}/activate`, {}, constant.params)
     }
 
     check(http.request("GET", `${pipelinePrivateHost}/v1alpha/admin/pipelines`, null, constant.params), {
@@ -123,6 +125,7 @@ export function CheckLookUp() {
     var reqBody = Object.assign(
       {
         id: randomString(10),
+        mode: "MODE_SYNC",
       },
       constant.detSyncHTTPSingleModelRecipe
     )

--- a/integration-test/rest-pipeline-public-with-jwt.js
+++ b/integration-test/rest-pipeline-public-with-jwt.js
@@ -14,6 +14,7 @@ export function CheckCreate() {
       {
         id: randomString(63),
         description: randomString(50),
+        mode: "MODE_SYNC",
       },
       constant.detSyncHTTPSingleModelRecipe
     )
@@ -45,6 +46,7 @@ export function CheckGet() {
       {
         id: randomString(10),
         description: randomString(50),
+        mode: "MODE_SYNC",
       },
       constant.detSyncHTTPSingleModelRecipe
     )
@@ -74,6 +76,7 @@ export function CheckUpdate() {
     var reqBody = Object.assign(
       {
         id: randomString(10),
+        mode: "MODE_SYNC",
       },
       constant.detSyncHTTPSingleModelRecipe
     )
@@ -114,14 +117,16 @@ export function CheckUpdateState() {
     var reqBodySync = Object.assign(
       {
         id: randomString(10),
+        mode: "MODE_SYNC",
       },
       constant.detSyncHTTPSingleModelRecipe
     )
 
     check(http.request("POST", `${pipelinePublicHost}/v1alpha/pipelines`, JSON.stringify(reqBodySync), constant.params), {
       "POST /v1alpha/pipelines sync pipeline creation response status is 201": (r) => r.status === 201,
-      "POST /v1alpha/pipelines sync pipeline creation response pipeline state ACTIVE": (r) => r.json().pipeline.state === "STATE_ACTIVE",
     });
+
+    http.request("POST", `${pipelinePublicHost}/v1alpha/pipelines/${reqBodySync.id}/activate`, {}, constant.params)
 
     // check(http.request("POST", `${pipelinePublicHost}/v1alpha/pipelines`, JSON.stringify(reqBodyAsync), constant.params), {
     //   "POST /v1alpha/pipelines async pipeline creation response status is 201": (r) => r.status === 201,
@@ -154,6 +159,7 @@ export function CheckRename() {
     var reqBody = Object.assign(
       {
         id: id,
+        mode: "MODE_SYNC",
       },
       constant.detSyncHTTPSingleModelRecipe
     )
@@ -189,6 +195,7 @@ export function CheckLookUp() {
     var reqBody = Object.assign(
       {
         id: randomString(10),
+        mode: "MODE_SYNC",
       },
       constant.detSyncHTTPSingleModelRecipe
     )

--- a/integration-test/rest-trigger-async.js
+++ b/integration-test/rest-trigger-async.js
@@ -15,6 +15,7 @@ export function CheckTriggerAsyncSingleImageSingleModel() {
     {
       id: randomString(10),
       description: randomString(50),
+      mode: "MODE_ASYNC",
     },
     constant.detAsyncSingleModelRecipe
   );
@@ -75,6 +76,7 @@ export function CheckTriggerAsyncMultiImageSingleModel() {
     {
       id: randomString(10),
       description: randomString(50),
+      mode: "MODE_ASYNC",
     },
     constant.detAsyncSingleModelRecipe
   );
@@ -156,6 +158,7 @@ export function CheckTriggerAsyncMultiImageMultiModel() {
     {
       id: randomString(10),
       description: randomString(50),
+      mode: "MODE_ASYNC",
     },
     constant.detAsyncMultiModelRecipe
   );
@@ -244,6 +247,7 @@ export function CheckTriggerAsyncMultiImageMultiModelMultipleDestination() {
     {
       id: randomString(10),
       description: randomString(50),
+      mode: "MODE_ASYNC",
     },
     constant.detAsyncMultiModelMultipleDestinationRecipe
   );

--- a/integration-test/rest-trigger-sync.js
+++ b/integration-test/rest-trigger-sync.js
@@ -17,6 +17,7 @@ export function CheckTriggerSyncSingleImageSingleModel() {
       {
         id: randomString(10),
         description: randomString(50),
+        mode: "MODE_SYNC",
       },
       constant.detSyncHTTPSingleModelRecipe
     );
@@ -104,6 +105,7 @@ export function CheckTriggerSyncSingleImageSingleModel() {
       {
         id: randomString(10),
         description: randomString(50),
+        mode: "MODE_SYNC",
       },
       constant.detSyncGRPCSingleModelRecipe
     );
@@ -132,6 +134,7 @@ export function CheckTriggerSyncMultiImageSingleModel() {
       {
         id: randomString(10),
         description: randomString(50),
+        mode: "MODE_SYNC",
       },
       constant.detSyncHTTPSingleModelRecipe
     );
@@ -245,6 +248,7 @@ export function CheckTriggerSyncMultiImageMultiModel() {
       {
         id: randomString(10),
         description: randomString(50),
+        mode: "MODE_SYNC",
       },
       constant.detSyncHTTPMultiModelRecipe
     );

--- a/pkg/handler/fieldannotation.go
+++ b/pkg/handler/fieldannotation.go
@@ -12,4 +12,4 @@ var triggerRequiredFields = []string{"name", "inputs"}
 var immutableFields = []string{"id", "recipe"}
 
 // outputOnlyFields are Protobuf message fields with OUTPUT_ONLY field_behavior annotation
-var outputOnlyFields = []string{"name", "uid", "mode", "state", "owner", "create_time", "update_time"}
+var outputOnlyFields = []string{"name", "uid", "state", "owner", "create_time", "update_time"}

--- a/pkg/handler/publicHandler.go
+++ b/pkg/handler/publicHandler.go
@@ -327,6 +327,9 @@ func (h *PublicHandler) UpdatePipeline(ctx context.Context, req *pipelinePB.Upda
 	}
 
 	pbPipelineToUpdate := getResp.GetPipeline()
+	if pbPipelineToUpdate.State == pipelinePB.Pipeline_STATE_ACTIVE {
+		return &pipelinePB.UpdatePipelineResponse{}, status.Error(codes.InvalidArgument, "can not update a active pipeline")
+	}
 
 	// Return error if IMMUTABLE fields are intentionally changed
 	if err := checkfield.CheckUpdateImmutableFields(pbPipelineReq, pbPipelineToUpdate, immutableFields); err != nil {

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -100,15 +100,8 @@ func (h *service) GetRedisClient() *redis.Client {
 
 func (s *service) CreatePipeline(owner *mgmtPB.User, dbPipeline *datamodel.Pipeline) (*datamodel.Pipeline, error) {
 
-	mode, err := s.checkRecipe(owner, dbPipeline.Recipe)
-	if err != nil {
-		return nil, err
-	}
-
-	dbPipeline.Mode = mode
-
 	// User desires to be active
-	dbPipeline.State = datamodel.PipelineState(pipelinePB.Pipeline_STATE_ACTIVE)
+	dbPipeline.State = datamodel.PipelineState(pipelinePB.Pipeline_STATE_INACTIVE)
 
 	ownerPermalink := utils.GenOwnerPermalink(owner)
 	dbPipeline.Owner = ownerPermalink
@@ -265,15 +258,9 @@ func (s *service) UpdatePipeline(id string, owner *mgmtPB.User, toUpdPipeline *d
 	resourceState := toUpdPipeline.State
 
 	if toUpdPipeline.Recipe != nil {
-		mode, err := s.checkRecipe(owner, toUpdPipeline.Recipe)
-		if err != nil {
-			return nil, err
-		}
-
-		toUpdPipeline.Mode = mode
 
 		// User desires to be active
-		toUpdPipeline.State = datamodel.PipelineState(pipelinePB.Pipeline_STATE_ACTIVE)
+		toUpdPipeline.State = datamodel.PipelineState(pipelinePB.Pipeline_STATE_INACTIVE)
 
 		recipePermalink, err := s.recipeNameToPermalink(owner, toUpdPipeline.Recipe)
 		if err != nil {


### PR DESCRIPTION
Because

- The setting of pipeline may be complex, so we must let user has the ability to save the unfinished pipeline

This commit

- When creating pipeline, the desired state will be inactive
- If the pipeline desired state is active, then you can not update the pipeline
