### PR TITLE
refactor(pipeline): update start operator flows

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,8 +13,8 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0
 	github.com/iancoleman/strcase v0.2.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/component v0.6.1-alpha.0.20231106092458-e4a7b537a08e
-	github.com/instill-ai/operator v0.3.0-alpha.0.20231106092646-9d0caa7af524
+	github.com/instill-ai/component v0.6.1-alpha.0.20231106153938-6032b6ce48ed
+	github.com/instill-ai/operator v0.3.0-alpha.0.20231106160006-74980c141828
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231019202606-71607ddcd93f
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20231019203021-70410a0a8061
 	github.com/instill-ai/x v0.3.0-alpha

--- a/go.sum
+++ b/go.sum
@@ -1112,10 +1112,10 @@ github.com/influxdata/influxdb-client-go/v2 v2.12.3 h1:28nRlNMRIV4QbtIUvxhWqaxn0
 github.com/influxdata/influxdb-client-go/v2 v2.12.3/go.mod h1:IrrLUbCjjfkmRuaCiGQg4m2GbkaeJDcuWoxiWdQEbA0=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/instill-ai/component v0.6.1-alpha.0.20231106092458-e4a7b537a08e h1:fEKsQ9ZCGoWLkLm6BBArFUj4zcMU6ngTFj3eNywSLrI=
-github.com/instill-ai/component v0.6.1-alpha.0.20231106092458-e4a7b537a08e/go.mod h1:aQfeKtOn74cRQJOxvua1mQGpecasDaD+l46C60ILgdA=
-github.com/instill-ai/operator v0.3.0-alpha.0.20231106092646-9d0caa7af524 h1:eOA47/Glmy6LO+ULgswfmoQ1IZ6Y4wV7GagDTL4v9lA=
-github.com/instill-ai/operator v0.3.0-alpha.0.20231106092646-9d0caa7af524/go.mod h1:s2cWvyAzgrxj5m2S5A3p152wjtfrxhEeDoy7FI9fmoA=
+github.com/instill-ai/component v0.6.1-alpha.0.20231106153938-6032b6ce48ed h1:cZfbReRzNeNdMEIFNs7oW+6ewxH87GtHGlEkLdDAEqU=
+github.com/instill-ai/component v0.6.1-alpha.0.20231106153938-6032b6ce48ed/go.mod h1:aQfeKtOn74cRQJOxvua1mQGpecasDaD+l46C60ILgdA=
+github.com/instill-ai/operator v0.3.0-alpha.0.20231106160006-74980c141828 h1:IUK+jDlVvAN6rcr3bmZ5/QtM4NdQZMA/3uT2k2WtQmE=
+github.com/instill-ai/operator v0.3.0-alpha.0.20231106160006-74980c141828/go.mod h1:tRa5+YWM4Cl1yryETvehUN3s4AiFQRbZJQigp0Fk9Rs=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231019202606-71607ddcd93f h1:hweU93u6qsg8GH/YSogOfa+wOZEnkilGsijcy1xKX7E=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231019202606-71607ddcd93f/go.mod h1:q/YL5TZXD9nvmJ7Rih4gY3/B2HT2+GiFdxeZp9D+yE4=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20231019203021-70410a0a8061 h1:lOp2fORCj76/gfPuLqB3TEN2cvFRJHUQOxwFSl4qxEw=

