### PR TITLE
chore(workflow): use Redis to cache trigger count

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -1550,6 +1550,7 @@ func (s *service) triggerPipeline(
 			UserPermalink:              authUser.Permalink(),
 			ReturnTraces:               returnTraces,
 			Mode:                       mgmtPB.Mode_MODE_SYNC,
+			IsPublic:                   isPublic,
 		})
 	if err != nil {
 		logger.Error(fmt.Sprintf("unable to execute workflow: %s", err.Error()))
@@ -1641,6 +1642,7 @@ func (s *service) triggerAsyncPipeline(
 			UserPermalink:              authUser.Permalink(),
 			ReturnTraces:               returnTraces,
 			Mode:                       mgmtPB.Mode_MODE_ASYNC,
+			IsPublic:                   isPublic,
 		})
 	if err != nil {
 		logger.Error(fmt.Sprintf("unable to execute workflow: %s", err.Error()))

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -89,6 +89,7 @@ type PipelineUsageMetricData struct {
 	PipelineTriggerUID  string
 	TriggerTime         string
 	ComputeTimeDuration float64
+	IsPublic            bool
 }
 
 func NewPipelineDataPoint(data PipelineUsageMetricData) *write.Point {
@@ -110,6 +111,7 @@ func NewPipelineDataPoint(data PipelineUsageMetricData) *write.Point {
 			"pipeline_trigger_id":   data.PipelineTriggerUID,
 			"trigger_time":          data.TriggerTime,
 			"compute_time_duration": data.ComputeTimeDuration,
+			"is_public":             data.IsPublic,
 		},
 		time.Now(),
 	)


### PR DESCRIPTION
Because

- we need to cache private trigger count

This commit

- use Redis to cache private trigger count
