### PR TITLE
chore(service): remove unsafe user_id injection and update default_user_id

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/go-redis/redis/v9"
-	"github.com/gofrs/uuid"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"go.opentelemetry.io/contrib/propagators/b3"
 	"go.opentelemetry.io/otel"
@@ -46,7 +45,6 @@ import (
 
 	database "github.com/instill-ai/pipeline-backend/pkg/db"
 	custom_otel "github.com/instill-ai/pipeline-backend/pkg/logger/otel"
-	mgmtPB "github.com/instill-ai/protogen-go/base/mgmt/v1alpha"
 	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1alpha"
 )
 
@@ -242,11 +240,6 @@ func main() {
 
 	repository := repository.NewRepository(db)
 
-	resp, err := mgmtPrivateServiceClient.GetUserAdmin(ctx, &mgmtPB.GetUserAdminRequest{Name: "users/" + constant.DefaultUserID})
-	if err != nil {
-		panic(err)
-	}
-	defaultUserUID := uuid.FromStringOrNil(*resp.User.Uid)
 	service := service.NewService(
 		repository,
 		mgmtPrivateServiceClient,
@@ -256,7 +249,6 @@ func main() {
 		redisClient,
 		temporalClient,
 		influxDBWriteClient,
-		defaultUserUID,
 	)
 
 	privateGrpcS := grpc.NewServer(grpcServerOpts...)

--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -12,7 +12,7 @@ const MaxBatchSize int = 32
 const MaxPayloadSize = 1024 * 1024 * 32
 
 // Constants for resource owner
-const DefaultUserID string = "instill-ai"
+const DefaultUserID string = "admin"
 const HeaderUserUIDKey = "jwt-sub"
 const StartConnectorId = "start-operator"
 const EndConnectorId = "end-operator"

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -118,7 +118,6 @@ type service struct {
 	temporalClient                client.Client
 	influxDBWriteClient           api.WriteAPI
 	operator                      operator.Operator
-	defaultUserUid                uuid.UUID
 }
 
 // NewService initiates a service instance
@@ -130,7 +129,6 @@ func NewService(r repository.Repository,
 	rc *redis.Client,
 	t client.Client,
 	i api.WriteAPI,
-	defaultUserUid uuid.UUID,
 ) Service {
 	return &service{
 		repository:                    r,
@@ -142,7 +140,6 @@ func NewService(r repository.Repository,
 		temporalClient:                t,
 		influxDBWriteClient:           i,
 		operator:                      operator.InitOperator(),
-		defaultUserUid:                defaultUserUid,
 	}
 }
 
@@ -163,7 +160,7 @@ func (s *service) GetUser(ctx context.Context) (string, uuid.UUID, error) {
 		return resp.User.Id, uuid.FromStringOrNil(headerUserUId), nil
 	}
 
-	return constant.DefaultUserID, s.defaultUserUid, nil
+	return "", uuid.Nil, status.Errorf(codes.Unauthenticated, "Unauthorized")
 }
 
 func (s *service) ConvertOwnerPermalinkToName(permalink string) (string, error) {


### PR DESCRIPTION
Because

- the `user_id` injection in backend is unsafe
- we are going to change the default_user_id to `admin`

This commit

- remove `user_id` injection
- change the default_user_id to `admin`
