### PR TITLE
chore(service): fix trigger component error

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -1198,7 +1198,7 @@ func (s *service) triggerPipeline(
 			computeTime[comp.Id] = 0
 		} else if utils.IsOperatorDefinition(comp.DefinitionName) {
 
-			op, err := s.operator.GetOperatorDefinitionByID(strings.Split(comp.DefinitionName, "/")[1])
+			op, err := s.operator.GetOperatorDefinitionByUID(uuid.FromStringOrNil(strings.Split(comp.DefinitionName, "/")[1]))
 			if err != nil {
 				return nil, nil, err
 			}

--- a/pkg/worker/workflow.go
+++ b/pkg/worker/workflow.go
@@ -519,7 +519,7 @@ func (w *worker) ConnectorActivity(ctx context.Context, param *ExecuteConnectorA
 		return nil, err
 	}
 
-	con, err := w.connector.GetConnectorDefinitionByID(strings.Split(param.DefinitionName, "/")[1])
+	con, err := w.connector.GetConnectorDefinitionByUID(uuid.FromStringOrNil(strings.Split(param.DefinitionName, "/")[1]))
 	if err != nil {
 		return nil, err
 	}
@@ -570,7 +570,7 @@ func (w *worker) OperatorActivity(ctx context.Context, param *ExecuteOperatorAct
 		return nil, err
 	}
 
-	op, err := w.operator.GetOperatorDefinitionByID(strings.Split(param.DefinitionName, "/")[1])
+	op, err := w.operator.GetOperatorDefinitionByUID(uuid.FromStringOrNil(strings.Split(param.DefinitionName, "/")[1]))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Because

- the trigger function didn't get the correct component definitions

This commit

- fix trigger component error
