### PR TITLE
chore: increase grpc message size limit

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -87,7 +87,7 @@ func InitPipelinePublicServiceClient(ctx context.Context) (pipelinePB.PipelinePu
 		clientDialOpts = grpc.WithTransportCredentials(insecure.NewCredentials())
 	}
 
-	clientConn, err := grpc.Dial(fmt.Sprintf(":%v", config.Config.Server.PublicPort), clientDialOpts)
+	clientConn, err := grpc.Dial(fmt.Sprintf(":%v", config.Config.Server.PublicPort), clientDialOpts, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(constant.MaxPayloadSize), grpc.MaxCallSendMsgSize(constant.MaxPayloadSize)))
 	if err != nil {
 		logger.Error(err.Error())
 		return nil, nil
@@ -199,6 +199,9 @@ func main() {
 		}
 		grpcServerOpts = append(grpcServerOpts, grpc.Creds(creds))
 	}
+
+	grpcServerOpts = append(grpcServerOpts, grpc.MaxRecvMsgSize(constant.MaxPayloadSize))
+	grpcServerOpts = append(grpcServerOpts, grpc.MaxSendMsgSize(constant.MaxPayloadSize))
 
 	pipelinePublicServiceClient, pipelinePublicServiceClientConn := InitPipelinePublicServiceClient(ctx)
 	if pipelinePublicServiceClientConn != nil {

--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -9,16 +9,7 @@ const (
 )
 
 const MaxBatchSize int = 32
-
-// Constants for text to image task.
-const DefaultStep int = 10
-const DefaultCfgScale float64 = 7.0
-const DefaultSeed int = 1024
-const DefaultSamples int = 1
-
-// Constants for text generation task.
-const DefaultOutputLen int = 100
-const DefaultTopK int = 40
+const MaxPayloadSize = 1024 * 1024 * 32
 
 // Constants for resource owner
 const DefaultUserID string = "instill-ai"

--- a/pkg/external/external.go
+++ b/pkg/external/external.go
@@ -15,6 +15,7 @@ import (
 	influxdb2 "github.com/influxdata/influxdb-client-go/v2"
 
 	"github.com/instill-ai/pipeline-backend/config"
+	"github.com/instill-ai/pipeline-backend/pkg/constant"
 	"github.com/instill-ai/pipeline-backend/pkg/logger"
 
 	mgmtPB "github.com/instill-ai/protogen-go/base/mgmt/v1alpha"
@@ -38,7 +39,8 @@ func InitConnectorPublicServiceClient(ctx context.Context) (connectorPB.Connecto
 		clientDialOpts = grpc.WithTransportCredentials(insecure.NewCredentials())
 	}
 
-	clientConn, err := grpc.Dial(fmt.Sprintf("%v:%v", config.Config.ConnectorBackend.Host, config.Config.ConnectorBackend.PublicPort), clientDialOpts)
+	clientConn, err := grpc.Dial(fmt.Sprintf("%v:%v", config.Config.ConnectorBackend.Host, config.Config.ConnectorBackend.PublicPort),
+		clientDialOpts, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(constant.MaxPayloadSize), grpc.MaxCallSendMsgSize(constant.MaxPayloadSize)))
 	if err != nil {
 		logger.Error(err.Error())
 		return nil, nil
@@ -62,7 +64,8 @@ func InitConnectorPrivateServiceClient(ctx context.Context) (connectorPB.Connect
 		clientDialOpts = grpc.WithTransportCredentials(insecure.NewCredentials())
 	}
 
-	clientConn, err := grpc.Dial(fmt.Sprintf("%v:%v", config.Config.ConnectorBackend.Host, config.Config.ConnectorBackend.PrivatePort), clientDialOpts)
+	clientConn, err := grpc.Dial(fmt.Sprintf("%v:%v", config.Config.ConnectorBackend.Host, config.Config.ConnectorBackend.PrivatePort),
+		clientDialOpts, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(constant.MaxPayloadSize), grpc.MaxCallSendMsgSize(constant.MaxPayloadSize)))
 	if err != nil {
 		logger.Error(err.Error())
 		return nil, nil


### PR DESCRIPTION
Because

- the default grpc message size limit is only 4MB, which is not enough

This commit

- increase grpc message size limit to 32MB
