### PR TITLE
chore: generate OpenAPI schema for each pipeline automatically

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0
 	github.com/iancoleman/strcase v0.2.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230829070319-de6fd3400ef0
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230831041425-adb93d4977bb
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20230814155646-874e57a1e4b0
 	github.com/instill-ai/x v0.3.0-alpha
 	github.com/knadh/koanf v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -1078,6 +1078,8 @@ github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230829070319-de6fd3400ef0 h1:E1t9KbLVAJXY4GWqDrwN/kgZKwu/C3qZCqHddm4EHtE=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230829070319-de6fd3400ef0/go.mod h1:qsq5ecnA1xi2rLnVQFo/9xksA7I7wQu8c7rqM5xbIrQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230831041425-adb93d4977bb h1:fmgs54mqel13elwZr6scmtCWtTgV99CcQHxIcsov/ZY=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230831041425-adb93d4977bb/go.mod h1:qsq5ecnA1xi2rLnVQFo/9xksA7I7wQu8c7rqM5xbIrQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20230814155646-874e57a1e4b0 h1:9QoCxaktvqGJYGjN8KhkWsv1DVfwbt5G1d/Ycx1kJxo=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20230814155646-874e57a1e4b0/go.mod h1:SELFgirs+28Wfnh0kGw02zttit4pUeKLKp17zGsTu6g=
 github.com/instill-ai/x v0.3.0-alpha h1:z9fedROOG2dVHhswBfVwU/hzHuq8/JKSUON7inF+FH8=

--- a/pkg/service/convert.go
+++ b/pkg/service/convert.go
@@ -480,6 +480,11 @@ func (s *service) DBToPBPipeline(ctx context.Context, userUid uuid.UUID, dbPipel
 			}
 		}
 	}
