### PR TITLE
chore: let pipeline mode be unspecified when created

### DIFF
--- a/integration-test/grpc-pipeline-private.js
+++ b/integration-test/grpc-pipeline-private.js
@@ -40,7 +40,6 @@ export function CheckList() {
       reqBodies[i] = Object.assign({
         id: randomString(10),
         description: randomString(50),
-        mode: "MODE_SYNC",
       },
         constant.detSyncHTTPSingleModelRecipe
       )
@@ -106,18 +105,12 @@ export function CheckList() {
     });
 
     // Filtering
-    check(clientPrivate.invoke('vdp.pipeline.v1alpha.PipelinePrivateService/ListPipelinesAdmin', {
-      filter: "mode=MODE_SYNC"
-    }, {}), {
-      [`vdp.pipeline.v1alpha.PipelinePrivateService/ListPipelinesAdmin filter: "mode=MODE_SYNC" response StatusOK`]: (r) => r.status === grpc.StatusOK,
-      [`vdp.pipeline.v1alpha.PipelinePrivateService/ListPipelinesAdmin filter: "mode=MODE_SYNC" response pipelines.length`]: (r) => r.message.pipelines.length > 0,
-    });
 
     check(clientPrivate.invoke('vdp.pipeline.v1alpha.PipelinePrivateService/ListPipelinesAdmin', {
-      filter: 'mode=MODE_SYNC AND state=STATE_ACTIVE'
+      filter: 'state=STATE_ACTIVE'
     }, {}), {
-      [`vdp.pipeline.v1alpha.PipelinePrivateService/ListPipelinesAdmin filter: mode=MODE_SYNC AND state=STATE_ACTIVE response StatusOK`]: (r) => r.status === grpc.StatusOK,
-      [`vdp.pipeline.v1alpha.PipelinePrivateService/ListPipelinesAdmin filter: mode=MODE_SYNC AND state=STATE_ACTIVE response pipelines.length`]: (r) => r.message.pipelines.length > 0,
+      [`vdp.pipeline.v1alpha.PipelinePrivateService/ListPipelinesAdmin filter: state=STATE_ACTIVE response StatusOK`]: (r) => r.status === grpc.StatusOK,
+      [`vdp.pipeline.v1alpha.PipelinePrivateService/ListPipelinesAdmin filter: state=STATE_ACTIVE response pipelines.length`]: (r) => r.message.pipelines.length > 0,
     });
 
     check(clientPrivate.invoke('vdp.pipeline.v1alpha.PipelinePrivateService/ListPipelinesAdmin', {
@@ -138,10 +131,10 @@ export function CheckList() {
     // var modelPermalink = `models/${modelUid}`
 
     check(clientPrivate.invoke('vdp.pipeline.v1alpha.PipelinePrivateService/ListPipelinesAdmin', {
-      filter: `mode=MODE_SYNC AND recipe.components.resource_name:"${srcConnPermalink}"`
+      filter: `recipe.components.resource_name:"${srcConnPermalink}"`
     }, {}), {
-      [`vdp.pipeline.v1alpha.PipelinePrivateService/ListPipelinesAdmin filter: mode=MODE_SYNC AND recipe.components.resource_name:"${srcConnPermalink}" response StatusOK`]: (r) => r.status === grpc.StatusOK,
-      [`vdp.pipeline.v1alpha.PipelinePrivateService/ListPipelinesAdmin filter: mode=MODE_SYNC AND recipe.components.resource_name:"${srcConnPermalink}" response pipelines.length`]: (r) => r.message.pipelines.length > 0,
+      [`vdp.pipeline.v1alpha.PipelinePrivateService/ListPipelinesAdmin filter: recipe.components.resource_name:"${srcConnPermalink}" response StatusOK`]: (r) => r.status === grpc.StatusOK,
+      [`vdp.pipeline.v1alpha.PipelinePrivateService/ListPipelinesAdmin filter: recipe.components.resource_name:"${srcConnPermalink}" response pipelines.length`]: (r) => r.message.pipelines.length > 0,
     });
 
     // check(clientPrivate.invoke('vdp.pipeline.v1alpha.PipelinePrivateService/ListPipelinesAdmin', {

--- a/integration-test/grpc-pipeline-public-with-jwt.js
+++ b/integration-test/grpc-pipeline-public-with-jwt.js
@@ -23,7 +23,6 @@ export function CheckCreate() {
     var reqBody = Object.assign({
       id: randomString(63),
       description: randomString(50),
-      mode: "MODE_SYNC",
     },
       constant.detSyncHTTPSingleModelRecipe
     )
@@ -67,7 +66,6 @@ export function CheckGet() {
     var reqBody = Object.assign({
       id: randomString(10),
       description: randomString(50),
-      mode: "MODE_SYNC",
     },
       constant.detSyncHTTPSingleModelRecipe
     )
@@ -106,7 +104,6 @@ export function CheckUpdate() {
 
     var reqBody = Object.assign({
       id: randomString(10),
-      mode: "MODE_SYNC",
     },
       constant.detSyncHTTPSingleModelRecipe
     )
@@ -157,7 +154,6 @@ export function CheckUpdateState() {
 
     var reqBodySync = Object.assign({
       id: randomString(10),
-      mode: "MODE_SYNC",
     },
       constant.detSyncHTTPSingleModelRecipe
     )
@@ -214,7 +210,6 @@ export function CheckRename() {
 
     var reqBody = Object.assign({
       id: randomString(10),
-      mode: "MODE_SYNC",
     },
       constant.detSyncHTTPSingleModelRecipe
     )
@@ -261,7 +256,6 @@ export function CheckLookUp() {
 
     var reqBody = Object.assign({
       id: randomString(10),
-      mode: "MODE_SYNC",
     },
       constant.detSyncHTTPSingleModelRecipe
     )

--- a/integration-test/grpc-pipeline-public.js
+++ b/integration-test/grpc-pipeline-public.js
@@ -66,7 +66,6 @@ export function CheckCreate() {
     var reqBody = Object.assign({
       id: randomString(63),
       description: randomString(50),
-      mode: "MODE_SYNC",
     },
       constant.detSyncHTTPSingleModelRecipe
     )
@@ -83,7 +82,6 @@ export function CheckCreate() {
       "vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline response pipeline description": (r) => r.message.pipeline.description === reqBody.description,
       "vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline response pipeline recipe is valid": (r) => helper.validateRecipeGRPC(r.message.pipeline.recipe, false),
       "vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline response pipeline owner is UUID": (r) => helper.isValidOwner(r.message.pipeline.user),
-      "vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline response pipeline mode": (r) => r.message.pipeline.mode == "MODE_SYNC",
       "vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline response pipeline create_time": (r) => new Date(r.message.pipeline.createTime).getTime() > new Date().setTime(0),
       "vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline response pipeline update_time": (r) => new Date(r.message.pipeline.updateTime).getTime() > new Date().setTime(0)
     });
@@ -184,7 +182,6 @@ export function CheckList() {
       reqBodies[i] = Object.assign({
         id: randomString(10),
         description: randomString(50),
-        mode: "MODE_SYNC",
       },
         constant.detSyncHTTPSingleModelRecipe
       )
@@ -250,18 +247,12 @@ export function CheckList() {
     });
 
     // Filtering
-    check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/ListPipelines', {
-      filter: "mode=MODE_SYNC"
-    }, {}), {
-      [`vdp.pipeline.v1alpha.PipelinePublicService/ListPipelines filter: "mode=MODE_SYNC" response StatusOK`]: (r) => r.status === grpc.StatusOK,
-      [`vdp.pipeline.v1alpha.PipelinePublicService/ListPipelines filter: "mode=MODE_SYNC" response pipelines.length`]: (r) => r.message.pipelines.length > 0,
-    });
 
     check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/ListPipelines', {
-      filter: 'mode=MODE_SYNC AND state=STATE_ACTIVE'
+      filter: 'state=STATE_ACTIVE'
     }, {}), {
-      [`vdp.pipeline.v1alpha.PipelinePublicService/ListPipelines filter: mode=MODE_SYNC AND state=STATE_ACTIVE response StatusOK`]: (r) => r.status === grpc.StatusOK,
-      [`vdp.pipeline.v1alpha.PipelinePublicService/ListPipelines filter: mode=MODE_SYNC AND state=STATE_ACTIVE response pipelines.length`]: (r) => r.message.pipelines.length > 0,
+      [`vdp.pipeline.v1alpha.PipelinePublicService/ListPipelines filter: state=STATE_ACTIVE response StatusOK`]: (r) => r.status === grpc.StatusOK,
+      [`vdp.pipeline.v1alpha.PipelinePublicService/ListPipelines filter: state=STATE_ACTIVE response pipelines.length`]: (r) => r.message.pipelines.length > 0,
     });
 
     check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/ListPipelines', {
@@ -282,10 +273,10 @@ export function CheckList() {
     // var modelPermalink = `models/${modelUid}`
 
     check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/ListPipelines', {
-      filter: `mode=MODE_SYNC AND recipe.components.resource_name:"${srcConnPermalink}"`
+      filter: `recipe.components.resource_name:"${srcConnPermalink}"`
     }, {}), {
-      [`vdp.pipeline.v1alpha.PipelinePublicService/ListPipelines filter: mode=MODE_SYNC AND recipe.components.resource_name:"${srcConnPermalink}" response StatusOK`]: (r) => r.status === grpc.StatusOK,
-      [`vdp.pipeline.v1alpha.PipelinePublicService/ListPipelines filter: mode=MODE_SYNC AND recipe.components.resource_name:"${srcConnPermalink}" response pipelines.length`]: (r) => r.message.pipelines.length > 0,
+      [`vdp.pipeline.v1alpha.PipelinePublicService/ListPipelines filter: recipe.components.resource_name:"${srcConnPermalink}" response StatusOK`]: (r) => r.status === grpc.StatusOK,
+      [`vdp.pipeline.v1alpha.PipelinePublicService/ListPipelines filter: recipe.components.resource_name:"${srcConnPermalink}" response pipelines.length`]: (r) => r.message.pipelines.length > 0,
     });
 
     // check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/ListPipelines', {
@@ -319,7 +310,6 @@ export function CheckGet() {
     var reqBody = Object.assign({
       id: randomString(10),
       description: randomString(50),
-      mode: "MODE_SYNC",
     },
       constant.detSyncHTTPSingleModelRecipe
     )
@@ -378,7 +368,6 @@ export function CheckUpdate() {
 
     var reqBody = Object.assign({
       id: randomString(10),
-      mode: "MODE_SYNC",
     },
       constant.detSyncHTTPSingleModelRecipe
     )
@@ -470,7 +459,6 @@ export function CheckUpdateState() {
 
     var reqBodySync = Object.assign({
       id: randomString(10),
-      mode: "MODE_SYNC",
     },
       constant.detSyncHTTPSingleModelRecipe
     )
@@ -506,7 +494,6 @@ export function CheckUpdateState() {
 
     var reqBodyAsync = Object.assign({
       id: randomString(10),
-      mode: "MODE_ASYNC",
     },
       constant.detAsyncSingleModelRecipe
     )
@@ -584,7 +571,6 @@ export function CheckRename() {
 
     var reqBody = Object.assign({
       id: randomString(10),
-      mode: "MODE_SYNC",
     },
       constant.detSyncHTTPSingleModelRecipe
     )
@@ -632,7 +618,6 @@ export function CheckLookUp() {
 
     var reqBody = Object.assign({
       id: randomString(10),
-      mode: "MODE_SYNC",
     },
       constant.detSyncHTTPSingleModelRecipe
     )
@@ -675,7 +660,6 @@ export function CheckWatch() {
 
     var reqBody = Object.assign({
       id: randomString(10),
-      mode: "MODE_SYNC",
     },
       constant.detSyncHTTPSingleModelRecipe
     )

--- a/integration-test/grpc-trigger-async.js
+++ b/integration-test/grpc-trigger-async.js
@@ -30,7 +30,6 @@ export function CheckTriggerAsyncSingleImageSingleModel() {
     var reqBody = Object.assign({
       id: randomString(10),
       description: randomString(50),
-      mode: "MODE_ASYNC",
     },
       constant.detAsyncSingleModelRecipe
     );
@@ -95,7 +94,6 @@ export function CheckTriggerAsyncMultiImageSingleModel() {
     var reqBody = Object.assign({
       id: randomString(10),
       description: randomString(50),
-      mode: "MODE_ASYNC",
     },
       constant.detAsyncSingleModelRecipe
     );
@@ -177,7 +175,6 @@ export function CheckTriggerAsyncMultiImageMultiModel() {
     var reqBody = Object.assign({
       id: randomString(10),
       description: randomString(50),
-      mode: "MODE_ASYNC",
     },
       constant.detAsyncMultiModelRecipe
     );
@@ -268,7 +265,6 @@ export function CheckTriggerAsyncMultiImageMultiModelMultipleDestination() {
     var reqBody = Object.assign({
       id: randomString(10),
       description: randomString(50),
-      mode: "MODE_ASYNC",
     },
       constant.detAsyncMultiModelMultipleDestinationRecipe
     );

--- a/integration-test/grpc-trigger-sync.js
+++ b/integration-test/grpc-trigger-sync.js
@@ -25,7 +25,6 @@ export function CheckTriggerSyncSingleImageSingleModel() {
     var reqGRPC = Object.assign({
       id: randomString(10),
       description: randomString(50),
-      mode: "MODE_SYNC",
     },
       constant.detSyncGRPCSingleModelRecipe
     );
@@ -93,7 +92,6 @@ export function CheckTriggerSyncSingleImageSingleModel() {
     var reqHTTP = Object.assign({
       id: randomString(10),
       description: randomString(50),
-      mode: "MODE_SYNC",
     },
       constant.detSyncHTTPSingleModelRecipe
     );
@@ -133,7 +131,6 @@ export function CheckTriggerSyncMultiImageSingleModel() {
     var reqGRPC = Object.assign({
       id: randomString(10),
       description: randomString(50),
-      mode: "MODE_SYNC",
     },
       constant.detSyncGRPCSingleModelRecipe
     );
@@ -235,7 +232,6 @@ export function CheckTriggerSyncMultiImageMultiModel() {
     var reqGRPC = Object.assign({
       id: randomString(10),
       description: randomString(50),
-      mode: "MODE_SYNC",
     },
       constant.detSynGRPCMultiModelRecipe
     );

--- a/integration-test/rest-pipeline-private.js
+++ b/integration-test/rest-pipeline-private.js
@@ -24,7 +24,6 @@ export function CheckList() {
         {
           id: randomString(10),
           description: randomString(50),
-          mode: "MODE_SYNC"
         },
         constant.detSyncHTTPSingleModelRecipe
       )
@@ -71,14 +70,14 @@ export function CheckList() {
     });
 
     // Filtering
-    check(http.request("GET", `${pipelinePrivateHost}/v1alpha/admin/pipelines?filter=mode=MODE_SYNC`, null, constant.params), {
-      [`GET /v1alpha/admin/pipelines?filter=mode=MODE_SYNC response 200`]: (r) => r.status == 200,
-      [`GET /v1alpha/admin/pipelines?filter=mode=MODE_SYNC response pipelines.length > 0`]: (r) => r.json().pipelines.length > 0,
+    check(http.request("GET", `${pipelinePrivateHost}/v1alpha/admin/pipelines`, null, constant.params), {
+      [`GET /v1alpha/admin/pipelines response 200`]: (r) => r.status == 200,
+      [`GET /v1alpha/admin/pipelines response pipelines.length > 0`]: (r) => r.json().pipelines.length > 0,
     });
 
-    check(http.request("GET", `${pipelinePrivateHost}/v1alpha/admin/pipelines?filter=mode=MODE_SYNC%20AND%20state=STATE_ACTIVE`, null, constant.params), {
-      [`GET /v1alpha/admin/pipelines?filter=mode=MODE_SYNC%20AND%20state=STATE_ACTIVE response 200`]: (r) => r.status == 200,
-      [`GET /v1alpha/admin/pipelines?filter=mode=MODE_SYNC%20AND%20state=STATE_ACTIVE response pipelines.length > 0`]: (r) => r.json().pipelines.length > 0,
+    check(http.request("GET", `${pipelinePrivateHost}/v1alpha/admin/pipelines?filter=state=STATE_ACTIVE`, null, constant.params), {
+      [`GET /v1alpha/admin/pipelines?filter=state=STATE_ACTIVE response 200`]: (r) => r.status == 200,
+      [`GET /v1alpha/admin/pipelines?filter=state=STATE_ACTIVE response pipelines.length > 0`]: (r) => r.json().pipelines.length > 0,
     });
 
     check(http.request("GET", `${pipelinePrivateHost}/v1alpha/admin/pipelines?filter=state=STATE_ACTIVE%20AND%20create_time>timestamp%28%222000-06-19T23:31:08.657Z%22%29`, null, constant.params), {
@@ -96,9 +95,9 @@ export function CheckList() {
     // var modelUid = http.get(`${modelPublicHost}/v1alpha/models/${constant.model_id}`, {}, constant.params).json().model.uid
     // var modelPermalink = `models/${modelUid}`
 
-    check(http.request("GET", `${pipelinePrivateHost}/v1alpha/admin/pipelines?filter=mode=MODE_SYNC%20AND%20recipe.components.resource_name:%22${srcConnPermalink}%22`, null, constant.params), {
-      [`GET /v1alpha/admin/pipelines?filter=mode=MODE_SYNC%20AND%20recipe.components.resource_name:%22${srcConnPermalink}%22 response 200`]: (r) => r.status == 200,
-      [`GET /v1alpha/admin/pipelines?filter=mode=MODE_SYNC%20AND%20recipe.components.resource_name:%22${srcConnPermalink}%22 response pipelines.length > 0`]: (r) => r.json().pipelines.length > 0,
+    check(http.request("GET", `${pipelinePrivateHost}/v1alpha/admin/pipelines?filter=recipe.components.resource_name:%22${srcConnPermalink}%22`, null, constant.params), {
+      [`GET /v1alpha/admin/pipelines?filter=recipe.components.resource_name:%22${srcConnPermalink}%22 response 200`]: (r) => r.status == 200,
+      [`GET /v1alpha/admin/pipelines?filter=recipe.components.resource_name:%22${srcConnPermalink}%22 response pipelines.length > 0`]: (r) => r.json().pipelines.length > 0,
     });
 
     // check(http.request("GET", `${pipelinePrivateHost}/v1alpha/admin/pipelines?filter=mode=MODE_SYNC%20AND%20recipe.components.resource_name:%22${dstConnPermalink}%22%20AND%20recipe.components.resource_name:%22${modelPermalink}%22`, null, constant.params), {
@@ -125,7 +124,6 @@ export function CheckLookUp() {
     var reqBody = Object.assign(
       {
         id: randomString(10),
-        mode: "MODE_SYNC",
       },
       constant.detSyncHTTPSingleModelRecipe
     )

--- a/integration-test/rest-pipeline-public-with-jwt.js
+++ b/integration-test/rest-pipeline-public-with-jwt.js
@@ -14,7 +14,6 @@ export function CheckCreate() {
       {
         id: randomString(63),
         description: randomString(50),
-        mode: "MODE_SYNC",
       },
       constant.detSyncHTTPSingleModelRecipe
     )
@@ -46,7 +45,6 @@ export function CheckGet() {
       {
         id: randomString(10),
         description: randomString(50),
-        mode: "MODE_SYNC",
       },
       constant.detSyncHTTPSingleModelRecipe
     )
@@ -76,7 +74,6 @@ export function CheckUpdate() {
     var reqBody = Object.assign(
       {
         id: randomString(10),
-        mode: "MODE_SYNC",
       },
       constant.detSyncHTTPSingleModelRecipe
     )
@@ -117,7 +114,6 @@ export function CheckUpdateState() {
     var reqBodySync = Object.assign(
       {
         id: randomString(10),
-        mode: "MODE_SYNC",
       },
       constant.detSyncHTTPSingleModelRecipe
     )
@@ -159,7 +155,6 @@ export function CheckRename() {
     var reqBody = Object.assign(
       {
         id: id,
-        mode: "MODE_SYNC",
       },
       constant.detSyncHTTPSingleModelRecipe
     )
@@ -195,7 +190,6 @@ export function CheckLookUp() {
     var reqBody = Object.assign(
       {
         id: randomString(10),
-        mode: "MODE_SYNC",
       },
       constant.detSyncHTTPSingleModelRecipe
     )

--- a/integration-test/rest-pipeline-public.js
+++ b/integration-test/rest-pipeline-public.js
@@ -53,7 +53,6 @@ export function CheckCreate() {
       {
         id: randomString(63),
         description: randomString(50),
-        mode: "MODE_SYNC",
       },
       constant.detSyncHTTPSingleModelRecipe
     )
@@ -68,12 +67,9 @@ export function CheckCreate() {
       "POST /v1alpha/pipelines response pipeline description": (r) => r.json().pipeline.description === reqBody.description,
       "POST /v1alpha/pipelines response pipeline recipe is valid": (r) => helper.validateRecipe(r.json().pipeline.recipe, false),
       "POST /v1alpha/pipelines response pipeline user is UUID": (r) => helper.isValidOwner(r.json().pipeline.user),
-      "POST /v1alpha/pipelines response pipeline mode": (r) => r.json().pipeline.mode === "MODE_SYNC",
       "POST /v1alpha/pipelines response pipeline create_time": (r) => new Date(r.json().pipeline.create_time).getTime() > new Date().setTime(0),
       "POST /v1alpha/pipelines response pipeline update_time": (r) => new Date(r.json().pipeline.update_time).getTime() > new Date().setTime(0)
     });
-
-    http.request("POST", `${pipelinePublicHost}/v1alpha/pipelines/${reqBody.id}/activate`, {}, constant.params)
 
     check(http.request("GET", `${pipelinePublicHost}/v1alpha/pipelines/${reqBody.id}/watch`, null, constant.params), {
       "GET /v1alpha/pipelines/watch sync pipeline response status is 200": (r) => r.status === 200,
@@ -149,7 +145,6 @@ export function CheckList() {
         {
           id: randomString(10),
           description: randomString(50),
-          mode: "MODE_SYNC",
         },
         constant.detSyncHTTPSingleModelRecipe
       )
@@ -196,14 +191,14 @@ export function CheckList() {
     });
 
     // Filtering
-    check(http.request("GET", `${pipelinePublicHost}/v1alpha/pipelines?filter=mode=MODE_SYNC`, null, constant.params), {
-      [`GET /v1alpha/pipelines?filter=mode=MODE_SYNC response 200`]: (r) => r.status == 200,
-      [`GET /v1alpha/pipelines?filter=mode=MODE_SYNC response pipelines.length > 0`]: (r) => r.json().pipelines.length > 0,
+    check(http.request("GET", `${pipelinePublicHost}/v1alpha/pipelines`, null, constant.params), {
+      [`GET /v1alpha/pipelines response 200`]: (r) => r.status == 200,
+      [`GET /v1alpha/pipelines response pipelines.length > 0`]: (r) => r.json().pipelines.length > 0,
     });
 
-    check(http.request("GET", `${pipelinePublicHost}/v1alpha/pipelines?filter=mode=MODE_SYNC%20AND%20state=STATE_ACTIVE`, null, constant.params), {
-      [`GET /v1alpha/pipelines?filter=mode=MODE_SYNC%20AND%20state=STATE_ACTIVE response 200`]: (r) => r.status == 200,
-      [`GET /v1alpha/pipelines?filter=mode=MODE_SYNC%20AND%20state=STATE_ACTIVE response pipelines.length > 0`]: (r) => r.json().pipelines.length > 0,
+    check(http.request("GET", `${pipelinePublicHost}/v1alpha/pipelines?filter=state=STATE_ACTIVE`, null, constant.params), {
+      [`GET /v1alpha/pipelines?filter=state=STATE_ACTIVE response 200`]: (r) => r.status == 200,
+      [`GET /v1alpha/pipelines?filter=state=STATE_ACTIVE response pipelines.length > 0`]: (r) => r.json().pipelines.length > 0,
     });
 
     check(http.request("GET", `${pipelinePublicHost}/v1alpha/pipelines?filter=state=STATE_ACTIVE%20AND%20create_time>timestamp%28%222000-06-19T23:31:08.657Z%22%29`, null,constant.params), {
@@ -221,9 +216,9 @@ export function CheckList() {
     // var modelUid = http.get(`${modelPublicHost}/v1alpha/models/${constant.model_id}`, {}, constant.params).json().model.uid
     // var modelPermalink = `models/${modelUid}`
 
-    check(http.request("GET", `${pipelinePublicHost}/v1alpha/pipelines?filter=mode=MODE_SYNC%20AND%20recipe.components.resource_name:%22${srcConnPermalink}%22`, null, constant.params), {
-      [`GET /v1alpha/pipelines?filter=mode=MODE_SYNC%20AND%20recipe.components.resource_name:%22${srcConnPermalink}%22 response 200`]: (r) => r.status == 200,
-      [`GET /v1alpha/pipelines?filter=mode=MODE_SYNC%20AND%20recipe.components.resource_name:%22${srcConnPermalink}%22 response pipelines.length > 0`]: (r) => r.json().pipelines.length > 0,
+    check(http.request("GET", `${pipelinePublicHost}/v1alpha/pipelines?filter=recipe.components.resource_name:%22${srcConnPermalink}%22`, null, constant.params), {
+      [`GET /v1alpha/pipelines?filter=recipe.components.resource_name:%22${srcConnPermalink}%22 response 200`]: (r) => r.status == 200,
+      [`GET /v1alpha/pipelines?filter=recipe.components.resource_name:%22${srcConnPermalink}%22 response pipelines.length > 0`]: (r) => r.json().pipelines.length > 0,
     });
 
     // check(http.request("GET", `${pipelinePublicHost}/v1alpha/pipelines?filter=mode=MODE_SYNC%20AND%20recipe.components.resource_name:%22${dstConnPermalink}%22%20AND%20recipe.components.resource_name:%22${modelPermalink}%22`, null, constant.params), {
@@ -251,7 +246,6 @@ export function CheckGet() {
       {
         id: randomString(10),
         description: randomString(50),
-        mode: "MODE_SYNC",
       },
       constant.detSyncHTTPSingleModelRecipe
     )
@@ -296,7 +290,6 @@ export function CheckUpdate() {
     var reqBody = Object.assign(
       {
         id: randomString(10),
-        mode: "MODE_SYNC",
       },
       constant.detSyncHTTPSingleModelRecipe
     )
@@ -322,6 +315,7 @@ export function CheckUpdate() {
       [`PATCH /v1alpha/pipelines/${reqBody.id} response pipeline name (OUTPUT_ONLY)`]: (r) => r.json().pipeline.name === `pipelines/${resOrigin.json().pipeline.id}`,
       [`PATCH /v1alpha/pipelines/${reqBody.id} response pipeline uid (OUTPUT_ONLY)`]: (r) => r.json().pipeline.uid === resOrigin.json().pipeline.uid,
       [`PATCH /v1alpha/pipelines/${reqBody.id} response pipeline id (IMMUTABLE)`]: (r) => r.json().pipeline.id === resOrigin.json().pipeline.id,
+      [`PATCH /v1alpha/pipelines/${reqBody.id} response pipeline mode (OUTPUT_ONLY)`]: (r) => r.json().pipeline.mode === resOrigin.json().pipeline.mode,
       [`PATCH /v1alpha/pipelines/${reqBody.id} response pipeline state (OUTPUT_ONLY)`]: (r) => r.json().pipeline.state === resOrigin.json().pipeline.state,
       [`PATCH /v1alpha/pipelines/${reqBody.id} response pipeline description (OPTIONAL)`]: (r) => r.json().pipeline.description === reqBodyUpdate.description,
       [`PATCH /v1alpha/pipelines/${reqBody.id} response pipeline recipe (IMMUTABLE)`]: (r) => helper.checkRecipeIsImmutable(r.json().pipeline.recipe, reqBody.recipe),
@@ -373,7 +367,6 @@ export function CheckUpdateState() {
     var reqBodySync = Object.assign(
       {
         id: randomString(10),
-        mode: "MODE_SYNC",
       },
       constant.detSyncHTTPSingleModelRecipe
     )
@@ -400,7 +393,6 @@ export function CheckUpdateState() {
     var reqBodyAsync = Object.assign(
       {
         id: randomString(10),
-        mode: "MODE_ASYNC",
       },
       constant.detAsyncSingleModelRecipe
     )
@@ -451,7 +443,6 @@ export function CheckRename() {
     var reqBody = Object.assign(
       {
         id: randomString(10),
-        mode: "MODE_SYNC",
       },
       constant.detSyncHTTPSingleModelRecipe
     )
@@ -488,7 +479,6 @@ export function CheckLookUp() {
     var reqBody = Object.assign(
       {
         id: randomString(10),
-        mode: "MODE_SYNC",
       },
       constant.detSyncHTTPSingleModelRecipe
     )
@@ -521,7 +511,6 @@ export function CheckWatch() {
     var reqBody = Object.assign(
       {
         id: randomString(10),
-        mode: "MODE_SYNC",
       },
       constant.detSyncHTTPSingleModelRecipe
     )

--- a/integration-test/rest-trigger-async.js
+++ b/integration-test/rest-trigger-async.js
@@ -15,7 +15,6 @@ export function CheckTriggerAsyncSingleImageSingleModel() {
     {
       id: randomString(10),
       description: randomString(50),
-      mode: "MODE_ASYNC",
     },
     constant.detAsyncSingleModelRecipe
   );
@@ -76,7 +75,6 @@ export function CheckTriggerAsyncMultiImageSingleModel() {
     {
       id: randomString(10),
       description: randomString(50),
-      mode: "MODE_ASYNC",
     },
     constant.detAsyncSingleModelRecipe
   );
@@ -158,7 +156,6 @@ export function CheckTriggerAsyncMultiImageMultiModel() {
     {
       id: randomString(10),
       description: randomString(50),
-      mode: "MODE_ASYNC",
     },
     constant.detAsyncMultiModelRecipe
   );
@@ -247,7 +244,6 @@ export function CheckTriggerAsyncMultiImageMultiModelMultipleDestination() {
     {
       id: randomString(10),
       description: randomString(50),
-      mode: "MODE_ASYNC",
     },
     constant.detAsyncMultiModelMultipleDestinationRecipe
   );

--- a/integration-test/rest-trigger-sync.js
+++ b/integration-test/rest-trigger-sync.js
@@ -17,7 +17,6 @@ export function CheckTriggerSyncSingleImageSingleModel() {
       {
         id: randomString(10),
         description: randomString(50),
-        mode: "MODE_SYNC",
       },
       constant.detSyncHTTPSingleModelRecipe
     );
@@ -105,7 +104,6 @@ export function CheckTriggerSyncSingleImageSingleModel() {
       {
         id: randomString(10),
         description: randomString(50),
-        mode: "MODE_SYNC",
       },
       constant.detSyncGRPCSingleModelRecipe
     );
@@ -134,7 +132,6 @@ export function CheckTriggerSyncMultiImageSingleModel() {
       {
         id: randomString(10),
         description: randomString(50),
-        mode: "MODE_SYNC",
       },
       constant.detSyncHTTPSingleModelRecipe
     );
@@ -248,7 +245,6 @@ export function CheckTriggerSyncMultiImageMultiModel() {
       {
         id: randomString(10),
         description: randomString(50),
-        mode: "MODE_SYNC",
       },
       constant.detSyncHTTPMultiModelRecipe
     );

--- a/pkg/handler/fieldannotation.go
+++ b/pkg/handler/fieldannotation.go
@@ -12,4 +12,4 @@ var triggerRequiredFields = []string{"name", "inputs"}
 var immutableFields = []string{"id", "recipe"}
 
 // outputOnlyFields are Protobuf message fields with OUTPUT_ONLY field_behavior annotation
-var outputOnlyFields = []string{"name", "uid", "state", "owner", "create_time", "update_time"}
+var outputOnlyFields = []string{"name", "uid", "mode", "state", "owner", "create_time", "update_time"}


### PR DESCRIPTION
Because

- the pipeline can not know the mode because we allow unfinished pipeline

This commit

- let pipeline mode be unspecified when created
