### PR TITLE
fix(service): delete pipeline_release when pipeline is deleted

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -436,9 +436,16 @@ func (s *service) DeleteUserPipelineByID(ctx context.Context, ns resource.Namesp
 	if err != nil {
 		return err
 	}
-
-	if err := s.DeleteResourceState(dbPipeline.UID); err != nil {
+	// TODO: pagination
+	pipelineReleases, _, _, err := s.repository.ListUserPipelineReleases(ctx, ownerPermalink, userPermalink, dbPipeline.UID, 1000, "", false, filtering.Filter{}, false)
+	if err != nil {
 		return err
+	}
+	for _, pipelineRelease := range pipelineReleases {
+		err := s.DeleteUserPipelineReleaseByID(ctx, ns, userUid, dbPipeline.UID, pipelineRelease.ID)
+		if err != nil {
+			return err
+		}
 	}
 
 	return s.repository.DeleteUserPipelineByID(ctx, ownerPermalink, userPermalink, id)


### PR DESCRIPTION
Because

- the pipeline_release should be deleted when pipeline is deleted, or it will be dangling 

This commit

- delete pipeline_release when pipeline is deleted
