### PR TITLE
chore: adopt `connector-resources` endpoints

### DIFF
--- a/cmd/migration/000003_migrate.go
+++ b/cmd/migration/000003_migrate.go
@@ -103,20 +103,20 @@ func migratePipelineRecipeUp000003() error {
 		var model *Component
 		var destination *Component
 		for compIdx := range items[idx].Recipe.Components {
-			connector, err := connectorPrivateServiceClient.LookUpConnectorAdmin(context.Background(), &connectorPB.LookUpConnectorAdminRequest{
+			connector, err := connectorPrivateServiceClient.LookUpConnectorResourceAdmin(context.Background(), &connectorPB.LookUpConnectorResourceAdminRequest{
 				Permalink: items[idx].Recipe.Components[compIdx].ResourceName,
 			})
 			if err != nil {
 				panic(err)
 			}
 
-			if connector.Connector.ConnectorType == connectorPB.ConnectorType_CONNECTOR_TYPE_SOURCE {
+			if connector.ConnectorResource.ConnectorType == connectorPB.ConnectorType_CONNECTOR_TYPE_SOURCE {
 				source = items[idx].Recipe.Components[compIdx]
 			}
-			if connector.Connector.ConnectorType == connectorPB.ConnectorType_CONNECTOR_TYPE_AI {
+			if connector.ConnectorResource.ConnectorType == connectorPB.ConnectorType_CONNECTOR_TYPE_AI {
 				model = items[idx].Recipe.Components[compIdx]
 			}
-			if connector.Connector.ConnectorType == connectorPB.ConnectorType_CONNECTOR_TYPE_DESTINATION {
+			if connector.ConnectorResource.ConnectorType == connectorPB.ConnectorType_CONNECTOR_TYPE_DESTINATION {
 				destination = items[idx].Recipe.Components[compIdx]
 			}
 

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0
 	github.com/iancoleman/strcase v0.2.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/connector-backend v0.11.0-alpha
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230817132923-94c25875d8aa
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20230814155646-874e57a1e4b0
 	github.com/instill-ai/x v0.3.0-alpha
@@ -44,15 +43,19 @@ require (
 )
 
 require (
+	github.com/Microsoft/go-winio v0.6.1 // indirect
+	github.com/benbjohnson/clock v1.3.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
 	github.com/deepmap/oapi-codegen v1.8.2 // indirect
+	github.com/docker/distribution v2.8.2+incompatible // indirect
+	github.com/docker/docker v24.0.2+incompatible // indirect
+	github.com/docker/go-units v0.5.0 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	github.com/go-sql-driver/mysql v1.7.0 // indirect
 	github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 // indirect
-	github.com/jackc/pgx/v5 v5.3.0 // indirect
+	github.com/opencontainers/image-spec v1.1.0-rc2 // indirect
 	github.com/osteele/tuesday v1.0.3 // indirect
-	github.com/redis/go-redis/v9 v9.0.5 // indirect
+	github.com/rogpeppe/go-internal v1.10.0 // indirect
 	github.com/stretchr/testify v1.8.3 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.16.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric v0.39.0 // indirect
@@ -60,8 +63,6 @@ require (
 	go.opentelemetry.io/otel/metric v1.16.0 // indirect
 	go.opentelemetry.io/proto/otlp v0.19.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gorm.io/datatypes v1.0.7 // indirect
-	gorm.io/driver/mysql v1.4.7 // indirect
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/iancoleman/strcase v0.2.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
 	github.com/instill-ai/connector-backend v0.11.0-alpha
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230814104042-37ca0356defc
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230817132923-94c25875d8aa
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20230814155646-874e57a1e4b0
 	github.com/instill-ai/x v0.3.0-alpha
 	github.com/knadh/koanf v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -388,9 +388,6 @@ gioui.org v0.0.0-20210308172011-57750fc8a0a6/go.mod h1:RSH6KIUZ0p2xy5zHDxgAM4zum
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20210715213245-6c3934b029d8/go.mod h1:CzsSbkDixRphAF5hS6wbMKq0eI6ccJRb7/A0M6JBnwg=
 github.com/Azure/azure-pipeline-go v0.2.3/go.mod h1:x841ezTBIMG6O3lAcl8ATHnsOPVl2bqk7S3ta6S6u4k=
 github.com/Azure/azure-sdk-for-go v16.2.1+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.19.0/go.mod h1:h6H6c8enJmmocHUbLiiGY6sx7f9i+X3m1CHdd5c6Rdw=
-github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.11.0/go.mod h1:HcM1YX14R7CJcghJGOYCgdezslRSVzqwLf/q+4Y2r/0=
-github.com/Azure/azure-sdk-for-go/sdk/internal v0.7.0/go.mod h1:yqy467j36fJxcRV2TzfVZ1pCb5vxm4BtZPUdYWe/Xo8=
 github.com/Azure/azure-storage-blob-go v0.14.0/go.mod h1:SMqIBi+SuiQH32bvyjngEewEeXoPfKMgWlBDaYf6fck=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/Azure/go-ansiterm v0.0.0-20210608223527-2377c96fe795/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
@@ -426,6 +423,7 @@ github.com/Microsoft/go-winio v0.4.17/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOp
 github.com/Microsoft/go-winio v0.5.1/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
+github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/Microsoft/hcsshim v0.8.6/go.mod h1:Op3hHsoHPAvb6lceZHDtd9OkTew38wNoXnJs8iY7rUg=
 github.com/Microsoft/hcsshim v0.8.7-0.20190325164909-8abdbb8205e4/go.mod h1:Op3hHsoHPAvb6lceZHDtd9OkTew38wNoXnJs8iY7rUg=
 github.com/Microsoft/hcsshim v0.8.7/go.mod h1:OHd7sQqRFrYd3RmSgbgji+ctCwkbq2wbEYNSzOYtcBQ=
@@ -495,6 +493,7 @@ github.com/aws/smithy-go v1.7.0/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAm
 github.com/aws/smithy-go v1.8.0/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
+github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
@@ -510,8 +509,6 @@ github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnweb
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/bshuster-repo/logrus-logstash-hook v0.4.1/go.mod h1:zsTqEiSzDgAa/8GZR7E1qaXrhYNDKBYy5/dWPTIflbk=
-github.com/bsm/ginkgo/v2 v2.7.0 h1:ItPMPH90RbmZJt5GtkcNvIRuGEdwlBItdNVoyzaNQao=
-github.com/bsm/gomega v1.26.0 h1:LhQm+AFcgV2M0WyKroMASzAzCAJVpAxQXv4SaI9a69Y=
 github.com/buger/jsonparser v0.0.0-20180808090653-f4dd9f5a6b44/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
@@ -696,8 +693,6 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/deepmap/oapi-codegen v1.8.2 h1:SegyeYGcdi0jLLrpbCMoJxnUUn8GBXHsvr4rbzjuhfU=
 github.com/deepmap/oapi-codegen v1.8.2/go.mod h1:YLgSKSDv/bZQB7N4ws6luhozi3cEdRktEqrX88CvjIw=
 github.com/denisenkom/go-mssqldb v0.10.0/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
-github.com/denisenkom/go-mssqldb v0.12.0 h1:VtrkII767ttSPNRfFekePK3sctr+joXgO58stqQbtUA=
-github.com/denisenkom/go-mssqldb v0.12.0/go.mod h1:iiK0YP1ZeepvmBQk/QpLEhhTNJgfzrpArPY/aFvc9yU=
 github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba/go.mod h1:dV8lFg6daOBZbT6/BDGIz6Y3WFGn8juu6G+CQ6LHtl0=
 github.com/dgrijalva/jwt-go v0.0.0-20170104182250-a601269ab70c/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
@@ -707,16 +702,17 @@ github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8
 github.com/dhui/dktest v0.3.10 h1:0frpeeoM9pHouHjhLeZDuDTJ0PqjDTrycaHaMmkJAo8=
 github.com/dhui/dktest v0.3.10/go.mod h1:h5Enh0nG3Qbo9WjNFRrwmKUaePEBhXMOygbz3Ww7Sz0=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
-github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
 github.com/docker/cli v0.0.0-20191017083524-a8ff7f821017/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v0.0.0-20190905152932-14b96e55d84c/go.mod h1:0+TTO4EOBfRPhZXAeF1Vu+W3hHZ8eLp8PgKVZlcvtFY=
 github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.8.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.8.2+incompatible h1:T3de5rq0dB1j30rp0sA2rER+m322EBzniBPB6ZIzuh8=
+github.com/docker/distribution v2.8.2+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v1.4.2-0.20190924003213-a8608b5b67c7/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker v20.10.13+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker v24.0.2+incompatible h1:eATx+oLz9WdNVkQrr0qjQ8HvRJ4bOOxfzEo8R+dA3cg=
+github.com/docker/docker v24.0.2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.6.3/go.mod h1:WRaJzqw3CTB9bk10avuGsjVBZsD05qeibJ1/TYlvc0Y=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
@@ -726,6 +722,7 @@ github.com/docker/go-metrics v0.0.0-20180209012529-399ea8c73916/go.mod h1:/u0gXw
 github.com/docker/go-metrics v0.0.1/go.mod h1:cG1hvH2utMXtqgqqYE9plW6lDxS3/5ayHzueweSI3Vw=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
+github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/libtrust v0.0.0-20150114040149-fa567046d9b1/go.mod h1:cyGadeNEkKy96OOhEzfZl+yxihPEzKnqJwvfuSUqbZE=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
@@ -820,9 +817,6 @@ github.com/go-redis/redis/v9 v9.0.0-beta.2 h1:ZSr84TsnQyKMAg8gnV+oawuQezeJR11/09
 github.com/go-redis/redis/v9 v9.0.0-beta.2/go.mod h1:Bldcd/M/bm9HbnNPi/LUtYBSD8ttcZYBMupwMXhdU0o=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
-github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
-github.com/go-sql-driver/mysql v1.7.0 h1:ueSltNNllEqE3qcWBTD0iQd3IpL/6U+mJxLkazJ7YPc=
-github.com/go-sql-driver/mysql v1.7.0/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
@@ -881,10 +875,6 @@ github.com/golang-jwt/jwt/v4 v4.1.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzw
 github.com/golang-migrate/migrate/v4 v4.15.2 h1:vU+M05vs6jWHKDdmE1Ecwj0BznygFc4QsdRe2E/L7kc=
 github.com/golang-migrate/migrate/v4 v4.15.2/go.mod h1:f2toGLkYqD3JH+Todi4aZ2ZdbeUNx4sIwiOK96rE9Lw=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
-github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 h1:au07oEsX2xN0ktxqI+Sida1w446QrXBRJ0nee3SNZlA=
-github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
-github.com/golang-sql/sqlexp v0.0.0-20170517235910-f1bb20e5a188 h1:+eHOFJl1BaXrQxKX+T06f78590z4qA2ZzBTqahsKSE4=
-github.com/golang-sql/sqlexp v0.0.0-20170517235910-f1bb20e5a188/go.mod h1:vXjM/+wXQnTPR4KqTKDgJukSZ6amVRtWMPEjE6sQoK8=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=
@@ -1086,8 +1076,6 @@ github.com/influxdata/influxdb-client-go/v2 v2.12.3 h1:28nRlNMRIV4QbtIUvxhWqaxn0
 github.com/influxdata/influxdb-client-go/v2 v2.12.3/go.mod h1:IrrLUbCjjfkmRuaCiGQg4m2GbkaeJDcuWoxiWdQEbA0=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/instill-ai/connector-backend v0.11.0-alpha h1:3dOs5IAgp2Ea35xhg2zFpbGlO8O/0pYEgmkiS8VrD4M=
-github.com/instill-ai/connector-backend v0.11.0-alpha/go.mod h1:Zn/6uqq2NFwkZj0Qiqip9dkKk4ePo3Oprh6OZN7ZE7s=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230817132923-94c25875d8aa h1:QFj7GA+tLaxMCCIJfLMif2y0nPGDCU1+AJF08ORiRhQ=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230817132923-94c25875d8aa/go.mod h1:qsq5ecnA1xi2rLnVQFo/9xksA7I7wQu8c7rqM5xbIrQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20230814155646-874e57a1e4b0 h1:9QoCxaktvqGJYGjN8KhkWsv1DVfwbt5G1d/Ycx1kJxo=
@@ -1110,7 +1098,6 @@ github.com/jackc/pgconn v1.5.1-0.20200601181101-fa742c524853/go.mod h1:QeD3lBfpT
 github.com/jackc/pgconn v1.8.0/go.mod h1:1C2Pb36bGIP9QHGBYCjnyhqu7Rv3sGshaQUvmfGIB/o=
 github.com/jackc/pgconn v1.9.0/go.mod h1:YctiPyvzfU11JFxoXokUOOKQXQmDMoJL9vJzHH8/2JY=
 github.com/jackc/pgconn v1.9.1-0.20210724152538-d89c8390a530/go.mod h1:4z2w8XhRbP1hYxkpTuBjTS3ne3J48K83+u0zoyvg2pI=
-github.com/jackc/pgconn v1.11.0/go.mod h1:4z2w8XhRbP1hYxkpTuBjTS3ne3J48K83+u0zoyvg2pI=
 github.com/jackc/pgconn v1.13.0 h1:3L1XMNV2Zvca/8BYhzcRFS70Lr0WlDg16Di6SFGAbys=
 github.com/jackc/pgconn v1.13.0/go.mod h1:AnowpAqO4CMIIJNZl2VJp+KrkAZciAkhEl0W0JIobpI=
 github.com/jackc/pgerrcode v0.0.0-20201024163028-a0d42d470451/go.mod h1:a/s9Lp5W7n/DD0VrVoyJ00FbP2ytTPDVOivvn2bMlds=
@@ -1131,7 +1118,6 @@ github.com/jackc/pgproto3/v2 v2.0.1/go.mod h1:WfJCnwN3HIg9Ish/j3sgWXnAfK8A9Y0bwX
 github.com/jackc/pgproto3/v2 v2.0.6/go.mod h1:WfJCnwN3HIg9Ish/j3sgWXnAfK8A9Y0bwXYU5xKaEdA=
 github.com/jackc/pgproto3/v2 v2.0.7/go.mod h1:WfJCnwN3HIg9Ish/j3sgWXnAfK8A9Y0bwXYU5xKaEdA=
 github.com/jackc/pgproto3/v2 v2.1.1/go.mod h1:WfJCnwN3HIg9Ish/j3sgWXnAfK8A9Y0bwXYU5xKaEdA=
-github.com/jackc/pgproto3/v2 v2.2.0/go.mod h1:WfJCnwN3HIg9Ish/j3sgWXnAfK8A9Y0bwXYU5xKaEdA=
 github.com/jackc/pgproto3/v2 v2.3.1 h1:nwj7qwf0S+Q7ISFfBndqeLwSwxs+4DPsbRFjECT1Y4Y=
 github.com/jackc/pgproto3/v2 v2.3.1/go.mod h1:WfJCnwN3HIg9Ish/j3sgWXnAfK8A9Y0bwXYU5xKaEdA=
 github.com/jackc/pgservicefile v0.0.0-20200307190119-3430c5407db8/go.mod h1:vsD4gTJCa9TptPL8sPkXrLZ+hDuNrZCnj29CQpr4X1E=
@@ -1146,7 +1132,6 @@ github.com/jackc/pgtype v1.3.1-0.20200510190516-8cd94a14c75a/go.mod h1:vaogEUkAL
 github.com/jackc/pgtype v1.3.1-0.20200606141011-f6355165a91c/go.mod h1:cvk9Bgu/VzJ9/lxTO5R5sf80p0DiucVtN7ZxvaC4GmQ=
 github.com/jackc/pgtype v1.6.2/go.mod h1:JCULISAZBFGrHaOXIIFiyfzW5VY0GRitRr8NeJsrdig=
 github.com/jackc/pgtype v1.8.1-0.20210724151600-32e20a603178/go.mod h1:C516IlIV9NKqfsMCXTdChteoXmwgUceqaLfjg2e3NlM=
-github.com/jackc/pgtype v1.10.0/go.mod h1:LUMuVrfsFfdKGLw+AFFVv6KtHOFMwRgDDzBt76IqCA4=
 github.com/jackc/pgtype v1.12.0 h1:Dlq8Qvcch7kiehm8wPGIW0W3KsCCHJnRacKW0UM8n5w=
 github.com/jackc/pgtype v1.12.0/go.mod h1:LUMuVrfsFfdKGLw+AFFVv6KtHOFMwRgDDzBt76IqCA4=
 github.com/jackc/pgx/v4 v4.0.0-20190420224344-cc3461e65d96/go.mod h1:mdxmSJJuR08CZQyj1PVQBHy9XOp5p8/SHH6a0psbY9Y=
@@ -1157,17 +1142,13 @@ github.com/jackc/pgx/v4 v4.6.1-0.20200510190926-94ba730bb1e9/go.mod h1:t3/cdRQl6
 github.com/jackc/pgx/v4 v4.6.1-0.20200606145419-4e5062306904/go.mod h1:ZDaNWkt9sW1JMiNn0kdYBaLelIhw7Pg4qd+Vk6tw7Hg=
 github.com/jackc/pgx/v4 v4.10.1/go.mod h1:QlrWebbs3kqEZPHCTGyxecvzG6tvIsYu+A5b1raylkA=
 github.com/jackc/pgx/v4 v4.12.1-0.20210724153913-640aa07df17c/go.mod h1:1QD0+tgSXP7iUjYm9C1NxKhny7lq6ee99u/z+IHFcgs=
-github.com/jackc/pgx/v4 v4.15.0/go.mod h1:D/zyOyXiaM1TmVWnOM18p0xdDtdakRBa0RsVGI3U3bw=
 github.com/jackc/pgx/v4 v4.17.2 h1:0Ut0rpeKwvIVbMQ1KbMBU4h6wxehBI535LK6Flheh8E=
 github.com/jackc/pgx/v4 v4.17.2/go.mod h1:lcxIZN44yMIrWI78a5CpucdD14hX0SBDbNRvjDBItsw=
-github.com/jackc/pgx/v5 v5.3.0 h1:/NQi8KHMpKWHInxXesC8yD4DhkXPrVhmnwYkjp9AmBA=
-github.com/jackc/pgx/v5 v5.3.0/go.mod h1:t3JDKnCBlYIc0ewLF0Q7B8MXmoIaBOZj/ic7iHozM/8=
 github.com/jackc/puddle v0.0.0-20190413234325-e4ced69a3a2b/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.0/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.1/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.3/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
-github.com/jackc/puddle v1.2.1/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.3.0/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
@@ -1283,10 +1264,7 @@ github.com/mattn/go-shellwords v1.0.6/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vq
 github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
-github.com/mattn/go-sqlite3 v1.14.9/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/mattn/go-sqlite3 v1.14.10/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
-github.com/mattn/go-sqlite3 v1.14.12 h1:TJ1bhYJPV44phC+IMu1u2K/i5RriLTPe+yc68XDJ1Z0=
-github.com/mattn/go-sqlite3 v1.14.12/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2/go.mod h1:eD9eIE7cdwcMi9rYluz88Jz2VyhSmden33/aXg4oVIY=
@@ -1335,7 +1313,6 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/modocache/gover v0.0.0-20171022184752-b58185e213c5/go.mod h1:caMODM3PzxT8aQXRPkAt8xlV/e7d7w8GM5g0fa5F0D8=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
@@ -1393,6 +1370,7 @@ github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zM
 github.com/opencontainers/image-spec v1.0.2-0.20211117181255-693428a734f5/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/image-spec v1.0.2/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/image-spec v1.1.0-rc2 h1:2zx/Stx4Wc5pIPDvIxHXvXtQFW/7XWJGmnM7r3wg034=
+github.com/opencontainers/image-spec v1.1.0-rc2/go.mod h1:3OVijpioIKYWTqjiG0zfF6wvoJ4fAXGbjdZuI2NgsRQ=
 github.com/opencontainers/runc v0.0.0-20190115041553-12f6a991201f/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runc v0.1.1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runc v1.0.0-rc8.0.20190926000215-3e425f80a8c9/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
@@ -1430,7 +1408,6 @@ github.com/phpdave11/gofpdf v1.4.2/go.mod h1:zpO6xFn9yxo3YLyMvW8HcKWVdbNqgIfOOp2
 github.com/phpdave11/gofpdi v1.0.12/go.mod h1:vBmVV0Do6hSBHC8uKUQ71JGW+ZGQq74llk/7bXwjDoI=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pierrec/lz4/v4 v4.1.8/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
-github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4/go.mod h1:4OwLy04Bl9Ef3GJJCoec+30X3LQs/0/m4HFRt/2LUSA=
 github.com/pkg/browser v0.0.0-20210706143420-7d21f8c997e2/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -1478,8 +1455,6 @@ github.com/prometheus/procfs v0.2.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/redis/go-redis/v9 v9.0.5 h1:CuQcn5HIEeK7BgElubPP8CGtE0KakrnbBSTLjathl5o=
-github.com/redis/go-redis/v9 v9.0.5/go.mod h1:WqMKv5vnQbRuZstUwxQI195wHy+t4PuXDOjzMvcuQHk=
 github.com/remyoudompheng/bigfft v0.0.0-20190728182440-6a916e37a237/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rhnvrm/simples3 v0.6.1/go.mod h1:Y+3vYm2V7Y4VijFoJHHTrja6OgPrJ2cBti8dPGkC3sA=
@@ -1491,6 +1466,7 @@ github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.2.2/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
+github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/zerolog v1.13.0/go.mod h1:YbFCdg8HfsridGWAh22vktObvhZbQsZXe4/zB0OKkWU=
 github.com/rs/zerolog v1.15.0/go.mod h1:xYTKnLHcpfU2225ny5qZjxnj9NvkumZYjJHlAThCjNc=
@@ -1744,7 +1720,6 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201203163018-be400aefbc4c/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
@@ -1753,7 +1728,6 @@ golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/crypto v0.0.0-20220214200702-86341886e292/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.9.0 h1:LF6fAI+IutBocDJ2OT0Q1g8plpYljMZ4+lty+dsqw3g=
 golang.org/x/crypto v0.9.0/go.mod h1:yrmDGqONDYtNj3tH8X9dzUun2m2lzPa9ngI6/RUPGR0=
@@ -1867,7 +1841,6 @@ golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20210505024714-0287a6fb4125/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210520170846-37e1c6afe023/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20210610132358-84b48f89b13b/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210825183410-e898025ed96a/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
@@ -2511,23 +2484,11 @@ gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gorm.io/datatypes v1.0.7 h1:8NhJN4+annFjwV1WufDhFiPjdUvV1lSGUdg1UCjQIWY=
-gorm.io/datatypes v1.0.7/go.mod h1:l9qkCuy0CdzDEop9HKUdcnC9gHC2sRlaFtHkTzsZRqg=
-gorm.io/driver/mysql v1.3.2/go.mod h1:ChK6AHbHgDCFZyJp0F+BmVGb06PSIoh9uVYKAlRbb2U=
-gorm.io/driver/mysql v1.4.7 h1:rY46lkCspzGHn7+IYsNpSfEv9tA+SU4SkkB+GFX125Y=
-gorm.io/driver/mysql v1.4.7/go.mod h1:SxzItlnT1cb6e1e4ZRpgJN2VYtcqJgqnHxWr4wsP8oc=
 gorm.io/driver/postgres v1.0.8/go.mod h1:4eOzrI1MUfm6ObJU/UcmbXyiHSs8jSwH95G5P5dxcAg=
-gorm.io/driver/postgres v1.3.4/go.mod h1:y0vEuInFKJtijuSGu9e5bs5hzzSzPK+LancpKpvbRBw=
 gorm.io/driver/postgres v1.4.4 h1:zt1fxJ+C+ajparn0SteEnkoPg0BQ6wOWXEQ99bteAmw=
 gorm.io/driver/postgres v1.4.4/go.mod h1:whNfh5WhhHs96honoLjBAMwJGYEuA3m1hvgUbNXhPCw=
-gorm.io/driver/sqlite v1.3.1/go.mod h1:wJx0hJspfycZ6myN38x1O/AqLtNS6c5o9TndewFbELg=
-gorm.io/driver/sqlite v1.4.0 h1:yBOlrt1nu67+xnzMnr8AtklM7wOyki9HNBxHaozRUsA=
-gorm.io/driver/sqlserver v1.3.1/go.mod h1:w25Vrx2BG+CJNUu/xKbFhaKlGxT/nzRkhWCCoptX8tQ=
-gorm.io/driver/sqlserver v1.4.0 h1:3fjbsNkr/YqocSBW5CP16Lq6+APjRrWMzu7NbkXr9QU=
 gorm.io/gorm v1.20.12/go.mod h1:0HFTzE/SqkGTzK6TlDPPQbAYCluiVvhzoA1+aVyzenw=
 gorm.io/gorm v1.21.4/go.mod h1:0HFTzE/SqkGTzK6TlDPPQbAYCluiVvhzoA1+aVyzenw=
-gorm.io/gorm v1.23.1/go.mod h1:l2lP/RyAtc1ynaTjFksBde/O8v9oOGIApu2/xRitmZk=
-gorm.io/gorm v1.23.6/go.mod h1:l2lP/RyAtc1ynaTjFksBde/O8v9oOGIApu2/xRitmZk=
 gorm.io/gorm v1.23.7/go.mod h1:l2lP/RyAtc1ynaTjFksBde/O8v9oOGIApu2/xRitmZk=
 gorm.io/gorm v1.23.8 h1:h8sGJ+biDgBA1AD1Ha9gFCx7h8npU7AsLdlkX0n2TpE=
 gorm.io/gorm v1.23.8/go.mod h1:l2lP/RyAtc1ynaTjFksBde/O8v9oOGIApu2/xRitmZk=

--- a/go.sum
+++ b/go.sum
@@ -1088,8 +1088,8 @@ github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
 github.com/instill-ai/connector-backend v0.11.0-alpha h1:3dOs5IAgp2Ea35xhg2zFpbGlO8O/0pYEgmkiS8VrD4M=
 github.com/instill-ai/connector-backend v0.11.0-alpha/go.mod h1:Zn/6uqq2NFwkZj0Qiqip9dkKk4ePo3Oprh6OZN7ZE7s=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230814104042-37ca0356defc h1:1akaOOUCsVU2yzFIb5KwVw5GRy7v+hyNmNmJD+2x+l8=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230814104042-37ca0356defc/go.mod h1:qsq5ecnA1xi2rLnVQFo/9xksA7I7wQu8c7rqM5xbIrQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230817132923-94c25875d8aa h1:QFj7GA+tLaxMCCIJfLMif2y0nPGDCU1+AJF08ORiRhQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230817132923-94c25875d8aa/go.mod h1:qsq5ecnA1xi2rLnVQFo/9xksA7I7wQu8c7rqM5xbIrQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20230814155646-874e57a1e4b0 h1:9QoCxaktvqGJYGjN8KhkWsv1DVfwbt5G1d/Ycx1kJxo=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20230814155646-874e57a1e4b0/go.mod h1:SELFgirs+28Wfnh0kGw02zttit4pUeKLKp17zGsTu6g=
 github.com/instill-ai/x v0.3.0-alpha h1:z9fedROOG2dVHhswBfVwU/hzHuq8/JKSUON7inF+FH8=

--- a/integration-test/const.js
+++ b/integration-test/const.js
@@ -122,7 +122,7 @@ export const simpleRecipe = {
       },
       {
         id: "d01",
-        resource_name: `connectors/${dstCSVConnID1}`,
+        resource_name: `connector-resources/${dstCSVConnID1}`,
         definition_name: "connector-definitions/airbyte-destination-csv",
         configuration: {
           text: "{ start.body.input }"
@@ -130,7 +130,7 @@ export const simpleRecipe = {
       },
       {
         id: "d02",
-        resource_name: `connectors/${dstCSVConnID2}`,
+        resource_name: `connector-resources/${dstCSVConnID2}`,
         definition_name: "connector-definitions/airbyte-destination-csv",
         configuration: {
           text: "{ start.body.input }"
@@ -196,7 +196,7 @@ export const simpleRecipeDupId = {
       },
       {
         id: "d01",
-        resource_name: `connectors/${dstCSVConnID1}`,
+        resource_name: `connector-resources/${dstCSVConnID1}`,
         definition_name: "connector-definitions/airbyte-destination-csv",
         configuration: {
           text: "{ start.body.input }"
@@ -204,7 +204,7 @@ export const simpleRecipeDupId = {
       },
       {
         id: "d01",
-        resource_name: `connectors/${dstCSVConnID2}`,
+        resource_name: `connector-resources/${dstCSVConnID2}`,
         definition_name: "connector-definitions/airbyte-destination-csv",
         configuration: {
           text: "{ start.body.input }"

--- a/integration-test/grpc-pipeline-public.js
+++ b/integration-test/grpc-pipeline-public.js
@@ -120,7 +120,7 @@ export function CheckCreate() {
         }
       ),
       {
-        [`vdp.pipeline.v1alpha.ConnectorPublicService/DeletePipeline ${reqBody.id} response StatusOK`]:
+        [`vdp.pipeline.v1alpha.PipelinePublicService/DeletePipeline ${reqBody.id} response StatusOK`]:
           (r) => r.status === grpc.StatusOK,
       }
     );

--- a/integration-test/grpc.js
+++ b/integration-test/grpc.js
@@ -35,9 +35,9 @@ export function setup() {
     function () {
       check(
         client.invoke(
-          "vdp.connector.v1alpha.ConnectorPublicService/CreateConnector",
+          "vdp.connector.v1alpha.ConnectorPublicService/CreateConnectorResource",
           {
-            connector: {
+            connector_resource: {
               id: constant.dstCSVConnID1,
               connector_definition_name:
                 "connector-definitions/airbyte-destination-csv",
@@ -49,14 +49,14 @@ export function setup() {
           constant.paramsGrpc
         ),
         {
-          "vdp.connector.v1alpha.ConnectorPublicService/CreateConnector CSV response StatusOK":
+          "vdp.connector.v1alpha.ConnectorPublicService/CreateConnectorResource CSV response StatusOK":
             (r) => r.status === grpc.StatusOK,
         }
       );
       client.invoke(
-        "vdp.connector.v1alpha.ConnectorPublicService/ConnectConnector",
+        "vdp.connector.v1alpha.ConnectorPublicService/ConnectConnectorResource",
         {
-          name: `connectors/${constant.dstCSVConnID1}`,
+          name: `connector-resources/${constant.dstCSVConnID1}`,
         }
       );
     }
@@ -66,9 +66,9 @@ export function setup() {
     function () {
       check(
         client.invoke(
-          "vdp.connector.v1alpha.ConnectorPublicService/CreateConnector",
+          "vdp.connector.v1alpha.ConnectorPublicService/CreateConnectorResource",
           {
-            connector: {
+            connectorResource: {
               id: constant.dstCSVConnID2,
               connector_definition_name:
                 "connector-definitions/airbyte-destination-csv",
@@ -80,14 +80,14 @@ export function setup() {
           constant.paramsGrpc
         ),
         {
-          "vdp.connector.v1alpha.ConnectorPublicService/CreateConnector CSV response StatusOK":
+          "vdp.connector.v1alpha.ConnectorPublicService/CreateConnectorResource CSV response StatusOK":
             (r) => r.status === grpc.StatusOK,
         }
       );
       client.invoke(
-        "vdp.connector.v1alpha.ConnectorPublicService/ConnectConnector",
+        "vdp.connector.v1alpha.ConnectorPublicService/ConnectConnectorResource",
         {
-          name: `connectors/${constant.dstCSVConnID2}`,
+          name: `connector-resources/${constant.dstCSVConnID2}`,
         }
       );
     }
@@ -186,13 +186,13 @@ export function teardown(data) {
     function () {
       check(
         client.invoke(
-          `vdp.connector.v1alpha.ConnectorPublicService/DeleteConnector`,
+          `vdp.connector.v1alpha.ConnectorPublicService/DeleteConnectorResource`,
           {
-            name: `connectors/${constant.dstCSVConnID1}`,
+            name: `connector-resources/${constant.dstCSVConnID1}`,
           }
         ),
         {
-          [`vdp.connector.v1alpha.ConnectorPublicService/DeleteConnector response StatusOK`]:
+          [`vdp.connector.v1alpha.ConnectorPublicService/DeleteConnectorResource response StatusOK`]:
             (r) => r.status === grpc.StatusOK,
         }
       );
@@ -203,13 +203,13 @@ export function teardown(data) {
     function () {
       check(
         client.invoke(
-          `vdp.connector.v1alpha.ConnectorPublicService/DeleteConnector`,
+          `vdp.connector.v1alpha.ConnectorPublicService/DeleteConnectorResource`,
           {
-            name: `connectors/${constant.dstCSVConnID2}`,
+            name: `connector-resources/${constant.dstCSVConnID2}`,
           }
         ),
         {
-          [`vdp.connector.v1alpha.ConnectorPublicService/DeleteConnector response StatusOK`]:
+          [`vdp.connector.v1alpha.ConnectorPublicService/DeleteConnectorResource response StatusOK`]:
             (r) => r.status === grpc.StatusOK,
         }
       );

--- a/integration-test/proto/vdp/connector/v1alpha/connector.proto
+++ b/integration-test/proto/vdp/connector/v1alpha/connector.proto
@@ -38,9 +38,9 @@ message ReadinessResponse {
   common.healthcheck.v1alpha.HealthCheckResponse health_check_response = 1;
 }
 
-// Connector represents a connector data model
-message Connector {
-  // State enumerates the connector state
+// ConnectorResource represents a connector_resource data model
+message ConnectorResource {
+  // State enumerates the connector_resource state
   enum State {
     // State: UNSPECIFIED
     STATE_UNSPECIFIED = 0;
@@ -52,7 +52,7 @@ message Connector {
     STATE_ERROR = 3;
   }
 
-  // Connector visibility including public or private
+  // ConnectorResource visibility including public or private
   enum Visibility {
     // Visibility: UNSPECIFIED, equivalent to PRIVATE.
     VISIBILITY_UNSPECIFIED = 0;
@@ -63,16 +63,16 @@ message Connector {
   }
 
   option (google.api.resource) = {
-    type: "api.instill.tech/Connector"
-    pattern: "connectors/{connector}"
+    type: "api.instill.tech/ConnectorResource"
+    pattern: "connector-resources/{connector_resource}"
   };
 
-  // Connector resource name. It must have the format of
-  // "connectors/*"
+  // ConnectorResource resource name. It must have the format of
+  // "connector-resources/*"
   string name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Connector UUID
+  // ConnectorResource UUID
   string uid = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Connector resource ID (the last segment of the resource name)
+  // ConnectorResource resource ID (the last segment of the resource name)
   // used to construct the resource name. This conforms to RFC-1034, which
   // restricts to letters, numbers, and hyphen, with the first character a
   // letter, the last a letter or a number, and a 63 character maximum.
@@ -82,19 +82,19 @@ message Connector {
     (google.api.field_behavior) = IMMUTABLE,
     (google.api.resource_reference) = {type: "api.instill.tech/ConnectorDefinition"}
   ];
-  // Connector Type
+  // ConnectorResource Type
   ConnectorType connector_type = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Connector description
+  // ConnectorResource description
   common.task.v1alpha.Task task = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Connector description
+  // ConnectorResource description
   optional string description = 7 [(google.api.field_behavior) = OPTIONAL];
-  // Connector configuration in JSON format
+  // ConnectorResource configuration in JSON format
   google.protobuf.Struct configuration = 8 [(google.api.field_behavior) = REQUIRED];
-  // Connector state
+  // ConnectorResource state
   State state = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Connector tombstone
+  // ConnectorResource tombstone
   bool tombstone = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Connector owner
+  // ConnectorResource owner
   oneof owner {
     // The resource name with UUID of a user, e.g.,
     // "users/bfb978f8-78d3-4338-aa2b-a6c699cb07c5".
@@ -108,11 +108,11 @@ message Connector {
       (google.api.field_behavior) = OUTPUT_ONLY
     ];
   }
-  // Connector creation time
+  // ConnectorResource creation time
   google.protobuf.Timestamp create_time = 13 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Connector update time
+  // ConnectorResource update time
   google.protobuf.Timestamp update_time = 14 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Connector visibility including public or private
+  // ConnectorResource visibility including public or private
   Visibility visibility = 15 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Embed the content of the connector_definition
   ConnectorDefinition connector_definition = 16 [(google.api.field_behavior) = OUTPUT_ONLY];
@@ -122,293 +122,293 @@ message Connector {
 // RPC messages
 ///////////////////////////////////////////////////////////////////////
 
-// CreateConnectorRequest represents a request to create a
-// Connector resource
-message CreateConnectorRequest {
-  // Connector resource
-  Connector connector = 1 [(google.api.field_behavior) = REQUIRED];
+// CreateConnectorResourceRequest represents a request to create a
+// ConnectorResource resource
+message CreateConnectorResourceRequest {
+  // ConnectorResource resource
+  ConnectorResource connector_resource = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
-// CreateConnectorResponse represents a response for a
-// Connector resource
-message CreateConnectorResponse {
-  // Connector resource
-  Connector connector = 1;
+// CreateConnectorResourceResponse represents a response for a
+// ConnectorResource resource
+message CreateConnectorResourceResponse {
+  // ConnectorResource resource
+  ConnectorResource connector_resource = 1;
 }
 
-// ListConnectorsRequest represents a request to list
-// Connector resources
-message ListConnectorsRequest {
-  // The maximum number of connectors to return. The service may return fewer
-  // than this value. If unspecified, at most 10 connectors will be returned.
+// ListConnectorResourcesRequest represents a request to list
+// ConnectorResource resources
+message ListConnectorResourcesRequest {
+  // The maximum number of connector-resources to return. The service may return fewer
+  // than this value. If unspecified, at most 10 connector-resources will be returned.
   // The maximum value is 100; values above 100 will be coerced to 100.
   optional int64 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
   // Page token
   optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
-  // Connector view (default is VIEW_BASIC)
+  // ConnectorResource view (default is VIEW_BASIC)
   optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
-  // Filter expression to list connectors
+  // Filter expression to list connector-resources
   optional string filter = 4 [(google.api.field_behavior) = OPTIONAL];
 }
 
-// ListConnectorsResponse represents a response for a list of
-// Connector resources
-message ListConnectorsResponse {
-  // A list of Connector resources
-  repeated Connector connectors = 1;
+// ListConnectorResourcesResponse represents a response for a list of
+// ConnectorResource resources
+message ListConnectorResourcesResponse {
+  // A list of ConnectorResource resources
+  repeated ConnectorResource connector_resources = 1;
   // Next page token
   string next_page_token = 2;
-  // Total count of connector resources
+  // Total count of connector_resource resources
   int64 total_size = 3;
 }
 
-// GetConnectorRequest represents a request to query a
-// Connector resource
-message GetConnectorRequest {
-  // ConnectorConnector resource name. It must have the format of
-  // "connectors/*"
+// GetConnectorResourceRequest represents a request to query a
+// ConnectorResource resource
+message GetConnectorResourceRequest {
+  // ConnectorResourceConnectorResource resource name. It must have the format of
+  // "connector-resources/*"
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {type: "api.instill.tech/Connector"},
+    (google.api.resource_reference) = {type: "api.instill.tech/ConnectorResource"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "connector.name"}
+      field_configuration: {path_param_name: "connector_resource.name"}
     }
   ];
-  // Connector view (default is VIEW_BASIC)
+  // ConnectorResource view (default is VIEW_BASIC)
   optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
 }
 
-// GetConnectorResponse represents a response for a
-// Connector resource
-message GetConnectorResponse {
-  // Connector resource
-  Connector connector = 1;
+// GetConnectorResourceResponse represents a response for a
+// ConnectorResource resource
+message GetConnectorResourceResponse {
+  // ConnectorResource resource
+  ConnectorResource connector_resource = 1;
 }
 
-// UpdateConnectorRequest represents a request to update a
-// Connector resource
-message UpdateConnectorRequest {
-  // Connector resource
-  Connector connector = 1 [(google.api.field_behavior) = REQUIRED];
-  // Update mask for a Connector resource
+// UpdateConnectorResourceRequest represents a request to update a
+// ConnectorResource resource
+message UpdateConnectorResourceRequest {
+  // ConnectorResource resource
+  ConnectorResource connector_resource = 1 [(google.api.field_behavior) = REQUIRED];
+  // Update mask for a ConnectorResource resource
   google.protobuf.FieldMask update_mask = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
-// UpdateConnectorResponse represents a response for a
-// Connector resource
-message UpdateConnectorResponse {
-  // Connector resource
-  Connector connector = 1;
+// UpdateConnectorResourceResponse represents a response for a
+// ConnectorResource resource
+message UpdateConnectorResourceResponse {
+  // ConnectorResource resource
+  ConnectorResource connector_resource = 1;
 }
 
-// DeleteConnectorRequest represents a request to delete a
-// Connector resource
-message DeleteConnectorRequest {
-  // Connector resource name. It must have the format of
-  // "connectors/*"
+// DeleteConnectorResourceRequest represents a request to delete a
+// ConnectorResource resource
+message DeleteConnectorResourceRequest {
+  // ConnectorResource resource name. It must have the format of
+  // "connector-resources/*"
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {type: "api.instill.tech/Connector"},
+    (google.api.resource_reference) = {type: "api.instill.tech/ConnectorResource"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "connector.name"}
+      field_configuration: {path_param_name: "connector_resource.name"}
     }
   ];
 }
 
-// DeleteConnectorResponse represents an empty response
-message DeleteConnectorResponse {}
+// DeleteConnectorResourceResponse represents an empty response
+message DeleteConnectorResourceResponse {}
 
-// LookUpConnectorRequest represents a request to query a
-// connector via permalink
-message LookUpConnectorRequest {
-  // Permalink of a connector. For example:
-  // "connectors/{uid}"
+// LookUpConnectorResourceRequest represents a request to query a
+// connector_resource via permalink
+message LookUpConnectorResourceRequest {
+  // Permalink of a connector_resource. For example:
+  // "connector-resources/{uid}"
   string permalink = 1 [(google.api.field_behavior) = REQUIRED];
-  // Connector view (default is VIEW_BASIC)
+  // ConnectorResource view (default is VIEW_BASIC)
   optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
-// LookUpConnectorResponse represents a response for a
-// connector
-message LookUpConnectorResponse {
-  // Connector resource
-  Connector connector = 1;
+// LookUpConnectorResourceResponse represents a response for a
+// connector_resource
+message LookUpConnectorResourceResponse {
+  // ConnectorResource resource
+  ConnectorResource connector_resource = 1;
 }
 
-// ConnectConnectorRequest represents a request to connect a
-// connector
-message ConnectConnectorRequest {
-  // Connector resource name. It must have the format of
-  // "connectors/*"
+// ConnectConnectorResourceRequest represents a request to connect a
+// connector_resource
+message ConnectConnectorResourceRequest {
+  // ConnectorResource resource name. It must have the format of
+  // "connector-resources/*"
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {type: "api.instill.tech/Connector"}
+    (google.api.resource_reference) = {type: "api.instill.tech/ConnectorResource"}
   ];
 }
 
-// ConnectConnectorResponse represents a connected
-// connector
-message ConnectConnectorResponse {
-  // A Connector resource
-  Connector connector = 1;
+// ConnectConnectorResourceResponse represents a connected
+// connector_resource
+message ConnectConnectorResourceResponse {
+  // A ConnectorResource resource
+  ConnectorResource connector_resource = 1;
 }
 
-// DisconnectConnectorRequest represents a request to disconnect a
-// connector
-message DisconnectConnectorRequest {
-  // Connector resource name. It must have the format of
-  // "connectors/*"
+// DisconnectConnectorResourceRequest represents a request to disconnect a
+// connector_resource
+message DisconnectConnectorResourceRequest {
+  // ConnectorResource resource name. It must have the format of
+  // "connector-resources/*"
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {type: "api.instill.tech/Connector"}
+    (google.api.resource_reference) = {type: "api.instill.tech/ConnectorResource"}
   ];
 }
 
-// DisconnectConnectorResponse represents a disconnected
-// connector
-message DisconnectConnectorResponse {
-  // A Connector resource
-  Connector connector = 1;
+// DisconnectConnectorResourceResponse represents a disconnected
+// connector_resource
+message DisconnectConnectorResourceResponse {
+  // A ConnectorResource resource
+  ConnectorResource connector_resource = 1;
 }
 
-// RenameConnectorRequest represents a request to rename the
-// Connector resource name
-message RenameConnectorRequest {
-  // Connector resource name. It must have the format of
-  // "connectors/*"
+// RenameConnectorResourceRequest represents a request to rename the
+// ConnectorResource resource name
+message RenameConnectorResourceRequest {
+  // ConnectorResource resource name. It must have the format of
+  // "connector-resources/*"
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {type: "api.instill.tech/Connector"}
+    (google.api.resource_reference) = {type: "api.instill.tech/ConnectorResource"}
   ];
-  // Connector new resource id to replace with the
-  // Connector resource name to be
-  // "connectors/{new_connector_id}"
+  // ConnectorResource new resource id to replace with the
+  // ConnectorResource resource name to be
+  // "connector-resources/{new_connector_id}"
   string new_connector_id = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
-// RenameConnectorResponse represents a renamed Connector
+// RenameConnectorResourceResponse represents a renamed ConnectorResource
 // resource
-message RenameConnectorResponse {
-  // A Connector resource
-  Connector connector = 1;
+message RenameConnectorResourceResponse {
+  // A ConnectorResource resource
+  ConnectorResource connector_resource = 1;
 }
 
 // ========== Private endpoints
 
-// ListConnectorsAdminRequest represents a request to list
-// Connector resources from all users by admin
-message ListConnectorsAdminRequest {
-  // The maximum number of connectors to return. The service may return fewer
-  // than this value. If unspecified, at most 10 connectors will be returned.
+// ListConnectorResourcesAdminRequest represents a request to list
+// ConnectorResource resources from all users by admin
+message ListConnectorResourcesAdminRequest {
+  // The maximum number of connector-resources to return. The service may return fewer
+  // than this value. If unspecified, at most 10 connector-resources will be returned.
   // The maximum value is 100; values above 100 will be coerced to 100.
   optional int64 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
   // Page token
   optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
-  // Connector view (default is VIEW_BASIC)
+  // ConnectorResource view (default is VIEW_BASIC)
   optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
-  // Filter expression to list connectors
+  // Filter expression to list connector-resources
   optional string filter = 4 [(google.api.field_behavior) = OPTIONAL];
 }
 
-// ListConnectorsAdminResponse represents a response for a list of
-// Connector resources
-message ListConnectorsAdminResponse {
-  // A list of Connector resources
-  repeated Connector connectors = 1;
+// ListConnectorResourcesAdminResponse represents a response for a list of
+// ConnectorResource resources
+message ListConnectorResourcesAdminResponse {
+  // A list of ConnectorResource resources
+  repeated ConnectorResource connector_resources = 1;
   // Next page token
   string next_page_token = 2;
-  // Total count of connector resources
+  // Total count of connector_resource resources
   int64 total_size = 3;
 }
 
-// LookUpConnectorAdminRequest represents a request to query a
-// connector via permalink by admin
-message LookUpConnectorAdminRequest {
-  // Permalink of a connector. For example:
-  // "connectors/{uid}"
+// LookUpConnectorResourceAdminRequest represents a request to query a
+// connector_resource via permalink by admin
+message LookUpConnectorResourceAdminRequest {
+  // Permalink of a connector_resource. For example:
+  // "connector-resources/{uid}"
   string permalink = 1 [(google.api.field_behavior) = REQUIRED];
-  // Connector view (default is VIEW_BASIC)
+  // ConnectorResource view (default is VIEW_BASIC)
   optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
-// LookUpConnectorAdminResponse represents a response for a
-// connector
-message LookUpConnectorAdminResponse {
-  // Connector resource
-  Connector connector = 1;
+// LookUpConnectorResourceAdminResponse represents a response for a
+// connector_resource
+message LookUpConnectorResourceAdminResponse {
+  // ConnectorResource resource
+  ConnectorResource connector_resource = 1;
 }
 
-// WatchConnectorRequest represents a public request to query
-// a connector's current state
-message WatchConnectorRequest {
-  // Connector resource name. It must have the format of
-  // "connectors/*"
+// WatchConnectorResourceRequest represents a public request to query
+// a connector_resource's current state
+message WatchConnectorResourceRequest {
+  // ConnectorResource resource name. It must have the format of
+  // "connector-resources/*"
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "api.instill.tech/Connector",
+    (google.api.resource_reference).type = "api.instill.tech/ConnectorResource",
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "connector.name"}
+      field_configuration: {path_param_name: "connector_resource.name"}
     }
   ];
 }
 
-// WatchConnectorResponse represents a response to fetch a
-// connector's current state
-message WatchConnectorResponse {
-  // Retrieved connector state
-  Connector.State state = 1;
+// WatchConnectorResourceResponse represents a response to fetch a
+// connector_resource's current state
+message WatchConnectorResourceResponse {
+  // Retrieved connector_resource state
+  ConnectorResource.State state = 1;
 }
 
-// CheckConnectorRequest represents a private request to query
-// a connector's current state
-message CheckConnectorRequest {
-  // Permalink of a connector. For example:
-  // "connectors/{uid}"
-  string connector_permalink = 1 [(google.api.field_behavior) = REQUIRED];
+// CheckConnectorResourceRequest represents a private request to query
+// a connector_resource's current state
+message CheckConnectorResourceRequest {
+  // Permalink of a connector_resource. For example:
+  // "connector-resources/{uid}"
+  string permalink = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
-// CheckConnectorResponse represents a response to fetch a
-// connector's current state
-message CheckConnectorResponse {
-  // Retrieved connector state
-  Connector.State state = 1;
+// CheckConnectorResourceResponse represents a response to fetch a
+// connector_resource's current state
+message CheckConnectorResourceResponse {
+  // Retrieved connector_resource state
+  ConnectorResource.State state = 1;
 }
 
-// TestConnectorRequest represents a public request to trigger check
-// action on a connector
-message TestConnectorRequest {
-  // Connector resource name. It must have the format of
-  // "connectors/*"
+// TestConnectorResourceRequest represents a public request to trigger check
+// action on a connector_resource
+message TestConnectorResourceRequest {
+  // ConnectorResource resource name. It must have the format of
+  // "connector-resources/*"
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "api.instill.tech/Connector",
+    (google.api.resource_reference).type = "api.instill.tech/ConnectorResource",
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "connector.name"}
+      field_configuration: {path_param_name: "connector_resource.name"}
     }
   ];
 }
 
-// TestConnectorResponse represents a response containing a
-// connector's current state
-message TestConnectorResponse {
-  // Retrieved connector state
-  Connector.State state = 1;
+// TestConnectorResourceResponse represents a response containing a
+// connector_resource's current state
+message TestConnectorResourceResponse {
+  // Retrieved connector_resource state
+  ConnectorResource.State state = 1;
 }
 
-// ExecuteConnectorRequest represents a private request to execution
-// connector
-message ExecuteConnectorRequest {
-  // Name of a connector. For example:
-  // "connectors/{name}"
+// ExecuteConnectorResourceRequest represents a private request to execution
+// connector_resource
+message ExecuteConnectorResourceRequest {
+  // Name of a connector_resource. For example:
+  // "connector-resources/{name}"
   string name = 1 [(google.api.field_behavior) = REQUIRED];
 
   // Inputs
   repeated google.protobuf.Struct inputs = 2;
 }
 
-// ExecuteConnectorResponse represents a response for execution
+// ExecuteConnectorResourceResponse represents a response for execution
 // output
-message ExecuteConnectorResponse {
+message ExecuteConnectorResourceResponse {
   // Outputs
   repeated google.protobuf.Struct outputs = 1;
 }

--- a/integration-test/proto/vdp/connector/v1alpha/connector_definition.proto
+++ b/integration-test/proto/vdp/connector/v1alpha/connector_definition.proto
@@ -153,8 +153,8 @@ message LookUpConnectorDefinitionAdminRequest {
   optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
-// LookUpConnectorAdminResponse represents a response for a
-// connector
+// LookUpConnectorDefinitionAdminResponse represents a response for a
+// connector definition
 message LookUpConnectorDefinitionAdminResponse {
   // Connector resource
   ConnectorDefinition connector_definition = 1;

--- a/integration-test/proto/vdp/connector/v1alpha/connector_private_service.proto
+++ b/integration-test/proto/vdp/connector/v1alpha/connector_private_service.proto
@@ -18,24 +18,24 @@ service ConnectorPrivateService {
     option (google.api.method_signature) = "permalink";
   }
 
-  // ListConnectorsAdmin method receives a ListConnectorsAdminRequest
-  // message and returns a ListConnectorsResponse message.
-  rpc ListConnectorsAdmin(ListConnectorsAdminRequest) returns (ListConnectorsAdminResponse) {
-    option (google.api.http) = {get: "/v1alpha/admin/connectors"};
+  // ListConnectorResourcesAdmin method receives a ListConnectorResourcesAdminRequest
+  // message and returns a ListConnectorResourcesResponse message.
+  rpc ListConnectorResourcesAdmin(ListConnectorResourcesAdminRequest) returns (ListConnectorResourcesAdminResponse) {
+    option (google.api.http) = {get: "/v1alpha/admin/connector-resources"};
   }
 
-  // LookUpConnectorAdmin method receives a
-  // LookUpConnectorAdminRequest message and returns a
-  // LookUpConnectorAdminResponse
-  rpc LookUpConnectorAdmin(LookUpConnectorAdminRequest) returns (LookUpConnectorAdminResponse) {
-    option (google.api.http) = {get: "/v1alpha/admin/{permalink=connectors/*}/lookUp"};
+  // LookUpConnectorResourceAdmin method receives a
+  // LookUpConnectorResourceAdminRequest message and returns a
+  // LookUpConnectorResourceAdminResponse
+  rpc LookUpConnectorResourceAdmin(LookUpConnectorResourceAdminRequest) returns (LookUpConnectorResourceAdminResponse) {
+    option (google.api.http) = {get: "/v1alpha/admin/{permalink=connector-resources/*}/lookUp"};
     option (google.api.method_signature) = "permalink";
   }
 
-  // CheckConnector method receives a CheckConnectorRequest message and returns a
-  // CheckConnectorResponse
-  rpc CheckConnector(CheckConnectorRequest) returns (CheckConnectorResponse) {
-    option (google.api.http) = {get: "/v1alpha/admin/{connector_permalink=connectors/*}/check"};
-    option (google.api.method_signature) = "connector_permalink";
+  // CheckConnectorResource method receives a CheckConnectorResourceRequest message and returns a
+  // CheckConnectorResourceResponse
+  rpc CheckConnectorResource(CheckConnectorResourceRequest) returns (CheckConnectorResourceResponse) {
+    option (google.api.http) = {get: "/v1alpha/admin/{permalink=connector-resources/*}/check"};
+    option (google.api.method_signature) = "permalink";
   }
 }

--- a/integration-test/proto/vdp/connector/v1alpha/connector_public_service.proto
+++ b/integration-test/proto/vdp/connector/v1alpha/connector_public_service.proto
@@ -50,121 +50,121 @@ service ConnectorPublicService {
   }
 
   /////////////////////////////////
-  // Connector methods
+  // Connector-Resource methods
   /////////////////////////////////
 
-  // CreateConnector method receives a
-  // CreateConnectorRequest message and returns a
-  // CreateConnectorResponse message.
-  rpc CreateConnector(CreateConnectorRequest) returns (CreateConnectorResponse) {
+  // CreateConnectorResource method receives a
+  // CreateConnectorResourceRequest message and returns a
+  // CreateConnectorResourceResponse message.
+  rpc CreateConnectorResource(CreateConnectorResourceRequest) returns (CreateConnectorResourceResponse) {
     option (google.api.http) = {
-      post: "/v1alpha/connectors"
-      body: "connector"
+      post: "/v1alpha/connector-resources"
+      body: "connector_resource"
     };
-    option (google.api.method_signature) = "connector";
+    option (google.api.method_signature) = "connector_resource";
   }
 
-  // ListConnectors method receives a
-  // ListConnectorsRequest message and returns a
-  // ListConnectorsResponse message.
-  rpc ListConnectors(ListConnectorsRequest) returns (ListConnectorsResponse) {
-    option (google.api.http) = {get: "/v1alpha/connectors"};
+  // ListConnectorResources method receives a
+  // ListConnectorResourcesRequest message and returns a
+  // ListConnectorResourcesResponse message.
+  rpc ListConnectorResources(ListConnectorResourcesRequest) returns (ListConnectorResourcesResponse) {
+    option (google.api.http) = {get: "/v1alpha/connector-resources"};
   }
 
-  // GetConnector method receives a GetConnectorRequest
-  // message and returns a GetConnectorResponse message.
-  rpc GetConnector(GetConnectorRequest) returns (GetConnectorResponse) {
-    option (google.api.http) = {get: "/v1alpha/{name=connectors/*}"};
+  // GetConnectorResource method receives a GetConnectorResourceRequest
+  // message and returns a GetConnectorResourceResponse message.
+  rpc GetConnectorResource(GetConnectorResourceRequest) returns (GetConnectorResourceResponse) {
+    option (google.api.http) = {get: "/v1alpha/{name=connector-resources/*}"};
     option (google.api.method_signature) = "name";
   }
 
-  // UpdateConnector method receives a
-  // UpdateConnectorRequest message and returns a
-  // UpdateConnectorResponse message.
-  rpc UpdateConnector(UpdateConnectorRequest) returns (UpdateConnectorResponse) {
+  // UpdateConnectorResource method receives a
+  // UpdateConnectorResourceRequest message and returns a
+  // UpdateConnectorResourceResponse message.
+  rpc UpdateConnectorResource(UpdateConnectorResourceRequest) returns (UpdateConnectorResourceResponse) {
     option (google.api.http) = {
-      patch: "/v1alpha/{connector.name=connectors/*}"
-      body: "connector"
+      patch: "/v1alpha/{connector_resource.name=connector-resources/*}"
+      body: "connector_resource"
     };
-    option (google.api.method_signature) = "connector,update_mask";
+    option (google.api.method_signature) = "connector_resource,update_mask";
   }
 
-  // DeleteConnector method receives a
-  // DeleteConnectorRequest message and returns a
-  // DeleteConnectorResponse message.
-  rpc DeleteConnector(DeleteConnectorRequest) returns (DeleteConnectorResponse) {
-    option (google.api.http) = {delete: "/v1alpha/{name=connectors/*}"};
+  // DeleteConnectorResource method receives a
+  // DeleteConnectorResourceRequest message and returns a
+  // DeleteConnectorResourceResponse message.
+  rpc DeleteConnectorResource(DeleteConnectorResourceRequest) returns (DeleteConnectorResourceResponse) {
+    option (google.api.http) = {delete: "/v1alpha/{name=connector-resources/*}"};
     option (google.api.method_signature) = "name";
   }
 
-  // LookUpConnector method receives a
-  // LookUpConnectorRequest message and returns a
-  // LookUpConnectorResponse
-  rpc LookUpConnector(LookUpConnectorRequest) returns (LookUpConnectorResponse) {
-    option (google.api.http) = {get: "/v1alpha/{permalink=connectors/*}/lookUp"};
+  // LookUpConnectorResource method receives a
+  // LookUpConnectorResourceRequest message and returns a
+  // LookUpConnectorResourceResponse
+  rpc LookUpConnectorResource(LookUpConnectorResourceRequest) returns (LookUpConnectorResourceResponse) {
+    option (google.api.http) = {get: "/v1alpha/{permalink=connector-resources/*}/lookUp"};
     option (google.api.method_signature) = "permalink";
   }
 
-  // Connect a connector.
-  // The "state" of the connector after connecting is "CONNECTED".
-  // ConnectConnector can be called on Connector in the
-  // state `DISCONNECTED`; Connector in a different state (including
+  // Connect a connector resource.
+  // The "state" of the connector resource after connecting is "CONNECTED".
+  // ConnectConnectorResource can be called on ConnectorResource in the
+  // state `DISCONNECTED`; ConnectorResource in a different state (including
   // `CONNECTED`) returns an error.
-  rpc ConnectConnector(ConnectConnectorRequest) returns (ConnectConnectorResponse) {
+  rpc ConnectConnectorResource(ConnectConnectorResourceRequest) returns (ConnectConnectorResourceResponse) {
     option (google.api.http) = {
-      post: "/v1alpha/{name=connectors/*}/connect"
+      post: "/v1alpha/{name=connector-resources/*}/connect"
       body: "*"
     };
     option (google.api.method_signature) = "name";
   }
 
-  // Disconnect a connector.
-  // The "state" of the connector after disconnecting is "DISCONNECTED".
-  // DisconnectConnector can be called on Connector in the
-  // state `CONNECTED`; Connector in a different state (including
+  // Disconnect a connectorResource.
+  // The "state" of the connectorResource after disconnecting is "DISCONNECTED".
+  // DisconnectConnectorResource can be called on ConnectorResource in the
+  // state `CONNECTED`; ConnectorResource in a different state (including
   // `DISCONNECTED`) returns an error.
-  rpc DisconnectConnector(DisconnectConnectorRequest) returns (DisconnectConnectorResponse) {
+  rpc DisconnectConnectorResource(DisconnectConnectorResourceRequest) returns (DisconnectConnectorResourceResponse) {
     option (google.api.http) = {
-      post: "/v1alpha/{name=connectors/*}/disconnect"
+      post: "/v1alpha/{name=connector-resources/*}/disconnect"
       body: "*"
     };
     option (google.api.method_signature) = "name";
   }
 
-  // RenameConnector method receives a
-  // RenameConnectorRequest message and returns a
-  // RenameConnectorResponse message.
-  rpc RenameConnector(RenameConnectorRequest) returns (RenameConnectorResponse) {
+  // RenameConnectorResource method receives a
+  // RenameConnectorResourceRequest message and returns a
+  // RenameConnectorResourceResponse message.
+  rpc RenameConnectorResource(RenameConnectorResourceRequest) returns (RenameConnectorResourceResponse) {
     option (google.api.http) = {
-      post: "/v1alpha/{name=connectors/*}/rename"
+      post: "/v1alpha/{name=connector-resources/*}/rename"
       body: "*"
     };
-    option (google.api.method_signature) = "name,new_connector_id";
+    option (google.api.method_signature) = "name,new_connector_resource_id";
   }
 
-  // ExecuteConnector method receives a
-  // ExecuteConnectorRequest message and returns a
-  // ExecuteConnectorResponse message.
-  rpc ExecuteConnector(ExecuteConnectorRequest) returns (ExecuteConnectorResponse) {
+  // ExecuteConnectorResource method receives a
+  // ExecuteConnectorResourceRequest message and returns a
+  // ExecuteConnectorResourceResponse message.
+  rpc ExecuteConnectorResource(ExecuteConnectorResourceRequest) returns (ExecuteConnectorResourceResponse) {
     option (google.api.http) = {
-      post: "/v1alpha/{name=connectors/*}/execute"
+      post: "/v1alpha/{name=connector-resources/*}/execute"
       body: "*"
     };
     option (google.api.method_signature) = "name";
   }
 
-  // WatchConnector method receives a
-  // WatchConnectorRequest message and returns a
-  // WatchConnectorResponse
-  rpc WatchConnector(WatchConnectorRequest) returns (WatchConnectorResponse) {
-    option (google.api.http) = {get: "/v1alpha/{name=connectors/*}/watch"};
+  // WatchConnectorResource method receives a
+  // WatchConnectorResourceRequest message and returns a
+  // WatchConnectorResourceResponse
+  rpc WatchConnectorResource(WatchConnectorResourceRequest) returns (WatchConnectorResourceResponse) {
+    option (google.api.http) = {get: "/v1alpha/{name=connector-resources/*}/watch"};
     option (google.api.method_signature) = "name";
   }
 
-  // TestConnector method receives a TestConnectorRequest
-  // message and returns a TestConnectorResponse
-  rpc TestConnector(TestConnectorRequest) returns (TestConnectorResponse) {
-    option (google.api.http) = {post: "/v1alpha/{name=connectors/*}/testConnection"};
+  // TestConnectorResource method receives a TestConnectorResourceRequest
+  // message and returns a TestConnectorResourceResponse
+  rpc TestConnectorResource(TestConnectorResourceRequest) returns (TestConnectorResourceResponse) {
+    option (google.api.http) = {post: "/v1alpha/{name=connector-resources/*}/testConnection"};
     option (google.api.method_signature) = "name";
   }
 }

--- a/integration-test/proto/vdp/pipeline/v1alpha/common.proto
+++ b/integration-test/proto/vdp/pipeline/v1alpha/common.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package vdp.pipeline.v1alpha;
+
+// View represents a view of any resource. The resource view is implemented by
+// adding a parameter to the method request which allows the client to specify
+// which view of the resource it wants to receive in the response.
+enum View {
+  // View: UNSPECIFIED
+  VIEW_UNSPECIFIED = 0;
+  // View: BASIC
+  VIEW_BASIC = 1;
+  // View: FULL
+  VIEW_FULL = 2;
+}

--- a/integration-test/proto/vdp/pipeline/v1alpha/operator_definition.proto
+++ b/integration-test/proto/vdp/pipeline/v1alpha/operator_definition.proto
@@ -8,7 +8,7 @@ import "google/api/resource.proto";
 // Protocol Buffers Well-Known Types
 import "google/protobuf/struct.proto";
 import "protoc-gen-openapiv2/options/annotations.proto";
-import "../../../vdp/pipeline/v1alpha/pipeline.proto";
+import "../../../vdp/pipeline/v1alpha/common.proto";
 
 // View enumerates the definition views
 message Spec {

--- a/integration-test/proto/vdp/pipeline/v1alpha/pipeline.proto
+++ b/integration-test/proto/vdp/pipeline/v1alpha/pipeline.proto
@@ -12,6 +12,10 @@ import "google/protobuf/field_mask.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 import "protoc-gen-openapiv2/options/annotations.proto";
+import "../../../vdp/connector/v1alpha/connector.proto";
+import "../../../vdp/connector/v1alpha/connector_definition.proto";
+import "../../../vdp/pipeline/v1alpha/common.proto";
+import "../../../vdp/pipeline/v1alpha/operator_definition.proto";
 
 // LivenessRequest represents a request to check a service liveness status
 message LivenessRequest {
@@ -37,6 +41,20 @@ message ReadinessResponse {
   common.healthcheck.v1alpha.HealthCheckResponse health_check_response = 1;
 }
 
+// ComponentType
+enum ComponentType {
+  // TYPE_UNSPECIFIED
+  COMPONENT_TYPE_UNSPECIFIED = 0;
+  // CONNECTOR_AI
+  COMPONENT_TYPE_CONNECTOR_AI = 1;
+  // CONNECTOR_DATA
+  COMPONENT_TYPE_CONNECTOR_DATA = 2;
+  // CONNECTOR_BLOCKCHAIN
+  COMPONENT_TYPE_CONNECTOR_BLOCKCHAIN = 3;
+  // CONNECTOR_OPERATOR
+  COMPONENT_TYPE_OPERATOR = 4;
+}
+
 // Represents a pipeline component
 message Component {
   // Component id that is given by the users
@@ -44,18 +62,23 @@ message Component {
   // A pipeline component resource name
   string resource_name = 2 [(google.api.resource_reference).type = "*"];
   // A pipeline component resource detail
-  google.protobuf.Struct resource_detail = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+  vdp.connector.v1alpha.ConnectorResource resource = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Configuration for the pipeline component
   google.protobuf.Struct configuration = 4;
   // Resource Type
-  string type = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
+  ComponentType type = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
   // A pipeline component definition name
   string definition_name = 7 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference).type = "*"
   ];
   // A pipeline component definition detail
-  google.protobuf.Struct definition_detail = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
+  oneof definition {
+    // operator definition detail
+    OperatorDefinition operator_definition = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
+    // connector definition detail
+    vdp.connector.v1alpha.ConnectorDefinition connector_definition = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
+  }
 }
 
 // Pipeline represents a pipeline recipe
@@ -130,18 +153,6 @@ message CreatePipelineRequest {
 message CreatePipelineResponse {
   // The created pipeline resource
   Pipeline pipeline = 1;
-}
-
-// View represents a view of any resource. The resource view is implemented by
-// adding a parameter to the method request which allows the client to specify
-// which view of the resource it wants to receive in the response.
-enum View {
-  // View: UNSPECIFIED
-  VIEW_UNSPECIFIED = 0;
-  // View: BASIC
-  VIEW_BASIC = 1;
-  // View: FULL
-  VIEW_FULL = 2;
 }
 
 // ListPipelinesRequest represents a request to list pipelines

--- a/integration-test/rest.js
+++ b/integration-test/rest.js
@@ -29,7 +29,7 @@ export function setup() {
 
   group("Connector Backend API: Create a CSV destination connector 1", function () {
 
-    var res = http.request("POST", `${connectorPublicHost}/v1alpha/connectors`,
+    var res = http.request("POST", `${connectorPublicHost}/v1alpha/connector-resources`,
       JSON.stringify({
         "id": constant.dstCSVConnID1,
         "connector_definition_name": "connector-definitions/airbyte-destination-csv",
@@ -42,13 +42,13 @@ export function setup() {
       "POST /v1alpha/connectors response status for creating CSV destination connector 201": (r) => r.status === 201,
     })
 
-    http.request("POST", `${connectorPublicHost}/v1alpha/connectors/${constant.dstCSVConnID1}/connect`, {}, constant.params)
+    http.request("POST", `${connectorPublicHost}/v1alpha/connector-resources/${constant.dstCSVConnID1}/connect`, {}, constant.params)
 
   });
 
   group("Connector Backend API: Create a CSV destination connector 2", function () {
 
-    var res = http.request("POST", `${connectorPublicHost}/v1alpha/connectors`,
+    var res = http.request("POST", `${connectorPublicHost}/v1alpha/connector-resources`,
       JSON.stringify({
         "id": constant.dstCSVConnID2,
         "connector_definition_name": "connector-definitions/airbyte-destination-csv",
@@ -61,7 +61,7 @@ export function setup() {
       "POST /v1alpha/connectors response status for creating CSV destination connector 201": (r) => r.status === 201,
     })
 
-    http.request("POST", `${connectorPublicHost}/v1alpha/connectors/${constant.dstCSVConnID2}/connect`, {}, constant.params)
+    http.request("POST", `${connectorPublicHost}/v1alpha/connector-resources/${constant.dstCSVConnID2}/connect`, {}, constant.params)
 
   });
 
@@ -121,13 +121,13 @@ export function teardown(data) {
     }
   });
   group("Connector Backend API: Delete the csv destination connector", function () {
-    check(http.request("DELETE", `${connectorPublicHost}/v1alpha/connectors/${constant.dstCSVConnID1}`), {
-      [`DELETE /v1alpha/connectors/${constant.dstCSVConnID1} response status 204`]: (r) => r.status === 204,
+    check(http.request("DELETE", `${connectorPublicHost}/v1alpha/connector-resources/${constant.dstCSVConnID1}`), {
+      [`DELETE /v1alpha/connector-resources/${constant.dstCSVConnID1} response status 204`]: (r) => r.status === 204,
     });
   });
   group("Connector Backend API: Delete the csv destination connector", function () {
-    check(http.request("DELETE", `${connectorPublicHost}/v1alpha/connectors/${constant.dstCSVConnID2}`), {
-      [`DELETE /v1alpha/connectors/${constant.dstCSVConnID2} response status 204`]: (r) => r.status === 204,
+    check(http.request("DELETE", `${connectorPublicHost}/v1alpha/connector-resources/${constant.dstCSVConnID2}`), {
+      [`DELETE /v1alpha/connector-resources/${constant.dstCSVConnID2} response status 204`]: (r) => r.status === 204,
     });
   });
 }

--- a/pkg/datamodel/datamodel.go
+++ b/pkg/datamodel/datamodel.go
@@ -64,12 +64,10 @@ type Recipe struct {
 }
 
 type Component struct {
-	Id               string           `json:"id"`
-	DefinitionName   string           `json:"definition_name"`
-	DefinitionDetail *structpb.Struct `json:"definition_detail,omitempty"`
-	ResourceName     string           `json:"resource_name"`
-	ResourceDetail   *structpb.Struct `json:"resource_detail,omitempty"`
-	Configuration    *structpb.Struct `json:"configuration"`
+	Id             string           `json:"id"`
+	DefinitionName string           `json:"definition_name"`
+	ResourceName   string           `json:"resource_name"`
+	Configuration  *structpb.Struct `json:"configuration"`
 }
 
 // Scan function for custom GORM type Recipe

--- a/pkg/handler/convert.go
+++ b/pkg/handler/convert.go
@@ -110,8 +110,8 @@ func DBToPBPipeline(ctx context.Context, dbPipeline *datamodel.Pipeline) *pipeli
 				for i := range pbRecipe.Components {
 					// TODO: use enum
 					if strings.HasPrefix(pbRecipe.Components[i].DefinitionName, "connector-definitions/") {
-						if pbRecipe.Components[i].ResourceDetail != nil {
-							switch pbRecipe.Components[i].ResourceDetail.ConnectorType {
+						if pbRecipe.Components[i].Resource != nil {
+							switch pbRecipe.Components[i].Resource.ConnectorType {
 							case connectorPB.ConnectorType_CONNECTOR_TYPE_AI:
 								pbRecipe.Components[i].Type = pipelinePB.ComponentType_COMPONENT_TYPE_CONNECTOR_AI
 							case connectorPB.ConnectorType_CONNECTOR_TYPE_BLOCKCHAIN:
@@ -166,7 +166,7 @@ func IncludeDetailInRecipeAdmin(recipe *pipelinePB.Recipe, s service.Service) er
 				return unmarshalErr
 			}
 
-			recipe.Components[idx].ResourceDetail = resp.ConnectorResource
+			recipe.Components[idx].Resource = resp.ConnectorResource
 		}
 		if service.IsConnectorDefinition(recipe.Components[idx].DefinitionName) {
 			resp, err := s.GetConnectorPrivateServiceClient().LookUpConnectorDefinitionAdmin(ctx, &connectorPB.LookUpConnectorDefinitionAdminRequest{
@@ -187,7 +187,7 @@ func IncludeDetailInRecipeAdmin(recipe *pipelinePB.Recipe, s service.Service) er
 				return unmarshalErr
 			}
 
-			recipe.Components[idx].DefinitionDetail = &pipelinePB.Component_ConnectorDefinitionDetail{ConnectorDefinitionDetail: resp.ConnectorDefinition}
+			recipe.Components[idx].Definition = &pipelinePB.Component_ConnectorDefinition{ConnectorDefinition: resp.ConnectorDefinition}
 		}
 		if service.IsOperatorDefinition(recipe.Components[idx].DefinitionName) {
 			uid, err := resource.GetPermalinkUID(recipe.Components[idx].DefinitionName)
@@ -210,7 +210,7 @@ func IncludeDetailInRecipeAdmin(recipe *pipelinePB.Recipe, s service.Service) er
 				return unmarshalErr
 			}
 
-			recipe.Components[idx].DefinitionDetail = &pipelinePB.Component_OperatorDefinitionDetail{OperatorDefinitionDetail: def}
+			recipe.Components[idx].Definition = &pipelinePB.Component_OperatorDefinition{OperatorDefinition: def}
 		}
 
 	}
@@ -243,7 +243,7 @@ func IncludeDetailInRecipe(recipe *pipelinePB.Recipe, s service.Service) error {
 				return unmarshalErr
 			}
 
-			recipe.Components[idx].ResourceDetail = resp.ConnectorResource
+			recipe.Components[idx].Resource = resp.ConnectorResource
 		}
 		if service.IsConnectorDefinition(recipe.Components[idx].DefinitionName) {
 			resp, err := s.GetConnectorPublicServiceClient().GetConnectorDefinition(ctx, &connectorPB.GetConnectorDefinitionRequest{
@@ -264,7 +264,7 @@ func IncludeDetailInRecipe(recipe *pipelinePB.Recipe, s service.Service) error {
 				return unmarshalErr
 			}
 
-			recipe.Components[idx].DefinitionDetail = &pipelinePB.Component_ConnectorDefinitionDetail{ConnectorDefinitionDetail: resp.ConnectorDefinition}
+			recipe.Components[idx].Definition = &pipelinePB.Component_ConnectorDefinition{ConnectorDefinition: resp.ConnectorDefinition}
 		}
 		if service.IsOperatorDefinition(recipe.Components[idx].DefinitionName) {
 			id, err := resource.GetRscNameID(recipe.Components[idx].DefinitionName)
@@ -287,7 +287,7 @@ func IncludeDetailInRecipe(recipe *pipelinePB.Recipe, s service.Service) error {
 				return unmarshalErr
 			}
 
-			recipe.Components[idx].DefinitionDetail = &pipelinePB.Component_OperatorDefinitionDetail{OperatorDefinitionDetail: def}
+			recipe.Components[idx].Definition = &pipelinePB.Component_OperatorDefinition{OperatorDefinition: def}
 		}
 
 	}

--- a/pkg/handler/convert.go
+++ b/pkg/handler/convert.go
@@ -148,7 +148,7 @@ func IncludeDetailInRecipeAdmin(recipe *pipelinePB.Recipe, s service.Service) er
 	for idx := range recipe.Components {
 
 		if service.IsConnector(recipe.Components[idx].ResourceName) {
-			resp, err := s.GetConnectorPrivateServiceClient().LookUpConnectorAdmin(ctx, &connectorPB.LookUpConnectorAdminRequest{
+			resp, err := s.GetConnectorPrivateServiceClient().LookUpConnectorResourceAdmin(ctx, &connectorPB.LookUpConnectorResourceAdminRequest{
 				Permalink: recipe.Components[idx].ResourceName,
 				View:      connectorPB.View_VIEW_FULL.Enum(),
 			})
@@ -157,7 +157,7 @@ func IncludeDetailInRecipeAdmin(recipe *pipelinePB.Recipe, s service.Service) er
 			}
 			detail := &structpb.Struct{}
 			// Note: need to deal with camelCase or under_score for grpc in future
-			json, marshalErr := protojson.MarshalOptions{UseProtoNames: true}.Marshal(resp.GetConnector())
+			json, marshalErr := protojson.MarshalOptions{UseProtoNames: true}.Marshal(resp.GetConnectorResource())
 			if marshalErr != nil {
 				return marshalErr
 			}
@@ -166,7 +166,7 @@ func IncludeDetailInRecipeAdmin(recipe *pipelinePB.Recipe, s service.Service) er
 				return unmarshalErr
 			}
 
-			recipe.Components[idx].ResourceDetail = resp.Connector
+			recipe.Components[idx].ResourceDetail = resp.ConnectorResource
 		}
 		if service.IsConnectorDefinition(recipe.Components[idx].DefinitionName) {
 			resp, err := s.GetConnectorPrivateServiceClient().LookUpConnectorDefinitionAdmin(ctx, &connectorPB.LookUpConnectorDefinitionAdminRequest{
@@ -225,7 +225,7 @@ func IncludeDetailInRecipe(recipe *pipelinePB.Recipe, s service.Service) error {
 	for idx := range recipe.Components {
 
 		if service.IsConnector(recipe.Components[idx].ResourceName) {
-			resp, err := s.GetConnectorPublicServiceClient().GetConnector(ctx, &connectorPB.GetConnectorRequest{
+			resp, err := s.GetConnectorPublicServiceClient().GetConnectorResource(ctx, &connectorPB.GetConnectorResourceRequest{
 				Name: recipe.Components[idx].ResourceName,
 				View: connectorPB.View_VIEW_FULL.Enum(),
 			})
@@ -234,7 +234,7 @@ func IncludeDetailInRecipe(recipe *pipelinePB.Recipe, s service.Service) error {
 			}
 			detail := &structpb.Struct{}
 			// Note: need to deal with camelCase or under_score for grpc in future
-			json, marshalErr := protojson.MarshalOptions{UseProtoNames: true}.Marshal(resp.GetConnector())
+			json, marshalErr := protojson.MarshalOptions{UseProtoNames: true}.Marshal(resp.GetConnectorResource())
 			if marshalErr != nil {
 				return marshalErr
 			}
@@ -243,7 +243,7 @@ func IncludeDetailInRecipe(recipe *pipelinePB.Recipe, s service.Service) error {
 				return unmarshalErr
 			}
 
-			recipe.Components[idx].ResourceDetail = resp.Connector
+			recipe.Components[idx].ResourceDetail = resp.ConnectorResource
 		}
 		if service.IsConnectorDefinition(recipe.Components[idx].DefinitionName) {
 			resp, err := s.GetConnectorPublicServiceClient().GetConnectorDefinition(ctx, &connectorPB.GetConnectorDefinitionRequest{

--- a/pkg/handler/privateHandler.go
+++ b/pkg/handler/privateHandler.go
@@ -80,7 +80,13 @@ func (h *PrivateHandler) ListPipelinesAdmin(ctx context.Context, req *pipelinePB
 
 	pbPipelines := []*pipelinePB.Pipeline{}
 	for idx := range dbPipelines {
-		pbPipelines = append(pbPipelines, DBToPBPipeline(ctx, &dbPipelines[idx]))
+		pbPipeline := DBToPBPipeline(ctx, &dbPipelines[idx])
+		if !isBasicView {
+			if err := IncludeDetailInRecipe(pbPipeline.Recipe, h.service); err != nil {
+				return nil, err
+			}
+		}
+		pbPipelines = append(pbPipelines, pbPipeline)
 	}
 
 	resp := pipelinePB.ListPipelinesAdminResponse{
@@ -117,6 +123,11 @@ func (h *PrivateHandler) LookUpPipelineAdmin(ctx context.Context, req *pipelineP
 	}
 
 	pbPipeline := DBToPBPipeline(ctx, dbPipeline)
+	if !isBasicView {
+		if err := IncludeDetailInRecipeAdmin(pbPipeline.Recipe, h.service); err != nil {
+			return nil, err
+		}
+	}
 	resp := pipelinePB.LookUpPipelineAdminResponse{
 		Pipeline: pbPipeline,
 	}

--- a/pkg/handler/privateHandler.go
+++ b/pkg/handler/privateHandler.go
@@ -82,7 +82,7 @@ func (h *PrivateHandler) ListPipelinesAdmin(ctx context.Context, req *pipelinePB
 	for idx := range dbPipelines {
 		pbPipeline := DBToPBPipeline(ctx, &dbPipelines[idx])
 		if !isBasicView {
-			if err := IncludeDetailInRecipe(pbPipeline.Recipe, h.service); err != nil {
+			if err := IncludeDetailInRecipeAdmin(pbPipeline.Recipe, h.service); err != nil {
 				return nil, err
 			}
 		}

--- a/pkg/handler/publicHandler.go
+++ b/pkg/handler/publicHandler.go
@@ -21,11 +21,11 @@ import (
 
 	fieldmask_utils "github.com/mennanov/fieldmask-utils"
 
-	"github.com/instill-ai/connector-backend/pkg/repository"
 	"github.com/instill-ai/pipeline-backend/internal/resource"
 	"github.com/instill-ai/pipeline-backend/pkg/datamodel"
 	"github.com/instill-ai/pipeline-backend/pkg/logger"
 	"github.com/instill-ai/pipeline-backend/pkg/operator"
+	"github.com/instill-ai/pipeline-backend/pkg/repository"
 	"github.com/instill-ai/pipeline-backend/pkg/service"
 	"github.com/instill-ai/pipeline-backend/pkg/utils"
 	"github.com/instill-ai/x/checkfield"

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -112,7 +112,7 @@ func (o *Operator) ListOperatorDefinitions() []*pipelinePB.OperatorDefinition {
 func (o *Operator) GetOperatorDefinitionByUid(defUid uuid.UUID) (*pipelinePB.OperatorDefinition, error) {
 	val, ok := o.definitionMapByUid[defUid]
 	if !ok {
-		return nil, fmt.Errorf("get operator defintion error")
+		return nil, fmt.Errorf("get operator defintion error1 %s", defUid.String())
 	}
 	return val, nil
 }
@@ -121,7 +121,7 @@ func (o *Operator) GetOperatorDefinitionById(defId string) (*pipelinePB.Operator
 
 	val, ok := o.definitionMapById[defId]
 	if !ok {
-		return nil, fmt.Errorf("get operator defintion error")
+		return nil, fmt.Errorf("get operator defintion error %s", defId)
 	}
 	return val, nil
 }

--- a/pkg/service/convert.go
+++ b/pkg/service/convert.go
@@ -16,7 +16,7 @@ import (
 )
 
 func IsConnector(resourceName string) bool {
-	return strings.HasPrefix(resourceName, "connectors/")
+	return strings.HasPrefix(resourceName, "connector-resources/")
 }
 
 func IsConnectorDefinition(resourceName string) bool {
@@ -106,8 +106,8 @@ func (s *service) recipePermalinkToName(recipePermalink *datamodel.Recipe) (*dat
 
 func (s *service) connectorNameToPermalink(ctx context.Context, name string) (string, error) {
 
-	getSrcConnResp, err := s.connectorPublicServiceClient.GetConnector(ctx,
-		&connectorPB.GetConnectorRequest{
+	getSrcConnResp, err := s.connectorPublicServiceClient.GetConnectorResource(ctx,
+		&connectorPB.GetConnectorResourceRequest{
 			Name: name,
 		})
 	if err != nil {
@@ -119,15 +119,15 @@ func (s *service) connectorNameToPermalink(ctx context.Context, name string) (st
 		return "", err
 	}
 
-	return srcColID + "/" + getSrcConnResp.GetConnector().GetUid(), nil
+	return srcColID + "/" + getSrcConnResp.GetConnectorResource().GetUid(), nil
 }
 
 func (s *service) connectorPermalinkToName(permalink string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	lookUpSrcConnResp, err := s.connectorPrivateServiceClient.LookUpConnectorAdmin(ctx,
-		&connectorPB.LookUpConnectorAdminRequest{
+	lookUpSrcConnResp, err := s.connectorPrivateServiceClient.LookUpConnectorResourceAdmin(ctx,
+		&connectorPB.LookUpConnectorResourceAdminRequest{
 			Permalink: permalink,
 		})
 	if err != nil {
@@ -139,7 +139,7 @@ func (s *service) connectorPermalinkToName(permalink string) (string, error) {
 		return "", err
 	}
 
-	return srcColID + "/" + lookUpSrcConnResp.GetConnector().GetId(), nil
+	return srcColID + "/" + lookUpSrcConnResp.GetConnectorResource().GetId(), nil
 }
 
 func (s *service) connectorDefinitionNameToPermalink(ctx context.Context, name string) (string, error) {

--- a/pkg/service/mock_connector_private_grpc_test.go
+++ b/pkg/service/mock_connector_private_grpc_test.go
@@ -36,62 +36,82 @@ func (m *MockConnectorPrivateServiceClient) EXPECT() *MockConnectorPrivateServic
 	return m.recorder
 }
 
-// CheckConnector mocks base method.
-func (m *MockConnectorPrivateServiceClient) CheckConnector(arg0 context.Context, arg1 *connectorv1alpha.CheckConnectorRequest, arg2 ...grpc.CallOption) (*connectorv1alpha.CheckConnectorResponse, error) {
+// CheckConnectorResource mocks base method.
+func (m *MockConnectorPrivateServiceClient) CheckConnectorResource(arg0 context.Context, arg1 *connectorv1alpha.CheckConnectorResourceRequest, arg2 ...grpc.CallOption) (*connectorv1alpha.CheckConnectorResourceResponse, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
-	ret := m.ctrl.Call(m, "CheckConnector", varargs...)
-	ret0, _ := ret[0].(*connectorv1alpha.CheckConnectorResponse)
+	ret := m.ctrl.Call(m, "CheckConnectorResource", varargs...)
+	ret0, _ := ret[0].(*connectorv1alpha.CheckConnectorResourceResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// CheckConnector indicates an expected call of CheckConnector.
-func (mr *MockConnectorPrivateServiceClientMockRecorder) CheckConnector(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+// CheckConnectorResource indicates an expected call of CheckConnectorResource.
+func (mr *MockConnectorPrivateServiceClientMockRecorder) CheckConnectorResource(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckConnector", reflect.TypeOf((*MockConnectorPrivateServiceClient)(nil).CheckConnector), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckConnectorResource", reflect.TypeOf((*MockConnectorPrivateServiceClient)(nil).CheckConnectorResource), varargs...)
 }
 
-// ListConnectorsAdmin mocks base method.
-func (m *MockConnectorPrivateServiceClient) ListConnectorsAdmin(arg0 context.Context, arg1 *connectorv1alpha.ListConnectorsAdminRequest, arg2 ...grpc.CallOption) (*connectorv1alpha.ListConnectorsAdminResponse, error) {
+// ListConnectorResourcesAdmin mocks base method.
+func (m *MockConnectorPrivateServiceClient) ListConnectorResourcesAdmin(arg0 context.Context, arg1 *connectorv1alpha.ListConnectorResourcesAdminRequest, arg2 ...grpc.CallOption) (*connectorv1alpha.ListConnectorResourcesAdminResponse, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
-	ret := m.ctrl.Call(m, "ListConnectorsAdmin", varargs...)
-	ret0, _ := ret[0].(*connectorv1alpha.ListConnectorsAdminResponse)
+	ret := m.ctrl.Call(m, "ListConnectorResourcesAdmin", varargs...)
+	ret0, _ := ret[0].(*connectorv1alpha.ListConnectorResourcesAdminResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListConnectorsAdmin indicates an expected call of ListConnectorsAdmin.
-func (mr *MockConnectorPrivateServiceClientMockRecorder) ListConnectorsAdmin(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+// ListConnectorResourcesAdmin indicates an expected call of ListConnectorResourcesAdmin.
+func (mr *MockConnectorPrivateServiceClientMockRecorder) ListConnectorResourcesAdmin(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListConnectorsAdmin", reflect.TypeOf((*MockConnectorPrivateServiceClient)(nil).ListConnectorsAdmin), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListConnectorResourcesAdmin", reflect.TypeOf((*MockConnectorPrivateServiceClient)(nil).ListConnectorResourcesAdmin), varargs...)
 }
 
-// LookUpConnectorAdmin mocks base method.
-func (m *MockConnectorPrivateServiceClient) LookUpConnectorAdmin(arg0 context.Context, arg1 *connectorv1alpha.LookUpConnectorAdminRequest, arg2 ...grpc.CallOption) (*connectorv1alpha.LookUpConnectorAdminResponse, error) {
+// LookUpConnectorDefinitionAdmin mocks base method.
+func (m *MockConnectorPrivateServiceClient) LookUpConnectorDefinitionAdmin(arg0 context.Context, arg1 *connectorv1alpha.LookUpConnectorDefinitionAdminRequest, arg2 ...grpc.CallOption) (*connectorv1alpha.LookUpConnectorDefinitionAdminResponse, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
-	ret := m.ctrl.Call(m, "LookUpConnectorAdmin", varargs...)
-	ret0, _ := ret[0].(*connectorv1alpha.LookUpConnectorAdminResponse)
+	ret := m.ctrl.Call(m, "LookUpConnectorDefinitionAdmin", varargs...)
+	ret0, _ := ret[0].(*connectorv1alpha.LookUpConnectorDefinitionAdminResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// LookUpConnectorAdmin indicates an expected call of LookUpConnectorAdmin.
-func (mr *MockConnectorPrivateServiceClientMockRecorder) LookUpConnectorAdmin(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+// LookUpConnectorDefinitionAdmin indicates an expected call of LookUpConnectorDefinitionAdmin.
+func (mr *MockConnectorPrivateServiceClientMockRecorder) LookUpConnectorDefinitionAdmin(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LookUpConnectorAdmin", reflect.TypeOf((*MockConnectorPrivateServiceClient)(nil).LookUpConnectorAdmin), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LookUpConnectorDefinitionAdmin", reflect.TypeOf((*MockConnectorPrivateServiceClient)(nil).LookUpConnectorDefinitionAdmin), varargs...)
+}
+
+// LookUpConnectorResourceAdmin mocks base method.
+func (m *MockConnectorPrivateServiceClient) LookUpConnectorResourceAdmin(arg0 context.Context, arg1 *connectorv1alpha.LookUpConnectorResourceAdminRequest, arg2 ...grpc.CallOption) (*connectorv1alpha.LookUpConnectorResourceAdminResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "LookUpConnectorResourceAdmin", varargs...)
+	ret0, _ := ret[0].(*connectorv1alpha.LookUpConnectorResourceAdminResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// LookUpConnectorResourceAdmin indicates an expected call of LookUpConnectorResourceAdmin.
+func (mr *MockConnectorPrivateServiceClientMockRecorder) LookUpConnectorResourceAdmin(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LookUpConnectorResourceAdmin", reflect.TypeOf((*MockConnectorPrivateServiceClient)(nil).LookUpConnectorResourceAdmin), varargs...)
 }

--- a/pkg/service/mock_connector_public_grpc_test.go
+++ b/pkg/service/mock_connector_public_grpc_test.go
@@ -36,124 +36,104 @@ func (m *MockConnectorPublicServiceClient) EXPECT() *MockConnectorPublicServiceC
 	return m.recorder
 }
 
-// ConnectConnector mocks base method.
-func (m *MockConnectorPublicServiceClient) ConnectConnector(arg0 context.Context, arg1 *connectorv1alpha.ConnectConnectorRequest, arg2 ...grpc.CallOption) (*connectorv1alpha.ConnectConnectorResponse, error) {
+// ConnectConnectorResource mocks base method.
+func (m *MockConnectorPublicServiceClient) ConnectConnectorResource(arg0 context.Context, arg1 *connectorv1alpha.ConnectConnectorResourceRequest, arg2 ...grpc.CallOption) (*connectorv1alpha.ConnectConnectorResourceResponse, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
-	ret := m.ctrl.Call(m, "ConnectConnector", varargs...)
-	ret0, _ := ret[0].(*connectorv1alpha.ConnectConnectorResponse)
+	ret := m.ctrl.Call(m, "ConnectConnectorResource", varargs...)
+	ret0, _ := ret[0].(*connectorv1alpha.ConnectConnectorResourceResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ConnectConnector indicates an expected call of ConnectConnector.
-func (mr *MockConnectorPublicServiceClientMockRecorder) ConnectConnector(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+// ConnectConnectorResource indicates an expected call of ConnectConnectorResource.
+func (mr *MockConnectorPublicServiceClientMockRecorder) ConnectConnectorResource(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectConnector", reflect.TypeOf((*MockConnectorPublicServiceClient)(nil).ConnectConnector), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectConnectorResource", reflect.TypeOf((*MockConnectorPublicServiceClient)(nil).ConnectConnectorResource), varargs...)
 }
 
-// CreateConnector mocks base method.
-func (m *MockConnectorPublicServiceClient) CreateConnector(arg0 context.Context, arg1 *connectorv1alpha.CreateConnectorRequest, arg2 ...grpc.CallOption) (*connectorv1alpha.CreateConnectorResponse, error) {
+// CreateConnectorResource mocks base method.
+func (m *MockConnectorPublicServiceClient) CreateConnectorResource(arg0 context.Context, arg1 *connectorv1alpha.CreateConnectorResourceRequest, arg2 ...grpc.CallOption) (*connectorv1alpha.CreateConnectorResourceResponse, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
-	ret := m.ctrl.Call(m, "CreateConnector", varargs...)
-	ret0, _ := ret[0].(*connectorv1alpha.CreateConnectorResponse)
+	ret := m.ctrl.Call(m, "CreateConnectorResource", varargs...)
+	ret0, _ := ret[0].(*connectorv1alpha.CreateConnectorResourceResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// CreateConnector indicates an expected call of CreateConnector.
-func (mr *MockConnectorPublicServiceClientMockRecorder) CreateConnector(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+// CreateConnectorResource indicates an expected call of CreateConnectorResource.
+func (mr *MockConnectorPublicServiceClientMockRecorder) CreateConnectorResource(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateConnector", reflect.TypeOf((*MockConnectorPublicServiceClient)(nil).CreateConnector), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateConnectorResource", reflect.TypeOf((*MockConnectorPublicServiceClient)(nil).CreateConnectorResource), varargs...)
 }
 
-// DeleteConnector mocks base method.
-func (m *MockConnectorPublicServiceClient) DeleteConnector(arg0 context.Context, arg1 *connectorv1alpha.DeleteConnectorRequest, arg2 ...grpc.CallOption) (*connectorv1alpha.DeleteConnectorResponse, error) {
+// DeleteConnectorResource mocks base method.
+func (m *MockConnectorPublicServiceClient) DeleteConnectorResource(arg0 context.Context, arg1 *connectorv1alpha.DeleteConnectorResourceRequest, arg2 ...grpc.CallOption) (*connectorv1alpha.DeleteConnectorResourceResponse, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
-	ret := m.ctrl.Call(m, "DeleteConnector", varargs...)
-	ret0, _ := ret[0].(*connectorv1alpha.DeleteConnectorResponse)
+	ret := m.ctrl.Call(m, "DeleteConnectorResource", varargs...)
+	ret0, _ := ret[0].(*connectorv1alpha.DeleteConnectorResourceResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// DeleteConnector indicates an expected call of DeleteConnector.
-func (mr *MockConnectorPublicServiceClientMockRecorder) DeleteConnector(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+// DeleteConnectorResource indicates an expected call of DeleteConnectorResource.
+func (mr *MockConnectorPublicServiceClientMockRecorder) DeleteConnectorResource(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteConnector", reflect.TypeOf((*MockConnectorPublicServiceClient)(nil).DeleteConnector), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteConnectorResource", reflect.TypeOf((*MockConnectorPublicServiceClient)(nil).DeleteConnectorResource), varargs...)
 }
 
-// DisconnectConnector mocks base method.
-func (m *MockConnectorPublicServiceClient) DisconnectConnector(arg0 context.Context, arg1 *connectorv1alpha.DisconnectConnectorRequest, arg2 ...grpc.CallOption) (*connectorv1alpha.DisconnectConnectorResponse, error) {
+// DisconnectConnectorResource mocks base method.
+func (m *MockConnectorPublicServiceClient) DisconnectConnectorResource(arg0 context.Context, arg1 *connectorv1alpha.DisconnectConnectorResourceRequest, arg2 ...grpc.CallOption) (*connectorv1alpha.DisconnectConnectorResourceResponse, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
-	ret := m.ctrl.Call(m, "DisconnectConnector", varargs...)
-	ret0, _ := ret[0].(*connectorv1alpha.DisconnectConnectorResponse)
+	ret := m.ctrl.Call(m, "DisconnectConnectorResource", varargs...)
+	ret0, _ := ret[0].(*connectorv1alpha.DisconnectConnectorResourceResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// DisconnectConnector indicates an expected call of DisconnectConnector.
-func (mr *MockConnectorPublicServiceClientMockRecorder) DisconnectConnector(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+// DisconnectConnectorResource indicates an expected call of DisconnectConnectorResource.
+func (mr *MockConnectorPublicServiceClientMockRecorder) DisconnectConnectorResource(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisconnectConnector", reflect.TypeOf((*MockConnectorPublicServiceClient)(nil).DisconnectConnector), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisconnectConnectorResource", reflect.TypeOf((*MockConnectorPublicServiceClient)(nil).DisconnectConnectorResource), varargs...)
 }
 
-// ExecuteConnector mocks base method.
-func (m *MockConnectorPublicServiceClient) ExecuteConnector(arg0 context.Context, arg1 *connectorv1alpha.ExecuteConnectorRequest, arg2 ...grpc.CallOption) (*connectorv1alpha.ExecuteConnectorResponse, error) {
+// ExecuteConnectorResource mocks base method.
+func (m *MockConnectorPublicServiceClient) ExecuteConnectorResource(arg0 context.Context, arg1 *connectorv1alpha.ExecuteConnectorResourceRequest, arg2 ...grpc.CallOption) (*connectorv1alpha.ExecuteConnectorResourceResponse, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
-	ret := m.ctrl.Call(m, "ExecuteConnector", varargs...)
-	ret0, _ := ret[0].(*connectorv1alpha.ExecuteConnectorResponse)
+	ret := m.ctrl.Call(m, "ExecuteConnectorResource", varargs...)
+	ret0, _ := ret[0].(*connectorv1alpha.ExecuteConnectorResourceResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ExecuteConnector indicates an expected call of ExecuteConnector.
-func (mr *MockConnectorPublicServiceClientMockRecorder) ExecuteConnector(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+// ExecuteConnectorResource indicates an expected call of ExecuteConnectorResource.
+func (mr *MockConnectorPublicServiceClientMockRecorder) ExecuteConnectorResource(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecuteConnector", reflect.TypeOf((*MockConnectorPublicServiceClient)(nil).ExecuteConnector), varargs...)
-}
-
-// GetConnector mocks base method.
-func (m *MockConnectorPublicServiceClient) GetConnector(arg0 context.Context, arg1 *connectorv1alpha.GetConnectorRequest, arg2 ...grpc.CallOption) (*connectorv1alpha.GetConnectorResponse, error) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
-	for _, a := range arg2 {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "GetConnector", varargs...)
-	ret0, _ := ret[0].(*connectorv1alpha.GetConnectorResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetConnector indicates an expected call of GetConnector.
-func (mr *MockConnectorPublicServiceClientMockRecorder) GetConnector(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConnector", reflect.TypeOf((*MockConnectorPublicServiceClient)(nil).GetConnector), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecuteConnectorResource", reflect.TypeOf((*MockConnectorPublicServiceClient)(nil).ExecuteConnectorResource), varargs...)
 }
 
 // GetConnectorDefinition mocks base method.
@@ -176,6 +156,26 @@ func (mr *MockConnectorPublicServiceClientMockRecorder) GetConnectorDefinition(a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConnectorDefinition", reflect.TypeOf((*MockConnectorPublicServiceClient)(nil).GetConnectorDefinition), varargs...)
 }
 
+// GetConnectorResource mocks base method.
+func (m *MockConnectorPublicServiceClient) GetConnectorResource(arg0 context.Context, arg1 *connectorv1alpha.GetConnectorResourceRequest, arg2 ...grpc.CallOption) (*connectorv1alpha.GetConnectorResourceResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetConnectorResource", varargs...)
+	ret0, _ := ret[0].(*connectorv1alpha.GetConnectorResourceResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetConnectorResource indicates an expected call of GetConnectorResource.
+func (mr *MockConnectorPublicServiceClientMockRecorder) GetConnectorResource(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConnectorResource", reflect.TypeOf((*MockConnectorPublicServiceClient)(nil).GetConnectorResource), varargs...)
+}
+
 // ListConnectorDefinitions mocks base method.
 func (m *MockConnectorPublicServiceClient) ListConnectorDefinitions(arg0 context.Context, arg1 *connectorv1alpha.ListConnectorDefinitionsRequest, arg2 ...grpc.CallOption) (*connectorv1alpha.ListConnectorDefinitionsResponse, error) {
 	m.ctrl.T.Helper()
@@ -196,24 +196,24 @@ func (mr *MockConnectorPublicServiceClientMockRecorder) ListConnectorDefinitions
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListConnectorDefinitions", reflect.TypeOf((*MockConnectorPublicServiceClient)(nil).ListConnectorDefinitions), varargs...)
 }
 
-// ListConnectors mocks base method.
-func (m *MockConnectorPublicServiceClient) ListConnectors(arg0 context.Context, arg1 *connectorv1alpha.ListConnectorsRequest, arg2 ...grpc.CallOption) (*connectorv1alpha.ListConnectorsResponse, error) {
+// ListConnectorResources mocks base method.
+func (m *MockConnectorPublicServiceClient) ListConnectorResources(arg0 context.Context, arg1 *connectorv1alpha.ListConnectorResourcesRequest, arg2 ...grpc.CallOption) (*connectorv1alpha.ListConnectorResourcesResponse, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
-	ret := m.ctrl.Call(m, "ListConnectors", varargs...)
-	ret0, _ := ret[0].(*connectorv1alpha.ListConnectorsResponse)
+	ret := m.ctrl.Call(m, "ListConnectorResources", varargs...)
+	ret0, _ := ret[0].(*connectorv1alpha.ListConnectorResourcesResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListConnectors indicates an expected call of ListConnectors.
-func (mr *MockConnectorPublicServiceClientMockRecorder) ListConnectors(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+// ListConnectorResources indicates an expected call of ListConnectorResources.
+func (mr *MockConnectorPublicServiceClientMockRecorder) ListConnectorResources(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListConnectors", reflect.TypeOf((*MockConnectorPublicServiceClient)(nil).ListConnectors), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListConnectorResources", reflect.TypeOf((*MockConnectorPublicServiceClient)(nil).ListConnectorResources), varargs...)
 }
 
 // Liveness mocks base method.
@@ -236,24 +236,24 @@ func (mr *MockConnectorPublicServiceClientMockRecorder) Liveness(arg0, arg1 inte
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Liveness", reflect.TypeOf((*MockConnectorPublicServiceClient)(nil).Liveness), varargs...)
 }
 
-// LookUpConnector mocks base method.
-func (m *MockConnectorPublicServiceClient) LookUpConnector(arg0 context.Context, arg1 *connectorv1alpha.LookUpConnectorRequest, arg2 ...grpc.CallOption) (*connectorv1alpha.LookUpConnectorResponse, error) {
+// LookUpConnectorResource mocks base method.
+func (m *MockConnectorPublicServiceClient) LookUpConnectorResource(arg0 context.Context, arg1 *connectorv1alpha.LookUpConnectorResourceRequest, arg2 ...grpc.CallOption) (*connectorv1alpha.LookUpConnectorResourceResponse, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
-	ret := m.ctrl.Call(m, "LookUpConnector", varargs...)
-	ret0, _ := ret[0].(*connectorv1alpha.LookUpConnectorResponse)
+	ret := m.ctrl.Call(m, "LookUpConnectorResource", varargs...)
+	ret0, _ := ret[0].(*connectorv1alpha.LookUpConnectorResourceResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// LookUpConnector indicates an expected call of LookUpConnector.
-func (mr *MockConnectorPublicServiceClientMockRecorder) LookUpConnector(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+// LookUpConnectorResource indicates an expected call of LookUpConnectorResource.
+func (mr *MockConnectorPublicServiceClientMockRecorder) LookUpConnectorResource(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LookUpConnector", reflect.TypeOf((*MockConnectorPublicServiceClient)(nil).LookUpConnector), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LookUpConnectorResource", reflect.TypeOf((*MockConnectorPublicServiceClient)(nil).LookUpConnectorResource), varargs...)
 }
 
 // Readiness mocks base method.
@@ -276,82 +276,82 @@ func (mr *MockConnectorPublicServiceClientMockRecorder) Readiness(arg0, arg1 int
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Readiness", reflect.TypeOf((*MockConnectorPublicServiceClient)(nil).Readiness), varargs...)
 }
 
-// RenameConnector mocks base method.
-func (m *MockConnectorPublicServiceClient) RenameConnector(arg0 context.Context, arg1 *connectorv1alpha.RenameConnectorRequest, arg2 ...grpc.CallOption) (*connectorv1alpha.RenameConnectorResponse, error) {
+// RenameConnectorResource mocks base method.
+func (m *MockConnectorPublicServiceClient) RenameConnectorResource(arg0 context.Context, arg1 *connectorv1alpha.RenameConnectorResourceRequest, arg2 ...grpc.CallOption) (*connectorv1alpha.RenameConnectorResourceResponse, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
-	ret := m.ctrl.Call(m, "RenameConnector", varargs...)
-	ret0, _ := ret[0].(*connectorv1alpha.RenameConnectorResponse)
+	ret := m.ctrl.Call(m, "RenameConnectorResource", varargs...)
+	ret0, _ := ret[0].(*connectorv1alpha.RenameConnectorResourceResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// RenameConnector indicates an expected call of RenameConnector.
-func (mr *MockConnectorPublicServiceClientMockRecorder) RenameConnector(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+// RenameConnectorResource indicates an expected call of RenameConnectorResource.
+func (mr *MockConnectorPublicServiceClientMockRecorder) RenameConnectorResource(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RenameConnector", reflect.TypeOf((*MockConnectorPublicServiceClient)(nil).RenameConnector), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RenameConnectorResource", reflect.TypeOf((*MockConnectorPublicServiceClient)(nil).RenameConnectorResource), varargs...)
 }
 
-// TestConnector mocks base method.
-func (m *MockConnectorPublicServiceClient) TestConnector(arg0 context.Context, arg1 *connectorv1alpha.TestConnectorRequest, arg2 ...grpc.CallOption) (*connectorv1alpha.TestConnectorResponse, error) {
+// TestConnectorResource mocks base method.
+func (m *MockConnectorPublicServiceClient) TestConnectorResource(arg0 context.Context, arg1 *connectorv1alpha.TestConnectorResourceRequest, arg2 ...grpc.CallOption) (*connectorv1alpha.TestConnectorResourceResponse, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
-	ret := m.ctrl.Call(m, "TestConnector", varargs...)
-	ret0, _ := ret[0].(*connectorv1alpha.TestConnectorResponse)
+	ret := m.ctrl.Call(m, "TestConnectorResource", varargs...)
+	ret0, _ := ret[0].(*connectorv1alpha.TestConnectorResourceResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// TestConnector indicates an expected call of TestConnector.
-func (mr *MockConnectorPublicServiceClientMockRecorder) TestConnector(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+// TestConnectorResource indicates an expected call of TestConnectorResource.
+func (mr *MockConnectorPublicServiceClientMockRecorder) TestConnectorResource(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TestConnector", reflect.TypeOf((*MockConnectorPublicServiceClient)(nil).TestConnector), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TestConnectorResource", reflect.TypeOf((*MockConnectorPublicServiceClient)(nil).TestConnectorResource), varargs...)
 }
 
-// UpdateConnector mocks base method.
-func (m *MockConnectorPublicServiceClient) UpdateConnector(arg0 context.Context, arg1 *connectorv1alpha.UpdateConnectorRequest, arg2 ...grpc.CallOption) (*connectorv1alpha.UpdateConnectorResponse, error) {
+// UpdateConnectorResource mocks base method.
+func (m *MockConnectorPublicServiceClient) UpdateConnectorResource(arg0 context.Context, arg1 *connectorv1alpha.UpdateConnectorResourceRequest, arg2 ...grpc.CallOption) (*connectorv1alpha.UpdateConnectorResourceResponse, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
-	ret := m.ctrl.Call(m, "UpdateConnector", varargs...)
-	ret0, _ := ret[0].(*connectorv1alpha.UpdateConnectorResponse)
+	ret := m.ctrl.Call(m, "UpdateConnectorResource", varargs...)
+	ret0, _ := ret[0].(*connectorv1alpha.UpdateConnectorResourceResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// UpdateConnector indicates an expected call of UpdateConnector.
-func (mr *MockConnectorPublicServiceClientMockRecorder) UpdateConnector(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+// UpdateConnectorResource indicates an expected call of UpdateConnectorResource.
+func (mr *MockConnectorPublicServiceClientMockRecorder) UpdateConnectorResource(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateConnector", reflect.TypeOf((*MockConnectorPublicServiceClient)(nil).UpdateConnector), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateConnectorResource", reflect.TypeOf((*MockConnectorPublicServiceClient)(nil).UpdateConnectorResource), varargs...)
 }
 
-// WatchConnector mocks base method.
-func (m *MockConnectorPublicServiceClient) WatchConnector(arg0 context.Context, arg1 *connectorv1alpha.WatchConnectorRequest, arg2 ...grpc.CallOption) (*connectorv1alpha.WatchConnectorResponse, error) {
+// WatchConnectorResource mocks base method.
+func (m *MockConnectorPublicServiceClient) WatchConnectorResource(arg0 context.Context, arg1 *connectorv1alpha.WatchConnectorResourceRequest, arg2 ...grpc.CallOption) (*connectorv1alpha.WatchConnectorResourceResponse, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
-	ret := m.ctrl.Call(m, "WatchConnector", varargs...)
-	ret0, _ := ret[0].(*connectorv1alpha.WatchConnectorResponse)
+	ret := m.ctrl.Call(m, "WatchConnectorResource", varargs...)
+	ret0, _ := ret[0].(*connectorv1alpha.WatchConnectorResourceResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// WatchConnector indicates an expected call of WatchConnector.
-func (mr *MockConnectorPublicServiceClientMockRecorder) WatchConnector(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+// WatchConnectorResource indicates an expected call of WatchConnectorResource.
+func (mr *MockConnectorPublicServiceClientMockRecorder) WatchConnectorResource(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchConnector", reflect.TypeOf((*MockConnectorPublicServiceClient)(nil).WatchConnector), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchConnectorResource", reflect.TypeOf((*MockConnectorPublicServiceClient)(nil).WatchConnectorResource), varargs...)
 }

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -578,7 +578,7 @@ func (s *service) TriggerPipeline(ctx context.Context, req *pipelinePB.TriggerPi
 		}
 
 		if comp.ResourceName != "" {
-			resp, err := s.connectorPublicServiceClient.ExecuteConnector(
+			resp, err := s.connectorPublicServiceClient.ExecuteConnectorResource(
 				utils.InjectOwnerToContextWithOwnerPermalink(
 					metadata.AppendToOutgoingContext(ctx,
 						"id", dbPipeline.ID,
@@ -587,7 +587,7 @@ func (s *service) TriggerPipeline(ctx context.Context, req *pipelinePB.TriggerPi
 						"trigger_id", pipelineTriggerId,
 					),
 					utils.GenOwnerPermalink(owner)),
-				&connectorPB.ExecuteConnectorRequest{
+				&connectorPB.ExecuteConnectorResourceRequest{
 					Name:   comp.ResourceName,
 					Inputs: compInputs,
 				},

--- a/pkg/service/validator.go
+++ b/pkg/service/validator.go
@@ -72,10 +72,10 @@ func (s *service) checkRecipe(owner *mgmtPB.User, recipePermalink *datamodel.Rec
 		}
 		if IsConnector(recipePermalink.Components[idx].ResourceName) {
 
-			checkResp, err := s.connectorPrivateServiceClient.CheckConnector(
+			checkResp, err := s.connectorPrivateServiceClient.CheckConnectorResource(
 				utils.InjectOwnerToContext(ctx, owner),
-				&connectorPB.CheckConnectorRequest{
-					ConnectorPermalink: recipePermalink.Components[idx].ResourceName,
+				&connectorPB.CheckConnectorResourceRequest{
+					Permalink: recipePermalink.Components[idx].ResourceName,
 				},
 			)
 			if err != nil {
@@ -83,7 +83,7 @@ func (s *service) checkRecipe(owner *mgmtPB.User, recipePermalink *datamodel.Rec
 					"CheckConnector", recipePermalink.Components[idx].ResourceName, err.Error())
 
 			}
-			if checkResp.State != connectorPB.Connector_STATE_CONNECTED {
+			if checkResp.State != connectorPB.ConnectorResource_STATE_CONNECTED {
 				return status.Errorf(codes.InvalidArgument, "[connector-backend] %s is not connected", recipePermalink.Components[idx].ResourceName)
 			}
 		}

--- a/pkg/worker/workflow.go
+++ b/pkg/worker/workflow.go
@@ -376,7 +376,7 @@ func (w *worker) ConnectorActivity(ctx context.Context, param *ExecuteConnectorA
 		return nil, err
 	}
 
-	resp, err := w.connectorPublicServiceClient.ExecuteConnector(
+	resp, err := w.connectorPublicServiceClient.ExecuteConnectorResource(
 		utils.InjectOwnerToContextWithOwnerPermalink(
 			metadata.AppendToOutgoingContext(ctx,
 				"id", param.PipelineMetadata.Id,
@@ -385,7 +385,7 @@ func (w *worker) ConnectorActivity(ctx context.Context, param *ExecuteConnectorA
 				"trigger_id", param.PipelineMetadata.TriggerId,
 			),
 			param.OwnerPermalink),
-		&connectorPB.ExecuteConnectorRequest{
+		&connectorPB.ExecuteConnectorResourceRequest{
 			Name:   param.Name,
 			Inputs: inputs,
 		},


### PR DESCRIPTION
Because

- In proto, `Connector` has been renamed to `ConnectorResource`

This commit

- adopt `connector-resources/` endpoints
