### PR TITLE
chore(permission): rename the share-code permission header

### DIFF
--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -14,7 +14,7 @@ const MaxPayloadSize = 1024 * 1024 * 32
 // Constants for resource owner
 const DefaultUserID string = "admin"
 const HeaderUserUIDKey = "jwt-sub"
-const HeaderInstillCodeKey = "instill-code"
+const HeaderInstillCodeKey = "instill-share-code"
 const StartConnectorId = "start-operator"
 const EndConnectorId = "end-operator"
 const ReturnTracesKey = "instill-return-traces"

--- a/pkg/middleware/misc.go
+++ b/pkg/middleware/misc.go
@@ -154,7 +154,7 @@ func CustomMatcher(key string) (string, bool) {
 	switch key {
 	case "request-id":
 		return key, true
-	case "Instill-Return-Traces", "Instill-Code":
+	case "Instill-Return-Traces", "Instill-Share-Code":
 		return key, true
 	case "X-B3-Traceid", "X-B3-Spanid", "X-B3-Sampled":
 		return key, true


### PR DESCRIPTION
Because

- the original header `Instill-Code` has no clear meaning

This commit

- rename it to `Instill-Share-Code`
