### PR TITLE
refactor(service): use Temporal as worker queue for `trigger` endpoint

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -105,7 +105,7 @@ func main() {
 		MaxConcurrentActivityExecutionSize: 2,
 	})
 
-	w.RegisterWorkflow(cw.TriggerAsyncPipelineWorkflow)
+	w.RegisterWorkflow(cw.TriggerPipelineWorkflow)
 	w.RegisterActivity(cw.ConnectorActivity)
 	w.RegisterActivity(cw.OperatorActivity)
 

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -1318,8 +1318,8 @@ func (s *service) triggerPipeline(
 	we, err := s.temporalClient.ExecuteWorkflow(
 		ctx,
 		workflowOptions,
-		"TriggerAsyncPipelineWorkflow",
-		&worker.TriggerAsyncPipelineWorkflowRequest{
+		"TriggerPipelineWorkflow",
+		&worker.TriggerPipelineWorkflowRequest{
 			PipelineInputBlobRedisKeys: inputBlobRedisKeys,
 			PipelineId:                 pipelineId,
 			PipelineUid:                pipelineUid,
@@ -1335,7 +1335,7 @@ func (s *service) triggerPipeline(
 		return nil, nil, err
 	}
 
-	var result *worker.TriggerAsyncPipelineWorkflowResponse
+	var result *worker.TriggerPipelineWorkflowResponse
 	err = we.Get(context.Background(), &result)
 	if err != nil {
 		return nil, nil, err
@@ -1406,8 +1406,8 @@ func (s *service) triggerAsyncPipeline(
 	we, err := s.temporalClient.ExecuteWorkflow(
 		ctx,
 		workflowOptions,
-		"TriggerAsyncPipelineWorkflow",
-		&worker.TriggerAsyncPipelineWorkflowRequest{
+		"TriggerPipelineWorkflow",
+		&worker.TriggerPipelineWorkflowRequest{
 			PipelineInputBlobRedisKeys: inputBlobRedisKeys,
 			PipelineId:                 pipelineId,
 			PipelineUid:                pipelineUid,

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"go/parser"
 	"math/rand"
 	"strings"
 	"time"
@@ -1270,6 +1269,7 @@ func (s *service) SetDefaultNamespacePipelineReleaseByID(ctx context.Context, ns
 func (s *service) triggerPipeline(
 	ctx context.Context,
 	ownerPermalink string,
+	userPermalink string,
 	recipe *datamodel.Recipe,
 	pipelineId string,
 	pipelineUid uuid.UUID,
@@ -1286,298 +1286,73 @@ func (s *service) triggerPipeline(
 		return nil, nil, err
 	}
 
-	var inputs [][]byte
-
-	batchSize := len(pipelineInputs)
-
-	for idx := range pipelineInputs {
-		inputStruct := structpb.NewStructValue(pipelineInputs[idx])
-		input, err := protojson.Marshal(inputStruct)
+	inputBlobRedisKeys := []string{}
+	for idx, input := range pipelineInputs {
+		inputJson, err := protojson.Marshal(input)
 		if err != nil {
 			return nil, nil, err
 		}
-		inputs = append(inputs, input)
+
+		inputBlobRedisKey := fmt.Sprintf("async_pipeline_request:%s:%d", pipelineTriggerId, idx)
+		s.redisClient.Set(
+			context.Background(),
+			inputBlobRedisKey,
+			inputJson,
+			time.Duration(config.Config.Server.Workflow.MaxWorkflowTimeout)*time.Second,
+		)
+		inputBlobRedisKeys = append(inputBlobRedisKeys, inputBlobRedisKey)
+	}
+	memo := map[string]interface{}{}
+	memo["number_of_data"] = len(inputBlobRedisKeys)
+
+	workflowOptions := client.StartWorkflowOptions{
+		ID:                       pipelineTriggerId,
+		TaskQueue:                worker.TaskQueue,
+		WorkflowExecutionTimeout: time.Duration(config.Config.Server.Workflow.MaxWorkflowTimeout) * time.Second,
+		RetryPolicy: &temporal.RetryPolicy{
+			MaximumAttempts: config.Config.Server.Workflow.MaxWorkflowRetry,
+		},
+		Memo: memo,
 	}
 
-	dag, err := utils.GenerateDAG(recipe.Components)
+	we, err := s.temporalClient.ExecuteWorkflow(
+		ctx,
+		workflowOptions,
+		"TriggerAsyncPipelineWorkflow",
+		&worker.TriggerAsyncPipelineWorkflowRequest{
+			PipelineInputBlobRedisKeys: inputBlobRedisKeys,
+			PipelineId:                 pipelineId,
+			PipelineUid:                pipelineUid,
+			PipelineReleaseId:          pipelineReleaseId,
+			PipelineReleaseUid:         pipelineReleaseUid,
+			PipelineRecipe:             recipe,
+			OwnerPermalink:             ownerPermalink,
+			UserPermalink:              userPermalink,
+			ReturnTraces:               returnTraces,
+		})
+	if err != nil {
+		logger.Error(fmt.Sprintf("unable to execute workflow: %s", err.Error()))
+		return nil, nil, err
+	}
+
+	var result *worker.TriggerAsyncPipelineWorkflowResponse
+	err = we.Get(context.Background(), &result)
+	if err != nil {
+		return nil, nil, err
+	}
+	pipelineResp := &pipelinePB.TriggerUserPipelineResponse{}
+
+	blob, err := s.redisClient.Get(context.Background(), result.OutputBlobRedisKey).Bytes()
 	if err != nil {
 		return nil, nil, err
 	}
 
-	orderedComp, err := dag.TopologicalSort()
+	err = protojson.Unmarshal(blob, pipelineResp)
 	if err != nil {
 		return nil, nil, err
 	}
-	var startCompId string
-	for _, c := range orderedComp {
-		if c.DefinitionName == "operator-definitions/2ac8be70-0f7a-4b61-a33d-098b8acfa6f3" {
-			startCompId = c.Id
-		}
-	}
 
-	memory := make([]map[string]interface{}, batchSize)
-	statuses := make([]map[string]*utils.ComponentStatus, batchSize)
-	computeTime := map[string]float32{}
-
-	for idx := range inputs {
-		memory[idx] = map[string]interface{}{}
-		var inputStruct map[string]interface{}
-		err := json.Unmarshal(inputs[idx], &inputStruct)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		memory[idx][startCompId] = inputStruct
-		computeTime[startCompId] = 0
-
-		memory[idx]["global"], err = utils.GenerateGlobalValue(pipelineUid, recipe, ownerPermalink)
-		if err != nil {
-			return nil, nil, err
-		}
-		statuses[idx] = map[string]*utils.ComponentStatus{}
-		statuses[idx][startCompId] = &utils.ComponentStatus{}
-		statuses[idx][startCompId].Started = true
-		statuses[idx][startCompId].Completed = true
-	}
-
-	responseCompId := ""
-	for _, comp := range orderedComp {
-		if comp.Id == startCompId {
-			continue
-		}
-
-		for idx := 0; idx < batchSize; idx++ {
-			statuses[idx][comp.Id] = &utils.ComponentStatus{}
-		}
-
-		var compInputs []*structpb.Struct
-
-		idxMap := map[int]int{}
-		for idx := 0; idx < batchSize; idx++ {
-
-			for _, ancestorID := range dag.GetAncestorIDs(comp.Id) {
-				if statuses[idx][ancestorID].Skipped {
-					statuses[idx][comp.Id].Skipped = true
-					break
-				}
-			}
-
-			if !statuses[idx][comp.Id].Skipped {
-				if comp.Configuration.Fields["condition"].GetStringValue() != "" {
-					expr, err := parser.ParseExpr(comp.Configuration.Fields["condition"].GetStringValue())
-					if err != nil {
-						return nil, nil, err
-					}
-					cond, err := utils.EvalCondition(expr, memory[idx])
-					if err != nil {
-						return nil, nil, err
-					}
-					if cond == false {
-						statuses[idx][comp.Id].Skipped = true
-					} else {
-						statuses[idx][comp.Id].Started = true
-					}
-				} else {
-					statuses[idx][comp.Id].Started = true
-				}
-			}
-
-			memory[idx][comp.Id] = map[string]interface{}{
-				"input":  map[string]interface{}{},
-				"output": map[string]interface{}{},
-			}
-
-			if statuses[idx][comp.Id].Started {
-				compInputTemplate := comp.Configuration
-				// TODO: remove this hardcode injection
-				// blockchain-number
-				if comp.DefinitionName == "connector-definitions/70d8664a-d512-4517-a5e8-5d4da81756a7" {
-					recipeByte, err := json.Marshal(recipe)
-					if err != nil {
-						return nil, nil, err
-					}
-					recipePb := &structpb.Struct{}
-					err = protojson.Unmarshal(recipeByte, recipePb)
-					if err != nil {
-						return nil, nil, err
-					}
-
-					metadata, err := structpb.NewValue(map[string]interface{}{
-						"pipeline": map[string]interface{}{
-							"uid":    "{global.pipeline.uid}",
-							"recipe": "{global.pipeline.recipe}",
-						},
-						"owner": map[string]interface{}{
-							"uid": "{global.owner.uid}",
-						},
-					})
-					if err != nil {
-						return nil, nil, err
-					}
-					if compInputTemplate.Fields["input"].GetStructValue().Fields["custom"].GetStructValue() == nil {
-						compInputTemplate.Fields["input"].GetStructValue().Fields["custom"] = structpb.NewStructValue(&structpb.Struct{Fields: map[string]*structpb.Value{}})
-					}
-					compInputTemplate.Fields["input"].GetStructValue().Fields["custom"].GetStructValue().Fields["metadata"] = metadata
-				}
-
-				compInputTemplateJson, err := protojson.Marshal(compInputTemplate.Fields["input"].GetStructValue())
-				if err != nil {
-					return nil, nil, err
-				}
-
-				var compInputTemplateStruct interface{}
-				err = json.Unmarshal(compInputTemplateJson, &compInputTemplateStruct)
-				if err != nil {
-					return nil, nil, err
-				}
-
-				compInputStruct, err := utils.RenderInput(compInputTemplateStruct, memory[idx])
-				if err != nil {
-					return nil, nil, err
-				}
-				compInputJson, err := json.Marshal(compInputStruct)
-				if err != nil {
-					return nil, nil, err
-				}
-
-				compInput := &structpb.Struct{}
-				err = protojson.Unmarshal([]byte(compInputJson), compInput)
-				if err != nil {
-					return nil, nil, err
-				}
-
-				memory[idx][comp.Id].(map[string]interface{})["input"] = compInputStruct
-				idxMap[len(compInputs)] = idx
-				compInputs = append(compInputs, compInput)
-			}
-
-		}
-
-		task := ""
-		if comp.Configuration.Fields["task"] != nil {
-			task = comp.Configuration.Fields["task"].GetStringValue()
-		}
-
-		if utils.IsConnectorDefinition(comp.DefinitionName) && comp.ResourceName != "" {
-
-			con, err := s.connector.GetConnectorDefinitionByUID(uuid.FromStringOrNil(strings.Split(comp.DefinitionName, "/")[1]))
-			if err != nil {
-				return nil, nil, err
-			}
-
-			dbConnector, err := s.repository.GetConnectorByUIDAdmin(ctx, uuid.FromStringOrNil(strings.Split(comp.ResourceName, "/")[1]), false)
-			if err != nil {
-				return nil, nil, err
-			}
-
-			configuration := func() *structpb.Struct {
-				if dbConnector.Configuration != nil {
-					str := structpb.Struct{}
-					err := str.UnmarshalJSON(dbConnector.Configuration)
-					if err != nil {
-						logger.Fatal(err.Error())
-					}
-					return &str
-				}
-				return nil
-			}()
-
-			execution, err := s.connector.CreateExecution(uuid.FromStringOrNil(con.Uid), task, configuration, logger)
-			if err != nil {
-				return nil, nil, err
-			}
-			start := time.Now()
-			compOutputs, err := execution.ExecuteWithValidation(compInputs)
-
-			computeTime[comp.Id] = float32(time.Since(start).Seconds())
-			if err != nil {
-				return nil, nil, fmt.Errorf("[Component %s Execution Data Error] %w", comp.Id, err)
-			}
-			for compBatchIdx := range compOutputs {
-
-				outputJson, err := protojson.Marshal(compOutputs[compBatchIdx])
-				if err != nil {
-					return nil, nil, err
-				}
-				var outputStruct map[string]interface{}
-				err = json.Unmarshal(outputJson, &outputStruct)
-				if err != nil {
-					return nil, nil, err
-				}
-				memory[idxMap[compBatchIdx]][comp.Id].(map[string]interface{})["output"] = outputStruct
-				statuses[idxMap[compBatchIdx]][comp.Id].Completed = true
-			}
-
-		} else if comp.DefinitionName == "operator-definitions/4f39c8bc-8617-495d-80de-80d0f5397516" {
-			// op end
-			responseCompId = comp.Id
-			for compBatchIdx := range compInputs {
-				statuses[idxMap[compBatchIdx]][comp.Id].Completed = true
-			}
-			computeTime[comp.Id] = 0
-		} else if utils.IsOperatorDefinition(comp.DefinitionName) {
-
-			op, err := s.operator.GetOperatorDefinitionByUID(uuid.FromStringOrNil(strings.Split(comp.DefinitionName, "/")[1]))
-			if err != nil {
-				return nil, nil, err
-			}
-
-			execution, err := s.operator.CreateExecution(uuid.FromStringOrNil(op.Uid), task, nil, logger)
-			if err != nil {
-				return nil, nil, err
-			}
-			start := time.Now()
-			compOutputs, err := execution.ExecuteWithValidation(compInputs)
-
-			computeTime[comp.Id] = float32(time.Since(start).Seconds())
-			if err != nil {
-				return nil, nil, fmt.Errorf("[Component %s Execution Data Error] %w", comp.Id, err)
-			}
-			for compBatchIdx := range compOutputs {
-
-				outputJson, err := protojson.Marshal(compOutputs[compBatchIdx])
-				if err != nil {
-					return nil, nil, err
-				}
-				var outputStruct map[string]interface{}
-				err = json.Unmarshal(outputJson, &outputStruct)
-				if err != nil {
-					return nil, nil, err
-				}
-				memory[idxMap[compBatchIdx]][comp.Id].(map[string]interface{})["output"] = outputStruct
-				statuses[idxMap[compBatchIdx]][comp.Id].Completed = true
-			}
-
-		}
-
-	}
-
-	pipelineOutputs := []*structpb.Struct{}
-	for idx := 0; idx < batchSize; idx++ {
-		pipelineOutput := &structpb.Struct{Fields: map[string]*structpb.Value{}}
-		for key, value := range memory[idx][responseCompId].(map[string]interface{})["input"].(map[string]interface{}) {
-			structVal, err := structpb.NewValue(value)
-			if err != nil {
-				return nil, nil, err
-			}
-			pipelineOutput.Fields[key] = structVal
-
-		}
-		pipelineOutputs = append(pipelineOutputs, pipelineOutput)
-
-	}
-	var traces map[string]*pipelinePB.Trace
-	if returnTraces {
-		traces, err = utils.GenerateTraces(orderedComp, memory, statuses, computeTime, batchSize)
-		if err != nil {
-			return nil, nil, err
-		}
-	}
-	metadata := &pipelinePB.TriggerMetadata{
-		Traces: traces,
-	}
-
-	return pipelineOutputs, metadata, nil
+	return pipelineResp.Outputs, pipelineResp.Metadata, nil
 }
 
 func (s *service) triggerAsyncPipeline(
@@ -1660,6 +1435,7 @@ func (s *service) triggerAsyncPipeline(
 func (s *service) TriggerNamespacePipelineByID(ctx context.Context, ns resource.Namespace, authUser *AuthUser, id string, inputs []*structpb.Struct, pipelineTriggerId string, returnTraces bool) ([]*structpb.Struct, *pipelinePB.TriggerMetadata, error) {
 
 	ownerPermalink := ns.String()
+	userPermalink := fmt.Sprintf("users/%s", authUser.UID)
 
 	dbPipeline, err := s.repository.GetNamespacePipelineByID(ctx, ownerPermalink, id, false)
 	if err != nil {
@@ -1678,7 +1454,7 @@ func (s *service) TriggerNamespacePipelineByID(ctx context.Context, ns resource.
 		return nil, nil, ErrNoPermission
 	}
 
-	return s.triggerPipeline(ctx, ownerPermalink, dbPipeline.Recipe, dbPipeline.ID, dbPipeline.UID, "", uuid.Nil, inputs, pipelineTriggerId, returnTraces)
+	return s.triggerPipeline(ctx, ownerPermalink, userPermalink, dbPipeline.Recipe, dbPipeline.ID, dbPipeline.UID, "", uuid.Nil, inputs, pipelineTriggerId, returnTraces)
 
 }
 
@@ -1710,6 +1486,7 @@ func (s *service) TriggerAsyncNamespacePipelineByID(ctx context.Context, ns reso
 func (s *service) TriggerNamespacePipelineReleaseByID(ctx context.Context, ns resource.Namespace, authUser *AuthUser, pipelineUid uuid.UUID, id string, inputs []*structpb.Struct, pipelineTriggerId string, returnTraces bool) ([]*structpb.Struct, *pipelinePB.TriggerMetadata, error) {
 
 	ownerPermalink := ns.String()
+	userPermalink := fmt.Sprintf("users/%s", authUser.UID)
 
 	dbPipeline, err := s.repository.GetPipelineByUID(ctx, pipelineUid, false)
 	if err != nil {
@@ -1732,7 +1509,7 @@ func (s *service) TriggerNamespacePipelineReleaseByID(ctx context.Context, ns re
 		return nil, nil, err
 	}
 
-	return s.triggerPipeline(ctx, ownerPermalink, dbPipelineRelease.Recipe, dbPipeline.ID, dbPipeline.UID, dbPipelineRelease.ID, dbPipelineRelease.UID, inputs, pipelineTriggerId, returnTraces)
+	return s.triggerPipeline(ctx, ownerPermalink, userPermalink, dbPipelineRelease.Recipe, dbPipeline.ID, dbPipeline.UID, dbPipelineRelease.ID, dbPipelineRelease.UID, inputs, pipelineTriggerId, returnTraces)
 }
 
 func (s *service) TriggerAsyncNamespacePipelineReleaseByID(ctx context.Context, ns resource.Namespace, authUser *AuthUser, pipelineUid uuid.UUID, id string, inputs []*structpb.Struct, pipelineTriggerId string, returnTraces bool) (*longrunningpb.Operation, error) {

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -21,7 +21,7 @@ const TaskQueue = "pipeline-backend"
 
 // Worker interface
 type Worker interface {
-	TriggerAsyncPipelineWorkflow(ctx workflow.Context, param *TriggerAsyncPipelineWorkflowRequest) error
+	TriggerAsyncPipelineWorkflow(ctx workflow.Context, param *TriggerAsyncPipelineWorkflowRequest) (*TriggerAsyncPipelineWorkflowResponse, error)
 	ConnectorActivity(ctx context.Context, param *ExecuteConnectorActivityRequest) (*ExecuteConnectorActivityResponse, error)
 	OperatorActivity(ctx context.Context, param *ExecuteOperatorActivityRequest) (*ExecuteOperatorActivityResponse, error)
 }

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -21,7 +21,7 @@ const TaskQueue = "pipeline-backend"
 
 // Worker interface
 type Worker interface {
-	TriggerAsyncPipelineWorkflow(ctx workflow.Context, param *TriggerAsyncPipelineWorkflowRequest) (*TriggerAsyncPipelineWorkflowResponse, error)
+	TriggerPipelineWorkflow(ctx workflow.Context, param *TriggerPipelineWorkflowRequest) (*TriggerPipelineWorkflowResponse, error)
 	ConnectorActivity(ctx context.Context, param *ExecuteConnectorActivityRequest) (*ExecuteConnectorActivityResponse, error)
 	OperatorActivity(ctx context.Context, param *ExecuteOperatorActivityRequest) (*ExecuteOperatorActivityResponse, error)
 }

--- a/pkg/worker/workflow.go
+++ b/pkg/worker/workflow.go
@@ -26,7 +26,7 @@ import (
 	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
 
-type TriggerAsyncPipelineWorkflowRequest struct {
+type TriggerPipelineWorkflowRequest struct {
 	PipelineInputBlobRedisKeys []string
 	PipelineId                 string
 	PipelineUid                uuid.UUID
@@ -38,7 +38,7 @@ type TriggerAsyncPipelineWorkflowRequest struct {
 	ReturnTraces               bool
 }
 
-type TriggerAsyncPipelineWorkflowResponse struct {
+type TriggerPipelineWorkflowResponse struct {
 	OutputBlobRedisKey string
 }
 
@@ -120,18 +120,18 @@ func (w *worker) SetBlob(inputs []*structpb.Struct) ([]string, error) {
 	return blobRedisKeys, nil
 }
 
-// TriggerAsyncPipelineWorkflow is a pipeline trigger workflow definition.
-func (w *worker) TriggerAsyncPipelineWorkflow(ctx workflow.Context, param *TriggerAsyncPipelineWorkflowRequest) (*TriggerAsyncPipelineWorkflowResponse, error) {
+// TriggerPipelineWorkflow is a pipeline trigger workflow definition.
+func (w *worker) TriggerPipelineWorkflow(ctx workflow.Context, param *TriggerPipelineWorkflowRequest) (*TriggerPipelineWorkflowResponse, error) {
 
 	startTime := time.Now()
-	eventName := "TriggerAsyncPipelineWorkflow"
+	eventName := "TriggerPipelineWorkflow"
 
 	sCtx, span := tracer.Start(context.Background(), eventName,
 		trace.WithSpanKind(trace.SpanKindServer))
 	defer span.End()
 
 	logger, _ := logger.GetZapLogger(sCtx)
-	logger.Info("TriggerAsyncPipelineWorkflow started")
+	logger.Info("TriggerPipelineWorkflow started")
 
 	namespace := strings.Split(param.OwnerPermalink, "/")[0]
 	var ownerType mgmtPB.OwnerType
@@ -588,8 +588,8 @@ func (w *worker) TriggerAsyncPipelineWorkflow(ctx workflow.Context, param *Trigg
 	if err := w.writeNewDataPoint(sCtx, dataPoint); err != nil {
 		logger.Warn(err.Error())
 	}
-	logger.Info("TriggerAsyncPipelineWorkflow completed")
-	return &TriggerAsyncPipelineWorkflowResponse{
+	logger.Info("TriggerPipelineWorkflow completed")
+	return &TriggerPipelineWorkflowResponse{
 		OutputBlobRedisKey: blobRedisKey,
 	}, nil
 }

--- a/pkg/worker/workflow.go
+++ b/pkg/worker/workflow.go
@@ -38,6 +38,10 @@ type TriggerAsyncPipelineWorkflowRequest struct {
 	ReturnTraces               bool
 }
 
+type TriggerAsyncPipelineWorkflowResponse struct {
+	OutputBlobRedisKey string
+}
+
 // ExecuteConnectorActivityRequest represents the parameters for TriggerActivity
 type ExecuteConnectorActivityRequest struct {
 	Id                 string
@@ -117,7 +121,7 @@ func (w *worker) SetBlob(inputs []*structpb.Struct) ([]string, error) {
 }
 
 // TriggerAsyncPipelineWorkflow is a pipeline trigger workflow definition.
-func (w *worker) TriggerAsyncPipelineWorkflow(ctx workflow.Context, param *TriggerAsyncPipelineWorkflowRequest) error {
+func (w *worker) TriggerAsyncPipelineWorkflow(ctx workflow.Context, param *TriggerAsyncPipelineWorkflowRequest) (*TriggerAsyncPipelineWorkflowResponse, error) {
 
 	startTime := time.Now()
 	eventName := "TriggerAsyncPipelineWorkflow"
@@ -168,7 +172,7 @@ func (w *worker) TriggerAsyncPipelineWorkflow(ctx workflow.Context, param *Trigg
 		dataPoint.ComputeTimeDuration = time.Since(startTime).Seconds()
 		dataPoint.Status = mgmtPB.Status_STATUS_ERRORED
 		_ = w.writeNewDataPoint(sCtx, dataPoint)
-		return err
+		return nil, err
 	}
 
 	orderedComp, err := dag.TopologicalSort()
@@ -177,7 +181,7 @@ func (w *worker) TriggerAsyncPipelineWorkflow(ctx workflow.Context, param *Trigg
 		dataPoint.ComputeTimeDuration = time.Since(startTime).Seconds()
 		dataPoint.Status = mgmtPB.Status_STATUS_ERRORED
 		_ = w.writeNewDataPoint(sCtx, dataPoint)
-		return err
+		return nil, err
 	}
 	var startCompId string
 	for _, c := range orderedComp {
@@ -196,7 +200,7 @@ func (w *worker) TriggerAsyncPipelineWorkflow(ctx workflow.Context, param *Trigg
 		dataPoint.ComputeTimeDuration = time.Since(startTime).Seconds()
 		dataPoint.Status = mgmtPB.Status_STATUS_ERRORED
 		_ = w.writeNewDataPoint(sCtx, dataPoint)
-		return err
+		return nil, err
 	}
 	batchSize := len(pipelineInputs)
 	for idx := range pipelineInputs {
@@ -208,7 +212,7 @@ func (w *worker) TriggerAsyncPipelineWorkflow(ctx workflow.Context, param *Trigg
 			dataPoint.ComputeTimeDuration = time.Since(startTime).Seconds()
 			dataPoint.Status = mgmtPB.Status_STATUS_ERRORED
 			_ = w.writeNewDataPoint(sCtx, dataPoint)
-			return err
+			return nil, err
 		}
 		inputs = append(inputs, input)
 	}
@@ -226,14 +230,14 @@ func (w *worker) TriggerAsyncPipelineWorkflow(ctx workflow.Context, param *Trigg
 			dataPoint.ComputeTimeDuration = time.Since(startTime).Seconds()
 			dataPoint.Status = mgmtPB.Status_STATUS_ERRORED
 			_ = w.writeNewDataPoint(sCtx, dataPoint)
-			return err
+			return nil, err
 		}
 		memory[idx][startCompId] = inputStruct
 		computeTime[startCompId] = 0
 
 		memory[idx]["global"], err = utils.GenerateGlobalValue(param.PipelineUid, param.PipelineRecipe, param.OwnerPermalink)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		statuses[idx] = map[string]*utils.ComponentStatus{}
 		statuses[idx][startCompId] = &utils.ComponentStatus{}
@@ -269,11 +273,11 @@ func (w *worker) TriggerAsyncPipelineWorkflow(ctx workflow.Context, param *Trigg
 				if comp.Configuration.Fields["condition"].GetStringValue() != "" {
 					expr, err := parser.ParseExpr(comp.Configuration.Fields["condition"].GetStringValue())
 					if err != nil {
-						return err
+						return nil, err
 					}
 					cond, err := utils.EvalCondition(expr, memory[idx])
 					if err != nil {
-						return err
+						return nil, err
 					}
 					if cond == false {
 						statuses[idx][comp.Id].Skipped = true
@@ -298,12 +302,12 @@ func (w *worker) TriggerAsyncPipelineWorkflow(ctx workflow.Context, param *Trigg
 				if comp.DefinitionName == "connector-definitions/70d8664a-d512-4517-a5e8-5d4da81756a7" {
 					recipeByte, err := json.Marshal(param.PipelineRecipe)
 					if err != nil {
-						return err
+						return nil, err
 					}
 					recipePb := &structpb.Struct{}
 					err = protojson.Unmarshal(recipeByte, recipePb)
 					if err != nil {
-						return err
+						return nil, err
 					}
 
 					// TODO: remove this hardcode injection
@@ -318,7 +322,7 @@ func (w *worker) TriggerAsyncPipelineWorkflow(ctx workflow.Context, param *Trigg
 							},
 						})
 						if err != nil {
-							return err
+							return nil, err
 						}
 						if compInputTemplate.Fields["input"].GetStructValue().Fields["custom"].GetStructValue() == nil {
 							compInputTemplate.Fields["input"].GetStructValue().Fields["custom"] = structpb.NewStructValue(&structpb.Struct{Fields: map[string]*structpb.Value{}})
@@ -333,7 +337,7 @@ func (w *worker) TriggerAsyncPipelineWorkflow(ctx workflow.Context, param *Trigg
 					dataPoint.ComputeTimeDuration = time.Since(startTime).Seconds()
 					dataPoint.Status = mgmtPB.Status_STATUS_ERRORED
 					_ = w.writeNewDataPoint(sCtx, dataPoint)
-					return err
+					return nil, err
 				}
 
 				var compInputTemplateStruct interface{}
@@ -343,7 +347,7 @@ func (w *worker) TriggerAsyncPipelineWorkflow(ctx workflow.Context, param *Trigg
 					dataPoint.ComputeTimeDuration = time.Since(startTime).Seconds()
 					dataPoint.Status = mgmtPB.Status_STATUS_ERRORED
 					_ = w.writeNewDataPoint(sCtx, dataPoint)
-					return err
+					return nil, err
 				}
 
 				compInputStruct, err := utils.RenderInput(compInputTemplateStruct, memory[idx])
@@ -352,7 +356,7 @@ func (w *worker) TriggerAsyncPipelineWorkflow(ctx workflow.Context, param *Trigg
 					dataPoint.ComputeTimeDuration = time.Since(startTime).Seconds()
 					dataPoint.Status = mgmtPB.Status_STATUS_ERRORED
 					_ = w.writeNewDataPoint(sCtx, dataPoint)
-					return err
+					return nil, err
 				}
 				compInputJson, err := json.Marshal(compInputStruct)
 				if err != nil {
@@ -360,7 +364,7 @@ func (w *worker) TriggerAsyncPipelineWorkflow(ctx workflow.Context, param *Trigg
 					dataPoint.ComputeTimeDuration = time.Since(startTime).Seconds()
 					dataPoint.Status = mgmtPB.Status_STATUS_ERRORED
 					_ = w.writeNewDataPoint(sCtx, dataPoint)
-					return err
+					return nil, err
 				}
 
 				compInput := &structpb.Struct{}
@@ -370,7 +374,7 @@ func (w *worker) TriggerAsyncPipelineWorkflow(ctx workflow.Context, param *Trigg
 					dataPoint.ComputeTimeDuration = time.Since(startTime).Seconds()
 					dataPoint.Status = mgmtPB.Status_STATUS_ERRORED
 					_ = w.writeNewDataPoint(sCtx, dataPoint)
-					return err
+					return nil, err
 				}
 
 				memory[idx][comp.Id].(map[string]interface{})["input"] = compInputStruct
@@ -392,7 +396,7 @@ func (w *worker) TriggerAsyncPipelineWorkflow(ctx workflow.Context, param *Trigg
 				dataPoint.ComputeTimeDuration = time.Since(startTime).Seconds()
 				dataPoint.Status = mgmtPB.Status_STATUS_ERRORED
 				_ = w.writeNewDataPoint(sCtx, dataPoint)
-				return err
+				return nil, err
 			}
 			for idx := range result.OutputBlobRedisKeys {
 				defer w.redisClient.Del(context.Background(), inputBlobRedisKeys[idx])
@@ -420,7 +424,7 @@ func (w *worker) TriggerAsyncPipelineWorkflow(ctx workflow.Context, param *Trigg
 				dataPoint.ComputeTimeDuration = time.Since(startTime).Seconds()
 				dataPoint.Status = mgmtPB.Status_STATUS_ERRORED
 				_ = w.writeNewDataPoint(sCtx, dataPoint)
-				return err
+				return nil, err
 			}
 			computeTime[comp.Id] = float32(time.Since(start).Seconds())
 			outputs, err := w.GetBlob(result.OutputBlobRedisKeys)
@@ -432,18 +436,18 @@ func (w *worker) TriggerAsyncPipelineWorkflow(ctx workflow.Context, param *Trigg
 				dataPoint.ComputeTimeDuration = time.Since(startTime).Seconds()
 				dataPoint.Status = mgmtPB.Status_STATUS_ERRORED
 				_ = w.writeNewDataPoint(sCtx, dataPoint)
-				return err
+				return nil, err
 			}
 			for compBatchIdx := range outputs {
 
 				outputJson, err := protojson.Marshal(outputs[compBatchIdx])
 				if err != nil {
-					return err
+					return nil, err
 				}
 				var outputStruct map[string]interface{}
 				err = json.Unmarshal(outputJson, &outputStruct)
 				if err != nil {
-					return err
+					return nil, err
 				}
 				memory[idxMap[compBatchIdx]][comp.Id].(map[string]interface{})["output"] = outputStruct
 				statuses[idxMap[compBatchIdx]][comp.Id].Completed = true
@@ -463,7 +467,7 @@ func (w *worker) TriggerAsyncPipelineWorkflow(ctx workflow.Context, param *Trigg
 				dataPoint.ComputeTimeDuration = time.Since(startTime).Seconds()
 				dataPoint.Status = mgmtPB.Status_STATUS_ERRORED
 				_ = w.writeNewDataPoint(sCtx, dataPoint)
-				return err
+				return nil, err
 			}
 			for idx := range result.OutputBlobRedisKeys {
 				defer w.redisClient.Del(context.Background(), inputBlobRedisKeys[idx])
@@ -490,7 +494,7 @@ func (w *worker) TriggerAsyncPipelineWorkflow(ctx workflow.Context, param *Trigg
 				dataPoint.ComputeTimeDuration = time.Since(startTime).Seconds()
 				dataPoint.Status = mgmtPB.Status_STATUS_ERRORED
 				_ = w.writeNewDataPoint(sCtx, dataPoint)
-				return err
+				return nil, err
 			}
 			computeTime[comp.Id] = float32(time.Since(start).Seconds())
 			outputs, err := w.GetBlob(result.OutputBlobRedisKeys)
@@ -502,18 +506,18 @@ func (w *worker) TriggerAsyncPipelineWorkflow(ctx workflow.Context, param *Trigg
 				dataPoint.ComputeTimeDuration = time.Since(startTime).Seconds()
 				dataPoint.Status = mgmtPB.Status_STATUS_ERRORED
 				_ = w.writeNewDataPoint(sCtx, dataPoint)
-				return err
+				return nil, err
 			}
 			for compBatchIdx := range outputs {
 
 				outputJson, err := protojson.Marshal(outputs[compBatchIdx])
 				if err != nil {
-					return err
+					return nil, err
 				}
 				var outputStruct map[string]interface{}
 				err = json.Unmarshal(outputJson, &outputStruct)
 				if err != nil {
-					return err
+					return nil, err
 				}
 				memory[idxMap[compBatchIdx]][comp.Id].(map[string]interface{})["output"] = outputStruct
 				statuses[idxMap[compBatchIdx]][comp.Id].Completed = true
@@ -534,7 +538,7 @@ func (w *worker) TriggerAsyncPipelineWorkflow(ctx workflow.Context, param *Trigg
 			for key, value := range memory[idx][responseCompId].(map[string]interface{})["input"].(map[string]interface{}) {
 				structVal, err := structpb.NewValue(value)
 				if err != nil {
-					return err
+					return nil, err
 				}
 				pipelineOutput.Fields[key] = structVal
 
@@ -553,7 +557,7 @@ func (w *worker) TriggerAsyncPipelineWorkflow(ctx workflow.Context, param *Trigg
 			dataPoint.ComputeTimeDuration = time.Since(startTime).Seconds()
 			dataPoint.Status = mgmtPB.Status_STATUS_ERRORED
 			_ = w.writeNewDataPoint(sCtx, dataPoint)
-			return err
+			return nil, err
 		}
 	}
 
@@ -569,7 +573,7 @@ func (w *worker) TriggerAsyncPipelineWorkflow(ctx workflow.Context, param *Trigg
 		dataPoint.ComputeTimeDuration = time.Since(startTime).Seconds()
 		dataPoint.Status = mgmtPB.Status_STATUS_ERRORED
 		_ = w.writeNewDataPoint(sCtx, dataPoint)
-		return err
+		return nil, err
 	}
 	blobRedisKey := fmt.Sprintf("async_pipeline_response:%s", workflow.GetInfo(ctx).WorkflowExecution.ID)
 	w.redisClient.Set(
@@ -585,7 +589,9 @@ func (w *worker) TriggerAsyncPipelineWorkflow(ctx workflow.Context, param *Trigg
 		logger.Warn(err.Error())
 	}
 	logger.Info("TriggerAsyncPipelineWorkflow completed")
-	return nil
+	return &TriggerAsyncPipelineWorkflowResponse{
+		OutputBlobRedisKey: blobRedisKey,
+	}, nil
 }
 
 func (w *worker) ConnectorActivity(ctx context.Context, param *ExecuteConnectorActivityRequest) (*ExecuteConnectorActivityResponse, error) {


### PR DESCRIPTION
Because

- We want to use Temporal to serve all pipeline jobs for the robustness.

This commit

- use Temporal as worker queue for `trigger` endpoint
