### PR TITLE
chore: fix namespace problem for multipart handler

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -342,10 +342,16 @@ func main() {
 		logger.Fatal(err.Error())
 	}
 
-	if err := publicServeMux.HandlePath("POST", "/v1alpha/{name=pipelines/*}/trigger", middleware.AppendCustomHeaderMiddleware(publicServeMux, pipelinePublicServiceClient, handler.HandleTrigger)); err != nil {
+	if err := publicServeMux.HandlePath("POST", "/v1alpha/{name=users/*/pipelines/*}/trigger", middleware.AppendCustomHeaderMiddleware(publicServeMux, pipelinePublicServiceClient, handler.HandleTrigger)); err != nil {
 		logger.Fatal(err.Error())
 	}
-	if err := publicServeMux.HandlePath("POST", "/v1alpha/{name=pipelines/*}/triggerAsync", middleware.AppendCustomHeaderMiddleware(publicServeMux, pipelinePublicServiceClient, handler.HandleTriggerAsync)); err != nil {
+	if err := publicServeMux.HandlePath("POST", "/v1alpha/{name=users/*/pipelines/*}/triggerAsync", middleware.AppendCustomHeaderMiddleware(publicServeMux, pipelinePublicServiceClient, handler.HandleTriggerAsync)); err != nil {
+		logger.Fatal(err.Error())
+	}
+	if err := publicServeMux.HandlePath("POST", "/v1alpha/{name=users/*/pipelines/*/releases/*}/trigger", middleware.AppendCustomHeaderMiddleware(publicServeMux, pipelinePublicServiceClient, handler.HandleTriggerRelease)); err != nil {
+		logger.Fatal(err.Error())
+	}
+	if err := publicServeMux.HandlePath("POST", "/v1alpha/{name=users/*/pipelines/*/releases/*}/triggerAsync", middleware.AppendCustomHeaderMiddleware(publicServeMux, pipelinePublicServiceClient, handler.HandleTriggerAsyncRelease)); err != nil {
 		logger.Fatal(err.Error())
 	}
 	privateHTTPServer := &http.Server{

--- a/pkg/handler/handle.go
+++ b/pkg/handler/handle.go
@@ -21,6 +21,7 @@ import (
 )
 
 var forward_PipelinePublicService_TriggerUserPipeline_0 = runtime.ForwardResponseMessage
+var forward_PipelinePublicService_TriggerUserPipelineRelease_0 = runtime.ForwardResponseMessage
 
 func convertFormData(ctx context.Context, mux *runtime.ServeMux, req *http.Request) ([]*structpb.Struct, error) {
 
@@ -386,6 +387,221 @@ func request_PipelinePublicService_TriggerAsyncUserPipeline_0_form(ctx context.C
 	}
 
 	msg, err := client.TriggerAsyncUserPipeline(ctx, protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+// HandleTrigger
+func HandleTriggerRelease(mux *runtime.ServeMux, client pipelinePB.PipelinePublicServiceClient, w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+
+	ctx, cancel := context.WithCancel(req.Context())
+	defer cancel()
+
+	inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+	var err error
+	var annotatedContext context.Context
+	var resp protoreflect.ProtoMessage
+	var md runtime.ServerMetadata
+
+	annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/vdp.pipeline.v1alpha.PipelinePublicService/TriggerUserPipelineRelease", runtime.WithHTTPPathPattern("/v1alpha/{name=users/*/pipelines/*/releases/*}/trigger"))
+	if err != nil {
+		runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+		return
+	}
+
+	contentType := req.Header.Get("Content-Type")
+	if strings.Contains(contentType, "multipart/form-data") {
+		inputs, err := convertFormData(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err = request_PipelinePublicService_TriggerUserPipelineRelease_0_form(annotatedContext, inboundMarshaler, client, &pipelinePB.TriggerUserPipelineReleaseRequest{
+			Inputs: inputs,
+		}, pathParams)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+	} else {
+		resp, md, err = request_PipelinePublicService_TriggerUserPipelineRelease_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+	}
+
+	annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+
+	forward_PipelinePublicService_TriggerUserPipelineRelease_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+}
+
+// HandleTriggerAsync
+func HandleTriggerAsyncRelease(mux *runtime.ServeMux, client pipelinePB.PipelinePublicServiceClient, w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+
+	ctx, cancel := context.WithCancel(req.Context())
+	defer cancel()
+
+	inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+	var err error
+	var annotatedContext context.Context
+	var resp protoreflect.ProtoMessage
+	var md runtime.ServerMetadata
+
+	annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/vdp.pipeline.v1alpha.PipelinePublicService/TriggerAsyncUserPipelineRelease", runtime.WithHTTPPathPattern("/v1alpha/{name=users/*/pipelines/*/releases/*}/triggerAsync"))
+	if err != nil {
+		runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+		return
+	}
+
+	contentType := req.Header.Get("Content-Type")
+	if strings.Contains(contentType, "multipart/form-data") {
+		inputs, err := convertFormData(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err = request_PipelinePublicService_TriggerAsyncUserPipelineRelease_0_form(annotatedContext, inboundMarshaler, client, &pipelinePB.TriggerAsyncUserPipelineReleaseRequest{
+			Inputs: inputs,
+		}, pathParams)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+	} else {
+		resp, md, err = request_PipelinePublicService_TriggerAsyncUserPipelineRelease_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+	}
+
+	annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+
+	forward_PipelinePublicService_TriggerUserPipelineRelease_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+}
+
+// ref: the generated protogen-go files
+func request_PipelinePublicService_TriggerUserPipelineRelease_0(ctx context.Context, marshaler runtime.Marshaler, client pipelinePB.PipelinePublicServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq pipelinePB.TriggerUserPipelineReleaseRequest
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["name"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
+	}
+
+	protoReq.Name, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "name", err)
+	}
+
+	msg, err := client.TriggerUserPipelineRelease(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+// ref: the generated protogen-go files
+func request_PipelinePublicService_TriggerUserPipelineRelease_0_form(ctx context.Context, marshaler runtime.Marshaler, client pipelinePB.PipelinePublicServiceClient, protoReq *pipelinePB.TriggerUserPipelineReleaseRequest, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var metadata runtime.ServerMetadata
+
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["name"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
+	}
+
+	protoReq.Name, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "name", err)
+	}
+
+	msg, err := client.TriggerUserPipelineRelease(ctx, protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func request_PipelinePublicService_TriggerAsyncUserPipelineRelease_0(ctx context.Context, marshaler runtime.Marshaler, client pipelinePB.PipelinePublicServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq pipelinePB.TriggerAsyncUserPipelineReleaseRequest
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["name"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
+	}
+
+	protoReq.Name, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "name", err)
+	}
+
+	msg, err := client.TriggerAsyncUserPipelineRelease(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+// ref: the generated protogen-go files
+func request_PipelinePublicService_TriggerAsyncUserPipelineRelease_0_form(ctx context.Context, marshaler runtime.Marshaler, client pipelinePB.PipelinePublicServiceClient, protoReq *pipelinePB.TriggerAsyncUserPipelineReleaseRequest, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var metadata runtime.ServerMetadata
+
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["name"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
+	}
+
+	protoReq.Name, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "name", err)
+	}
+
+	msg, err := client.TriggerAsyncUserPipelineRelease(ctx, protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 
 }


### PR DESCRIPTION
Because

- the multipart handler didn't use the right path

This commit

- fix namespace problem for multipart handler
