### PR TITLE
fix: fix pipeline can not generate correct output schema

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/iancoleman/strcase v0.2.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
 	github.com/instill-ai/component v0.8.0-beta
-	github.com/instill-ai/connector v0.8.0-beta.0.20231219105932-d0dea69b3d0c
+	github.com/instill-ai/connector v0.8.1-beta
 	github.com/instill-ai/operator v0.6.0-beta
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231214110613-21be2ae5d3e9
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20231206162018-6ccbff13136b

--- a/go.sum
+++ b/go.sum
@@ -1187,8 +1187,8 @@ github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
 github.com/instill-ai/component v0.8.0-beta h1:xXePzuaKhh9RjSnmo6mZE4QD8OkaAuWVxxero6b4Kyo=
 github.com/instill-ai/component v0.8.0-beta/go.mod h1:fWyVPJVJ4WyFSQMgWCc7KvcS7m9QpdS3VXCL2CZE8OY=
-github.com/instill-ai/connector v0.8.0-beta.0.20231219105932-d0dea69b3d0c h1:dXT4lToRM9h18y2+/8fzzj2QwZk5hvG2QAyhjl+X9sE=
-github.com/instill-ai/connector v0.8.0-beta.0.20231219105932-d0dea69b3d0c/go.mod h1:y7QDqft1AARunXwHi7+D0veMbwWWDO7WJ/1YeV8uUN8=
+github.com/instill-ai/connector v0.8.1-beta h1:KQOnOrkeXl3a9xFTDz9Kd/vxrTyAP6AajiQ0gsxF9z0=
+github.com/instill-ai/connector v0.8.1-beta/go.mod h1:QgaSVMIVkqZS4y5TGMrfk01h6dDVTGAZxVCRncA2grs=
 github.com/instill-ai/operator v0.6.0-beta h1:G3imamqb9tDmOKYwzKqbvnKRaseX+PcNXpUJKu03lv8=
 github.com/instill-ai/operator v0.6.0-beta/go.mod h1:exFYtKdZFyzAczduFxQlD4X7+/B4OLYJ3ihA7j8Kcsg=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231214110613-21be2ae5d3e9 h1:Yv0wikxsdNbvyQSk1gsiUXTRlWDmh7+Qqb3mGy2qw80=

--- a/pkg/service/openapi.go
+++ b/pkg/service/openapi.go
@@ -352,10 +352,10 @@ func (s *service) GenerateOpenApiSpec(startCompOrigin *pipelinePB.Component, end
 								target := strings.Split(curr, "[")[0]
 								if _, ok := walk.GetStructValue().Fields["properties"]; ok {
 									if _, ok := walk.GetStructValue().Fields["properties"].GetStructValue().Fields[target]; !ok {
-										return nil, fmt.Errorf("openapi error")
+										break
 									}
 								} else {
-									return nil, fmt.Errorf("openapi error")
+									break
 								}
 								walk = walk.GetStructValue().Fields["properties"].GetStructValue().Fields[target].GetStructValue().Fields["items"]
 							} else {
@@ -363,10 +363,10 @@ func (s *service) GenerateOpenApiSpec(startCompOrigin *pipelinePB.Component, end
 
 								if _, ok := walk.GetStructValue().Fields["properties"]; ok {
 									if _, ok := walk.GetStructValue().Fields["properties"].GetStructValue().Fields[target]; !ok {
-										return nil, fmt.Errorf("openapi error")
+										break
 									}
 								} else {
-									return nil, fmt.Errorf("openapi error")
+									break
 								}
 
 								walk = walk.GetStructValue().Fields["properties"].GetStructValue().Fields[target]


### PR DESCRIPTION
Because

- pipeline can not generate correct output schema when it contains `semi-structured/object`

This commit

- fix pipeline can not generate correct output schema
