### PR TITLE
chore(metric): fix pipeline release nil uuid value

### DIFF
--- a/pkg/handler/publicHandler.go
+++ b/pkg/handler/publicHandler.go
@@ -824,6 +824,8 @@ func (h *PublicHandler) TriggerUserPipeline(ctx context.Context, req *pipelinePB
 		TriggerMode:        mgmtPB.Mode_MODE_SYNC,
 		PipelineID:         pbPipeline.Id,
 		PipelineUID:        pbPipeline.Uid,
+		PipelineReleaseID:  "",
+		PipelineReleaseUID: uuid.Nil.String(),
 		PipelineTriggerUID: logUUID.String(),
 		TriggerTime:        startTime.Format(time.RFC3339Nano),
 	}


### PR DESCRIPTION
Because

- fix pipeline release nil uuid value

This commit

- fix pipeline release nil uuid value
