### PR TITLE
chore(metric): update pipeline metric

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0
 	github.com/iancoleman/strcase v0.2.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230714175129-4d1c7febd58e
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230717175816-09fb1ab0a259
 	github.com/instill-ai/usage-client v0.2.4-alpha
 	github.com/instill-ai/x v0.3.0-alpha
 	github.com/knadh/koanf v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -1072,8 +1072,8 @@ github.com/influxdata/influxdb-client-go/v2 v2.12.3 h1:28nRlNMRIV4QbtIUvxhWqaxn0
 github.com/influxdata/influxdb-client-go/v2 v2.12.3/go.mod h1:IrrLUbCjjfkmRuaCiGQg4m2GbkaeJDcuWoxiWdQEbA0=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230714175129-4d1c7febd58e h1:pWOHPmTcvEYnTqEIP2gKhv+6bkZp3bTQsPYbzOSWMy8=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230714175129-4d1c7febd58e/go.mod h1:qsq5ecnA1xi2rLnVQFo/9xksA7I7wQu8c7rqM5xbIrQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230717175816-09fb1ab0a259 h1:QGK1dDhR2drZ24HuwYbQVcL71hdKF63+mjR77WhBCWQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230717175816-09fb1ab0a259/go.mod h1:qsq5ecnA1xi2rLnVQFo/9xksA7I7wQu8c7rqM5xbIrQ=
 github.com/instill-ai/usage-client v0.2.4-alpha h1:mYXd62eZsmGKBlzwMcdEgTBgn8zlbagYUHro6+p50c8=
 github.com/instill-ai/usage-client v0.2.4-alpha/go.mod h1:BMxgyr02sqH6SeITXSV4M1ewwvfklzXIc5yzIqaN0c8=
 github.com/instill-ai/x v0.3.0-alpha h1:z9fedROOG2dVHhswBfVwU/hzHuq8/JKSUON7inF+FH8=

--- a/pkg/handler/publicHandler.go
+++ b/pkg/handler/publicHandler.go
@@ -693,7 +693,7 @@ func (h *PublicHandler) TriggerPipeline(ctx context.Context, req *pipelinePB.Tri
 		startTime,
 	)
 
-	resp, err := h.service.TriggerPipeline(ctx, req, owner, dbPipeline)
+	resp, err := h.service.TriggerPipeline(ctx, req, owner, dbPipeline, logUUID.String())
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		dataPoint = dataPoint.AddField("compute_time_duration", time.Since(startTime).Seconds())

--- a/pkg/handler/publicHandler.go
+++ b/pkg/handler/publicHandler.go
@@ -697,7 +697,7 @@ func (h *PublicHandler) TriggerPipeline(ctx context.Context, req *pipelinePB.Tri
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		dataPoint = dataPoint.AddField("compute_time_duration", time.Since(startTime).Seconds())
-		h.service.WriteNewDataPoint(dataPoint.AddTag("status", "errored"))
+		h.service.WriteNewDataPoint(dataPoint.AddTag("status", mgmtPB.Status_STATUS_ERRORED.String()))
 		return &pipelinePB.TriggerPipelineResponse{}, err
 	}
 
@@ -710,7 +710,7 @@ func (h *PublicHandler) TriggerPipeline(ctx context.Context, req *pipelinePB.Tri
 	)))
 
 	dataPoint = dataPoint.AddField("compute_time_duration", time.Since(startTime).Seconds())
