### PR TITLE
chore(usage,metric): adopt latest protobuf to add org data

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/instill-ai/connector v0.7.0-alpha.0.20231206040111-5a57a09f2adc
 	github.com/instill-ai/operator v0.5.0-alpha.0.20231206040107-22ee0cae199a
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231206140543-1a9ff59ec23b
-	github.com/instill-ai/usage-client v0.2.4-alpha.0.20231206035716-4c05f872df97
+	github.com/instill-ai/usage-client v0.2.4-alpha.0.20231206162018-6ccbff13136b
 	github.com/instill-ai/x v0.3.0-alpha.0.20231124062833-3236165f5782
 	github.com/knadh/koanf v1.5.0
 	github.com/mennanov/fieldmask-utils v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1193,6 +1193,8 @@ github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231206140543-1a9ff59ec23b h1:
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231206140543-1a9ff59ec23b/go.mod h1:q/YL5TZXD9nvmJ7Rih4gY3/B2HT2+GiFdxeZp9D+yE4=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20231206035716-4c05f872df97 h1:WycXqzJP1ihjJwrkxlNP2TQc1DSUxUtfl/PtCpLBa3Y=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20231206035716-4c05f872df97/go.mod h1:Da8RdKakfxy1iNdvI5FSTcL1lSDtda+b9jOgOEEO68E=
+github.com/instill-ai/usage-client v0.2.4-alpha.0.20231206162018-6ccbff13136b h1:YwXracXgTWxaPfIsbC3uaZFjGO0E2y1e3hK9ZUq7ipE=
+github.com/instill-ai/usage-client v0.2.4-alpha.0.20231206162018-6ccbff13136b/go.mod h1:4uTzVtcC+UVKhRaNvJc2+LFLcr/fv3vsYE5QCWu6TQ0=
 github.com/instill-ai/x v0.3.0-alpha.0.20231124062833-3236165f5782 h1:ErsJ1IkjD6Rtif0YI898fv/qllW5x9vb2fdt69EYwug=
 github.com/instill-ai/x v0.3.0-alpha.0.20231124062833-3236165f5782/go.mod h1:YVYjkbqc5FKatJ+jZa1S/8e4xHkQ8j9V3RYboqBpoR0=
 github.com/intel/goresctrl v0.2.0/go.mod h1:+CZdzouYFn5EsxgqAQTEzMfwKwuc0fVdMrT9FCCAVRQ=

--- a/pkg/handler/connector.go
+++ b/pkg/handler/connector.go
@@ -1284,8 +1284,21 @@ func (h *PublicHandler) executeNamespaceConnector(ctx context.Context, req Execu
 		return nil, st.Err()
 	}
 
