### PR TITLE
chore: use redis as data blob for both temporal input/output

### DIFF
--- a/integration-test/grpc-pipeline-public.js
+++ b/integration-test/grpc-pipeline-public.js
@@ -483,7 +483,7 @@ export function CheckUpdateState() {
     check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/DeactivatePipeline', {
       name: `pipelines/${reqBodySync.id}`
     }), {
-      [`vdp.pipeline.v1alpha.PipelinePublicService/DeactivatePipeline ${reqBodySync.id} response status is StatusInvalidArgument for sync pipeline`]: (r) => r.status === grpc.StatusInvalidArgument,
+      [`vdp.pipeline.v1alpha.PipelinePublicService/DeactivatePipeline ${reqBodySync.id} response status is StatusOK for sync pipeline`]: (r) => r.status === grpc.StatusOK,
     });
 
     check(client.invoke('vdp.pipeline.v1alpha.PipelinePublicService/ActivatePipeline', {

--- a/integration-test/rest-pipeline-public.js
+++ b/integration-test/rest-pipeline-public.js
@@ -383,7 +383,7 @@ export function CheckUpdateState() {
     });
 
     check(http.request("POST", `${pipelinePublicHost}/v1alpha/pipelines/${reqBodySync.id}/deactivate`, null, constant.params), {
-      [`POST /v1alpha/pipelines/${reqBodySync.id}/deactivate response status is 400 for sync pipeline`]: (r) => r.status === 400,
+      [`POST /v1alpha/pipelines/${reqBodySync.id}/deactivate response status is 200 for sync pipeline`]: (r) => r.status === 200,
     });
 
     check(http.request("POST", `${pipelinePublicHost}/v1alpha/pipelines/${reqBodySync.id}/activate`, null, constant.params), {

--- a/pkg/handler/fieldannotation.go
+++ b/pkg/handler/fieldannotation.go
@@ -9,7 +9,7 @@ var renameRequiredFields = []string{"name", "new_pipeline_id"}
 var triggerRequiredFields = []string{"name", "inputs"}
 
 // immutableFields are Protobuf message fields with IMMUTABLE field_behavior annotation
-var immutableFields = []string{"id", "recipe"}
+var immutableFields = []string{"id"}
 
 // outputOnlyFields are Protobuf message fields with OUTPUT_ONLY field_behavior annotation
 var outputOnlyFields = []string{"name", "uid", "mode", "state", "owner", "create_time", "update_time"}

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -32,6 +32,7 @@ type Repository interface {
 	DeletePipeline(id string, owner string) error
 	UpdatePipelineID(id string, owner string, newID string) error
 	UpdatePipelineState(id string, owner string, state datamodel.PipelineState) error
+	UpdatePipelineMode(id string, owner string, mode datamodel.PipelineMode) error
 
 	ListPipelinesAdmin(pageSize int64, pageToken string, isBasicView bool, filter filtering.Filter) ([]datamodel.Pipeline, int64, string, error)
 	GetPipelineByIDAdmin(id string, isBasicView bool) (*datamodel.Pipeline, error)
@@ -289,6 +290,17 @@ func (r *repository) UpdatePipelineState(id string, owner string, state datamode
 		return status.Error(codes.Internal, result.Error.Error())
 	} else if result.RowsAffected == 0 {
 		return status.Errorf(codes.NotFound, "[UpdatePipelineState] The pipeline id %s you specified is not found", id)
+	}
+	return nil
+}
+
+func (r *repository) UpdatePipelineMode(id string, owner string, mode datamodel.PipelineMode) error {
+	if result := r.db.Model(&datamodel.Pipeline{}).
+		Where("id = ? AND owner = ?", id, owner).
+		Update("mode", mode); result.Error != nil {
+		return status.Error(codes.Internal, result.Error.Error())
+	} else if result.RowsAffected == 0 {
+		return status.Errorf(codes.NotFound, "[UpdatePipelineMode] The pipeline id %s you specified is not found", id)
 	}
 	return nil
 }


### PR DESCRIPTION
Because

- we may have large size data in temporal output, we must put them in another storage

This commit

- use redis as data blob for both temporal input/output
- refactor check recipe and pipeline activation logic
