### PR TITLE
chore(datamodel): add pipeline readme field

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -31,7 +31,7 @@ database:
   host: pg-sql
   port: 5432
   name: pipeline
-  version: 8
+  version: 9
   timezone: Etc/UTC
   pool:
     idleconnections: 5

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/instill-ai/component v0.7.1-alpha.0.20231206035822-12eee341c80e
 	github.com/instill-ai/connector v0.7.0-alpha.0.20231206040111-5a57a09f2adc
 	github.com/instill-ai/operator v0.5.0-alpha.0.20231206181023-581e551939b9
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231207085447-cfd519576573
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231207112549-0e2a5afcd9c4
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20231206162018-6ccbff13136b
 	github.com/instill-ai/x v0.3.0-alpha.0.20231124062833-3236165f5782
 	github.com/knadh/koanf v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -1189,8 +1189,8 @@ github.com/instill-ai/connector v0.7.0-alpha.0.20231206040111-5a57a09f2adc h1:i3
 github.com/instill-ai/connector v0.7.0-alpha.0.20231206040111-5a57a09f2adc/go.mod h1:d4/IGbcK8YM7IqrvRRN3oMQVOk4jtFRzZGnflKY1IzI=
 github.com/instill-ai/operator v0.5.0-alpha.0.20231206181023-581e551939b9 h1:Fx6UwbFek49Kgo6cbMlnxycmrvC3TPfs8Zkd1jjF99w=
 github.com/instill-ai/operator v0.5.0-alpha.0.20231206181023-581e551939b9/go.mod h1:oUG3J+ndGK0Ebxz664FaM7Csn+qPbR0gxitlFaRXTaI=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231207085447-cfd519576573 h1:ySb1aR1iqXF60O4FfiGJAkqUIS//D3d3Ql7wh7hEbBw=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231207085447-cfd519576573/go.mod h1:q/YL5TZXD9nvmJ7Rih4gY3/B2HT2+GiFdxeZp9D+yE4=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231207112549-0e2a5afcd9c4 h1:SHDewY9zWZSxN2ahSMxgINnBdLIrsAqjUKplwqNm398=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231207112549-0e2a5afcd9c4/go.mod h1:q/YL5TZXD9nvmJ7Rih4gY3/B2HT2+GiFdxeZp9D+yE4=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20231206162018-6ccbff13136b h1:YwXracXgTWxaPfIsbC3uaZFjGO0E2y1e3hK9ZUq7ipE=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20231206162018-6ccbff13136b/go.mod h1:4uTzVtcC+UVKhRaNvJc2+LFLcr/fv3vsYE5QCWu6TQ0=
 github.com/instill-ai/x v0.3.0-alpha.0.20231124062833-3236165f5782 h1:ErsJ1IkjD6Rtif0YI898fv/qllW5x9vb2fdt69EYwug=

--- a/pkg/datamodel/datamodel.go
+++ b/pkg/datamodel/datamodel.go
@@ -54,6 +54,7 @@ type Pipeline struct {
 	Permission        *Permission `gorm:"type:jsonb"`
 	ShareCode         string
 	Metadata          datatypes.JSON `gorm:"type:jsonb"`
+	Readme            string
 }
 
 // PipelineRelease is the data model of the pipeline release table
@@ -64,6 +65,7 @@ type PipelineRelease struct {
 	Description sql.NullString
 	Recipe      *Recipe        `gorm:"type:jsonb"`
 	Metadata    datatypes.JSON `gorm:"type:jsonb"`
+	Readme      string
 }
 
 // Recipe is the data model of the pipeline recipe

--- a/pkg/db/migration/000009_init.up.sql
+++ b/pkg/db/migration/000009_init.up.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE public.pipeline ADD COLUMN "readme" TEXT DEFAULT '';
+ALTER TABLE public.pipeline_release ADD COLUMN "readme" TEXT DEFAULT '';
+
+COMMIT;

--- a/pkg/service/convert.go
+++ b/pkg/service/convert.go
@@ -344,7 +344,7 @@ func (s *service) PBToDBPipeline(ctx context.Context, pbPipeline *pipelinePB.Pip
 			String: pbPipeline.GetDescription(),
 			Valid:  true,
 		},
-
+		Readme:     pbPipeline.Readme,
 		Recipe:     recipe,
 		Permission: dbPermission,
 		Metadata: func() []byte {
@@ -466,6 +466,7 @@ func (s *service) DBToPBPipeline(ctx context.Context, dbPipeline *datamodel.Pipe
 			}
 		}(),
 		Description: &dbPipeline.Description.String,
+		Readme:      dbPipeline.Readme,
 		Recipe:      pbRecipe,
 		Permission:  pbPermission,
 		OwnerName:   ownerName,
@@ -579,7 +580,7 @@ func (s *service) PBToDBPipelineRelease(ctx context.Context, pipelineUid uuid.UU
 			String: pbPipelineRelease.GetDescription(),
 			Valid:  true,
 		},
-
+		Readme:      pbPipelineRelease.Readme,
 		Recipe:      recipe,
 		PipelineUID: pipelineUid,
 
@@ -683,6 +684,7 @@ func (s *service) DBToPBPipelineRelease(ctx context.Context, dbPipelineRelease *
 			}
 		}(),
 		Description: &dbPipelineRelease.Description.String,
+		Readme:      dbPipelineRelease.Readme,
 		Recipe:      pbRecipe,
 	}
 


### PR DESCRIPTION
Because

- we need to store pipeline `readme` data

This commit

- add pipeline `readme` field