+	var ownerType mgmtPB.OwnerType
+	switch ns.NsType {
+	case resource.Organization:
+		ownerType = mgmtPB.OwnerType_OWNER_TYPE_ORGANIZATION
+	case resource.User:
+		ownerType = mgmtPB.OwnerType_OWNER_TYPE_USER
+	default:
+		ownerType = mgmtPB.OwnerType_OWNER_TYPE_UNSPECIFIED
+	}
+
 	dataPoint := utils.ConnectorUsageMetricData{
-		OwnerUID:               authUser.UID.String(),
+		OwnerUID:               ns.NsUid.String(),
+		OwnerType:              ownerType,
+		UserUID:                authUser.UID.String(),
+		UserType:               mgmtPB.OwnerType_OWNER_TYPE_USER, // TODO: currently only support /users type, will change after beta
 		ConnectorID:            connector.Id,
 		ConnectorUID:           connector.Uid,
 		ConnectorExecuteUID:    logUUID.String(),

--- a/pkg/handler/pipeline.go
+++ b/pkg/handler/pipeline.go
@@ -860,8 +860,21 @@ func (h *PublicHandler) triggerNamespacePipeline(ctx context.Context, req Trigge
 		return nil, nil, err
 	}
 
+	var ownerType mgmtPB.OwnerType
+	switch ns.NsType {
+	case resource.Organization:
+		ownerType = mgmtPB.OwnerType_OWNER_TYPE_ORGANIZATION
+	case resource.User:
+		ownerType = mgmtPB.OwnerType_OWNER_TYPE_USER
+	default:
+		ownerType = mgmtPB.OwnerType_OWNER_TYPE_UNSPECIFIED
+	}
+
 	dataPoint := utils.PipelineUsageMetricData{
-		OwnerUID:           authUser.UID.String(),
+		OwnerUID:           ns.NsUid.String(),
+		OwnerType:          ownerType,
+		UserUID:            authUser.UID.String(),
+		UserType:           mgmtPB.OwnerType_OWNER_TYPE_USER, // TODO: currently only support /users type, will change after beta
 		TriggerMode:        mgmtPB.Mode_MODE_SYNC,
 		PipelineID:         pbPipeline.Id,
 		PipelineUID:        pbPipeline.Uid,
@@ -1607,8 +1620,21 @@ func (h *PublicHandler) triggerNamespacePipelineRelease(ctx context.Context, req
 		return nil, nil, err
 	}
 
+	var ownerType mgmtPB.OwnerType
+	switch ns.NsType {
+	case resource.Organization:
+		ownerType = mgmtPB.OwnerType_OWNER_TYPE_ORGANIZATION
+	case resource.User:
+		ownerType = mgmtPB.OwnerType_OWNER_TYPE_USER
+	default:
+		ownerType = mgmtPB.OwnerType_OWNER_TYPE_UNSPECIFIED
+	}
+
 	dataPoint := utils.PipelineUsageMetricData{
-		OwnerUID:           authUser.UID.String(),
+		OwnerUID:           ns.NsUid.String(),
+		OwnerType:          ownerType,
+		UserUID:            authUser.UID.String(),
+		UserType:           mgmtPB.OwnerType_OWNER_TYPE_USER, // TODO: currently only support /users type, will change after beta
 		TriggerMode:        mgmtPB.Mode_MODE_SYNC,
 		PipelineID:         pbPipeline.Id,
 		PipelineUID:        pbPipeline.Uid,

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -1526,6 +1526,7 @@ func (s *service) triggerPipeline(
 func (s *service) triggerAsyncPipeline(
 	ctx context.Context,
 	ownerPermalink string,
+	userPermalink string,
 	recipe *datamodel.Recipe,
 	pipelineId string,
 	pipelineUid uuid.UUID,
@@ -1582,6 +1583,7 @@ func (s *service) triggerAsyncPipeline(
 			PipelineReleaseUid:         pipelineReleaseUid,
 			PipelineRecipe:             recipe,
 			OwnerPermalink:             ownerPermalink,
+			UserPermalink:              userPermalink,
 			ReturnTraces:               returnTraces,
 		})
 	if err != nil {
@@ -1626,6 +1628,8 @@ func (s *service) TriggerNamespacePipelineByID(ctx context.Context, ns resource.
 func (s *service) TriggerAsyncNamespacePipelineByID(ctx context.Context, ns resource.Namespace, authUser *AuthUser, id string, inputs []*structpb.Struct, pipelineTriggerId string, returnTraces bool) (*longrunningpb.Operation, error) {
 
 	ownerPermalink := ns.String()
+	userPermalink := fmt.Sprintf("users/%s", authUser.UID)
+
 	dbPipeline, err := s.repository.GetNamespacePipelineByID(ctx, ownerPermalink, id, false)
 	if err != nil {
 		return nil, ErrNotFound
@@ -1642,7 +1646,7 @@ func (s *service) TriggerAsyncNamespacePipelineByID(ctx context.Context, ns reso
 		return nil, ErrNoPermission
 	}
 
-	return s.triggerAsyncPipeline(ctx, ownerPermalink, dbPipeline.Recipe, dbPipeline.ID, dbPipeline.UID, "", uuid.Nil, inputs, pipelineTriggerId, returnTraces)
+	return s.triggerAsyncPipeline(ctx, ownerPermalink, userPermalink, dbPipeline.Recipe, dbPipeline.ID, dbPipeline.UID, "", uuid.Nil, inputs, pipelineTriggerId, returnTraces)
 
 }
 
@@ -1677,6 +1681,7 @@ func (s *service) TriggerNamespacePipelineReleaseByID(ctx context.Context, ns re
 func (s *service) TriggerAsyncNamespacePipelineReleaseByID(ctx context.Context, ns resource.Namespace, authUser *AuthUser, pipelineUid uuid.UUID, id string, inputs []*structpb.Struct, pipelineTriggerId string, returnTraces bool) (*longrunningpb.Operation, error) {
 
 	ownerPermalink := ns.String()
+	userPermalink := fmt.Sprintf("users/%s", authUser.UID)
 
 	dbPipeline, err := s.repository.GetPipelineByUID(ctx, pipelineUid, false)
 	if err != nil {
@@ -1699,7 +1704,7 @@ func (s *service) TriggerAsyncNamespacePipelineReleaseByID(ctx context.Context, 
 		return nil, err
 	}
 
-	return s.triggerAsyncPipeline(ctx, ownerPermalink, dbPipelineRelease.Recipe, dbPipeline.ID, dbPipeline.UID, dbPipelineRelease.ID, dbPipelineRelease.UID, inputs, pipelineTriggerId, returnTraces)
+	return s.triggerAsyncPipeline(ctx, ownerPermalink, userPermalink, dbPipelineRelease.Recipe, dbPipeline.ID, dbPipeline.UID, dbPipelineRelease.ID, dbPipelineRelease.UID, inputs, pipelineTriggerId, returnTraces)
 }
 
 func (s *service) RemoveCredentialFieldsWithMaskString(dbConnDefID string, config *structpb.Struct) {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -77,6 +77,9 @@ func IsBillableEvent(eventName string) bool {
 
 type PipelineUsageMetricData struct {
 	OwnerUID            string
+	OwnerType           mgmtPB.OwnerType
+	UserUID             string
+	UserType            mgmtPB.OwnerType
 	TriggerMode         mgmtPB.Mode
 	Status              mgmtPB.Status
 	PipelineID          string
@@ -97,6 +100,9 @@ func NewPipelineDataPoint(data PipelineUsageMetricData) *write.Point {
 		},
 		map[string]interface{}{
 			"owner_uid":             data.OwnerUID,
+			"owner_type":            data.OwnerType,
+			"user_uid":              data.UserUID,
+			"user_type":             data.UserType,
 			"pipeline_id":           data.PipelineID,
 			"pipeline_uid":          data.PipelineUID,
 			"pipeline_release_id":   data.PipelineReleaseID,
@@ -111,6 +117,9 @@ func NewPipelineDataPoint(data PipelineUsageMetricData) *write.Point {
 
 type ConnectorUsageMetricData struct {
 	OwnerUID               string
+	OwnerType              mgmtPB.OwnerType
+	UserUID                string
+	UserType               mgmtPB.OwnerType
 	Status                 mgmtPB.Status
 	ConnectorID            string
 	ConnectorUID           string
@@ -135,6 +144,9 @@ func NewConnectorDataPoint(data ConnectorUsageMetricData, pipelineMetadata *stru
 			"pipeline_owner":           pipelineOwnerUUID,
 			"pipeline_trigger_id":      pipelineMetadata.GetStructValue().GetFields()["trigger_id"].GetStringValue(),
 			"connector_owner_uid":      data.OwnerUID,
+			"connector_owner_type":     data.OwnerType,
+			"connector_user_uid":       data.UserUID,
+			"connector_user_type":      data.UserType,
 			"connector_id":             data.ConnectorID,
 			"connector_uid":            data.ConnectorUID,
 			"connector_definition_uid": data.ConnectorDefinitionUid,


### PR DESCRIPTION
Because

- adopt org and acl data collection for usage and metric

This commit

- add `owner` and `user` data in each trigger/execute and support `org` type
