### PR TITLE
chore: add simple testcases for triggerAsync and getOperation

### DIFF
--- a/integration-test/const.js
+++ b/integration-test/const.js
@@ -215,6 +215,27 @@ export const detAsyncSingleModelRecipe = {
   },
 };
 
+export const detAsyncSingleResponseRecipe = {
+  recipe: {
+    version: "v1alpha",
+    components: [
+      {
+        id: "s01",
+        resource_name: "connectors/trigger",
+        dependencies: {},
+      },
+      {
+        id: "d01",
+        resource_name: `connectors/response`,
+        dependencies: {
+          images: "[*s01.images]",
+          structured_data: "{**s01.structured_data}",
+        },
+      },
+    ],
+  },
+};
+
 export const detAsyncMultiModelRecipe = {
   recipe: {
     version: "v1alpha",

--- a/integration-test/grpc-trigger-async.js
+++ b/integration-test/grpc-trigger-async.js
@@ -1,7 +1,7 @@
 import grpc from "k6/net/grpc";
 
 
-import { check, group } from "k6";
+import { check, group, sleep } from "k6";
 import { randomString } from "https://jslib.k6.io/k6-utils/1.1.0/index.js";
 
 import * as constant from "./const.js";
@@ -56,17 +56,18 @@ export function CheckTriggerAsyncSingleImageSingleModel() {
         ],
       };
 
-      check(
-        client.invoke(
-          "vdp.pipeline.v1alpha.PipelinePublicService/TriggerAsyncPipeline",
-          {
-            name: `pipelines/${reqBody.id}`,
-            inputs: payloadImageURL["inputs"],
-          }
-        ),
+      check(client.invoke(
+        "vdp.pipeline.v1alpha.PipelinePublicService/TriggerAsyncPipeline",
+        {
+          name: `pipelines/${reqBody.id}`,
+          inputs: payloadImageURL["inputs"],
+        }
+      ),
         {
           [`vdp.pipeline.v1alpha.PipelinePublicService/TriggerAsyncPipeline (url) response StatusOK`]:
             (r) => r.status === grpc.StatusOK,
+          [`vdp.pipeline.v1alpha.PipelinePublicService/TriggerAsyncPipeline (url) response has operation id`]:
+            (r) => r.message.operation.name.startsWith("operations/"),
         }
       );
 
@@ -93,6 +94,8 @@ export function CheckTriggerAsyncSingleImageSingleModel() {
         {
           [`vdp.pipeline.v1alpha.PipelinePublicService/TriggerAsyncPipeline (base64) response StatusOK`]:
             (r) => r.status === grpc.StatusOK,
+          [`vdp.pipeline.v1alpha.PipelinePublicService/TriggerAsyncPipeline (base64) response has operation id`]:
+            (r) => r.message.operation.name.startsWith("operations/"),
         }
       );
 
@@ -186,6 +189,8 @@ export function CheckTriggerAsyncMultiImageSingleModel() {
         {
           [`vdp.pipeline.v1alpha.PipelinePublicService/TriggerAsyncPipeline (url) response StatusOK`]:
             (r) => r.status === grpc.StatusOK,
+          [`vdp.pipeline.v1alpha.PipelinePublicService/TriggerAsyncPipeline (url) response has operation id`]:
+            (r) => r.message.operation.name.startsWith("operations/"),
         }
       );
 
@@ -226,6 +231,8 @@ export function CheckTriggerAsyncMultiImageSingleModel() {
         {
           [`vdp.pipeline.v1alpha.PipelinePublicService/TriggerAsyncPipeline (base64) response StatusOK`]:
             (r) => r.status === grpc.StatusOK,
+          [`vdp.pipeline.v1alpha.PipelinePublicService/TriggerAsyncPipeline (base64) response has operation id`]:
+            (r) => r.message.operation.name.startsWith("operations/"),
         }
       );
 
@@ -319,6 +326,8 @@ export function CheckTriggerAsyncMultiImageMultiModel() {
         {
           [`vdp.pipeline.v1alpha.PipelinePublicService/TriggerAsyncPipeline (url) response StatusOK`]:
             (r) => r.status === grpc.StatusOK,
+          [`vdp.pipeline.v1alpha.PipelinePublicService/TriggerAsyncPipeline (url) response has operation id`]:
+            (r) => r.message.operation.name.startsWith("operations/"),
         }
       );
 
@@ -359,6 +368,8 @@ export function CheckTriggerAsyncMultiImageMultiModel() {
         {
           [`vdp.pipeline.v1alpha.PipelinePublicService/TriggerAsyncPipeline (base64) response StatusOK`]:
             (r) => r.status === grpc.StatusOK,
+          [`vdp.pipeline.v1alpha.PipelinePublicService/TriggerAsyncPipeline (base64) response has operation id`]:
+            (r) => r.message.operation.name.startsWith("operations/"),
         }
       );
 
@@ -460,6 +471,8 @@ export function CheckTriggerAsyncMultiImageMultiModelMultipleDestination() {
         {
           [`vdp.pipeline.v1alpha.PipelinePublicService/TriggerAsyncPipeline (url) response StatusOK`]:
             (r) => r.status === grpc.StatusOK,
+          [`vdp.pipeline.v1alpha.PipelinePublicService/TriggerAsyncPipeline (url) response has operation id`]:
+            (r) => r.message.operation.name.startsWith("operations/"),
         }
       );
 
@@ -500,6 +513,123 @@ export function CheckTriggerAsyncMultiImageMultiModelMultipleDestination() {
         {
           [`vdp.pipeline.v1alpha.PipelinePublicService/TriggerAsyncPipeline (base64) response StatusOK`]:
             (r) => r.status === grpc.StatusOK,
+          [`vdp.pipeline.v1alpha.PipelinePublicService/TriggerAsyncPipeline (base64) response has operation id`]:
+            (r) => r.message.operation.name.startsWith("operations/"),
+        }
+      );
+
+      // Delete the pipeline
+      check(
+        client.invoke(
+          `vdp.pipeline.v1alpha.PipelinePublicService/DeletePipeline`,
+          {
+            name: `pipelines/${reqBody.id}`,
+          }
+        ),
+        {
+          [`vdp.pipeline.v1alpha.PipelinePublicService/DeletePipeline response StatusOK`]:
+            (r) => r.status === grpc.StatusOK,
+        }
+      );
+
+      client.close();
+    }
+  );
+}
+
+
+export function CheckTriggerAsyncSingleResponse() {
+  group(
+    "Pipelines API: Trigger an async pipeline and get the result from GetOperation",
+    () => {
+      client.connect(constant.pipelineGRPCPublicHost, {
+        plaintext: true,
+      });
+
+      var reqBody = Object.assign(
+        {
+          id: randomString(10),
+          description: randomString(50),
+        },
+        constant.detAsyncSingleResponseRecipe
+      );
+
+      check(
+        client.invoke(
+          "vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline",
+          {
+            pipeline: reqBody,
+          }
+        ),
+        {
+          "vdp.pipeline.v1alpha.PipelinePublicService/CreatePipeline Async GRPC pipeline response StatusOK":
+            (r) => r.status === grpc.StatusOK,
+        }
+      );
+      client.invoke(
+        "vdp.pipeline.v1alpha.PipelinePublicService/ActivatePipeline",
+        {
+          name: `pipelines/${reqBody.id}`,
+        }
+      );
+
+      var payloadImageURL = {
+        inputs: [
+          {
+            images: [
+              {
+                url: "https://artifacts.instill.tech/imgs/dog.jpg",
+              },
+            ],
+          },
+        ],
+      };
+
+      var resp = client.invoke(
+        "vdp.pipeline.v1alpha.PipelinePublicService/TriggerAsyncPipeline",
+        {
+          name: `pipelines/${reqBody.id}`,
+          inputs: payloadImageURL["inputs"],
+        }
+      )
+      check(resp,
+        {
+          [`vdp.pipeline.v1alpha.PipelinePublicService/TriggerAsyncPipeline (url) response StatusOK`]:
+            (r) => r.status === grpc.StatusOK,
+          [`vdp.pipeline.v1alpha.PipelinePublicService/TriggerAsyncPipeline (url) response has operation id`]:
+            (r) => r.message.operation.name.startsWith("operations/"),
+        }
+      );
+
+      for (var i = 0; i < 30; ++i) {
+        var resp = client.invoke(
+          "vdp.pipeline.v1alpha.PipelinePublicService/GetOperation",
+          {
+            name: resp.message.operation.name,
+          }
+        )
+        if (resp.message.operation.done) {
+          break
+        }
+        sleep(1)
+      }
+
+      check(
+        client.invoke(
+          "vdp.pipeline.v1alpha.PipelinePublicService/GetOperation",
+          {
+            name: resp.message.operation.name,
+          }
+        ),
+        {
+          [`vdp.pipeline.v1alpha.PipelinePublicService/GetOperation response StatusOK`]:
+            (r) => r.status === grpc.StatusOK,
+          [`vdp.pipeline.v1alpha.PipelinePublicService/GetOperation response done = true`]:
+            (r) => r.message.operation.done === true,
+          [`vdp.pipeline.v1alpha.PipelinePublicService/GetOperation response outputs.length = ${payloadImageURL["inputs"].length}`]:
+            (r) => r.message.operation.response.outputs.length === payloadImageURL["inputs"].length,
+          [`vdp.pipeline.v1alpha.PipelinePublicService/GetOperation response outputs[0].images.length = ${payloadImageURL["inputs"][0].images.length}`]:
+            (r) => r.message.operation.response.outputs[0].images.length === payloadImageURL["inputs"][0].images.length,
         }
       );
 

--- a/integration-test/grpc.js
+++ b/integration-test/grpc.js
@@ -171,15 +171,9 @@ export default function (data) {
 
   trigger.CheckTriggerSingleImageSingleModel();
   trigger.CheckTriggerMultiImageSingleModel();
-  // Don't support this temporarily
-  // trigger.CheckTriggerMultiImageMultiModel()
-
   triggerAsync.CheckTriggerAsyncSingleImageSingleModel();
   triggerAsync.CheckTriggerAsyncMultiImageSingleModel();
-
-  // Don't support this temporarily
-  // triggerAsync.CheckTriggerAsyncMultiImageMultiModel()
-  // triggerAsync.CheckTriggerAsyncMultiImageMultiModelMultipleDestination()
+  triggerAsync.CheckTriggerAsyncSingleResponse()
 
   if (!constant.apiGatewayMode) {
     pipelinePrivate.CheckList()

--- a/integration-test/rest-trigger-async.js
+++ b/integration-test/rest-trigger-async.js
@@ -1,7 +1,6 @@
 import http from "k6/http";
 
-import { FormData } from "https://jslib.k6.io/formdata/0.0.2/index.js";
-import { check, group } from "k6";
+import { check, group, sleep } from "k6";
 import { randomString } from "https://jslib.k6.io/k6-utils/1.1.0/index.js";
 
 import { pipelinePublicHost } from "./const.js";
@@ -37,6 +36,7 @@ export function CheckTriggerAsyncSingleImageSingleModel() {
 
     check(http.request("POST", `${pipelinePublicHost}/v1alpha/pipelines/${reqBody.id}/triggerAsync`, JSON.stringify(payloadImageURL), constant.params), {
       [`POST /v1alpha/pipelines/${reqBody.id}/triggerAsync (url) response status is 200`]: (r) => r.status === 200,
+      [`POST /v1alpha/pipelines/${reqBody.id}/triggerAsync (url) response status is 200`]: (r) => r.json().operation.name.startsWith("operations/"),
     });
 
     var payloadImageBase64 = {
@@ -51,6 +51,7 @@ export function CheckTriggerAsyncSingleImageSingleModel() {
 
     check(http.request("POST", `${pipelinePublicHost}/v1alpha/pipelines/${reqBody.id}/triggerAsync`, JSON.stringify(payloadImageBase64), constant.params), {
       [`POST /v1alpha/pipelines/${reqBody.id}/triggerAsync (base64) response status is 200`]: (r) => r.status === 200,
+      [`POST /v1alpha/pipelines/${reqBody.id}/triggerAsync (base64) response status is 200`]: (r) => r.json().operation.name.startsWith("operations/"),
     });
 
   });
@@ -99,6 +100,7 @@ export function CheckTriggerAsyncMultiImageSingleModel() {
 
     check(http.request("POST", `${pipelinePublicHost}/v1alpha/pipelines/${reqBody.id}/triggerAsync`, JSON.stringify(payloadImageURL), constant.params), {
       [`POST /v1alpha/pipelines/${reqBody.id}/triggerAsync (url) response status is 200`]: (r) => r.status === 200,
+      [`POST /v1alpha/pipelines/${reqBody.id}/triggerAsync (url) response status is 200`]: (r) => r.json().operation.name.startsWith("operations/"),
     });
 
     var payloadImageBase64 = {
@@ -123,6 +125,7 @@ export function CheckTriggerAsyncMultiImageSingleModel() {
 
     check(http.request("POST", `${pipelinePublicHost}/v1alpha/pipelines/${reqBody.id}/triggerAsync`, JSON.stringify(payloadImageBase64), constant.params), {
       [`POST /v1alpha/pipelines/${reqBody.id}/triggerAsync (base64) response status is 200`]: (r) => r.status === 200,
+      [`POST /v1alpha/pipelines/${reqBody.id}/triggerAsync (base64) response status is 200`]: (r) => r.json().operation.name.startsWith("operations/"),
     });
 
   });
@@ -176,6 +179,7 @@ export function CheckTriggerAsyncMultiImageMultiModel() {
 
     check(http.request("POST", `${pipelinePublicHost}/v1alpha/pipelines/${reqBody.id}/triggerAsync`, JSON.stringify(payloadImageURL), constant.params), {
       [`POST /v1alpha/pipelines/${reqBody.id}/triggerAsync (url) response status is 200`]: (r) => r.status === 200,
+      [`POST /v1alpha/pipelines/${reqBody.id}/triggerAsync (url) response status is 200`]: (r) => r.json().operation.name.startsWith("operations/"),
     });
 
     var payloadImageBase64 = {
@@ -200,20 +204,9 @@ export function CheckTriggerAsyncMultiImageMultiModel() {
 
     check(http.request("POST", `${pipelinePublicHost}/v1alpha/pipelines/${reqBody.id}/triggerAsync`, JSON.stringify(payloadImageBase64), constant.params), {
       [`POST /v1alpha/pipelines/${reqBody.id}/triggerAsync (base64) response status is 200`]: (r) => r.status === 200,
+      [`POST /v1alpha/pipelines/${reqBody.id}/triggerAsync (base64) response status is 200`]: (r) => r.json().operation.name.startsWith("operations/"),
     });
 
-    const fd = new FormData();
-    fd.append("file", http.file(constant.dogImg, "dog.jpg"));
-    fd.append("file", http.file(constant.catImg, "cat.jpg"));
-    fd.append("file", http.file(constant.bearImg, "bear.jpg"));
-    fd.append("file", http.file(constant.dogRGBAImg, "dog-rgba.png"));
-    check(http.request("POST", `${pipelinePublicHost}/v1alpha/pipelines/${reqBody.id}/triggerAsyncMultipart`, fd.body(), {
-      headers: {
-        "Content-Type": `multipart/form-data; boundary=${fd.boundary}`,
-      },
-    }), {
-      [`POST /v1alpha/pipelines/${reqBody.id}/triggerAsync (multipart) response status is 200`]: (r) => r.status === 200,
-    });
 
     // Delete the pipeline
     check(http.request("DELETE", `${pipelinePublicHost}/v1alpha/pipelines/${reqBody.id}`, null, constant.params), {
@@ -267,6 +260,7 @@ export function CheckTriggerAsyncMultiImageMultiModelMultipleDestination() {
 
     check(http.request("POST", `${pipelinePublicHost}/v1alpha/pipelines/${reqBody.id}/triggerAsync`, JSON.stringify(payloadImageURL), constant.params), {
       [`POST /v1alpha/pipelines/${reqBody.id}/triggerAsync (url) response status is 200`]: (r) => r.status === 200,
+      [`POST /v1alpha/pipelines/${reqBody.id}/triggerAsync (url) response status is 200`]: (r) => r.json().operation.name.startsWith("operations/"),
     });
 
     var payloadImageBase64 = {
@@ -291,9 +285,69 @@ export function CheckTriggerAsyncMultiImageMultiModelMultipleDestination() {
 
     check(http.request("POST", `${pipelinePublicHost}/v1alpha/pipelines/${reqBody.id}/triggerAsync`, JSON.stringify(payloadImageBase64), constant.params), {
       [`POST /v1alpha/pipelines/${reqBody.id}/triggerAsync (base64) response status is 200`]: (r) => r.status === 200,
+      [`POST /v1alpha/pipelines/${reqBody.id}/triggerAsync (base64) response status is 200`]: (r) => r.json().operation.name.startsWith("operations/"),
     });
 
 
+    // Delete the pipeline
+    check(http.request("DELETE", `${pipelinePublicHost}/v1alpha/pipelines/${reqBody.id}`, null, constant.params), {
+      [`DELETE /v1alpha/pipelines/${reqBody.id} response status 204`]: (r) => r.status === 204,
+    });
+
+  });
+
+}
+
+export function CheckTriggerAsyncSingleResponse() {
+  group("Pipelines API: Trigger an async pipeline and get the result from GetOperation", () => {
+    var reqBody = Object.assign(
+      {
+        id: randomString(10),
+        description: randomString(50),
+      },
+      constant.detAsyncSingleResponseRecipe
+    );
+
+    check(http.request("POST", `${pipelinePublicHost}/v1alpha/pipelines`, JSON.stringify(reqBody), constant.params), {
+      "POST /v1alpha/pipelines response status is 201": (r) => r.status === 201,
+    });
+    http.request("POST", `${pipelinePublicHost}/v1alpha/pipelines/${reqBody.id}/activate`, {}, constant.params)
+
+    var payloadImageURL = {
+      inputs: [
+        {
+          images: [{
+            url: "https://artifacts.instill.tech/imgs/dog.jpg",
+          }]
+        },
+      ]
+    };
+
+    var resp = http.request("POST", `${pipelinePublicHost}/v1alpha/pipelines/${reqBody.id}/triggerAsync`, JSON.stringify(payloadImageURL), constant.params);
+    check(resp, {
+      [`POST /v1alpha/pipelines/${reqBody.id}/triggerAsync (url) response status is 200`]: (r) => r.status === 200,
+      [`POST /v1alpha/pipelines/${reqBody.id}/triggerAsync (url) response status is 200`]: (r) => r.json().operation.name.startsWith("operations/"),
+    });
+
+    for (var i = 0; i < 30; ++i) {
+      var resp = http.request("GET", `${pipelinePublicHost}/v1alpha/${resp.json().operation.name}`);
+      if (resp.json().operation.done) {
+        break
+      }
+      sleep(1)
+    }
+
+    check(http.request("GET", `${pipelinePublicHost}/v1alpha/${resp.json().operation.name}`, null, constant.params), {
+      [`GET /v1alpha/pipelines/${resp.json().operation.name} response 200`]:
+        (r) => r.status === 200,
+      [`GET /v1alpha/pipelines/${resp.json().operation.name} response done = true`]:
+        (r) => r.json().operation.done === true,
+      [`GET /v1alpha/pipelines/${resp.json().operation.name} response outputs.length = ${payloadImageURL["inputs"].length}`]:
+        (r) => r.json().operation.response.outputs.length === payloadImageURL["inputs"].length,
+      [`GET /v1alpha/pipelines/${resp.json().operation.name} response outputs[0].images.length = ${payloadImageURL["inputs"][0].images.length}`]:
+        (r) => r.json().operation.response.outputs[0].images.length === payloadImageURL["inputs"][0].images.length,
+    }
+    );
     // Delete the pipeline
     check(http.request("DELETE", `${pipelinePublicHost}/v1alpha/pipelines/${reqBody.id}`, null, constant.params), {
       [`DELETE /v1alpha/pipelines/${reqBody.id} response status 204`]: (r) => r.status === 204,

--- a/integration-test/rest.js
+++ b/integration-test/rest.js
@@ -139,6 +139,7 @@ export default function (data) {
 
   triggerAsync.CheckTriggerAsyncSingleImageSingleModel()
   triggerAsync.CheckTriggerAsyncMultiImageSingleModel()
+  triggerAsync.CheckTriggerAsyncSingleResponse()
 
 
 }


### PR DESCRIPTION
Because

- For the pipeline triggerAsync, we'll return the operation id. We should use the operation id to get the trigger result.

This commit

- Add simple testcases for triggerAsync and getOperation
