### PR TITLE
fix(pipeline): fix trigger error when start operator has field `input`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apk add poppler-utils wv tidyhtml libc6-compat
 
 ARG TARGETARCH
 ARG BUILDARCH
-RUN if [[ "$BUILDARCH" = "amd64" && "$TARGETARCH" = "arm64" ]] ; \
+RUN if [[ "$TARGETARCH" = "arm64" ]] ; \
     then \
     apk add unrtf --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing/; \
     else \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ ARG TARGETARCH
 ARG BUILDARCH
 RUN if [[ "$TARGETARCH" = "arm64" ]] ; \
     then \
-    apk add unrtf --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing/; \
+    apk add unrtf --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing/ ; \
     else \
     apk add unrtf; \
     fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,15 @@ RUN --mount=target=. --mount=type=cache,target=/root/.cache/go-build --mount=typ
 FROM alpine:3.16
 
 RUN apk add poppler-utils wv tidyhtml libc6-compat
-RUN apk add unrtf --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing/
+
+ARG TARGETARCH
+ARG BUILDARCH
+RUN if [[ "$BUILDARCH" = "amd64" && "$TARGETARCH" = "arm64" ]] ; \
+    then \
+    apk add unrtf --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing/; \
+    else \
+    apk add unrtf; \
+    fi
 
 USER nobody:nogroup
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN if [[ "$TARGETARCH" = "arm64" ]] ; \
     then \
     apk add unrtf --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing/ ; \
     else \
-    apk add unrtf; \
+    apk add unrtf --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community/ ; \
     fi
 
 USER nobody:nogroup

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -147,6 +147,10 @@ func GenerateTraces(comps []*datamodel.Component, memory []map[string]interface{
 		inputs := []*structpb.Struct{}
 		outputs := []*structpb.Struct{}
 
+		// The traces data of op-start is different and we should skip it
+		if comps[compIdx].DefinitionName == "operator-definitions/op-start" {
+			continue
+		}
 		for dataIdx := 0; dataIdx < batchSize; dataIdx++ {
 			if _, ok := memory[dataIdx][comps[compIdx].Id].(map[string]interface{})["input"]; ok {
 				data, err := json.Marshal(memory[dataIdx][comps[compIdx].Id].(map[string]interface{})["input"])


### PR DESCRIPTION
Because

- when we have `input` in start operator, the trigger will be error when set `instill-return-traces=true`

This commit

- fix trigger error when start operator has field `input`
- fix `unrtf` package install error
- close https://github.com/instill-ai/community/issues/474