-	h.service.WriteNewDataPoint(dataPoint.AddTag("status", "completed"))
+	h.service.WriteNewDataPoint(dataPoint.AddTag("status", mgmtPB.Status_STATUS_COMPLETED.String()))
 
 	return resp, nil
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -73,7 +73,7 @@ func NewDataPoint(
 	return influxdb2.NewPoint(
 		"pipeline.trigger",
 		map[string]string{
-			"pipeline_mode": mode.String(),
+			"trigger_mode": mode.String(),
 		},
 		map[string]interface{}{
 			"owner_uid":           ownerUUID,

--- a/pkg/worker/workflow.go
+++ b/pkg/worker/workflow.go
@@ -126,7 +126,7 @@ func (w *worker) TriggerAsyncPipelineWorkflow(ctx workflow.Context, param *Trigg
 		if err != nil {
 			span.SetStatus(1, err.Error())
 			dataPoint = dataPoint.AddField("compute_time_duration", time.Since(startTime).Seconds())
-			w.influxDBWriteClient.WritePoint(dataPoint.AddTag("status", "errored"))
+			w.influxDBWriteClient.WritePoint(dataPoint.AddTag("status", mgmtPB.Status_STATUS_ERRORED.String()))
 			return err
 		}
 		for idx := range parents {
@@ -137,7 +137,7 @@ func (w *worker) TriggerAsyncPipelineWorkflow(ctx workflow.Context, param *Trigg
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		dataPoint = dataPoint.AddField("compute_time_duration", time.Since(startTime).Seconds())
-		w.influxDBWriteClient.WritePoint(dataPoint.AddTag("status", "errored"))
+		w.influxDBWriteClient.WritePoint(dataPoint.AddTag("status", mgmtPB.Status_STATUS_ERRORED.String()))
 		return err
 	}
 
@@ -146,7 +146,7 @@ func (w *worker) TriggerAsyncPipelineWorkflow(ctx workflow.Context, param *Trigg
 	if err := workflow.ExecuteActivity(ctx, w.DownloadActivity, param).Get(ctx, &result); err != nil {
 		span.SetStatus(1, err.Error())
 		dataPoint = dataPoint.AddField("compute_time_duration", time.Since(startTime).Seconds())
-		w.influxDBWriteClient.WritePoint(dataPoint.AddTag("status", "errored"))
+		w.influxDBWriteClient.WritePoint(dataPoint.AddTag("status", mgmtPB.Status_STATUS_ERRORED.String()))
 		return err
 	}
 
@@ -158,7 +158,7 @@ func (w *worker) TriggerAsyncPipelineWorkflow(ctx workflow.Context, param *Trigg
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		dataPoint = dataPoint.AddField("compute_time_duration", time.Since(startTime).Seconds())
-		w.influxDBWriteClient.WritePoint(dataPoint.AddTag("status", "errored"))
+		w.influxDBWriteClient.WritePoint(dataPoint.AddTag("status", mgmtPB.Status_STATUS_ERRORED.String()))
 		return err
 	}
 	cache[orderedComp[0].Id] = outputs
@@ -171,7 +171,7 @@ func (w *worker) TriggerAsyncPipelineWorkflow(ctx workflow.Context, param *Trigg
 		if err != nil {
 			span.SetStatus(1, err.Error())
 			dataPoint = dataPoint.AddField("compute_time_duration", time.Since(startTime).Seconds())
-			w.influxDBWriteClient.WritePoint(dataPoint.AddTag("status", "errored"))
+			w.influxDBWriteClient.WritePoint(dataPoint.AddTag("status", mgmtPB.Status_STATUS_ERRORED.String()))
 			return err
 		}
 		inputs := MergeData(cache, depMap, len(param.PipelineInputBlobRedisKeys), param.Pipeline, workflow.GetInfo(ctx).WorkflowExecution.ID)
@@ -188,14 +188,14 @@ func (w *worker) TriggerAsyncPipelineWorkflow(ctx workflow.Context, param *Trigg
 		}).Get(ctx, &result); err != nil {
 			span.SetStatus(1, err.Error())
 			dataPoint = dataPoint.AddField("compute_time_duration", time.Since(startTime).Seconds())
-			w.influxDBWriteClient.WritePoint(dataPoint.AddTag("status", "errored"))
+			w.influxDBWriteClient.WritePoint(dataPoint.AddTag("status", mgmtPB.Status_STATUS_ERRORED.String()))
 			return err
 		}
 
 		if err != nil {
 			span.SetStatus(1, err.Error())
 			dataPoint = dataPoint.AddField("compute_time_duration", time.Since(startTime).Seconds())
-			w.influxDBWriteClient.WritePoint(dataPoint.AddTag("status", "errored"))
+			w.influxDBWriteClient.WritePoint(dataPoint.AddTag("status", mgmtPB.Status_STATUS_ERRORED.String()))
 			return err
 		}
 		outputs, err := w.GetBlob(result.OutputBlobRedisKeys)
@@ -205,7 +205,7 @@ func (w *worker) TriggerAsyncPipelineWorkflow(ctx workflow.Context, param *Trigg
 		if err != nil {
 			span.SetStatus(1, err.Error())
 			dataPoint = dataPoint.AddField("compute_time_duration", time.Since(startTime).Seconds())
-			w.influxDBWriteClient.WritePoint(dataPoint.AddTag("status", "errored"))
+			w.influxDBWriteClient.WritePoint(dataPoint.AddTag("status", mgmtPB.Status_STATUS_ERRORED.String()))
 			return err
 		}
 		cache[comp.Id] = outputs
@@ -249,7 +249,7 @@ func (w *worker) TriggerAsyncPipelineWorkflow(ctx workflow.Context, param *Trigg
 		if err != nil {
 			span.SetStatus(1, err.Error())
 			dataPoint = dataPoint.AddField("compute_time_duration", time.Since(startTime).Seconds())
-			w.influxDBWriteClient.WritePoint(dataPoint.AddTag("status", "errored"))
+			w.influxDBWriteClient.WritePoint(dataPoint.AddTag("status", mgmtPB.Status_STATUS_ERRORED.String()))
 			return err
 		}
 
@@ -263,7 +263,7 @@ func (w *worker) TriggerAsyncPipelineWorkflow(ctx workflow.Context, param *Trigg
 	}
 
 	dataPoint = dataPoint.AddField("compute_time_duration", time.Since(startTime).Seconds())
-	w.influxDBWriteClient.WritePoint(dataPoint.AddTag("status", "completed"))
+	w.influxDBWriteClient.WritePoint(dataPoint.AddTag("status", mgmtPB.Status_STATUS_COMPLETED.String()))
 	logger.Info("TriggerAsyncPipelineWorkflow completed")
 	return nil
 }


### PR DESCRIPTION
Because

- drop pipeline mode
- add connector `execute` metric in `connector-backend`

This commit

- rename pipeline mode to trigger mode
- add `pipelineTriggerId` in payload metadata
