### PR TITLE
fix(handler): fix PATCH pipeline mask bug

### DIFF
--- a/pkg/handler/publicHandler.go
+++ b/pkg/handler/publicHandler.go
@@ -498,7 +498,7 @@ func (h *PublicHandler) UpdateUserPipeline(ctx context.Context, req *pipelinePB.
 		return nil, status.Error(codes.InvalidArgument, "The update_mask is invalid")
 	}
 
-	getResp, err := h.GetUserPipeline(ctx, &pipelinePB.GetUserPipelineRequest{Name: pbPipelineReq.GetName()})
+	getResp, err := h.GetUserPipeline(ctx, &pipelinePB.GetUserPipelineRequest{Name: pbPipelineReq.GetName(), View: pipelinePB.View_VIEW_RECIPE.Enum()})
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err


### PR DESCRIPTION
Because

- the recipe should preserve its original content when not patching it

This commit

- fix PATCH pipeline mask bug
