### PR TITLE
chore: check `api_token` in header

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -154,6 +154,27 @@ func NewService(r repository.Repository,
 func (s *service) GetUser(ctx context.Context) (string, uuid.UUID, error) {
 	// Verify if "jwt-sub" is in the header
 	headerUserUId := resource.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey)
+
+	// TODO: convert api_token in gateway
+	authorization := resource.GetRequestSingleHeader(ctx, constant.HeaderAuthorization)
+	apiToken := strings.Replace(authorization, "Bearer ", "", 1)
+	if apiToken != "" {
+		ownerPermalink, err := s.redisClient.Get(context.Background(), fmt.Sprintf(constant.AccessTokenKeyFormat, apiToken)).Result()
+		if err != nil {
+			return "", uuid.Nil, status.Errorf(codes.Unauthenticated, "Unauthorized")
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		resp, err := s.mgmtPrivateServiceClient.LookUpUserAdmin(ctx, &mgmtPB.LookUpUserAdminRequest{Permalink: ownerPermalink})
+		if err != nil {
+			return "", uuid.Nil, status.Errorf(codes.Unauthenticated, "Unauthorized")
+		}
+
+		return resp.User.Id, uuid.FromStringOrNil(*resp.User.Uid), nil
+	}
+
 	if headerUserUId != "" {
 		_, err := uuid.FromString(headerUserUId)
 		if err != nil {

--- a/pkg/utils/dag.go
+++ b/pkg/utils/dag.go
@@ -141,8 +141,6 @@ func traverseBinding(bindings interface{}, path string) (interface{}, error) {
 }
 func RenderInput(input interface{}, bindings map[string]interface{}) (interface{}, error) {
 
-	fmt.Println()
-	fmt.Println("input", input)
 	switch input := input.(type) {
 	case string:
 		if strings.HasPrefix(input, "{") && strings.HasSuffix(input, "}") && !strings.HasPrefix(input, "{{") && !strings.HasSuffix(input, "}}") {


### PR DESCRIPTION
Because

- the `api_token` checker was missing

This commit

- check `api_token` in header
