### PR TITLE
chore(serivce): use mgmtPublicClient to get subscription

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -239,6 +239,10 @@ func main() {
 	if mgmtPrivateServiceClientConn != nil {
 		defer mgmtPrivateServiceClientConn.Close()
 	}
+	mgmtPublicServiceClient, mgmtPublicServiceClientConn := external.InitMgmtPublicServiceClient(ctx)
+	if mgmtPublicServiceClientConn != nil {
+		defer mgmtPublicServiceClientConn.Close()
+	}
 
 	controllerServiceClient, controllerServiceClientConn := external.InitControllerPrivateServiceClient(ctx)
 	if controllerServiceClientConn != nil {
@@ -263,6 +267,7 @@ func main() {
 	service := service.NewService(
 		repository,
 		mgmtPrivateServiceClient,
+		mgmtPublicServiceClient,
 		controllerServiceClient,
 		redisClient,
 		temporalClient,

--- a/config/config.go
+++ b/config/config.go
@@ -134,6 +134,7 @@ type CacheConfig struct {
 // MgmtBackendConfig related to mgmt-backend
 type MgmtBackendConfig struct {
 	Host        string `koanf:"host"`
+	PublicPort  int    `koanf:"publicport"`
 	PrivatePort int    `koanf:"privateport"`
 	HTTPS       struct {
 		Cert string `koanf:"cert"`

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -64,6 +64,7 @@ temporal:
   servername:
 mgmtbackend:
   host: mgmt-backend
+  publicport: 8084
   privateport: 3084
   https:
     cert:

--- a/pkg/external/external.go
+++ b/pkg/external/external.go
@@ -46,6 +46,29 @@ func InitMgmtPrivateServiceClient(ctx context.Context) (mgmtPB.MgmtPrivateServic
 	return mgmtPB.NewMgmtPrivateServiceClient(clientConn), clientConn
 }
 
+func InitMgmtPublicServiceClient(ctx context.Context) (mgmtPB.MgmtPublicServiceClient, *grpc.ClientConn) {
+	logger, _ := logger.GetZapLogger(ctx)
+
+	var clientDialOpts grpc.DialOption
+	if config.Config.MgmtBackend.HTTPS.Cert != "" && config.Config.MgmtBackend.HTTPS.Key != "" {
+		creds, err := credentials.NewServerTLSFromFile(config.Config.MgmtBackend.HTTPS.Cert, config.Config.MgmtBackend.HTTPS.Key)
+		if err != nil {
+			logger.Fatal(err.Error())
+		}
+		clientDialOpts = grpc.WithTransportCredentials(creds)
+	} else {
+		clientDialOpts = grpc.WithTransportCredentials(insecure.NewCredentials())
+	}
+
+	clientConn, err := grpc.Dial(fmt.Sprintf("%v:%v", config.Config.MgmtBackend.Host, config.Config.MgmtBackend.PublicPort), clientDialOpts)
+	if err != nil {
+		logger.Error(err.Error())
+		return nil, nil
+	}
+
+	return mgmtPB.NewMgmtPublicServiceClient(clientConn), clientConn
+}
+
 // InitUsageServiceClient initialises a UsageServiceClient instance (no mTLS)
 func InitUsageServiceClient(ctx context.Context) (usagePB.UsageServiceClient, *grpc.ClientConn) {
 	logger, _ := logger.GetZapLogger(ctx)


### PR DESCRIPTION
Because

- we need to use public endpoints to get the user or org subscription

This commit

- use mgmtPublicClient to get subscription
