### PR TITLE
chore: add temporary check if influxdb is present

### DIFF
--- a/pkg/external/external.go
+++ b/pkg/external/external.go
@@ -170,7 +170,7 @@ func InitInfluxDBServiceClient(ctx context.Context) (influxdb2.Client, api.Write
 		influxOptions,
 	)
 
-	if _, err := client.Ping(ctx); err != nil {
+	if _, err := client.Ping(ctx); err != nil && config.Config.Log.External {
 		logger.Fatal(err.Error())
 	}
 

--- a/pkg/service/influx.go
+++ b/pkg/service/influx.go
@@ -2,8 +2,14 @@ package service
 
 import (
 	"github.com/influxdata/influxdb-client-go/v2/api/write"
+
+	"github.com/instill-ai/pipeline-backend/config"
 )
 
 func (s *service) WriteNewDataPoint(p *write.Point) {
-	s.influxDBWriteClient.WritePoint(p)
+	// TODO: influxDB will be updated to requied instead of optional
+	// will not need to consider the case if influxdb is not present
+	if config.Config.Log.External {
+		s.influxDBWriteClient.WritePoint(p)
+	}
 }


### PR DESCRIPTION
Because

- cause fatal error if influxdb is not present

This commit

- add temporary check for influxdb, influxdb will be always present soon as `base` adopt new envs
