### PR TITLE
chore(workflow): setup user jwt-sub and model-backend url for instill-model connector

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -19,16 +19,17 @@ var Config AppConfig
 
 // AppConfig defines
 type AppConfig struct {
-	Server      ServerConfig      `koanf:"server"`
-	Connector   ConnectorConfig   `koanf:"connector"`
-	Database    DatabaseConfig    `koanf:"database"`
-	InfluxDB    InfluxDBConfig    `koanf:"influxdb"`
-	Temporal    TemporalConfig    `koanf:"temporal"`
-	Cache       CacheConfig       `koanf:"cache"`
-	Log         LogConfig         `koanf:"log"`
-	MgmtBackend MgmtBackendConfig `koanf:"mgmtbackend"`
-	Controller  ControllerConfig  `koanf:"controller"`
-	OpenFGA     OpenFGAConfig     `koanf:"openfga"`
+	Server       ServerConfig       `koanf:"server"`
+	Connector    ConnectorConfig    `koanf:"connector"`
+	Database     DatabaseConfig     `koanf:"database"`
+	InfluxDB     InfluxDBConfig     `koanf:"influxdb"`
+	Temporal     TemporalConfig     `koanf:"temporal"`
+	Cache        CacheConfig        `koanf:"cache"`
+	Log          LogConfig          `koanf:"log"`
+	MgmtBackend  MgmtBackendConfig  `koanf:"mgmtbackend"`
+	ModelBackend ModelBackendConfig `koanf:"modelbackend"`
+	Controller   ControllerConfig   `koanf:"controller"`
+	OpenFGA      OpenFGAConfig      `koanf:"openfga"`
 }
 
 // OpenFGA config
@@ -137,6 +138,16 @@ type MgmtBackendConfig struct {
 	PublicPort  int    `koanf:"publicport"`
 	PrivatePort int    `koanf:"privateport"`
 	HTTPS       struct {
+		Cert string `koanf:"cert"`
+		Key  string `koanf:"key"`
+	}
+}
+
+// ModelBackendConfig related to mgmt-backend
+type ModelBackendConfig struct {
+	Host       string `koanf:"host"`
+	PublicPort int    `koanf:"publicport"`
+	HTTPS      struct {
 		Cert string `koanf:"cert"`
 		Key  string `koanf:"key"`
 	}

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -69,6 +69,12 @@ mgmtbackend:
   https:
     cert:
     key:
+modelbackend:
+  host: model-backend
+  publicport: 8083
+  https:
+    cert:
+    key:
 controller:
   host: controller-vdp
   privateport: 3085

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/iancoleman/strcase v0.2.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
 	github.com/instill-ai/component v0.7.1-alpha.0.20231208045032-bafec3495571
-	github.com/instill-ai/connector v0.7.0-alpha.0.20231206040111-5a57a09f2adc
+	github.com/instill-ai/connector v0.7.0-alpha.0.20231212074419-94a7b3cd13d7
 	github.com/instill-ai/operator v0.5.0-alpha.0.20231206181023-581e551939b9
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231210131526-67e990838339
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20231206162018-6ccbff13136b

--- a/go.sum
+++ b/go.sum
@@ -1185,8 +1185,8 @@ github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
 github.com/instill-ai/component v0.7.1-alpha.0.20231208045032-bafec3495571 h1:LdlHF/NN65GrM9kTnDMp3Ycxls3nU08/65UmHhIXjag=
 github.com/instill-ai/component v0.7.1-alpha.0.20231208045032-bafec3495571/go.mod h1:fWyVPJVJ4WyFSQMgWCc7KvcS7m9QpdS3VXCL2CZE8OY=
-github.com/instill-ai/connector v0.7.0-alpha.0.20231206040111-5a57a09f2adc h1:i34jk4bQi1jEcN66UNzK6UoPmZuCWrldV60qrZXa/H4=
-github.com/instill-ai/connector v0.7.0-alpha.0.20231206040111-5a57a09f2adc/go.mod h1:d4/IGbcK8YM7IqrvRRN3oMQVOk4jtFRzZGnflKY1IzI=
+github.com/instill-ai/connector v0.7.0-alpha.0.20231212074419-94a7b3cd13d7 h1:EQAXC2a+KXpzbRBzeYG3e032m5hLYW/WRsfMEjETsXs=
+github.com/instill-ai/connector v0.7.0-alpha.0.20231212074419-94a7b3cd13d7/go.mod h1:d4/IGbcK8YM7IqrvRRN3oMQVOk4jtFRzZGnflKY1IzI=
 github.com/instill-ai/operator v0.5.0-alpha.0.20231206181023-581e551939b9 h1:Fx6UwbFek49Kgo6cbMlnxycmrvC3TPfs8Zkd1jjF99w=
 github.com/instill-ai/operator v0.5.0-alpha.0.20231206181023-581e551939b9/go.mod h1:oUG3J+ndGK0Ebxz664FaM7Csn+qPbR0gxitlFaRXTaI=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231210131526-67e990838339 h1:Q48Mm+0i6gL4ZYMiHPddMfBQaslk83y3jmPg9T1T7IQ=


### PR DESCRIPTION
Because

- we'll support internal network mode for instill-model connector

This commit

- setup user jwt-sub and model-backend url for instill-model connector
