### PR TITLE
refactor(service): refactor `pipeline.permission` and `pipeline.sharing`

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -31,7 +31,7 @@ database:
   host: pg-sql
   port: 5432
   name: pipeline
-  version: 9
+  version: 10
   timezone: Etc/UTC
   pool:
     idleconnections: 5

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/instill-ai/component v0.7.1-alpha.0.20231208045032-bafec3495571
 	github.com/instill-ai/connector v0.7.0-alpha.0.20231213102646-578663e31e26
 	github.com/instill-ai/operator v0.5.0-alpha.0.20231206181023-581e551939b9
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231212091117-ca798a0535d1
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231214110613-21be2ae5d3e9
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20231206162018-6ccbff13136b
 	github.com/instill-ai/x v0.3.0-alpha.0.20231124062833-3236165f5782
 	github.com/knadh/koanf v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -1189,8 +1189,8 @@ github.com/instill-ai/connector v0.7.0-alpha.0.20231213102646-578663e31e26 h1:nF
 github.com/instill-ai/connector v0.7.0-alpha.0.20231213102646-578663e31e26/go.mod h1:lRIATE2Jjlo+imJ3+EzWLldE53S76ncoHO2fCMEpVWE=
 github.com/instill-ai/operator v0.5.0-alpha.0.20231206181023-581e551939b9 h1:Fx6UwbFek49Kgo6cbMlnxycmrvC3TPfs8Zkd1jjF99w=
 github.com/instill-ai/operator v0.5.0-alpha.0.20231206181023-581e551939b9/go.mod h1:oUG3J+ndGK0Ebxz664FaM7Csn+qPbR0gxitlFaRXTaI=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231212091117-ca798a0535d1 h1:3UyjuBjas7U7aTtuEWdSB/xp8E2ec2FHH2WNwzD/chE=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231212091117-ca798a0535d1/go.mod h1:q/YL5TZXD9nvmJ7Rih4gY3/B2HT2+GiFdxeZp9D+yE4=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231214110613-21be2ae5d3e9 h1:Yv0wikxsdNbvyQSk1gsiUXTRlWDmh7+Qqb3mGy2qw80=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231214110613-21be2ae5d3e9/go.mod h1:jhEL0SauySMoPLVvx105DWyThju9sYTbsXIySVCArmM=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20231206162018-6ccbff13136b h1:YwXracXgTWxaPfIsbC3uaZFjGO0E2y1e3hK9ZUq7ipE=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20231206162018-6ccbff13136b/go.mod h1:4uTzVtcC+UVKhRaNvJc2+LFLcr/fv3vsYE5QCWu6TQ0=
 github.com/instill-ai/x v0.3.0-alpha.0.20231124062833-3236165f5782 h1:ErsJ1IkjD6Rtif0YI898fv/qllW5x9vb2fdt69EYwug=

--- a/pkg/acl/acl.go
+++ b/pkg/acl/acl.go
@@ -68,7 +68,7 @@ func (c *ACLClient) SetPipelinePermissionMap(pipeline *datamodel.Pipeline) error
 	// TODO: use OpenFGA as single source of truth
 	// TODO: support fine-grained permission settings
 
-	for user, perm := range pipeline.Permission.Users {
+	for user, perm := range pipeline.Sharing.Users {
 		if user != "*/*" {
 			return fmt.Errorf("only support users: `*/*`")
 		}
@@ -91,18 +91,18 @@ func (c *ACLClient) SetPipelinePermissionMap(pipeline *datamodel.Pipeline) error
 		}
 	}
 