+	if view == pipelinePB.View_VIEW_FULL {
+		if err := s.includeDetailInRecipe(pbRecipe); err != nil {
+			return nil, err
+		}
+	}
 
 	pbPipeline := pipelinePB.Pipeline{
 		Name:        fmt.Sprintf("%s/pipelines/%s", owner, dbPipeline.ID),
@@ -493,7 +498,7 @@ func (s *service) DBToPBPipeline(ctx context.Context, userUid uuid.UUID, dbPipel
 	}
 
 	if pbRecipe != nil && view == pipelinePB.View_VIEW_FULL && startComp != nil && endComp != nil {
-		spec, err := s.GenerateOpenApiSpec(startComp, endComp)
+		spec, err := s.GenerateOpenApiSpec(startComp, endComp, pbRecipe.Components)
 		if err == nil {
 			pbPipeline.OpenapiSchema = spec
 		}
@@ -503,11 +508,6 @@ func (s *service) DBToPBPipeline(ctx context.Context, userUid uuid.UUID, dbPipel
 		pbPipeline.Owner = &pipelinePB.Pipeline_User{User: owner}
 	} else if strings.HasPrefix(dbPipeline.Owner, "orgs/") {
 		pbPipeline.Owner = &pipelinePB.Pipeline_Org{Org: owner}
-	}
-	if view == pipelinePB.View_VIEW_FULL {
-		if err := s.includeDetailInRecipe(pbPipeline.Recipe); err != nil {
-			return nil, err
-		}
 	}
 
 	return &pbPipeline, nil

--- a/pkg/service/openapi.go
+++ b/pkg/service/openapi.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -11,93 +12,142 @@ import (
 )
 
 const openApiSchemaTemplate = `{
-    "openapi": "3.0.0",
-    "info": {
-        "version": "dev",
-        "title": "Pipeline Trigger"
-    },
-    "paths": {
-        "/trigger": {
-            "post": {
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "inputs": {
-                                        "type": "array",
-                                        "items": {}
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "outputs": {
-                                            "type": "array",
-                                            "items": {}
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-		"/triggerAsync": {
-            "post": {
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "inputs": {
-                                        "type": "array",
-                                        "items": {}
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-									"type": "object",
-									"properties": {
-										"operation": {
-											"title": "Trigger async pipeline operation message",
-											"readOnly": true,
-											"type": "object"
-										}
+	"openapi": "3.0.0",
+	"info": {
+	  "version": "dev",
+	  "title": "Pipeline Trigger"
+	},
+	"paths": {
+	  "/trigger": {
+		"post": {
+		  "requestBody": {
+			"required": true,
+			"content": {
+			  "application/json": {
+				"schema": {
+				  "type": "object",
+				  "properties": {
+					"inputs": {
+					  "type": "array",
+					  "items": {}
+					}
+				  }
+				}
+			  }
+			}
+		  },
+		  "responses": {
+			"200": {
+			  "description": "",
+			  "content": {
+				"application/json": {
+				  "schema": {
+					"type": "object",
+					"properties": {
+					  "outputs": {
+						"type": "array",
+						"items": {}
+					  }
+					}
+				  }
+				}
+			  }
+			}
+		  }
+		}
+	  },
+	  "/triggerAsync": {
+		"post": {
+		  "requestBody": {
+			"required": true,
+			"content": {
+			  "application/json": {
+				"schema": {
+				  "type": "object",
+				  "properties": {
+					"inputs": {
+					  "type": "array",
+					  "items": {}
+					}
+				  }
+				}
+			  }
+			}
+		  },
+		  "responses": {
+			"200": {
+			  "description": "",
+			  "content": {
+				"application/json": {
+				  "schema": {
+					"type": "object",
+					"properties": {
+					  "operation": {
+						"type": "object",
+						"properties": {
+						  "name": {
+							"type": "string"
+						  },
+						  "metadata": {
+							"type": "object",
+							"properties": {
+							  "@type": {
+								"type": "string"
+							  }
+							},
+							"additionalProperties": {}
+						  },
+						  "done": {
+							"type": "boolean"
+						  },
+						  "error": {
+							"type": "object",
+							"properties": {
+							  "code": {
+								"type": "integer",
+								"format": "int32"
+							  },
+							  "message": {
+								"type": "string"
+							  },
+							  "details": {
+								"type": "array",
+								"items": {
+								  "type": "object",
+								  "properties": {
+									"@type": {
+									  "type": "string"
 									}
+								  },
+								  "additionalProperties": {}
 								}
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-}`
+							  }
+							}
+						  },
+						  "response": {
+							"type": "object",
+							"properties": {
+							  "@type": {
+								"type": "string"
+							  }
+							},
+							"additionalProperties": {}
+						  }
+						}
+					  }
+					}
+				  }
+				}
+			  }
+			}
+		  }
+		}
+	  }
+	}
+  }`
 
-func (s *service) GenerateOpenApiSpec(startComp *pipelinePB.Component, endComp *pipelinePB.Component) (*structpb.Struct, error) {
+// TODO: refactor these messy code
+func (s *service) GenerateOpenApiSpec(startComp *pipelinePB.Component, endComp *pipelinePB.Component, comps []*pipelinePB.Component) (*structpb.Struct, error) {
 	success := true
 	template := &structpb.Struct{}
 	err := protojson.Unmarshal([]byte(openApiSchemaTemplate), template)
@@ -122,9 +172,9 @@ func (s *service) GenerateOpenApiSpec(startComp *pipelinePB.Component, endComp *
 			attrType = "string"
 		default:
 			attrType = "array"
-			switch t2 := v.GetStructValue().Fields["type"].GetStringValue(); t {
+			switch t {
 			case "integer_array", "number_array", "boolean_array":
-				arrType = strings.Split(t2, "_")[0]
+				arrType = strings.Split(t, "_")[0]
 			case "text_array", "image_array", "audio_array", "video_array":
 				arrType = "string"
 			}
@@ -178,16 +228,206 @@ func (s *service) GenerateOpenApiSpec(startComp *pipelinePB.Component, endComp *
 		var m *structpb.Value
 
 		var err error
+
 		switch v.GetStructValue().Fields["value"].AsInterface().(type) {
 		case string:
 			str := v.GetStructValue().Fields["value"].GetStringValue()
 			if strings.HasPrefix(str, "{") && strings.HasSuffix(str, "}") && !strings.HasPrefix(str, "{{") && !strings.HasSuffix(str, "}}") {
 				// TODO
-				m, err = structpb.NewValue(map[string]interface{}{
-					"title":       v.GetStructValue().Fields["title"].GetStringValue(),
-					"description": v.GetStructValue().Fields["description"].GetStringValue(),
-					"type":        "object",
-				})
+				str = str[1:]
+				str = str[:len(str)-1]
+				str = strings.ReplaceAll(str, " ", "")
+				var b interface{}
+				unmarshalErr := json.Unmarshal([]byte(str), &b)
+
+				// if the json is Unmarshalable, means that it is not a reference
+				if unmarshalErr == nil {
+					attrType := ""
+					switch b.(type) {
+					case string:
+						attrType = "string"
+					case float64:
+						attrType = "number"
+					case bool:
+						attrType = "bool"
+					case nil:
+						attrType = "null"
+					}
+					m, err = structpb.NewValue(map[string]interface{}{
+						"title":       v.GetStructValue().Fields["title"].GetStringValue(),
+						"description": v.GetStructValue().Fields["description"].GetStringValue(),
+						"type":        attrType,
+					})
+				} else {
+					compId := strings.Split(str, ".")[0]
+					str = str[len(strings.Split(str, ".")[0]):]
+					for compIdx := range comps {
+						if comps[compIdx].Id == compId {
+							if strings.HasPrefix(comps[compIdx].DefinitionName, "connector-definitions") {
+								task := comps[compIdx].GetConfiguration().Fields["task"].GetStringValue()
+								walk = comps[compIdx].GetConnectorDefinition().Spec.OpenapiSpecifications.GetFields()[task]
+								for _, key := range []string{"paths", "/execute", "post", "responses", "200", "content", "application/json", "schema", "properties", "outputs", "items"} {
+									walk = walk.GetStructValue().Fields[key]
+								}
+
+								for {
+									splits := strings.Split(str, ".")
+									if len(str) == 0 {
+										break
+									}
+
+									curr := splits[1]
+
+									if strings.Contains(curr, "[") && strings.Contains(curr, "]") {
+										walk = walk.GetStructValue().Fields["properties"].GetStructValue().Fields[strings.Split(curr, "[")[0]].GetStructValue().Fields["items"]
+									} else {
+										walk = walk.GetStructValue().Fields["properties"].GetStructValue().Fields[curr]
+
+									}
+
+									str = str[len(curr)+1:]
+								}
+								m = structpb.NewStructValue(walk.GetStructValue())
+
+								if _, ok := v.GetStructValue().Fields["title"]; ok {
+									m.GetStructValue().Fields["title"] = v.GetStructValue().Fields["title"]
+								} else {
+									m.GetStructValue().Fields["title"] = structpb.NewStringValue("")
+								}
+								if _, ok := v.GetStructValue().Fields["description"]; ok {
+									m.GetStructValue().Fields["description"] = v.GetStructValue().Fields["description"]
+								} else {
+									m.GetStructValue().Fields["description"] = structpb.NewStringValue("")
+								}
+
+							}
+
+							if comps[compIdx].DefinitionName == "operator-definitions/start-operator" {
+
+								isFullBody := str == ".body"
+								str := str[len(strings.Split(str, ".")[1])+1:]
+
+								walk = comps[compIdx].GetConfiguration().Fields["body"]
+								for {
+
+									splits := strings.Split(str, ".")
+									if len(str) == 0 {
+										break
+									}
+
+									curr := splits[1]
+
+									if strings.Contains(curr, "[") && strings.Contains(curr, "]") {
+										walk = walk.GetStructValue().Fields[strings.Split(curr, "[")[0]]
+									} else {
+										walk = walk.GetStructValue().Fields[curr]
+									}
+
+									str = str[len(curr)+1:]
+								}
+
+								if isFullBody {
+									props := structpb.Struct{Fields: make(map[string]*structpb.Value)}
+									// props := structpb.NewStructValue(walk.GetStructValue())
+									for bodyK, bodyV := range walk.GetStructValue().Fields {
+										attrType := ""
+										arrType := ""
+										switch t := bodyV.GetStructValue().Fields["type"].GetStringValue(); t {
+										case "integer", "number", "boolean":
+											attrType = t
+										case "text", "image", "audio", "video":
+											attrType = "string"
+										default:
+											attrType = "array"
+											switch t {
+											case "integer_array", "number_array", "boolean_array":
+												arrType = strings.Split(t, "_")[0]
+											case "text_array", "image_array", "audio_array", "video_array":
+												arrType = "string"
+											}
+										}
+										if attrType != "array" {
+
+											props.Fields[bodyK], err = structpb.NewValue(map[string]interface{}{
+												"title":       v.GetStructValue().Fields["title"].GetStringValue(),
+												"description": v.GetStructValue().Fields["description"].GetStringValue(),
+												"type":        attrType,
+											})
+											if err != nil {
+												success = false
+											}
+										} else {
+											props.Fields[bodyK], err = structpb.NewValue(map[string]interface{}{
+												"title":       v.GetStructValue().Fields["title"].GetStringValue(),
+												"description": v.GetStructValue().Fields["description"].GetStringValue(),
+												"type":        attrType,
+												"items": map[string]interface{}{
+													"type": arrType,
+												},
+											})
+											if err != nil {
+												success = false
+											}
+										}
+									}
+									m, err = structpb.NewValue(map[string]interface{}{
+										"title":       v.GetStructValue().Fields["title"].GetStringValue(),
+										"description": v.GetStructValue().Fields["description"].GetStringValue(),
+										"type":        "object",
+									})
+
+									if err != nil {
+										success = false
+									}
+									m.GetStructValue().Fields["properties"] = structpb.NewStructValue(&props)
+								} else {
+									attrType := ""
+									arrType := ""
+									switch t := walk.GetStructValue().Fields["type"].GetStringValue(); t {
+									case "integer", "number", "boolean":
+										attrType = t
+									case "text", "image", "audio", "video":
+										attrType = "string"
+									default:
+										attrType = "array"
+										switch t {
+										case "integer_array", "number_array", "boolean_array":
+											arrType = strings.Split(t, "_")[0]
+										case "text_array", "image_array", "audio_array", "video_array":
+											arrType = "string"
+										}
+									}
+									if attrType != "array" {
+										m, err = structpb.NewValue(map[string]interface{}{
+											"title":       v.GetStructValue().Fields["title"].GetStringValue(),
+											"description": v.GetStructValue().Fields["description"].GetStringValue(),
+											"type":        attrType,
+										})
+										if err != nil {
+											success = false
+										}
+									} else {
+										m, err = structpb.NewValue(map[string]interface{}{
+											"title":       v.GetStructValue().Fields["title"].GetStringValue(),
+											"description": v.GetStructValue().Fields["description"].GetStringValue(),
+											"type":        attrType,
+											"items": map[string]interface{}{
+												"type": arrType,
+											},
+										})
+										if err != nil {
+											success = false
+										}
+									}
+								}
+
+							}
+
+						}
+					}
+
+				}
+
 			} else {
 				m, err = structpb.NewValue(map[string]interface{}{
 					"title":       v.GetStructValue().Fields["title"].GetStringValue(),
@@ -195,7 +435,6 @@ func (s *service) GenerateOpenApiSpec(startComp *pipelinePB.Component, endComp *
 					"type":        "string",
 				})
 			}
-
 		case float64:
 			m, err = structpb.NewValue(map[string]interface{}{
 				"title":       v.GetStructValue().Fields["title"].GetStringValue(),

--- a/pkg/service/openapi.go
+++ b/pkg/service/openapi.go
@@ -1,0 +1,205 @@
+package service
+
+import (
+	"fmt"
+	"strings"
+
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1alpha"
+)
+
+const openApiSchemaTemplate = `{
+    "openapi": "3.0.0",
+    "info": {
+        "version": "dev",
+        "title": "Pipeline Trigger"
+    },
+    "paths": {
+        "/trigger": {
+            "post": {
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "inputs": {
+                                        "type": "array",
+                                        "items": {}
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "outputs": {
+                                            "type": "array",
+                                            "items": {}
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+		"/triggerAsync": {
+            "post": {
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "inputs": {
+                                        "type": "array",
+                                        "items": {}
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+									"type": "object",
+									"properties": {
+										"operation": {
+											"title": "Trigger async pipeline operation message",
+											"readOnly": true,
+											"type": "object"
+										}
+									}
+								}
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}`
+
+func (s *service) GenerateOpenApiSpec(startComp *pipelinePB.Component, endComp *pipelinePB.Component) (*structpb.Struct, error) {
+	success := true
+	template := &structpb.Struct{}
+	err := protojson.Unmarshal([]byte(openApiSchemaTemplate), template)
+	if err != nil {
+		return nil, err
+	}
+
+	var walk *structpb.Value
+
+	openApiInput := &structpb.Struct{Fields: make(map[string]*structpb.Value)}
+	openApiInput.Fields["type"] = structpb.NewStringValue("object")
+	openApiInput.Fields["properties"] = structpb.NewStructValue(&structpb.Struct{Fields: make(map[string]*structpb.Value)})
+
+	for k, v := range startComp.Configuration.Fields["body"].GetStructValue().Fields {
+		var m *structpb.Value
+		attrType := ""
+		arrType := ""
+		switch t := v.GetStructValue().Fields["type"].GetStringValue(); t {
+		case "integer", "number", "boolean":
+			attrType = t
+		case "text", "image", "audio", "video":
+			attrType = "string"
+		default:
+			attrType = "array"
+			switch t2 := v.GetStructValue().Fields["type"].GetStringValue(); t {
+			case "integer_array", "number_array", "boolean_array":
+				arrType = strings.Split(t2, "_")[0]
+			case "text_array", "image_array", "audio_array", "video_array":
+				arrType = "string"
+			}
+
+		}
+		if attrType != "array" {
+			m, err = structpb.NewValue(map[string]interface{}{
+				"title":       v.GetStructValue().Fields["title"].GetStringValue(),
+				"description": v.GetStructValue().Fields["description"].GetStringValue(),
+				"type":        attrType,
+			})
+			if err != nil {
+				success = false
+			}
+		} else {
+			m, err = structpb.NewValue(map[string]interface{}{
+				"title":       v.GetStructValue().Fields["title"].GetStringValue(),
+				"description": v.GetStructValue().Fields["description"].GetStringValue(),
+				"type":        attrType,
+				"items": map[string]interface{}{
+					"type": arrType,
+				},
+			})
+			if err != nil {
+				success = false
+			}
+		}
+
+		openApiInput.Fields["properties"].GetStructValue().Fields[k] = m
+
+	}
+
+	walk = template.GetFields()["paths"]
+	for _, key := range []string{"/trigger", "post", "requestBody", "content", "application/json", "schema", "properties", "inputs", "items"} {
+		walk = walk.GetStructValue().Fields[key]
+	}
+	*walk = *structpb.NewStructValue(openApiInput)
+	walk = template.GetFields()["paths"]
+	for _, key := range []string{"/triggerAsync", "post", "requestBody", "content", "application/json", "schema", "properties", "inputs", "items"} {
+		walk = walk.GetStructValue().Fields[key]
+	}
+	*walk = *structpb.NewStructValue(openApiInput)
+
+	// output
+
+	openApiOutput := &structpb.Struct{Fields: make(map[string]*structpb.Value)}
+	openApiOutput.Fields["type"] = structpb.NewStringValue("object")
+	openApiOutput.Fields["properties"] = structpb.NewStructValue(&structpb.Struct{Fields: make(map[string]*structpb.Value)})
+
+	for k, v := range endComp.Configuration.Fields["body"].GetStructValue().Fields {
+		var m *structpb.Value
+
+		m, err = structpb.NewValue(map[string]interface{}{
+			"title":       v.GetStructValue().Fields["title"].GetStringValue(),
+			"description": v.GetStructValue().Fields["description"].GetStringValue(),
+			// "type":        attrType,
+		})
+
+		if err != nil {
+			success = false
+		}
+
+		openApiOutput.Fields["properties"].GetStructValue().Fields[k] = m
+
+	}
+
+	walk = template.GetFields()["paths"]
+	for _, key := range []string{"/trigger", "post", "responses", "200", "content", "application/json", "schema", "properties", "outputs", "items"} {
+		walk = walk.GetStructValue().Fields[key]
+	}
+	*walk = *structpb.NewStructValue(openApiOutput)
+
+	if success {
+		return template, nil
+	}
+	return nil, fmt.Errorf("generate OpenAPI spec error")
+
+}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -460,23 +460,41 @@ func (s *service) preTriggerPipeline(recipe *datamodel.Recipe, pipelineInputs []
 		for key, val := range pipelineInputs[idx].Fields {
 			switch typeMap[key] {
 			case "integer":
-				v, err := strconv.ParseInt(val.GetStringValue(), 10, 64)
-				if err != nil {
-					return err
+				switch val.AsInterface().(type) {
+				case string:
+					v, err := strconv.ParseInt(val.GetStringValue(), 10, 64)
+					if err != nil {
+						return err
+					}
+					pipelineInputs[idx].Fields[key] = structpb.NewNumberValue(float64(v))
+				default:
+					pipelineInputs[idx].Fields[key] = structpb.NewNumberValue(val.GetNumberValue())
 				}
-				pipelineInputs[idx].Fields[key] = structpb.NewNumberValue(float64(v))
+
 			case "number":
-				v, err := strconv.ParseFloat(val.GetStringValue(), 64)
-				if err != nil {
-					return err
+				switch val.AsInterface().(type) {
+				case string:
+					v, err := strconv.ParseFloat(val.GetStringValue(), 64)
+					if err != nil {
+						return err
+					}
+					pipelineInputs[idx].Fields[key] = structpb.NewNumberValue(v)
+				default:
+					pipelineInputs[idx].Fields[key] = structpb.NewNumberValue(val.GetNumberValue())
 				}
-				pipelineInputs[idx].Fields[key] = structpb.NewNumberValue(v)
+
 			case "boolean":
-				v, err := strconv.ParseBool(val.GetStringValue())
-				if err != nil {
-					return err
+				switch val.AsInterface().(type) {
+				case string:
+					v, err := strconv.ParseBool(val.GetStringValue())
+					if err != nil {
+						return err
+					}
+					pipelineInputs[idx].Fields[key] = structpb.NewBoolValue(v)
+				default:
+					pipelineInputs[idx].Fields[key] = structpb.NewBoolValue(val.GetBoolValue())
 				}
-				pipelineInputs[idx].Fields[key] = structpb.NewBoolValue(v)
+
 			case "text", "image", "audio", "video":
 			case "integer_array", "number_array", "boolean_array", "text_array", "image_array", "audio_array", "video_array":
 				if val.GetListValue() == nil {

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -605,24 +605,22 @@ func (s *service) CreateUserPipelineRelease(ctx context.Context, ns resource.Nam
 
 	ownerPermalink := ns.String()
 	userPermalink := resource.UserUidToUserPermalink(userUid)
-	fmt.Println()
-	fmt.Println(1)
+
 	pipeline, err := s.GetPipelineByUID(ctx, userUid, pipelineUid, pipelinePB.View_VIEW_FULL)
 	if err != nil {
 		return nil, err
 	}
 
 	pipelineRelease.Recipe = proto.Clone(pipeline.Recipe).(*pipelinePB.Recipe)
-	fmt.Println(2, pipelineRelease)
+
 	dbPipelineReleaseToCreate, err := s.PBToDBPipelineRelease(ctx, userUid, pipelineUid, pipelineRelease)
 	if err != nil {
 		return nil, err
 	}
-	fmt.Println(3, dbPipelineReleaseToCreate)
+
 	if err := s.repository.CreateUserPipelineRelease(ctx, ownerPermalink, userPermalink, pipelineUid, dbPipelineReleaseToCreate); err != nil {
 		return nil, err
 	}
-	fmt.Println(4)
 
 	dbCreatedPipelineRelease, err := s.repository.GetUserPipelineReleaseByID(ctx, ownerPermalink, userPermalink, pipelineUid, pipelineRelease.Id, false)
 	if err != nil {


### PR DESCRIPTION
Because

- We can derive the input/output of pipeline trigger endpoints from pipeline recipe. Thus, we can generate the OpenAPI schema and use this schema to generate code snippet.

This commit

- Implement OpenAPI schema generator
