### PR TITLE
chore: remove `body` in start/end operator to simplify recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,17 @@ dev:							## Run dev container
 	@docker run -d --rm \
 		-e DOCKER_HOST=${SOCAT_HOST}:${SOCAT_PORT} \
 		-v $(PWD):/${SERVICE_NAME} \
+		-p 3081:3081 \
 		-p ${SERVICE_PORT}:${SERVICE_PORT} \
+		-v $(PWD)/../connector:/connector \
+		-v $(PWD)/../connector-ai:/connector-ai \
+		-v $(PWD)/../connector-data:/connector-data \
+		-v $(PWD)/../connector-blockchain:/connector-blockchain \
+		-v $(PWD)/../connector-backend:/connector-backend \
+		-v $(PWD)/../protogengo:/protogengo \
+		-v $(PWD)/../controller-vdp:/controller-vdp \
+		-v $(PWD)/../go.work:/go.work \
+		-v $(PWD)/../go.work.sum:/go.work.sum \
 		--network instill-network \
 		--name ${SERVICE_NAME} \
 		instill/${SERVICE_NAME}:dev >/dev/null 2>&1

--- a/integration-test/const.js
+++ b/integration-test/const.js
@@ -106,11 +106,9 @@ export const simpleRecipe = {
         definition_name: "operator-definitions/start-operator",
         configuration: {
           metadata: {
-            body: {
-              input: {
-                title: "Input",
-                type: "text"
-              }
+            input: {
+              title: "Input",
+              type: "text"
             }
           }
         }
@@ -120,16 +118,12 @@ export const simpleRecipe = {
         definition_name: "operator-definitions/end-operator",
         configuration: {
           metadata: {
-            body: {
-              output: {
-                title: "output"
-              }
+            answer: {
+              title: "Answer"
             }
           },
           input: {
-            body: {
-              output: "{ start.body.input }"
-            }
+            answer: "{ start.input }"
           }
         }
       },
@@ -139,7 +133,7 @@ export const simpleRecipe = {
         definition_name: "connector-definitions/airbyte-destination-csv",
         configuration: {
           input: {
-            text: "{ start.body.input }"
+            text: "{ start.input }"
           }
         }
       },
@@ -149,7 +143,7 @@ export const simpleRecipe = {
         definition_name: "connector-definitions/airbyte-destination-csv",
         configuration: {
           input: {
-            text: "{ start.body.input }"
+            text: "{ start.input }"
           }
         }
       },
@@ -166,11 +160,9 @@ export const simpleRecipeWithoutCSV = {
         definition_name: "operator-definitions/start-operator",
         configuration: {
           metadata: {
-            body: {
-              input: {
-                title: "Input",
-                type: "text"
-              }
+            input: {
+              title: "Input",
+              type: "text"
             }
           }
         }
@@ -180,17 +172,12 @@ export const simpleRecipeWithoutCSV = {
         definition_name: "operator-definitions/end-operator",
         configuration: {
           metadata: {
-            body: {
-              output: {
-                title: "output"
-
-              }
+            answer: {
+              title: "Answer"
             }
           },
           input: {
-            body: {
-              output: "{ start.body.input }"
-            }
+            answer: "{ start.input }"
           }
         }
       },
@@ -207,11 +194,9 @@ export const simpleRecipeDupId = {
         definition_name: "operator-definitions/start-operator",
         configuration: {
           metadata: {
-            body: {
-              input: {
-                title: "Input",
-                type: "text"
-              }
+            input: {
+              title: "Input",
+              type: "text"
             }
           }
         }
@@ -220,10 +205,13 @@ export const simpleRecipeDupId = {
         id: "end",
         definition_name: "operator-definitions/end-operator",
         configuration: {
-          body: {
-            output: {
-              value: "{ start.body.input }"
+          metadata: {
+            answer: {
+              title: "Answer"
             }
+          },
+          input: {
+            answer: "{ start.input }"
           }
         }
       },
@@ -233,7 +221,7 @@ export const simpleRecipeDupId = {
         definition_name: "connector-definitions/airbyte-destination-csv",
         configuration: {
           input: {
-            text: "{ start.body.input }"
+            text: "{ start.input }"
           }
         }
       },
@@ -243,7 +231,7 @@ export const simpleRecipeDupId = {
         definition_name: "connector-definitions/airbyte-destination-csv",
         configuration: {
           input: {
-            text: "{ start.body.input }"
+            text: "{ start.input }"
           }
         }
       },

--- a/pkg/operator/end/config/definitions.json
+++ b/pkg/operator/end/config/definitions.json
@@ -16,39 +16,37 @@
           "metadata": {
             "type": "object",
             "properties": {
-              "body": {
-                "type": "object",
-                "additionalProperties": false,
-                "patternProperties": {
-                  "^[a-zA-Z_][a-zA-Z_0-9]*$": {
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "enum": [
-                          "integer",
-                          "integer_array",
-                          "number",
-                          "number_array",
-                          "boolean",
-                          "boolean_array",
-                          "text",
-                          "text_array",
-                          "image",
-                          "image_array",
-                          "audio",
-                          "audio_array",
-                          "video",
-                          "video_array"
-                        ],
-                        "title": "Type",
-                        "description": "Data Type"
-                      },
-                      "title": {
-                        "type": "string"
-                      },
-                      "description": {
-                        "type": "string"
-                      }
+              "type": "object",
+              "additionalProperties": false,
+              "patternProperties": {
+                "^[a-zA-Z_][a-zA-Z_0-9]*$": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "enum": [
+                        "integer",
+                        "integer_array",
+                        "number",
+                        "number_array",
+                        "boolean",
+                        "boolean_array",
+                        "text",
+                        "text_array",
+                        "image",
+                        "image_array",
+                        "audio",
+                        "audio_array",
+                        "video",
+                        "video_array"
+                      ],
+                      "title": "Type",
+                      "description": "Data Type"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
                     }
                   }
                 }
@@ -58,30 +56,28 @@
           "input": {
             "type": "object",
             "properties": {
-              "body": {
-                "type": "object",
-                "additionalProperties": false,
-                "patternProperties": {
-                  "^[a-zA-Z_][a-zA-Z_0-9]*$": {
-                    "oneOf": [
-                      {
-                        "type": "string",
-                        "pattern": "^\\{.*\\}$"
-                      },
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "type": "integer"
-                      },
-                      {
-                        "type": "boolean"
-                      }
-                    ]
-                  }
+              "type": "object",
+              "additionalProperties": false,
+              "patternProperties": {
+                "^[a-zA-Z_][a-zA-Z_0-9]*$": {
+                  "oneOf": [
+                    {
+                      "type": "string",
+                      "pattern": "^\\{.*\\}$"
+                    },
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "boolean"
+                    }
+                  ]
                 }
               }
             }

--- a/pkg/operator/end/config/seed/component.json
+++ b/pkg/operator/end/config/seed/component.json
@@ -7,39 +7,37 @@
     "metadata": {
       "type": "object",
       "properties": {
-        "body": {
-          "type": "object",
-          "additionalProperties": false,
-          "patternProperties": {
-            "^[a-zA-Z_][a-zA-Z_0-9]*$": {
-              "type": "object",
-              "properties": {
-                "type": {
-                  "enum": [
-                    "integer",
-                    "integer_array",
-                    "number",
-                    "number_array",
-                    "boolean",
-                    "boolean_array",
-                    "text",
-                    "text_array",
-                    "image",
-                    "image_array",
-                    "audio",
-                    "audio_array",
-                    "video",
-                    "video_array"
-                  ],
-                  "title": "Type",
-                  "description": "Data Type"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                }
+        "type": "object",
+        "additionalProperties": false,
+        "patternProperties": {
+          "^[a-zA-Z_][a-zA-Z_0-9]*$": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "enum": [
+                  "integer",
+                  "integer_array",
+                  "number",
+                  "number_array",
+                  "boolean",
+                  "boolean_array",
+                  "text",
+                  "text_array",
+                  "image",
+                  "image_array",
+                  "audio",
+                  "audio_array",
+                  "video",
+                  "video_array"
+                ],
+                "title": "Type",
+                "description": "Data Type"
+              },
+              "title": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
               }
             }
           }
@@ -49,19 +47,17 @@
     "input": {
       "type": "object",
       "properties": {
-        "body": {
-          "type": "object",
-          "additionalProperties": false,
-          "patternProperties": {
-            "^[a-zA-Z_][a-zA-Z_0-9]*$": {
-              "oneOf": [
-                { "type": "string", "pattern": "^\\{.*\\}$" },
-                { "type": "string" },
-                { "type": "number" },
-                { "type": "integer" },
-                { "type": "boolean" }
-              ]
-            }
+        "type": "object",
+        "additionalProperties": false,
+        "patternProperties": {
+          "^[a-zA-Z_][a-zA-Z_0-9]*$": {
+            "oneOf": [
+              { "type": "string", "pattern": "^\\{.*\\}$" },
+              { "type": "string" },
+              { "type": "number" },
+              { "type": "integer" },
+              { "type": "boolean" }
+            ]
           }
         }
       }

--- a/pkg/operator/start/config/definitions.json
+++ b/pkg/operator/start/config/definitions.json
@@ -16,39 +16,37 @@
           "metadata": {
             "type": "object",
             "properties": {
-              "body": {
-                "type": "object",
-                "additionalProperties": false,
-                "patternProperties": {
-                  "^[a-zA-Z_][a-zA-Z_0-9]*$": {
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "enum": [
-                          "integer",
-                          "integer_array",
-                          "number",
-                          "number_array",
-                          "boolean",
-                          "boolean_array",
-                          "text",
-                          "text_array",
-                          "image",
-                          "image_array",
-                          "audio",
-                          "audio_array",
-                          "video",
-                          "video_array"
-                        ],
-                        "title": "Type",
-                        "description": "Data Type"
-                      },
-                      "title": {
-                        "type": "string"
-                      },
-                      "description": {
-                        "type": "string"
-                      }
+              "type": "object",
+              "additionalProperties": false,
+              "patternProperties": {
+                "^[a-zA-Z_][a-zA-Z_0-9]*$": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "enum": [
+                        "integer",
+                        "integer_array",
+                        "number",
+                        "number_array",
+                        "boolean",
+                        "boolean_array",
+                        "text",
+                        "text_array",
+                        "image",
+                        "image_array",
+                        "audio",
+                        "audio_array",
+                        "video",
+                        "video_array"
+                      ],
+                      "title": "Type",
+                      "description": "Data Type"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
                     }
                   }
                 }

--- a/pkg/operator/start/config/seed/component.json
+++ b/pkg/operator/start/config/seed/component.json
@@ -7,39 +7,37 @@
     "metadata": {
       "type": "object",
       "properties": {
-        "body": {
-          "type": "object",
-          "additionalProperties": false,
-          "patternProperties": {
-            "^[a-zA-Z_][a-zA-Z_0-9]*$": {
-              "type": "object",
-              "properties": {
-                "type": {
-                  "enum": [
-                    "integer",
-                    "integer_array",
-                    "number",
-                    "number_array",
-                    "boolean",
-                    "boolean_array",
-                    "text",
-                    "text_array",
-                    "image",
-                    "image_array",
-                    "audio",
-                    "audio_array",
-                    "video",
-                    "video_array"
-                  ],
-                  "title": "Type",
-                  "description": "Data Type"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                }
+        "type": "object",
+        "additionalProperties": false,
+        "patternProperties": {
+          "^[a-zA-Z_][a-zA-Z_0-9]*$": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "enum": [
+                  "integer",
+                  "integer_array",
+                  "number",
+                  "number_array",
+                  "boolean",
+                  "boolean_array",
+                  "text",
+                  "text_array",
+                  "image",
+                  "image_array",
+                  "audio",
+                  "audio_array",
+                  "video",
+                  "video_array"
+                ],
+                "title": "Type",
+                "description": "Data Type"
+              },
+              "title": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
               }
             }
           }

--- a/pkg/service/openapi.go
+++ b/pkg/service/openapi.go
@@ -161,7 +161,7 @@ func (s *service) GenerateOpenApiSpec(startComp *pipelinePB.Component, endComp *
 	openApiInput.Fields["type"] = structpb.NewStringValue("object")
 	openApiInput.Fields["properties"] = structpb.NewStructValue(&structpb.Struct{Fields: make(map[string]*structpb.Value)})
 
-	for k, v := range startComp.Configuration.Fields["metadata"].GetStructValue().Fields["body"].GetStructValue().Fields {
+	for k, v := range startComp.Configuration.Fields["metadata"].GetStructValue().Fields {
 		var m *structpb.Value
 		attrType := ""
 		arrType := ""
@@ -224,8 +224,8 @@ func (s *service) GenerateOpenApiSpec(startComp *pipelinePB.Component, endComp *
 	openApiOutput.Fields["type"] = structpb.NewStringValue("object")
 	openApiOutput.Fields["properties"] = structpb.NewStructValue(&structpb.Struct{Fields: make(map[string]*structpb.Value)})
 
-	inputFields := endComp.Configuration.Fields["input"].GetStructValue().Fields["body"].GetStructValue().Fields
-	for k, v := range endComp.Configuration.Fields["metadata"].GetStructValue().Fields["body"].GetStructValue().Fields {
+	inputFields := endComp.Configuration.Fields["input"].GetStructValue().Fields
+	for k, v := range endComp.Configuration.Fields["metadata"].GetStructValue().Fields {
 		var m *structpb.Value
 
 		var err error
@@ -305,10 +305,10 @@ func (s *service) GenerateOpenApiSpec(startComp *pipelinePB.Component, endComp *
 
 							if comps[compIdx].DefinitionName == "operator-definitions/start-operator" {
 
-								isFullBody := str == ".body"
+								isFullBody := str == ""
 								str := str[len(strings.Split(str, ".")[1])+1:]
 
-								walk = comps[compIdx].GetConfiguration().Fields["metadata"].GetStructValue().Fields["body"]
+								walk = comps[compIdx].GetConfiguration().Fields["metadata"]
 								for {
 
 									splits := strings.Split(str, ".")

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -508,7 +508,7 @@ func (s *service) preTriggerPipeline(recipe *datamodel.Recipe, pipelineInputs []
 	typeMap := map[string]string{}
 	for _, comp := range recipe.Components {
 		if comp.DefinitionName == "operator-definitions/start-operator" {
-			for key, value := range comp.Configuration.Fields["metadata"].GetStructValue().Fields["body"].GetStructValue().Fields {
+			for key, value := range comp.Configuration.Fields["metadata"].GetStructValue().Fields {
 				typeMap[key] = value.GetStructValue().Fields["type"].GetStringValue()
 			}
 		}
@@ -874,11 +874,7 @@ func (s *service) triggerPipeline(ctx context.Context, ownerPermalink string, re
 	batchSize := len(pipelineInputs)
 
 	for idx := range pipelineInputs {
-		inputStruct := &structpb.Struct{
-			Fields: map[string]*structpb.Value{},
-		}
-		inputStruct.Fields["body"] = structpb.NewStructValue(pipelineInputs[idx])
-
+		inputStruct := structpb.NewStructValue(pipelineInputs[idx])
 		input, err := protojson.Marshal(inputStruct)
 		if err != nil {
 			return nil, nil, err
@@ -1012,7 +1008,7 @@ func (s *service) triggerPipeline(ctx context.Context, ownerPermalink string, re
 	pipelineOutputs := []*structpb.Struct{}
 	for idx := 0; idx < batchSize; idx++ {
 		pipelineOutput := &structpb.Struct{Fields: map[string]*structpb.Value{}}
-		for key, value := range outputCache[idx][responseCompId].(map[string]interface{})["body"].(map[string]interface{}) {
+		for key, value := range outputCache[idx][responseCompId].(map[string]interface{}) {
 			structVal, err := structpb.NewValue(value)
 			if err != nil {
 				return nil, nil, err

--- a/pkg/worker/workflow.go
+++ b/pkg/worker/workflow.go
@@ -159,10 +159,7 @@ func (w *worker) TriggerAsyncPipelineWorkflow(ctx workflow.Context, param *Trigg
 	}
 	batchSize := len(pipelineInputs)
 	for idx := range pipelineInputs {
-		inputStruct := &structpb.Struct{
-			Fields: map[string]*structpb.Value{},
-		}
-		inputStruct.Fields["body"] = structpb.NewStructValue(pipelineInputs[idx])
+		inputStruct := structpb.NewStructValue(pipelineInputs[idx])
 
 		input, err := protojson.Marshal(inputStruct)
 		if err != nil {
@@ -342,7 +339,7 @@ func (w *worker) TriggerAsyncPipelineWorkflow(ctx workflow.Context, param *Trigg
 	} else {
 		for idx := 0; idx < batchSize; idx++ {
 			pipelineOutput := &structpb.Struct{Fields: map[string]*structpb.Value{}}
-			for key, value := range outputCache[idx][responseCompId].(map[string]interface{})["body"].(map[string]interface{}) {
+			for key, value := range outputCache[idx][responseCompId].(map[string]interface{}) {
 				structVal, err := structpb.NewValue(value)
 				if err != nil {
 					return err


### PR DESCRIPTION
Because

- the `body` layer in start/end operator is redudent. 

This commit

- remove `body` in start/end operator to simplify the recipe
