### PR TITLE
chore: add `title` and `description` fields for start and end operator

### DIFF
--- a/integration-test/const.js
+++ b/integration-test/const.js
@@ -105,7 +105,7 @@ export const simpleRecipe = {
         configuration: {
           body: {
             input: {
-              display_name: "Input",
+              title: "Input",
               type: "text"
             }
           }
@@ -116,7 +116,9 @@ export const simpleRecipe = {
         definition_name: "operator-definitions/end-operator",
         configuration: {
           body: {
-            output: "{ start.body.input }"
+            output: {
+              value: "{ start.body.input }"
+            }
           }
         }
       },
@@ -150,7 +152,7 @@ export const simpleRecipeWithoutCSV = {
         configuration: {
           body: {
             input: {
-              display_name: "Input",
+              title: "Input",
               type: "text"
             }
           }
@@ -161,7 +163,9 @@ export const simpleRecipeWithoutCSV = {
         definition_name: "operator-definitions/end-operator",
         configuration: {
           body: {
-            output: "{ start.body.input }"
+            output: {
+              value: "{ start.body.input }"
+            }
           }
         }
       },
@@ -179,7 +183,7 @@ export const simpleRecipeDupId = {
         configuration: {
           body: {
             input: {
-              display_name: "Input",
+              title: "Input",
               type: "text"
             }
           }
@@ -190,7 +194,9 @@ export const simpleRecipeDupId = {
         definition_name: "operator-definitions/end-operator",
         configuration: {
           body: {
-            output: "{ start.body.input }"
+            output: {
+              value: "{ start.body.input }"
+            }
           }
         }
       },

--- a/pkg/operator/end/config/definitions.json
+++ b/pkg/operator/end/config/definitions.json
@@ -21,7 +21,18 @@
             "additionalProperties": false,
             "patternProperties": {
               "^[a-zA-Z_][a-zA-Z_0-9]*$": {
-                "type": "string"
+                "type": "object",
+                "properties": {
+                  "value": {
+                    "type": "string"
+                  },
+                  "title": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  }
+                }
               }
             }
           }

--- a/pkg/operator/end/config/seed/component.json
+++ b/pkg/operator/end/config/seed/component.json
@@ -10,7 +10,18 @@
       "additionalProperties": false,
       "patternProperties": {
         "^[a-zA-Z_][a-zA-Z_0-9]*$": {
-          "type": "string"
+          "type": "object",
+          "properties": {
+            "value": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            }
+          }
         }
       }
     }

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -112,7 +112,7 @@ func (o *Operator) ListOperatorDefinitions() []*pipelinePB.OperatorDefinition {
 func (o *Operator) GetOperatorDefinitionByUid(defUid uuid.UUID) (*pipelinePB.OperatorDefinition, error) {
 	val, ok := o.definitionMapByUid[defUid]
 	if !ok {
-		return nil, fmt.Errorf("get operator defintion error1 %s", defUid.String())
+		return nil, fmt.Errorf("get operator definition error1 %s", defUid.String())
 	}
 	return val, nil
 }
@@ -121,7 +121,7 @@ func (o *Operator) GetOperatorDefinitionById(defId string) (*pipelinePB.Operator
 
 	val, ok := o.definitionMapById[defId]
 	if !ok {
-		return nil, fmt.Errorf("get operator defintion error %s", defId)
+		return nil, fmt.Errorf("get operator definition error %s", defId)
 	}
 	return val, nil
 }

--- a/pkg/operator/start/config/definitions.json
+++ b/pkg/operator/start/config/definitions.json
@@ -23,8 +23,7 @@
               "^[a-zA-Z_][a-zA-Z_0-9]*$": {
                 "type": "object",
                 "required": [
-                  "type",
-                  "display_name"
+                  "type"
                 ],
                 "properties": {
                   "type": {
@@ -47,7 +46,10 @@
                     "title": "Type",
                     "description": "Data Type"
                   },
-                  "display_name": {
+                  "title": {
+                    "type": "string"
+                  },
+                  "description": {
                     "type": "string"
                   }
                 }

--- a/pkg/operator/start/config/seed/component.json
+++ b/pkg/operator/start/config/seed/component.json
@@ -11,7 +11,7 @@
       "patternProperties": {
         "^[a-zA-Z_][a-zA-Z_0-9]*$": {
           "type": "object",
-          "required": ["type", "display_name"],
+          "required": ["type"],
           "properties": {
             "type": {
               "enum": [
@@ -33,7 +33,10 @@
               "title": "Type",
               "description": "Data Type"
             },
-            "display_name": {
+            "title": {
+              "type": "string"
+            },
+            "description": {
               "type": "string"
             }
           }

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -610,14 +610,14 @@ func (s *service) triggerPipeline(ctx context.Context, pipelineInputs []*structp
 
 	pipelineOutputs := []*structpb.Struct{}
 	for idx := 0; idx < batchSize; idx++ {
-		pipelineOutputJson, err := json.Marshal(outputCache[idx][responseCompId].(map[string]interface{})["body"])
-		if err != nil {
-			return nil, nil, err
-		}
-		pipelineOutput := &structpb.Struct{}
-		err = protojson.Unmarshal(pipelineOutputJson, pipelineOutput)
-		if err != nil {
-			return nil, nil, err
+		pipelineOutput := &structpb.Struct{Fields: map[string]*structpb.Value{}}
+		for key, value := range outputCache[idx][responseCompId].(map[string]interface{})["body"].(map[string]interface{}) {
+			structVal, err := structpb.NewValue(value.(map[string]interface{})["value"])
+			if err != nil {
+				return nil, nil, err
+			}
+			pipelineOutput.Fields[key] = structVal
+
 		}
 		pipelineOutputs = append(pipelineOutputs, pipelineOutput)
 

--- a/pkg/worker/workflow.go
+++ b/pkg/worker/workflow.go
@@ -341,14 +341,14 @@ func (w *worker) TriggerAsyncPipelineWorkflow(ctx workflow.Context, param *Trigg
 		}
 	} else {
 		for idx := 0; idx < batchSize; idx++ {
-			pipelineOutputJson, err := json.Marshal(outputCache[idx][responseCompId].(map[string]interface{})["body"])
-			if err != nil {
-				return err
-			}
-			pipelineOutput := &structpb.Struct{}
-			err = protojson.Unmarshal(pipelineOutputJson, pipelineOutput)
-			if err != nil {
-				return err
+			pipelineOutput := &structpb.Struct{Fields: map[string]*structpb.Value{}}
+			for key, value := range outputCache[idx][responseCompId].(map[string]interface{})["body"].(map[string]interface{}) {
+				structVal, err := structpb.NewValue(value.(map[string]interface{})["value"])
+				if err != nil {
+					return err
+				}
+				pipelineOutput.Fields[key] = structVal
+
 			}
 			pipelineOutputs = append(pipelineOutputs, pipelineOutput)
 


### PR DESCRIPTION
Because

- we will generate OpenAPI-schema for each pipeline, thus, we need `title` and `description` fields for start and end operators

This commit

- add `title` and `description` fields for start and end operator