-	if pipeline.Permission.ShareCode != nil {
-		if pipeline.Permission.ShareCode.User != "*/*" {
+	if pipeline.Sharing.ShareCode != nil {
+		if pipeline.Sharing.ShareCode.User != "*/*" {
 			return fmt.Errorf("only support users: `*/*`")
 		}
-		if pipeline.Permission.ShareCode.Role == "ROLE_VIEWER" {
-			err := c.SetPipelinePermission(pipeline.UID, fmt.Sprintf("code:%s", pipeline.ShareCode), "reader", pipeline.Permission.ShareCode.Enabled)
+		if pipeline.Sharing.ShareCode.Role == "ROLE_VIEWER" {
+			err := c.SetPipelinePermission(pipeline.UID, fmt.Sprintf("code:%s", pipeline.ShareCode), "reader", pipeline.Sharing.ShareCode.Enabled)
 			if err != nil {
 				return err
 			}
 		}
-		if pipeline.Permission.ShareCode.Role == "ROLE_EXECUTOR" {
-			err := c.SetPipelinePermission(pipeline.UID, fmt.Sprintf("code:%s", pipeline.ShareCode), "executor", pipeline.Permission.ShareCode.Enabled)
+		if pipeline.Sharing.ShareCode.Role == "ROLE_EXECUTOR" {
+			err := c.SetPipelinePermission(pipeline.UID, fmt.Sprintf("code:%s", pipeline.ShareCode), "executor", pipeline.Sharing.ShareCode.Enabled)
 			if err != nil {
 				return err
 			}

--- a/pkg/datamodel/datamodel.go
+++ b/pkg/datamodel/datamodel.go
@@ -51,7 +51,7 @@ type Pipeline struct {
 	Description       sql.NullString
 	Recipe            *Recipe `gorm:"type:jsonb"`
 	DefaultReleaseUID uuid.UUID
-	Permission        *Permission `gorm:"type:jsonb"`
+	Sharing           *Sharing `gorm:"type:jsonb"`
 	ShareCode         string
 	Metadata          datatypes.JSON `gorm:"type:jsonb"`
 	Readme            string
@@ -81,18 +81,18 @@ type Component struct {
 	Configuration  *structpb.Struct `json:"configuration"`
 }
 
-type Permission struct {
-	Users     map[string]*PermissionUser `json:"users,omitempty"`
-	ShareCode *PermissionCode            `json:"share_code,omitempty"`
+type Sharing struct {
+	Users     map[string]*SharingUser `json:"users,omitempty"`
+	ShareCode *SharingCode            `json:"share_code,omitempty"`
 }
 
-// Permission
-type PermissionUser struct {
+// Sharing
+type SharingUser struct {
 	Enabled bool   `json:"enabled,omitempty"`
 	Role    string `json:"role,omitempty"`
 }
 
-type PermissionCode struct {
+type SharingCode struct {
 	User    string `json:"user"`
 	Code    string `json:"code"`
 	Enabled bool   `json:"enabled,omitempty"`
@@ -123,7 +123,7 @@ func (r *Recipe) Value() (driver.Value, error) {
 }
 
 // Scan function for custom GORM type Recipe
-func (p *Permission) Scan(value interface{}) error {
+func (p *Sharing) Scan(value interface{}) error {
 	bytes, ok := value.([]byte)
 	if !ok {
 		return errors.New(fmt.Sprint("Failed to unmarshal value:", value))
@@ -137,13 +137,13 @@ func (p *Permission) Scan(value interface{}) error {
 }
 
 // Value function for custom GORM type Recipe
-func (p *Permission) Value() (driver.Value, error) {
+func (p *Sharing) Value() (driver.Value, error) {
 	valueString, err := json.Marshal(p)
 	return string(valueString), err
 }
 
 // Scan function for custom GORM type Recipe
-func (p *PermissionUser) Scan(value interface{}) error {
+func (p *SharingUser) Scan(value interface{}) error {
 	bytes, ok := value.([]byte)
 	if !ok {
 		return errors.New(fmt.Sprint("Failed to unmarshal value:", value))
@@ -157,13 +157,13 @@ func (p *PermissionUser) Scan(value interface{}) error {
 }
 
 // Value function for custom GORM type Recipe
-func (p *PermissionUser) Value() (driver.Value, error) {
+func (p *SharingUser) Value() (driver.Value, error) {
 	valueString, err := json.Marshal(p)
 	return string(valueString), err
 }
 
 // Scan function for custom GORM type Recipe
-func (p *PermissionCode) Scan(value interface{}) error {
+func (p *SharingCode) Scan(value interface{}) error {
 	bytes, ok := value.([]byte)
 	if !ok {
 		return errors.New(fmt.Sprint("Failed to unmarshal value:", value))
@@ -177,7 +177,7 @@ func (p *PermissionCode) Scan(value interface{}) error {
 }
 
 // Value function for custom GORM type Recipe
-func (p *PermissionCode) Value() (driver.Value, error) {
+func (p *SharingCode) Value() (driver.Value, error) {
 	valueString, err := json.Marshal(p)
 	return string(valueString), err
 }

--- a/pkg/db/migration/000010_init.up.sql
+++ b/pkg/db/migration/000010_init.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE public.pipeline RENAME COLUMN permission TO sharing;
+
+COMMIT;

--- a/pkg/service/convert.go
+++ b/pkg/service/convert.go
@@ -292,18 +292,18 @@ func (s *service) PBToDBPipeline(ctx context.Context, pbPipeline *pipelinePB.Pip
 
 	}
 
-	dbPermission := &datamodel.Permission{}
-	if pbPipeline.GetPermission() != nil {
+	dbSharing := &datamodel.Sharing{}
+	if pbPipeline.GetSharing() != nil {
 
 		if err != nil {
 			return nil, err
 		}
 
-		b, err := protojson.MarshalOptions{UseProtoNames: true}.Marshal(pbPipeline.GetPermission())
+		b, err := protojson.MarshalOptions{UseProtoNames: true}.Marshal(pbPipeline.GetSharing())
 		if err != nil {
 			return nil, err
 		}
-		if err := json.Unmarshal(b, &dbPermission); err != nil {
+		if err := json.Unmarshal(b, &dbSharing); err != nil {
 			return nil, err
 		}
 
@@ -344,9 +344,9 @@ func (s *service) PBToDBPipeline(ctx context.Context, pbPipeline *pipelinePB.Pip
 			String: pbPipeline.GetDescription(),
 			Valid:  true,
 		},
-		Readme:     pbPipeline.Readme,
-		Recipe:     recipe,
-		Permission: dbPermission,
+		Readme:  pbPipeline.Readme,
+		Recipe:  recipe,
+		Sharing: dbSharing,
 		Metadata: func() []byte {
 			if pbPipeline.GetMetadata() != nil {
 				b, err := pbPipeline.GetMetadata().MarshalJSON()
@@ -437,19 +437,19 @@ func (s *service) DBToPBPipeline(ctx context.Context, dbPipeline *datamodel.Pipe
 		}
 	}
 
-	pbPermission := &pipelinePB.Permission{}
+	pbSharing := &pipelinePB.Sharing{}
 
-	b, err := json.Marshal(dbPipeline.Permission)
+	b, err := json.Marshal(dbPipeline.Sharing)
 	if err != nil {
 		return nil, err
 	}
 
-	err = protojson.Unmarshal(b, pbPermission)
+	err = protojson.Unmarshal(b, pbSharing)
 	if err != nil {
 		return nil, err
 	}
-	if pbPermission != nil && pbPermission.ShareCode != nil {
-		pbPermission.ShareCode.Code = dbPipeline.ShareCode
+	if pbSharing != nil && pbSharing.ShareCode != nil {
+		pbSharing.ShareCode.Code = dbPipeline.ShareCode
 	}
 
 	pbPipeline := pipelinePB.Pipeline{
@@ -468,7 +468,7 @@ func (s *service) DBToPBPipeline(ctx context.Context, dbPipeline *datamodel.Pipe
 		Description: &dbPipeline.Description.String,
 		Readme:      dbPipeline.Readme,
 		Recipe:      pbRecipe,
-		Permission:  pbPermission,
+		Sharing:     pbSharing,
 		OwnerName:   ownerName,
 		Owner:       owner,
 	}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -475,7 +475,7 @@ func (s *service) GetPipelineByUID(ctx context.Context, authUser *AuthUser, uid 
 
 func (s *service) checkPrivatePipelineQuota(ctx context.Context, ns resource.Namespace, dbPipeline *datamodel.Pipeline, quota int) error {
 
-	if val, ok := dbPipeline.Permission.Users["*/*"]; ok && val.Enabled {
+	if val, ok := dbPipeline.Sharing.Users["*/*"]; ok && val.Enabled {
 		return nil
 	}
 	privateCount := 0
@@ -490,8 +490,8 @@ func (s *service) checkPrivatePipelineQuota(ctx context.Context, ns resource.Nam
 		}
 		for _, pipeline := range pipelines {
 
-			if _, ok := pipeline.Permission.Users["*/*"]; ok {
-				if !pipeline.Permission.Users["*/*"].Enabled {
+			if _, ok := pipeline.Sharing.Users["*/*"]; ok {
+				if !pipeline.Sharing.Users["*/*"].Enabled {
 					privateCount += 1
 				}
 			} else {

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -113,8 +113,8 @@ type Service interface {
 	ConvertReleaseIdAlias(ctx context.Context, ns resource.Namespace, authUser *AuthUser, pipelineId string, releaseId string) (string, error)
 
 	PBToDBPipeline(ctx context.Context, pbPipeline *pipelinePB.Pipeline) (*datamodel.Pipeline, error)
-	DBToPBPipeline(ctx context.Context, dbPipeline *datamodel.Pipeline, view View) (*pipelinePB.Pipeline, error)
-	DBToPBPipelines(ctx context.Context, dbPipeline []*datamodel.Pipeline, view View) ([]*pipelinePB.Pipeline, error)
+	DBToPBPipeline(ctx context.Context, dbPipeline *datamodel.Pipeline, authUser *AuthUser, view View) (*pipelinePB.Pipeline, error)
+	DBToPBPipelines(ctx context.Context, dbPipeline []*datamodel.Pipeline, authUser *AuthUser, view View) ([]*pipelinePB.Pipeline, error)
 
 	PBToDBPipelineRelease(ctx context.Context, pipelineUid uuid.UUID, pbPipelineRelease *pipelinePB.PipelineRelease) (*datamodel.PipelineRelease, error)
 	DBToPBPipelineRelease(ctx context.Context, dbPipelineRelease *datamodel.PipelineRelease, view View, latestUUID uuid.UUID, defaultUUID uuid.UUID) (*pipelinePB.PipelineRelease, error)
@@ -452,7 +452,7 @@ func (s *service) ListPipelines(ctx context.Context, authUser *AuthUser, pageSiz
 	if err != nil {
 		return nil, 0, "", err
 	}
-	pbPipelines, err := s.DBToPBPipelines(ctx, dbPipelines, view)
+	pbPipelines, err := s.DBToPBPipelines(ctx, dbPipelines, authUser, view)
 	return pbPipelines, int32(totalSize), nextPageToken, err
 
 }
@@ -470,7 +470,7 @@ func (s *service) GetPipelineByUID(ctx context.Context, authUser *AuthUser, uid 
 		return nil, err
 	}
 
-	return s.DBToPBPipeline(ctx, dbPipeline, view)
+	return s.DBToPBPipeline(ctx, dbPipeline, authUser, view)
 }
 
 func (s *service) checkPrivatePipelineQuota(ctx context.Context, ns resource.Namespace, dbPipeline *datamodel.Pipeline, quota int) error {
@@ -621,7 +621,7 @@ func (s *service) CreateNamespacePipeline(ctx context.Context, ns resource.Names
 		return nil, err
 	}
 
-	return s.DBToPBPipeline(ctx, dbCreatedPipeline, VIEW_FULL)
+	return s.DBToPBPipeline(ctx, dbCreatedPipeline, authUser, VIEW_FULL)
 }
 
 func (s *service) ListNamespacePipelines(ctx context.Context, ns resource.Namespace, authUser *AuthUser, pageSize int32, pageToken string, view View, filter filtering.Filter, showDeleted bool) ([]*pipelinePB.Pipeline, int32, string, error) {
@@ -638,7 +638,7 @@ func (s *service) ListNamespacePipelines(ctx context.Context, ns resource.Namesp
 		return nil, 0, "", err
 	}
 
-	pbPipelines, err := s.DBToPBPipelines(ctx, dbPipelines, view)
+	pbPipelines, err := s.DBToPBPipelines(ctx, dbPipelines, authUser, view)
 	return pbPipelines, int32(ps), pt, err
 }
 
@@ -649,7 +649,7 @@ func (s *service) ListPipelinesAdmin(ctx context.Context, pageSize int32, pageTo
 		return nil, 0, "", err
 	}
 
-	pbPipelines, err := s.DBToPBPipelines(ctx, dbPipelines, view)
+	pbPipelines, err := s.DBToPBPipelines(ctx, dbPipelines, nil, view)
 	return pbPipelines, int32(ps), pt, err
 
 }
@@ -669,7 +669,7 @@ func (s *service) GetNamespacePipelineByID(ctx context.Context, ns resource.Name
 		return nil, ErrNotFound
 	}
 
-	return s.DBToPBPipeline(ctx, dbPipeline, view)
+	return s.DBToPBPipeline(ctx, dbPipeline, authUser, view)
 }
 
 func (s *service) GetNamespacePipelineDefaultReleaseUid(ctx context.Context, ns resource.Namespace, authUser *AuthUser, id string) (uuid.UUID, error) {
@@ -708,7 +708,7 @@ func (s *service) GetPipelineByUIDAdmin(ctx context.Context, uid uuid.UUID, view
 		return nil, err
 	}
 
-	return s.DBToPBPipeline(ctx, dbPipeline, view)
+	return s.DBToPBPipeline(ctx, dbPipeline, nil, view)
 
 }
 
@@ -811,7 +811,7 @@ func (s *service) UpdateNamespacePipelineByID(ctx context.Context, ns resource.N
 		return nil, err
 	}
 
-	return s.DBToPBPipeline(ctx, dbPipeline, VIEW_FULL)
+	return s.DBToPBPipeline(ctx, dbPipeline, authUser, VIEW_FULL)
 }
 
 func (s *service) DeleteNamespacePipelineByID(ctx context.Context, ns resource.Namespace, authUser *AuthUser, id string) error {
@@ -892,7 +892,7 @@ func (s *service) ValidateNamespacePipelineByID(ctx context.Context, ns resource
 		return nil, err
 	}
 
-	return s.DBToPBPipeline(ctx, dbPipeline, VIEW_FULL)
+	return s.DBToPBPipeline(ctx, dbPipeline, authUser, VIEW_FULL)
 
 }
 
@@ -926,7 +926,7 @@ func (s *service) UpdateNamespacePipelineIDByID(ctx context.Context, ns resource
 		return nil, err
 	}
 
-	return s.DBToPBPipeline(ctx, dbPipeline, VIEW_FULL)
+	return s.DBToPBPipeline(ctx, dbPipeline, authUser, VIEW_FULL)
 }
 
 func (s *service) preTriggerPipeline(ctx context.Context, isPublic bool, ns resource.Namespace, authUser *AuthUser, recipe *datamodel.Recipe, pipelineInputs []*structpb.Struct) error {

--- a/pkg/utils/dag.go
+++ b/pkg/utils/dag.go
@@ -438,7 +438,11 @@ func EvalCondition(expr ast.Expr, value map[string]interface{}) (interface{}, er
 	case *ast.ParenExpr:
 		return EvalCondition(e.X, value)
 	case *ast.SelectorExpr:
-		return EvalCondition(e.Sel, value[e.X.(*ast.Ident).String()].(map[string]interface{}))
+		v, err := EvalCondition(e.X, value)
+		if err != nil {
+			return nil, err
+		}
+		return v.(map[string]interface{})[e.Sel.String()], nil
 	case *ast.BasicLit:
 		if e.Kind == token.INT {
 			return strconv.ParseInt(e.Value, 10, 64)


### PR DESCRIPTION
Because

- We are going to refactor `pipeline.permission` as the corresponding permission of the authenticated user. And the original pipeline permission setting will now be `pipeline.sharing`

This commit

- refactor `pipeline.permission` and `pipeline.sharing`
- return corresponding permissions of the authenticated user
