### PR TITLE
refactor(service): optimize recipe validation error message

### DIFF
--- a/pkg/handler/fieldannotation.go
+++ b/pkg/handler/fieldannotation.go
@@ -3,7 +3,6 @@ package handler
 // *RequiredFields are Protobuf message fields with REQUIRED field_behavior annotation
 var createRequiredFields = []string{}
 var lookUpRequiredFields = []string{"permalink"}
-var validateRequiredFields = []string{"name"}
 var renameRequiredFields = []string{"name", "new_pipeline_id"}
 var triggerRequiredFields = []string{"name", "inputs"}
 

--- a/pkg/utils/dag.go
+++ b/pkg/utils/dag.go
@@ -80,7 +80,7 @@ func (d *dag) AddEdge(from *datamodel.Component, to *datamodel.Component) {
 
 func (d *dag) TopologicalSort() ([]*datamodel.Component, error) {
 	if len(d.comps) == 0 {
-		return nil, fmt.Errorf("[recipe error] no components")
+		return nil, fmt.Errorf("no components")
 	}
 
 	indegreesMap := map[*datamodel.Component]int{}
@@ -113,11 +113,11 @@ func (d *dag) TopologicalSort() ([]*datamodel.Component, error) {
 	}
 
 	if len(ans) < len(d.comps) {
-		return nil, fmt.Errorf("[recipe error] not a valid dag")
+		return nil, fmt.Errorf("not a valid dag")
 	}
 
 	if d.uf.Count() != 1 {
-		return nil, fmt.Errorf("[recipe error] more than a dag")
+		return nil, fmt.Errorf("more than a dag")
 	}
 
 	return ans, nil
@@ -131,7 +131,7 @@ func traverseBinding(bindings interface{}, path string) (interface{}, error) {
 		var ret interface{}
 		err := json.Unmarshal([]byte(path), &ret)
 		if err != nil {
-			return nil, fmt.Errorf("[recipe error] reference not correct: '%s'", path)
+			return nil, fmt.Errorf("reference not correct: '%s'", path)
 		}
 		return ret, nil
 	}
@@ -235,7 +235,7 @@ func GenerateDAG(components []*datamodel.Component) (*dag, error) {
 			if upstream, ok := componentIdMap[parents[idx]]; ok {
 				graph.AddEdge(upstream, component)
 			} else {
-				return nil, fmt.Errorf("[recipe error] no upstream component '%s'", parents[idx])
+				return nil, fmt.Errorf("no upstream component '%s'", parents[idx])
 			}
 
 		}


### PR DESCRIPTION
Because

- the error message formats of recipe validation are not consistent

This commit

- optimize recipe validation error message
- add pipeline recipe validation before triggering
