### PR TITLE
chore(service): add `alias` field for `pipeline_release`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
 	github.com/instill-ai/component v0.4.0-alpha.0.20230925171029-e3485c428e72
 	github.com/instill-ai/operator v0.0.0-20230925171700-a6531f0f304b
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230925170910-6416b8d2be1a
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230926065719-21b2e1fe684c
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20230814155646-874e57a1e4b0
 	github.com/instill-ai/x v0.3.0-alpha
 	github.com/knadh/koanf v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -1101,8 +1101,8 @@ github.com/instill-ai/component v0.4.0-alpha.0.20230925171029-e3485c428e72 h1:Vp
 github.com/instill-ai/component v0.4.0-alpha.0.20230925171029-e3485c428e72/go.mod h1:NoA019Wyez+2q8cfIiDGLOGfkSIm/lC/o1wOOU73oV0=
 github.com/instill-ai/operator v0.0.0-20230925171700-a6531f0f304b h1:EdAyrc1mjyR1iFJ/p0Zm0NMMfKMcusxEz+DdoLi2H24=
 github.com/instill-ai/operator v0.0.0-20230925171700-a6531f0f304b/go.mod h1:jtyb/uCXNMb0Z0bdfn+Yd3tck04Y92o0QwWR4fTtM/E=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230925170910-6416b8d2be1a h1:b8M9EZv80v5VUz1+xDgn+H3w9+rQks1e7QDoTOUg7CE=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230925170910-6416b8d2be1a/go.mod h1:z/L84htamlJ4QOR4jtJOaa+y3Hihu7WEqOipW0LEkmc=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230926065719-21b2e1fe684c h1:FIP3cWEOxYNfwdxZsD+wgv4l3xaaBF4O4XAgI+K0Jt0=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230926065719-21b2e1fe684c/go.mod h1:z/L84htamlJ4QOR4jtJOaa+y3Hihu7WEqOipW0LEkmc=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20230814155646-874e57a1e4b0 h1:9QoCxaktvqGJYGjN8KhkWsv1DVfwbt5G1d/Ycx1kJxo=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20230814155646-874e57a1e4b0/go.mod h1:SELFgirs+28Wfnh0kGw02zttit4pUeKLKp17zGsTu6g=
 github.com/instill-ai/x v0.3.0-alpha h1:z9fedROOG2dVHhswBfVwU/hzHuq8/JKSUON7inF+FH8=

--- a/pkg/service/convert.go
+++ b/pkg/service/convert.go
@@ -614,7 +614,7 @@ func (s *service) PBToDBPipelineRelease(ctx context.Context, userUid uuid.UUID, 
 }
 
 // DBToPBPipelineRelease converts db data model to protobuf data model
-func (s *service) DBToPBPipelineRelease(ctx context.Context, dbPipelineRelease *datamodel.PipelineRelease, view pipelinePB.View) (*pipelinePB.PipelineRelease, error) {
+func (s *service) DBToPBPipelineRelease(ctx context.Context, dbPipelineRelease *datamodel.PipelineRelease, view pipelinePB.View, latestUUID uuid.UUID, defaultUUID uuid.UUID) (*pipelinePB.PipelineRelease, error) {
 
 	dbPipeline, err := s.repository.GetPipelineByUIDAdmin(ctx, dbPipelineRelease.PipelineUID, true)
 	if err != nil {
@@ -709,12 +709,18 @@ func (s *service) DBToPBPipelineRelease(ctx context.Context, dbPipelineRelease *
 			pbPipelineRelease.OpenapiSchema = spec
 		}
 	}
+	if pbPipelineRelease.Uid == latestUUID.String() {
+		pbPipelineRelease.Alias = "latest"
+	}
+	if pbPipelineRelease.Uid == defaultUUID.String() {
+		pbPipelineRelease.Alias = "default"
+	}
 
 	return &pbPipelineRelease, nil
 }
 
 // DBToPBPipelineRelease converts db data model to protobuf data model
-func (s *service) DBToPBPipelineReleases(ctx context.Context, dbPipelineRelease []*datamodel.PipelineRelease, view pipelinePB.View) ([]*pipelinePB.PipelineRelease, error) {
+func (s *service) DBToPBPipelineReleases(ctx context.Context, dbPipelineRelease []*datamodel.PipelineRelease, view pipelinePB.View, latestUUID uuid.UUID, defaultUUID uuid.UUID) ([]*pipelinePB.PipelineRelease, error) {
 	var err error
 	pbPipelineReleases := make([]*pipelinePB.PipelineRelease, len(dbPipelineRelease))
 	for idx := range dbPipelineRelease {
@@ -722,6 +728,8 @@ func (s *service) DBToPBPipelineReleases(ctx context.Context, dbPipelineRelease 
 			ctx,
 			dbPipelineRelease[idx],
 			view,
+			latestUUID,
+			defaultUUID,
 		)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Because

- we need to show the `pipeline_release` `alias` name in response

This commit

- add `alias` field for `pipeline_release`
