### PR TITLE
chore: add `latest` tag for pipeline releases

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0
 	github.com/iancoleman/strcase v0.2.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230831041425-adb93d4977bb
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230831065318-d1d943f7d4a8
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20230814155646-874e57a1e4b0
 	github.com/instill-ai/x v0.3.0-alpha
 	github.com/knadh/koanf v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -1076,10 +1076,8 @@ github.com/influxdata/influxdb-client-go/v2 v2.12.3 h1:28nRlNMRIV4QbtIUvxhWqaxn0
 github.com/influxdata/influxdb-client-go/v2 v2.12.3/go.mod h1:IrrLUbCjjfkmRuaCiGQg4m2GbkaeJDcuWoxiWdQEbA0=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230829070319-de6fd3400ef0 h1:E1t9KbLVAJXY4GWqDrwN/kgZKwu/C3qZCqHddm4EHtE=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230829070319-de6fd3400ef0/go.mod h1:qsq5ecnA1xi2rLnVQFo/9xksA7I7wQu8c7rqM5xbIrQ=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230831041425-adb93d4977bb h1:fmgs54mqel13elwZr6scmtCWtTgV99CcQHxIcsov/ZY=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230831041425-adb93d4977bb/go.mod h1:qsq5ecnA1xi2rLnVQFo/9xksA7I7wQu8c7rqM5xbIrQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230831065318-d1d943f7d4a8 h1:uSPTihFcH8usFUZaHjhRwBCgm3COMOMOrTQ2Bn6A2FA=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230831065318-d1d943f7d4a8/go.mod h1:qsq5ecnA1xi2rLnVQFo/9xksA7I7wQu8c7rqM5xbIrQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20230814155646-874e57a1e4b0 h1:9QoCxaktvqGJYGjN8KhkWsv1DVfwbt5G1d/Ycx1kJxo=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20230814155646-874e57a1e4b0/go.mod h1:SELFgirs+28Wfnh0kGw02zttit4pUeKLKp17zGsTu6g=
 github.com/instill-ai/x v0.3.0-alpha h1:z9fedROOG2dVHhswBfVwU/hzHuq8/JKSUON7inF+FH8=


### PR DESCRIPTION
Because

- we need a special version tag `latest` point to the latest version (ordered by semantic version)

This commit

- add `latest` tag for pipeline releases
