### PR TITLE
chore(migration): fix db migration about the connectors renaming

### DIFF
--- a/pkg/db/migration/000008_init.up.sql
+++ b/pkg/db/migration/000008_init.up.sql
@@ -41,5 +41,6 @@ CREATE TABLE IF NOT EXISTS public.connector(
 CREATE INDEX connector_uid_create_time_pagination ON public.connector (uid, create_time);
 CREATE UNIQUE INDEX unique_owner_id_deleted_at ON public.connector (owner, id) WHERE delete_time IS NULL;
 
+UPDATE public.pipeline SET recipe = REPLACE(recipe::text,'connector-resources/','connectors/')::jsonb;
 
 COMMIT;


### PR DESCRIPTION
Because

- the db migration didn't update "connector-resource" -> "connector" renaming

This commit

- fix db migration about the connectors renaming
