### PR TITLE
fix(migration): fix db connection bug

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -125,7 +125,7 @@ func main() {
 	// verbosity 3 will avoid [transport] from emitting
 	grpc_zap.ReplaceGrpcLoggerV2WithVerbosity(logger, 3)
 
-	db := database.GetConnection()
+	db := database.GetSharedConnection()
 	defer database.Close(db)
 
 	var temporalClientOptions client.Options

--- a/cmd/migration/000006_migrate.go
+++ b/cmd/migration/000006_migrate.go
@@ -14,34 +14,33 @@ import (
 	database "github.com/instill-ai/pipeline-backend/pkg/db"
 )
 
-// Pipeline is the data model of the pipeline table
-type Pipeline06 struct {
+type pipeline06 struct {
 	datamodel.BaseDynamic
 	ID          string
 	Owner       string
 	Description sql.NullString
-	Recipe      *Recipe06 `gorm:"type:jsonb"`
+	Recipe      *recipe06 `gorm:"type:jsonb"`
 }
 
-func (Pipeline06) TableName() string {
+func (pipeline06) TableName() string {
 	return "pipeline"
 }
 
 // Recipe is the data model of the pipeline recipe
-type Recipe06 struct {
+type recipe06 struct {
 	Version    string         `json:"version,omitempty"`
-	Components []*Component06 `json:"components,omitempty"`
+	Components []*component06 `json:"components,omitempty"`
 }
 
-type Component06 struct {
-	Id             string           `json:"id"`
+type component06 struct {
+	ID             string           `json:"id"`
 	DefinitionName string           `json:"definition_name"`
 	ResourceName   string           `json:"resource_name"`
 	Configuration  *structpb.Struct `json:"configuration"`
 }
 
 // Scan function for custom GORM type Recipe
-func (r *Recipe06) Scan(value interface{}) error {
+func (r *recipe06) Scan(value interface{}) error {
 	bytes, ok := value.([]byte)
 	if !ok {
 		return errors.New(fmt.Sprint("Failed to unmarshal Recipe value:", value))
@@ -55,7 +54,7 @@ func (r *Recipe06) Scan(value interface{}) error {
 }
 
 // Value function for custom GORM type Recipe
-func (r *Recipe06) Value() (driver.Value, error) {
+func (r *recipe06) Value() (driver.Value, error) {
 	valueString, err := json.Marshal(r)
 	return string(valueString), err
 }
@@ -64,8 +63,8 @@ func migratePipelineRecipeUp000006() error {
 	db := database.GetConnection()
 	defer database.Close(db)
 
-	var items []Pipeline06
-	result := db.Model(&Pipeline06{})
+	var items []pipeline06
+	result := db.Model(&pipeline06{})
 	if result.Error != nil {
 		return result.Error
 	}
@@ -78,7 +77,7 @@ func migratePipelineRecipeUp000006() error {
 	defer rows.Close()
 
 	for rows.Next() {
-		var item Pipeline06
+		var item pipeline06
 		if err = db.ScanRows(rows, &item); err != nil {
 			return err
 		}

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -50,7 +50,7 @@ func main() {
 		_ = logger.Sync()
 	}()
 
-	db := database.GetConnection()
+	db := database.GetSharedConnection()
 	defer database.Close(db)
 
 	var err error


### PR DESCRIPTION
Because

- migration processes were using a shared db connection causing the very first migration process early closing the db connection resulting the subsequent migration processes failed to connect the db.
- this issue wasn't obvious in a `docker compose up` scenario because the restart policy `restart: on-failure` simply has the `pipeline-backend-migration` container re-launched several time until all migration processes are finished.

This commit

- make the migration processes using non-shared db connection
