### PR TITLE
refactor(logging): reduce unnecessary log emission

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -122,6 +122,9 @@ func main() {
 		_ = logger.Sync()
 	}()
 
+	// verbosity 3 will avoid [transport] from emitting
+	grpc_zap.ReplaceGrpcLoggerV2WithVerbosity(logger, 3)
+
 	db := database.GetConnection()
 	defer database.Close(db)
 
@@ -163,6 +166,10 @@ func main() {
 				if match, _ := regexp.MatchString("vdp.pipeline.v1alpha.PipelinePublicService/.*ness$", fullMethodName); match {
 					return false
 				}
+				// stop logging successful private function calls
+				if match, _ := regexp.MatchString("model.model.v1alpha.ModelPrivateService/.*Admin$", fullMethodName); match {
+					return false
+				}
 			}
 			// by default everything will be logged
 			return true
@@ -181,8 +188,6 @@ func main() {
 			grpc_recovery.UnaryServerInterceptor(middleware.RecoveryInterceptorOpt()),
 		)),
 	}
-
-	grpc_zap.ReplaceGrpcLoggerV2(logger)
 
 	// Create tls based credential.
 	var creds credentials.TransportCredentials

--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -167,7 +167,7 @@ func main() {
 					return false
 				}
 				// stop logging successful private function calls
-				if match, _ := regexp.MatchString("model.model.v1alpha.ModelPrivateService/.*Admin$", fullMethodName); match {
+				if match, _ := regexp.MatchString("vdp.pipeline.v1alpha.PipelinePrivateService/.*Admin$", fullMethodName); match {
 					return false
 				}
 			}


### PR DESCRIPTION
Because

- Currently backends in Instill Base Instill VDP and Instill Model will emit a huge amount of logs with level Info, which can overwhelm stdout

This commit

- Refactor grpc logger `verbosity` and bypass successful private function calls