### PR TITLE
chore(usage,metric): add pipeline release info in usage/metric data

### DIFF
--- a/pkg/handler/publicHandler.go
+++ b/pkg/handler/publicHandler.go
@@ -1515,8 +1515,10 @@ func (h *PublicHandler) TriggerUserPipelineRelease(ctx context.Context, req *pip
 	dataPoint := utils.UsageMetricData{
 		OwnerUID:           userUid.String(),
 		TriggerMode:        mgmtPB.Mode_MODE_SYNC,
-		PipelineID:         pbPipelineRelease.Id,
-		PipelineUID:        pbPipelineRelease.Uid,
+		PipelineID:         pbPipeline.Id,
+		PipelineUID:        pbPipeline.Uid,
+		PipelineReleaseID:  pbPipelineRelease.Id,
+		PipelineReleaseUID: pbPipelineRelease.Uid,
 		PipelineTriggerUID: logUUID.String(),
 		TriggerTime:        startTime.Format(time.RFC3339Nano),
 	}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -863,7 +863,17 @@ func (s *service) SetDefaultUserPipelineReleaseByID(ctx context.Context, ns reso
 	return nil
 }
 
-func (s *service) triggerPipeline(ctx context.Context, ownerPermalink string, recipe *datamodel.Recipe, pipelineId string, pipelineUid uuid.UUID, pipelineInputs []*structpb.Struct, pipelineTriggerId string, returnTraces bool) ([]*structpb.Struct, *pipelinePB.TriggerMetadata, error) {
+func (s *service) triggerPipeline(
+	ctx context.Context,
+	ownerPermalink string,
+	recipe *datamodel.Recipe,
+	pipelineId string,
+	pipelineUid uuid.UUID,
+	pipelineReleaseId string,
+	pipelineReleaseUid string,
+	pipelineInputs []*structpb.Struct,
+	pipelineTriggerId string,
+	returnTraces bool) ([]*structpb.Struct, *pipelinePB.TriggerMetadata, error) {
 	err := s.preTriggerPipeline(recipe, pipelineInputs)
 	if err != nil {
 		return nil, nil, err
@@ -956,6 +966,8 @@ func (s *service) triggerPipeline(ctx context.Context, ownerPermalink string, re
 					metadata.AppendToOutgoingContext(ctx,
 						"id", pipelineId,
 						"uid", pipelineUid.String(),
+						"release_id", pipelineReleaseId,
+						"release_uid", pipelineReleaseUid,
 						"owner", ownerPermalink,
 						"trigger_id", pipelineTriggerId,
 					),
@@ -1034,9 +1046,12 @@ func (s *service) triggerPipeline(ctx context.Context, ownerPermalink string, re
 }
 
 func (s *service) triggerAsyncPipeline(
-	ctx context.Context, ownerPermalink string,
-	recipe *datamodel.Recipe, pipelineId string,
-	pipelineUid uuid.UUID, pipelineReleaseId string,
+	ctx context.Context,
+	ownerPermalink string,
+	recipe *datamodel.Recipe,
+	pipelineId string,
+	pipelineUid uuid.UUID,
+	pipelineReleaseId string,
 	pipelineReleaseUid string,
 	pipelineInputs []*structpb.Struct,
 	pipelineTriggerId string,
@@ -1117,7 +1132,7 @@ func (s *service) TriggerUserPipelineByID(ctx context.Context, ns resource.Names
 	if err != nil {
 		return nil, nil, err
 	}
-	return s.triggerPipeline(ctx, ownerPermalink, recipe, dbPipeline.ID, dbPipeline.UID, inputs, pipelineTriggerId, returnTraces)
+	return s.triggerPipeline(ctx, ownerPermalink, recipe, dbPipeline.ID, dbPipeline.UID, "", "", inputs, pipelineTriggerId, returnTraces)
 
 }
 
@@ -1156,7 +1171,7 @@ func (s *service) TriggerUserPipelineReleaseByID(ctx context.Context, ns resourc
 	if err != nil {
 		return nil, nil, err
 	}
-	return s.triggerPipeline(ctx, ownerPermalink, recipe, dbPipeline.ID, dbPipeline.UID, inputs, pipelineTriggerId, returnTraces)
+	return s.triggerPipeline(ctx, ownerPermalink, recipe, dbPipeline.ID, dbPipeline.UID, dbPipelineRelease.ID, dbPipelineRelease.UID.String(), inputs, pipelineTriggerId, returnTraces)
 }
 
 func (s *service) TriggerAsyncUserPipelineReleaseByID(ctx context.Context, ns resource.Namespace, userUid uuid.UUID, pipelineUid uuid.UUID, id string, inputs []*structpb.Struct, pipelineTriggerId string, returnTraces bool) (*longrunningpb.Operation, error) {

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -1033,7 +1033,14 @@ func (s *service) triggerPipeline(ctx context.Context, ownerPermalink string, re
 	return pipelineOutputs, metadata, nil
 }
 
-func (s *service) triggerAsyncPipeline(ctx context.Context, ownerPermalink string, recipe *datamodel.Recipe, pipelineId string, pipelineUid uuid.UUID, pipelineInputs []*structpb.Struct, pipelineTriggerId string, returnTraces bool) (*longrunningpb.Operation, error) {
+func (s *service) triggerAsyncPipeline(
+	ctx context.Context, ownerPermalink string,
+	recipe *datamodel.Recipe, pipelineId string,
+	pipelineUid uuid.UUID, pipelineReleaseId string,
+	pipelineReleaseUid string,
+	pipelineInputs []*structpb.Struct,
+	pipelineTriggerId string,
+	returnTraces bool) (*longrunningpb.Operation, error) {
 
 	err := s.preTriggerPipeline(recipe, pipelineInputs)
 	if err != nil {
@@ -1078,6 +1085,8 @@ func (s *service) triggerAsyncPipeline(ctx context.Context, ownerPermalink strin
 			PipelineInputBlobRedisKeys: inputBlobRedisKeys,
 			PipelineId:                 pipelineId,
 			PipelineUid:                pipelineUid,
+			PipelineReleaseId:          pipelineReleaseId,
+			PipelineReleaseUid:         pipelineReleaseUid,
 			PipelineRecipe:             recipe,
 			OwnerPermalink:             ownerPermalink,
 			ReturnTraces:               returnTraces,
@@ -1124,7 +1133,7 @@ func (s *service) TriggerAsyncUserPipelineByID(ctx context.Context, ns resource.
 	if err != nil {
 		return nil, err
 	}
-	return s.triggerAsyncPipeline(ctx, ownerPermalink, recipe, dbPipeline.ID, dbPipeline.UID, inputs, pipelineTriggerId, returnTraces)
+	return s.triggerAsyncPipeline(ctx, ownerPermalink, recipe, dbPipeline.ID, dbPipeline.UID, "", "", inputs, pipelineTriggerId, returnTraces)
 
 }
 
@@ -1166,5 +1175,5 @@ func (s *service) TriggerAsyncUserPipelineReleaseByID(ctx context.Context, ns re
 	if err != nil {
 		return nil, err
 	}
-	return s.triggerAsyncPipeline(ctx, ownerPermalink, recipe, dbPipeline.ID, dbPipeline.UID, inputs, pipelineTriggerId, returnTraces)
+	return s.triggerAsyncPipeline(ctx, ownerPermalink, recipe, dbPipeline.ID, dbPipeline.UID, dbPipelineRelease.ID, dbPipelineRelease.UID.String(), inputs, pipelineTriggerId, returnTraces)
 }

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -1162,7 +1162,7 @@ func (s *service) TriggerUserPipelineReleaseByID(ctx context.Context, ns resourc
 		return nil, nil, err
 	}
 
-	dbPipeline, err := s.repository.GetUserPipelineReleaseByUID(ctx, ownerPermalink, userPermalink, pipelineUid, dbPipelineRelease.UID, false)
+	dbPipeline, err := s.repository.GetPipelineByUID(ctx, userPermalink, pipelineUid, false)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1182,7 +1182,7 @@ func (s *service) TriggerAsyncUserPipelineReleaseByID(ctx context.Context, ns re
 	if err != nil {
 		return nil, err
 	}
-	dbPipeline, err := s.repository.GetUserPipelineReleaseByUID(ctx, ownerPermalink, userPermalink, pipelineUid, dbPipelineRelease.UID, false)
+	dbPipeline, err := s.repository.GetPipelineByUID(ctx, userPermalink, pipelineUid, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -870,7 +870,7 @@ func (s *service) triggerPipeline(
 	pipelineId string,
 	pipelineUid uuid.UUID,
 	pipelineReleaseId string,
-	pipelineReleaseUid string,
+	pipelineReleaseUid uuid.UUID,
 	pipelineInputs []*structpb.Struct,
 	pipelineTriggerId string,
 	returnTraces bool) ([]*structpb.Struct, *pipelinePB.TriggerMetadata, error) {
@@ -967,7 +967,7 @@ func (s *service) triggerPipeline(
 						"id", pipelineId,
 						"uid", pipelineUid.String(),
 						"release_id", pipelineReleaseId,
-						"release_uid", pipelineReleaseUid,
+						"release_uid", pipelineReleaseUid.String(),
 						"owner", ownerPermalink,
 						"trigger_id", pipelineTriggerId,
 					),
@@ -1052,7 +1052,7 @@ func (s *service) triggerAsyncPipeline(
 	pipelineId string,
 	pipelineUid uuid.UUID,
 	pipelineReleaseId string,
-	pipelineReleaseUid string,
+	pipelineReleaseUid uuid.UUID,
 	pipelineInputs []*structpb.Struct,
 	pipelineTriggerId string,
 	returnTraces bool) (*longrunningpb.Operation, error) {
@@ -1132,7 +1132,7 @@ func (s *service) TriggerUserPipelineByID(ctx context.Context, ns resource.Names
 	if err != nil {
 		return nil, nil, err
 	}
-	return s.triggerPipeline(ctx, ownerPermalink, recipe, dbPipeline.ID, dbPipeline.UID, "", "", inputs, pipelineTriggerId, returnTraces)
+	return s.triggerPipeline(ctx, ownerPermalink, recipe, dbPipeline.ID, dbPipeline.UID, "", uuid.Nil, inputs, pipelineTriggerId, returnTraces)
 
 }
 
@@ -1148,7 +1148,7 @@ func (s *service) TriggerAsyncUserPipelineByID(ctx context.Context, ns resource.
 	if err != nil {
 		return nil, err
 	}
-	return s.triggerAsyncPipeline(ctx, ownerPermalink, recipe, dbPipeline.ID, dbPipeline.UID, "", "", inputs, pipelineTriggerId, returnTraces)
+	return s.triggerAsyncPipeline(ctx, ownerPermalink, recipe, dbPipeline.ID, dbPipeline.UID, "", uuid.Nil, inputs, pipelineTriggerId, returnTraces)
 
 }
 
@@ -1171,7 +1171,7 @@ func (s *service) TriggerUserPipelineReleaseByID(ctx context.Context, ns resourc
 	if err != nil {
 		return nil, nil, err
 	}
-	return s.triggerPipeline(ctx, ownerPermalink, recipe, dbPipeline.ID, dbPipeline.UID, dbPipelineRelease.ID, dbPipelineRelease.UID.String(), inputs, pipelineTriggerId, returnTraces)
+	return s.triggerPipeline(ctx, ownerPermalink, recipe, dbPipeline.ID, dbPipeline.UID, dbPipelineRelease.ID, dbPipelineRelease.UID, inputs, pipelineTriggerId, returnTraces)
 }
 
 func (s *service) TriggerAsyncUserPipelineReleaseByID(ctx context.Context, ns resource.Namespace, userUid uuid.UUID, pipelineUid uuid.UUID, id string, inputs []*structpb.Struct, pipelineTriggerId string, returnTraces bool) (*longrunningpb.Operation, error) {
@@ -1190,5 +1190,5 @@ func (s *service) TriggerAsyncUserPipelineReleaseByID(ctx context.Context, ns re
 	if err != nil {
 		return nil, err
 	}
-	return s.triggerAsyncPipeline(ctx, ownerPermalink, recipe, dbPipeline.ID, dbPipeline.UID, dbPipelineRelease.ID, dbPipelineRelease.UID.String(), inputs, pipelineTriggerId, returnTraces)
+	return s.triggerAsyncPipeline(ctx, ownerPermalink, recipe, dbPipeline.ID, dbPipeline.UID, dbPipelineRelease.ID, dbPipelineRelease.UID, inputs, pipelineTriggerId, returnTraces)
 }

--- a/pkg/usage/usage.go
+++ b/pkg/usage/usage.go
@@ -113,11 +113,13 @@ func (u *usage) RetrieveUsageData() interface{} {
 					triggerDataList = append(
 						triggerDataList,
 						&usagePB.PipelineUsageData_UserUsageData_PipelineTriggerData{
-							PipelineUid: triggerData.PipelineUID,
-							TriggerUid:  triggerData.PipelineTriggerUID,
-							TriggerTime: timestamppb.New(triggerTime),
-							TriggerMode: triggerData.TriggerMode,
-							Status:      triggerData.Status,
+							PipelineUid:        triggerData.PipelineUID,
+							PipelineReleaseId:  triggerData.PipelineReleaseID,
+							PipelineReleaseUid: triggerData.PipelineReleaseUID,
+							TriggerUid:         triggerData.PipelineTriggerUID,
+							TriggerTime:        timestamppb.New(triggerTime),
+							TriggerMode:        triggerData.TriggerMode,
+							Status:             triggerData.Status,
 						},
 					)
 				}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -68,6 +68,8 @@ type UsageMetricData struct {
 	Status              mgmtPB.Status
 	PipelineID          string
 	PipelineUID         string
+	PipelineReleaseID   string
+	PipelineReleaseUID  string
 	PipelineTriggerUID  string
 	TriggerTime         string
 	ComputeTimeDuration float64
@@ -84,6 +86,8 @@ func NewDataPoint(data UsageMetricData) *write.Point {
 			"owner_uid":             data.OwnerUID,
 			"pipeline_id":           data.PipelineID,
 			"pipeline_uid":          data.PipelineUID,
+			"pipeline_release_id":   data.PipelineReleaseID,
+			"pipeline_release_uid":  data.PipelineReleaseUID,
 			"pipeline_trigger_id":   data.PipelineTriggerUID,
 			"trigger_time":          data.TriggerTime,
 			"compute_time_duration": data.ComputeTimeDuration,

--- a/pkg/worker/workflow.go
+++ b/pkg/worker/workflow.go
@@ -32,7 +32,7 @@ type TriggerAsyncPipelineWorkflowRequest struct {
 	PipelineId                 string
 	PipelineUid                uuid.UUID
 	PipelineReleaseId          string
-	PipelineReleaseUid         string
+	PipelineReleaseUid         uuid.UUID
 	PipelineRecipe             *datamodel.Recipe
 	OwnerPermalink             string
 	ReturnTraces               bool
@@ -120,7 +120,7 @@ func (w *worker) TriggerAsyncPipelineWorkflow(ctx workflow.Context, param *Trigg
 		PipelineID:         param.PipelineId,
 		PipelineUID:        param.PipelineUid.String(),
 		PipelineReleaseID:  param.PipelineReleaseId,
-		PipelineReleaseUID: param.PipelineReleaseUid,
+		PipelineReleaseUID: param.PipelineReleaseUid.String(),
 		PipelineTriggerUID: workflow.GetInfo(ctx).WorkflowExecution.ID,
 		TriggerTime:        startTime.Format(time.RFC3339Nano),
 	}
@@ -280,7 +280,7 @@ func (w *worker) TriggerAsyncPipelineWorkflow(ctx workflow.Context, param *Trigg
 					Id:         param.PipelineId,
 					Uid:        param.PipelineUid.String(),
 					ReleaseId:  param.PipelineReleaseId,
-					ReleaseUid: param.PipelineReleaseUid,
+					ReleaseUid: param.PipelineReleaseUid.String(),
 					Owner:      param.OwnerPermalink,
 					TriggerId:  workflow.GetInfo(ctx).WorkflowExecution.ID,
 				},

--- a/pkg/worker/workflow.go
+++ b/pkg/worker/workflow.go
@@ -31,6 +31,8 @@ type TriggerAsyncPipelineWorkflowRequest struct {
 	PipelineInputBlobRedisKeys []string
 	PipelineId                 string
 	PipelineUid                uuid.UUID
+	PipelineReleaseId          string
+	PipelineReleaseUid         string
 	PipelineRecipe             *datamodel.Recipe
 	OwnerPermalink             string
 	ReturnTraces               bool
@@ -115,6 +117,8 @@ func (w *worker) TriggerAsyncPipelineWorkflow(ctx workflow.Context, param *Trigg
 		TriggerMode:        mgmtPB.Mode_MODE_ASYNC,
 		PipelineID:         param.PipelineId,
 		PipelineUID:        param.PipelineUid.String(),
+		PipelineReleaseID:  param.PipelineReleaseId,
+		PipelineReleaseUID: param.PipelineReleaseUid,
 		PipelineTriggerUID: workflow.GetInfo(ctx).WorkflowExecution.ID,
 		TriggerTime:        startTime.Format(time.RFC3339Nano),
 	}

--- a/pkg/worker/workflow.go
+++ b/pkg/worker/workflow.go
@@ -47,10 +47,12 @@ type ExecuteConnectorActivityRequest struct {
 }
 
 type PipelineMetadataStruct struct {
-	Id        string
-	Uid       string
-	Owner     string
-	TriggerId string
+	Id         string
+	Uid        string
+	ReleaseId  string
+	ReleaseUid string
+	Owner      string
+	TriggerId  string
 }
 
 type ExecuteConnectorActivityResponse struct {
@@ -275,10 +277,12 @@ func (w *worker) TriggerAsyncPipelineWorkflow(ctx workflow.Context, param *Trigg
 				Name:               comp.ResourceName,
 				OwnerPermalink:     param.OwnerPermalink,
 				PipelineMetadata: PipelineMetadataStruct{
-					Id:        param.PipelineId,
-					Uid:       param.PipelineUid.String(),
-					Owner:     param.OwnerPermalink,
-					TriggerId: workflow.GetInfo(ctx).WorkflowExecution.ID,
+					Id:         param.PipelineId,
+					Uid:        param.PipelineUid.String(),
+					ReleaseId:  param.PipelineReleaseId,
+					ReleaseUid: param.PipelineReleaseUid,
+					Owner:      param.OwnerPermalink,
+					TriggerId:  workflow.GetInfo(ctx).WorkflowExecution.ID,
 				},
 			}).Get(ctx, &result); err != nil {
 				span.SetStatus(1, err.Error())
@@ -414,6 +418,8 @@ func (w *worker) ConnectorActivity(ctx context.Context, param *ExecuteConnectorA
 			metadata.AppendToOutgoingContext(ctx,
 				"id", param.PipelineMetadata.Id,
 				"uid", param.PipelineMetadata.Uid,
+				"release_id", param.PipelineMetadata.ReleaseId,
+				"release_uid", param.PipelineMetadata.ReleaseUid,
 				"owner", param.PipelineMetadata.Owner,
 				"trigger_id", param.PipelineMetadata.TriggerId,
 			),


### PR DESCRIPTION
Because

- support pipeline release feature

This commit

- add pipeline release info in usage/metric data