--- a/integration-test/const.js
+++ b/integration-test/const.js
@@ -92,7 +92,7 @@ export const simpleRecipe = {
           metadata: {
             input: {
               title: "Input",
-              type: "text",
+              type: "string",
               instillAcceptFormats: ["string"]
             }
           }
@@ -151,7 +151,7 @@ export const simpleRecipeWithoutCSV = {
           metadata: {
             input: {
               title: "Input",
-              type: "text",
+              type: "string",
               instillAcceptFormats: ["string"]
             }
           }
@@ -186,7 +186,7 @@ export const simpleRecipeDupId = {
           metadata: {
             input: {
               title: "Input",
-              type: "text",
+              type: "string",
               instillAcceptFormats: ["string"]
             }
           }

--- a/integration-test/const.js
+++ b/integration-test/const.js
@@ -92,7 +92,8 @@ export const simpleRecipe = {
           metadata: {
             input: {
               title: "Input",
-              type: "text"
+              type: "text",
+              instillAcceptFormats: ["string"]
             }
           }
         }
@@ -150,7 +151,8 @@ export const simpleRecipeWithoutCSV = {
           metadata: {
             input: {
               title: "Input",
-              type: "text"
+              type: "text",
+              instillAcceptFormats: ["string"]
             }
           }
         }
@@ -184,7 +186,8 @@ export const simpleRecipeDupId = {
           metadata: {
             input: {
               title: "Input",
-              type: "text"
+              type: "text",
+              instillAcceptFormats: ["string"]
             }
           }
         }

--- a/pkg/service/openapi.go
+++ b/pkg/service/openapi.go
@@ -165,51 +165,7 @@ func (s *service) GenerateOpenApiSpec(startCompOrigin *pipelinePB.Component, end
 
 	startComp := proto.Clone(startCompOrigin).(*pipelinePB.Component)
 	for k, v := range startComp.Configuration.Fields["metadata"].GetStructValue().Fields {
-		var m *structpb.Value
-		attrType := ""
-		arrType := ""
-		switch t := v.GetStructValue().Fields["type"].GetStringValue(); t {
-		case "integer", "number", "boolean":
-			attrType = t
-		case "text", "image", "audio", "video":
-			attrType = "string"
-		default:
-			attrType = "array"
-			switch t {
-			case "integer_array", "number_array", "boolean_array":
-				arrType = strings.Split(t, "_")[0]
-			case "text_array", "image_array", "audio_array", "video_array":
-				arrType = "string"
-			}
-
-		}
-		if attrType != "array" {
-			m, err = structpb.NewValue(map[string]interface{}{
-				"title":         v.GetStructValue().Fields["title"].GetStringValue(),
-				"description":   v.GetStructValue().Fields["description"].GetStringValue(),
-				"type":          attrType,
-				"instillFormat": v.GetStructValue().Fields["type"].GetStringValue(),
-			})
-			if err != nil {
-				success = false
-			}
-		} else {
-			m, err = structpb.NewValue(map[string]interface{}{
-				"title":       v.GetStructValue().Fields["title"].GetStringValue(),
-				"description": v.GetStructValue().Fields["description"].GetStringValue(),
-				"type":        attrType,
-				"items": map[string]interface{}{
-					"type":          arrType,
-					"instillFormat": strings.Split(v.GetStructValue().Fields["type"].GetStringValue(), "_")[0],
-				},
-			})
-			if err != nil {
-				success = false
-			}
-		}
-
-		openApiInput.Fields["properties"].GetStructValue().Fields[k] = m
-
+		openApiInput.Fields["properties"].GetStructValue().Fields[k] = v
 	}
 
 	templateWalk = template.GetFields()["paths"]

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"strings"
 	"time"
 
@@ -94,51 +93,6 @@ func NewDataPoint(data UsageMetricData) *write.Point {
 		},
 		time.Now(),
 	)
-}
-
-// we only support the simple case for now
-//
-//	"dependencies": {
-//		"texts": "[*c1.texts, *c2.texts]",
-//		"images": "[*c1.images, *c2.images]",
-//		"structured_data": "{**c1.structured_data, **c2.structured_data}",
-//		"metadata": "{**c1.metadata, **c2.metadata}"
-//	}
-//
-//	"dependencies": {
-//		"texts": "[*c2.texts]",
-//		"images": "[*c1.images]",
-//		"structured_data": "{**c1.structured_data}",
-//		"metadata": "{**c1.metadata, **c2.metadata}"
-//	}
-func ParseDependency(dep map[string]string) ([]string, map[string][]string, error) {
-	parentMap := map[string]bool{}
-	depMap := map[string][]string{}
-	for _, key := range []string{"images", "audios", "texts", "structured_data", "metadata"} {
-		depMap[key] = []string{}
-
-		if str, ok := dep[key]; ok {
-			str = strings.ReplaceAll(str, " ", "")
-			str = str[1 : len(str)-1]
-			if len(str) > 0 {
-				items := strings.Split(str, ",")
-				for idx := range items {
-
-					name := strings.Split(items[idx], ".")[0]
-					depKey := strings.Split(items[idx], ".")[1]
-					name = strings.ReplaceAll(name, "*", "")
-					parentMap[name] = true
-					depMap[key] = append(depMap[key], fmt.Sprintf("%s.%s", name, depKey))
-				}
-			}
-
-		}
-	}
-	parent := []string{}
-	for k := range parentMap {
-		parent = append(parent, k)
-	}
-	return parent, depMap, nil
 }
 
 func GenerateTraces(comps []*datamodel.Component, memory []map[string]interface{}, computeTime map[string]float32, batchSize int) (map[string]*pipelinePB.Trace, error) {


### PR DESCRIPTION
Because

- we'd like to refactor start operator so that it has a JSON-schema structure similar to other components.
- we should use json encoded string in form-data

This commit

- refactor start operator to use `instillAcceptFormats`
- update corresponding OpenAPI generator
