### PR TITLE
fix: remove unnecessary mgmt-backend request

### DIFF
--- a/integration-test/connector/const.js
+++ b/integration-test/connector/const.js
@@ -56,14 +56,14 @@ const randomUUID = uuidv4();
 export const paramsGRPCWithJwt = {
   metadata: {
     "Content-Type": "application/json",
-    "Jwt-Sub": randomUUID,
+    "Instill-User-Uid": randomUUID,
   },
 }
 
 export const paramsHTTPWithJwt = {
   headers: {
     "Content-Type": "application/json",
-    "Jwt-Sub": randomUUID,
+    "Instill-User-Uid": randomUUID,
   },
 }
 

--- a/integration-test/connector/grpc-data-connector-public-with-jwt.js
+++ b/integration-test/connector/grpc-data-connector-public-with-jwt.js
@@ -16,7 +16,7 @@ client.load(['../proto/vdp/pipeline/v1beta'], 'pipeline_public_service.proto');
 
 export function CheckCreate(metadata) {
 
-    group(`Connector API: Create destination connectors [with random "jwt-sub" header]`, () => {
+    group(`Connector API: Create destination connectors [with random "Instill-User-Uid" header]`, () => {
 
         client.connect(constant.pipelineGRPCPublicHost, {
             plaintext: true
@@ -35,7 +35,7 @@ export function CheckCreate(metadata) {
             parent: `${constant.namespace}`,
             connector: csvDstConnector
         }, constant.paramsGRPCWithJwt), {
-            [`[with random "jwt-sub" header] vdp.pipeline.v1beta.PipelinePublicService/CreateUserConnector CSV response StatusUnauthenticated`]: (r) => r.status === grpc.StatusUnauthenticated,
+            [`[with random "Instill-User-Uid" header] vdp.pipeline.v1beta.PipelinePublicService/CreateUserConnector CSV response StatusUnauthenticated`]: (r) => r.status === grpc.StatusUnauthenticated,
         })
 
         // destination-mysql (will end up with STATE_ERROR)
@@ -55,7 +55,7 @@ export function CheckCreate(metadata) {
             parent: `${constant.namespace}`,
             connector: mySQLDstConnector
         }, constant.paramsGRPCWithJwt), {
-            [`[with random "jwt-sub" header] vdp.pipeline.v1beta.PipelinePublicService/CreateUserConnector MySQL response StatusUnauthenticated`]: (r) => r.status === grpc.StatusUnauthenticated,
+            [`[with random "Instill-User-Uid" header] vdp.pipeline.v1beta.PipelinePublicService/CreateUserConnector MySQL response StatusUnauthenticated`]: (r) => r.status === grpc.StatusUnauthenticated,
         })
 
         client.close();
@@ -65,7 +65,7 @@ export function CheckCreate(metadata) {
 
 export function CheckList(metadata) {
 
-    group(`Connector API: List destination connectors [with random "jwt-sub" header]`, () => {
+    group(`Connector API: List destination connectors [with random "Instill-User-Uid" header]`, () => {
 
         client.connect(constant.pipelineGRPCPublicHost, {
             plaintext: true
@@ -76,7 +76,7 @@ export function CheckList(metadata) {
             parent: `${constant.namespace}`,
             filter: "connector_type=CONNECTOR_TYPE_DATA",
         }, constant.paramsGRPCWithJwt), {
-            [`[with random "jwt-sub" header] vdp.pipeline.v1beta.PipelinePublicService/ListUserConnectors response StatusUnauthenticated`]: (r) => r.status === grpc.StatusUnauthenticated,
+            [`[with random "Instill-User-Uid" header] vdp.pipeline.v1beta.PipelinePublicService/ListUserConnectors response StatusUnauthenticated`]: (r) => r.status === grpc.StatusUnauthenticated,
         })
 
         client.close();
@@ -85,7 +85,7 @@ export function CheckList(metadata) {
 
 export function CheckGet(metadata) {
 
-    group(`Connector API: Get destination connectors by ID [with random "jwt-sub" header]`, () => {
+    group(`Connector API: Get destination connectors by ID [with random "Instill-User-Uid" header]`, () => {
 
         client.connect(constant.pipelineGRPCPublicHost, {
             plaintext: true
@@ -117,7 +117,7 @@ export function CheckGet(metadata) {
         check(client.invoke('vdp.pipeline.v1beta.PipelinePublicService/GetUserConnector', {
             name: `${constant.namespace}/connectors/${resCSVDst.message.connector.id}`
         }, constant.paramsGRPCWithJwt), {
-            [`[with random "jwt-sub" header] vdp.pipeline.v1beta.PipelinePublicService/GetUserConnector CSV ${resCSVDst.message.connector.id} response StatusUnauthenticated`]: (r) => r.status === grpc.StatusUnauthenticated,
+            [`[with random "Instill-User-Uid" header] vdp.pipeline.v1beta.PipelinePublicService/GetUserConnector CSV ${resCSVDst.message.connector.id} response StatusUnauthenticated`]: (r) => r.status === grpc.StatusUnauthenticated,
         })
 
         check(client.invoke(`vdp.pipeline.v1beta.PipelinePublicService/DeleteUserConnector`, {
@@ -132,7 +132,7 @@ export function CheckGet(metadata) {
 
 export function CheckUpdate(metadata) {
 
-    group(`Connector API: Update destination connectors [with random "jwt-sub" header]`, () => {
+    group(`Connector API: Update destination connectors [with random "Instill-User-Uid" header]`, () => {
 
         client.connect(constant.pipelineGRPCPublicHost, {
             plaintext: true
@@ -170,7 +170,7 @@ export function CheckUpdate(metadata) {
             connector: csvDstConnectorUpdate,
             update_mask: "description,configuration",
         }, constant.paramsGRPCWithJwt), {
-            [`[with random "jwt-sub" header] vdp.pipeline.v1beta.PipelinePublicService/UpdateUserConnector ${csvDstConnectorUpdate.id} response StatusUnauthenticated`]: (r) => r.status === grpc.StatusUnauthenticated,
+            [`[with random "Instill-User-Uid" header] vdp.pipeline.v1beta.PipelinePublicService/UpdateUserConnector ${csvDstConnectorUpdate.id} response StatusUnauthenticated`]: (r) => r.status === grpc.StatusUnauthenticated,
         })
 
         check(client.invoke(`vdp.pipeline.v1beta.PipelinePublicService/DeleteUserConnector`, {
@@ -185,7 +185,7 @@ export function CheckUpdate(metadata) {
 
 export function CheckLookUp(metadata) {
 
-    group(`Connector API: Look up destination connectors by UID [with random "jwt-sub" header]`, () => {
+    group(`Connector API: Look up destination connectors by UID [with random "Instill-User-Uid" header]`, () => {
 
         client.connect(constant.pipelineGRPCPublicHost, {
             plaintext: true
@@ -211,7 +211,7 @@ export function CheckLookUp(metadata) {
         check(client.invoke('vdp.pipeline.v1beta.PipelinePublicService/LookUpConnector', {
             permalink: `connectors/${resCSVDst.message.connector.uid}`
         }, constant.paramsGRPCWithJwt), {
-            [`[with random "jwt-sub" header] vdp.pipeline.v1beta.PipelinePublicService/LookUpConnector CSV ${resCSVDst.message.connector.id} response StatusUnauthenticated`]: (r) => r.status === grpc.StatusUnauthenticated,
+            [`[with random "Instill-User-Uid" header] vdp.pipeline.v1beta.PipelinePublicService/LookUpConnector CSV ${resCSVDst.message.connector.id} response StatusUnauthenticated`]: (r) => r.status === grpc.StatusUnauthenticated,
         })
 
         check(client.invoke(`vdp.pipeline.v1beta.PipelinePublicService/DeleteUserConnector`, {
@@ -226,7 +226,7 @@ export function CheckLookUp(metadata) {
 
 export function CheckState(metadata) {
 
-    group(`Connector API: Change state destination connectors [with random "jwt-sub" header]`, () => {
+    group(`Connector API: Change state destination connectors [with random "Instill-User-Uid" header]`, () => {
 
         client.connect(constant.pipelineGRPCPublicHost, {
             plaintext: true
@@ -252,14 +252,14 @@ export function CheckState(metadata) {
         check(client.invoke('vdp.pipeline.v1beta.PipelinePublicService/ConnectUserConnector', {
             name: `${constant.namespace}/connectors/${resCSVDst.message.connector.id}`
         }, constant.paramsGRPCWithJwt), {
-            [`[with random "jwt-sub" header] vdp.pipeline.v1beta.PipelinePublicService/ConnectUserConnector ${resCSVDst.message.connector.id} response StatusUnauthenticated`]: (r) => r.status === grpc.StatusUnauthenticated,
+            [`[with random "Instill-User-Uid" header] vdp.pipeline.v1beta.PipelinePublicService/ConnectUserConnector ${resCSVDst.message.connector.id} response StatusUnauthenticated`]: (r) => r.status === grpc.StatusUnauthenticated,
         })
 
         // Cannot disconnect destination connector of a non-exist user
         check(client.invoke('vdp.pipeline.v1beta.PipelinePublicService/DisconnectUserConnector', {
             name: `${constant.namespace}/connectors/${resCSVDst.message.connector.id}`
         }, constant.paramsGRPCWithJwt), {
-            [`[with random "jwt-sub" header] vdp.pipeline.v1beta.PipelinePublicService/DisconnectUserConnector ${resCSVDst.message.connector.id} response at UNSPECIFIED StatusUnauthenticated`]: (r) => r.status === grpc.StatusUnauthenticated,
+            [`[with random "Instill-User-Uid" header] vdp.pipeline.v1beta.PipelinePublicService/DisconnectUserConnector ${resCSVDst.message.connector.id} response at UNSPECIFIED StatusUnauthenticated`]: (r) => r.status === grpc.StatusUnauthenticated,
         })
 
         check(client.invoke('vdp.pipeline.v1beta.PipelinePublicService/WatchUserConnector', {
@@ -272,28 +272,28 @@ export function CheckState(metadata) {
         check(client.invoke('vdp.pipeline.v1beta.PipelinePublicService/ConnectUserConnector', {
             name: `${constant.namespace}/connectors/${resCSVDst.message.connector.id}`
         }, constant.paramsGRPCWithJwt), {
-            [`[with random "jwt-sub" header] vdp.pipeline.v1beta.PipelinePublicService/ConnectUserConnector ${resCSVDst.message.connector.id} response at STATE_CONNECTED state StatusUnauthenticated`]: (r) => r.status === grpc.StatusUnauthenticated,
+            [`[with random "Instill-User-Uid" header] vdp.pipeline.v1beta.PipelinePublicService/ConnectUserConnector ${resCSVDst.message.connector.id} response at STATE_CONNECTED state StatusUnauthenticated`]: (r) => r.status === grpc.StatusUnauthenticated,
         })
 
         // Cannot disconnect destination connector of a non-exist user
         check(client.invoke('vdp.pipeline.v1beta.PipelinePublicService/DisconnectUserConnector', {
             name: `${constant.namespace}/connectors/${resCSVDst.message.connector.id}`
         }, constant.paramsGRPCWithJwt), {
-            [`[with random "jwt-sub" header] vdp.pipeline.v1beta.PipelinePublicService/DisconnectUserConnector ${resCSVDst.message.connector.id} response at STATE_CONNECTED state StatusUnauthenticated`]: (r) => r.status === grpc.StatusUnauthenticated,
+            [`[with random "Instill-User-Uid" header] vdp.pipeline.v1beta.PipelinePublicService/DisconnectUserConnector ${resCSVDst.message.connector.id} response at STATE_CONNECTED state StatusUnauthenticated`]: (r) => r.status === grpc.StatusUnauthenticated,
         })
 
         // Cannot connect destination connector of a non-exist user
         check(client.invoke('vdp.pipeline.v1beta.PipelinePublicService/ConnectUserConnector', {
             name: `${constant.namespace}/connectors/${resCSVDst.message.connector.id}`
         }, constant.paramsGRPCWithJwt), {
-            [`[with random "jwt-sub" header] vdp.pipeline.v1beta.PipelinePublicService/ConnectUserConnector ${resCSVDst.message.connector.id} response at STATE_DISCONNECTED state StatusUnauthenticated`]: (r) => r.status === grpc.StatusUnauthenticated,
+            [`[with random "Instill-User-Uid" header] vdp.pipeline.v1beta.PipelinePublicService/ConnectUserConnector ${resCSVDst.message.connector.id} response at STATE_DISCONNECTED state StatusUnauthenticated`]: (r) => r.status === grpc.StatusUnauthenticated,
         })
 
         // Cannot disconnect destination connector of a non-exist user
         check(client.invoke('vdp.pipeline.v1beta.PipelinePublicService/DisconnectUserConnector', {
             name: `${constant.namespace}/connectors/${resCSVDst.message.connector.id}`
         }, constant.paramsGRPCWithJwt), {
-            [`[with random "jwt-sub" header] vdp.pipeline.v1beta.PipelinePublicService/DisconnectUserConnector ${resCSVDst.message.connector.id} response at STATE_DISCONNECTED state StatusUnauthenticated`]: (r) => r.status === grpc.StatusUnauthenticated,
+            [`[with random "Instill-User-Uid" header] vdp.pipeline.v1beta.PipelinePublicService/DisconnectUserConnector ${resCSVDst.message.connector.id} response at STATE_DISCONNECTED state StatusUnauthenticated`]: (r) => r.status === grpc.StatusUnauthenticated,
         })
 
         check(client.invoke(`vdp.pipeline.v1beta.PipelinePublicService/DeleteUserConnector`, {
@@ -308,7 +308,7 @@ export function CheckState(metadata) {
 
 export function CheckRename(metadata) {
 
-    group(`Connector API: Rename destination connectors [with random "jwt-sub" header]`, () => {
+    group(`Connector API: Rename destination connectors [with random "Instill-User-Uid" header]`, () => {
 
         client.connect(constant.pipelineGRPCPublicHost, {
             plaintext: true
@@ -337,7 +337,7 @@ export function CheckRename(metadata) {
             name: `${constant.namespace}/connectors/resCSVDst.message.connector.id`,
             new_connector_id: new_id
         }, constant.paramsGRPCWithJwt), {
-            [`[with random "jwt-sub" header] vdp.pipeline.v1beta.PipelinePublicService/RenameUserConnector ${resCSVDst.message.connector.id} response StatusUnauthenticated`]: (r) => r.status === grpc.StatusUnauthenticated,
+            [`[with random "Instill-User-Uid" header] vdp.pipeline.v1beta.PipelinePublicService/RenameUserConnector ${resCSVDst.message.connector.id} response StatusUnauthenticated`]: (r) => r.status === grpc.StatusUnauthenticated,
         })
 
         check(client.invoke(`vdp.pipeline.v1beta.PipelinePublicService/DeleteUserConnector`, {
@@ -352,7 +352,7 @@ export function CheckRename(metadata) {
 
 export function CheckExecute(metadata) {
 
-    group(`Connector API: Write destination connectors [with random "jwt-sub" header]`, () => {
+    group(`Connector API: Write destination connectors [with random "Instill-User-Uid" header]`, () => {
 
         client.connect(constant.pipelineGRPCPublicHost, {
             plaintext: true
@@ -390,7 +390,7 @@ export function CheckExecute(metadata) {
             "name": `${constant.namespace}/connectors/${resCSVDst.message.connector.id}`,
             "inputs": constant.clsModelOutputs
         }, constant.paramsGRPCWithJwt), {
-            [`[with random "jwt-sub" header] vdp.pipeline.v1beta.PipelinePublicService/ExecuteUserConnector ${resCSVDst.message.connector.id} response (classification) StatusUnauthenticated`]: (r) => r.status === grpc.StatusUnauthenticated,
+            [`[with random "Instill-User-Uid" header] vdp.pipeline.v1beta.PipelinePublicService/ExecuteUserConnector ${resCSVDst.message.connector.id} response (classification) StatusUnauthenticated`]: (r) => r.status === grpc.StatusUnauthenticated,
         });
 
         // Wait for 1 sec for the connector writing to the destination-csv before deleting it
@@ -408,7 +408,7 @@ export function CheckExecute(metadata) {
 
 export function CheckTest(metadata) {
 
-    group(`Connector API: Test destination connectors' connection [with random "jwt-sub" header]`, () => {
+    group(`Connector API: Test destination connectors' connection [with random "Instill-User-Uid" header]`, () => {
 
         client.connect(constant.pipelineGRPCPublicHost, {
             plaintext: true
@@ -434,7 +434,7 @@ export function CheckTest(metadata) {
         check(client.invoke('vdp.pipeline.v1beta.PipelinePublicService/TestUserConnector', {
             name: `${constant.namespace}/connectors/${resCSVDst.message.connector.id}`
         }, constant.paramsGRPCWithJwt), {
-            [`[with random "jwt-sub" header] vdp.pipeline.v1beta.PipelinePublicService/TestUserConnector CSV ${resCSVDst.message.connector.id} response StatusUnauthenticated`]: (r) => r.status === grpc.StatusUnauthenticated,
+            [`[with random "Instill-User-Uid" header] vdp.pipeline.v1beta.PipelinePublicService/TestUserConnector CSV ${resCSVDst.message.connector.id} response StatusUnauthenticated`]: (r) => r.status === grpc.StatusUnauthenticated,
         })
 
         check(client.invoke(`vdp.pipeline.v1beta.PipelinePublicService/DeleteUserConnector`, {

--- a/integration-test/connector/grpc.js
+++ b/integration-test/connector/grpc.js
@@ -87,7 +87,7 @@ export default function (metadata) {
 
   } else {
 
-    // data public with jwt-sub
+    // data public with Instill-User-Uid
     dataConnectorPublicWithJwt.CheckCreate(metadata)
     dataConnectorPublicWithJwt.CheckList(metadata)
     dataConnectorPublicWithJwt.CheckGet(metadata)

--- a/integration-test/connector/rest-data-connector-public-with-jwt.js
+++ b/integration-test/connector/rest-data-connector-public-with-jwt.js
@@ -9,7 +9,7 @@ import * as helper from "./helper.js"
 
 export function CheckCreate(header) {
 
-    group(`Connector API: Create destination connectors [with random "jwt-sub" header]`, () => {
+    group(`Connector API: Create destination connectors [with random "Instill-User-Uid" header]`, () => {
 
         // end
         var httpDstConnector = {
@@ -24,7 +24,7 @@ export function CheckCreate(header) {
         check(http.request("POST",
             `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors`,
             JSON.stringify(httpDstConnector), constant.paramsHTTPWithJwt), {
-            [`[with random "jwt-sub" header] POST /v1beta/${constant.namespace}/connectors response for creating HTTP destination status is 401`]: (r) => r.status === 401,
+            [`[with random "Instill-User-Uid" header] POST /v1beta/${constant.namespace}/connectors response for creating HTTP destination status is 401`]: (r) => r.status === 401,
         });
 
     });
@@ -33,18 +33,18 @@ export function CheckCreate(header) {
 
 export function CheckList(header) {
 
-    group(`Connector API: List destination connectors [with random "jwt-sub" header]`, () => {
+    group(`Connector API: List destination connectors [with random "Instill-User-Uid" header]`, () => {
 
         // Cannot list destination connector of a non-exist user
         check(http.request("GET", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors?filter=connector_type=CONNECTOR_TYPE_DATA`, null, constant.paramsHTTPWithJwt), {
-            [`[with random "jwt-sub" header] GET /v1beta/${constant.namespace}/connectors response status is 401`]: (r) => r.status === 401,
+            [`[with random "Instill-User-Uid" header] GET /v1beta/${constant.namespace}/connectors response status is 401`]: (r) => r.status === 401,
         });
     });
 }
 
 export function CheckGet(header) {
 
-    group(`Connector API: Get destination connectors by ID [with random "jwt-sub" header]`, () => {
+    group(`Connector API: Get destination connectors by ID [with random "Instill-User-Uid" header]`, () => {
 
         var csvDstConnector = {
             "id": randomString(10),
@@ -65,7 +65,7 @@ export function CheckGet(header) {
 
         // Cannot get a destination connector of a non-exist user
         check(http.request("GET", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id}`, null, constant.paramsHTTPWithJwt), {
-            [`[with random "jwt-sub" header] GET /v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id} response status is 401`]: (r) => r.status === 401,
+            [`[with random "Instill-User-Uid" header] GET /v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id} response status is 401`]: (r) => r.status === 401,
         });
 
         check(http.request("DELETE", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id}`, null, header), {
@@ -76,7 +76,7 @@ export function CheckGet(header) {
 
 export function CheckUpdate(header) {
 
-    group(`Connector API: Update destination connectors [with random "jwt-sub" header]`, () => {
+    group(`Connector API: Update destination connectors [with random "Instill-User-Uid" header]`, () => {
 
         var csvDstConnector = {
             "id": randomString(10),
@@ -103,7 +103,7 @@ export function CheckUpdate(header) {
             "PATCH",
             `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id}`,
             JSON.stringify(csvDstConnectorUpdate), constant.paramsHTTPWithJwt), {
-            [`[with random "jwt-sub" header] PATCH /v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id} response status 401`]: (r) => r.status === 401,
+            [`[with random "Instill-User-Uid" header] PATCH /v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id} response status 401`]: (r) => r.status === 401,
         });
 
         check(http.request("DELETE", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors/${csvDstConnector.id}`, null, header), {
@@ -114,7 +114,7 @@ export function CheckUpdate(header) {
 
 export function CheckLookUp(header) {
 
-    group(`Connector API: Look up destination connectors by UID [with random "jwt-sub" header]`, () => {
+    group(`Connector API: Look up destination connectors by UID [with random "Instill-User-Uid" header]`, () => {
 
         var csvDstConnector = {
             "id": randomString(10),
@@ -128,7 +128,7 @@ export function CheckLookUp(header) {
 
         // Cannot look up a destination connector of a non-exist user
         check(http.request("GET", `${pipelinePublicHost}/v1beta/connectors/${resCSVDst.json().connector.uid}/lookUp`, null, constant.paramsHTTPWithJwt), {
-            [`[with random "jwt-sub" header] GET /v1beta/connectors/${resCSVDst.json().connector.uid}/lookUp response status 401`]: (r) => r.status === 401,
+            [`[with random "Instill-User-Uid" header] GET /v1beta/connectors/${resCSVDst.json().connector.uid}/lookUp response status 401`]: (r) => r.status === 401,
         });
 
         check(http.request("DELETE", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id}`, null, header), {
@@ -140,7 +140,7 @@ export function CheckLookUp(header) {
 
 export function CheckState(header) {
 
-    group(`Connector API: Change state destination connectors [with random "jwt-sub" header]`, () => {
+    group(`Connector API: Change state destination connectors [with random "Instill-User-Uid" header]`, () => {
         var csvDstConnector = {
             "id": randomString(10),
             "connector_definition_name": constant.csvDstDefRscName,
@@ -152,11 +152,11 @@ export function CheckState(header) {
             JSON.stringify(csvDstConnector), header)
 
         check(http.request("POST", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id}/disconnect`, null, constant.paramsHTTPWithJwt), {
-            [`[with random "jwt-sub" header] POST /v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id}/disconnect response at UNSPECIFIED state status 401`]: (r) => r.status === 401,
+            [`[with random "Instill-User-Uid" header] POST /v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id}/disconnect response at UNSPECIFIED state status 401`]: (r) => r.status === 401,
         });
 
         check(http.request("POST", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id}/connect`, null, constant.paramsHTTPWithJwt), {
-            [`[with random "jwt-sub" header] POST /v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id}/connect response at UNSPECIFIED state status 401`]: (r) => r.status === 401,
+            [`[with random "Instill-User-Uid" header] POST /v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id}/connect response at UNSPECIFIED state status 401`]: (r) => r.status === 401,
         });
 
         check(http.request("DELETE", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id}`, null, header), {
@@ -169,7 +169,7 @@ export function CheckState(header) {
 
 export function CheckRename(header) {
 
-    group(`Connector API: Rename destination connectors [with random "jwt-sub" header]`, () => {
+    group(`Connector API: Rename destination connectors [with random "Instill-User-Uid" header]`, () => {
 
         var csvDstConnector = {
             "id": randomString(10),
@@ -186,7 +186,7 @@ export function CheckRename(header) {
             JSON.stringify({
                 "new_connector_id": `some_id_not_${resCSVDst.json().connector.id}`
             }), constant.paramsHTTPWithJwt), {
-            [`[with random "jwt-sub" header] POST /v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id}/rename response status 401`]: (r) => r.status === 401,
+            [`[with random "Instill-User-Uid" header] POST /v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id}/rename response status 401`]: (r) => r.status === 401,
         });
 
         check(http.request("DELETE", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors/${csvDstConnector.id}`, null, header), {
@@ -197,7 +197,7 @@ export function CheckRename(header) {
 
 export function CheckExecute(header) {
 
-    group(`Connector API: Write destination connectors [with random "jwt-sub" header]`, () => {
+    group(`Connector API: Write destination connectors [with random "Instill-User-Uid" header]`, () => {
 
         var csvDstConnector, resCSVDst, currentTime, timeoutTime
 
@@ -218,7 +218,7 @@ export function CheckExecute(header) {
             {}, header)
 
         check(http.request("GET", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id}/watch`, null, header), {
-            [`[with random "jwt-sub" header] GET /v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id}/watch response connector state is STATE_CONNECTED`]: (r) => r.json().state === "STATE_CONNECTED",
+            [`[with random "Instill-User-Uid" header] GET /v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id}/watch response connector state is STATE_CONNECTED`]: (r) => r.json().state === "STATE_CONNECTED",
         })
 
         // Cannot write to destination connector of a non-exist user
@@ -226,7 +226,7 @@ export function CheckExecute(header) {
             JSON.stringify({
                 "inputs": constant.clsModelOutputs
             }), constant.paramsHTTPWithJwt), {
-            [`[with random "jwt-sub" header] POST /v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id}/execute response status 401 (classification)`]: (r) => r.status === 401,
+            [`[with random "Instill-User-Uid" header] POST /v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id}/execute response status 401 (classification)`]: (r) => r.status === 401,
         });
 
         // Wait for 1 sec for the connector writing to the destination-csv before deleting it
@@ -240,7 +240,7 @@ export function CheckExecute(header) {
 
 export function CheckTest(header) {
 
-    group(`Connector API: Test destination connectors by ID [with random "jwt-sub" header]`, () => {
+    group(`Connector API: Test destination connectors by ID [with random "Instill-User-Uid" header]`, () => {
 
         var csvDstConnector = {
             "id": randomString(10),
@@ -261,7 +261,7 @@ export function CheckTest(header) {
 
         // Cannot test destination connector of a non-exist user
         check(http.request("POST", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id}/testConnection`, null, constant.paramsHTTPWithJwt), {
-            [`[with random "jwt-sub" header] POST /v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id}/testConnection response status is 401`]: (r) => r.status === 401,
+            [`[with random "Instill-User-Uid" header] POST /v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id}/testConnection response status is 401`]: (r) => r.status === 401,
         });
 
         check(http.request("DELETE", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id}`, null, header), {

--- a/integration-test/connector/rest.js
+++ b/integration-test/connector/rest.js
@@ -72,7 +72,7 @@ export default function (header) {
 
   } else {
 
-    // data public with jwt-sub
+    // data public with Instill-User-Uid
     dataConnectorPublicWithJwt.CheckCreate(header)
     dataConnectorPublicWithJwt.CheckList(header)
     dataConnectorPublicWithJwt.CheckGet(header)

--- a/integration-test/pipeline/const.js
+++ b/integration-test/pipeline/const.js
@@ -65,14 +65,14 @@ const randomUUID = uuidv4();
 export const paramsGRPCWithJwt = {
   metadata: {
     "Content-Type": "application/json",
-    "Jwt-Sub": randomUUID,
+    "Instill-User-Uid": randomUUID,
   },
 };
 
 export const paramsHTTPWithJwt = {
   headers: {
     "Content-Type": "application/json",
-    "Jwt-Sub": randomUUID,
+    "Instill-User-Uid": randomUUID,
   },
 };
 

--- a/integration-test/pipeline/grpc-pipeline-public-with-jwt.js
+++ b/integration-test/pipeline/grpc-pipeline-public-with-jwt.js
@@ -9,7 +9,7 @@ client.load(["../proto/vdp/pipeline/v1beta"], "pipeline_public_service.proto");
 
 export function CheckCreate(metadata) {
   group(
-    `Pipelines API: Create a pipeline [with random "jwt-sub" header]`,
+    `Pipelines API: Create a pipeline [with random "Instill-User-Uid" header]`,
     () => {
       client.connect(constant.pipelineGRPCPublicHost, {
         plaintext: true,
@@ -34,7 +34,7 @@ export function CheckCreate(metadata) {
           constant.paramsGRPCWithJwt
         ),
         {
-          [`[with random "jwt-sub" header] vdp.pipeline.v1beta.PipelinePublicService/CreateUserPipeline response StatusUnauthenticated`]:
+          [`[with random "Instill-User-Uid" header] vdp.pipeline.v1beta.PipelinePublicService/CreateUserPipeline response StatusUnauthenticated`]:
             (r) => r.status === grpc.StatusUnauthenticated,
         }
       );
@@ -45,7 +45,7 @@ export function CheckCreate(metadata) {
 }
 
 export function CheckList(metadata) {
-  group(`Pipelines API: List pipelines [with random "jwt-sub" header]`, () => {
+  group(`Pipelines API: List pipelines [with random "Instill-User-Uid" header]`, () => {
     client.connect(constant.pipelineGRPCPublicHost, {
       plaintext: true,
     });
@@ -60,7 +60,7 @@ export function CheckList(metadata) {
         constant.paramsGRPCWithJwt
       ),
       {
-        [`[with random "jwt-sub" header] vdp.pipeline.v1beta.PipelinePublicService/ListUserPipelines response StatusOK`]:
+        [`[with random "Instill-User-Uid" header] vdp.pipeline.v1beta.PipelinePublicService/ListUserPipelines response StatusOK`]:
           (r) => r.status === grpc.StatusOK,
       }
     );
@@ -70,7 +70,7 @@ export function CheckList(metadata) {
 }
 
 export function CheckGet(metadata) {
-  group(`Pipelines API: Get a pipeline [with random "jwt-sub" header]`, () => {
+  group(`Pipelines API: Get a pipeline [with random "Instill-User-Uid" header]`, () => {
     client.connect(constant.pipelineGRPCPublicHost, {
       plaintext: true,
     });
@@ -109,7 +109,7 @@ export function CheckGet(metadata) {
         constant.paramsGRPCWithJwt
       ),
       {
-        [`[with random "jwt-sub" header] vdp.pipeline.v1beta.PipelinePublicService/GetUserPipeline response StatusNotFound`]:
+        [`[with random "Instill-User-Uid" header] vdp.pipeline.v1beta.PipelinePublicService/GetUserPipeline response StatusNotFound`]:
           (r) => r.status === grpc.StatusNotFound,
       }
     );
@@ -135,7 +135,7 @@ export function CheckGet(metadata) {
 
 export function CheckUpdate(metadata) {
   group(
-    `Pipelines API: Update a pipeline [with random "jwt-sub" header]`,
+    `Pipelines API: Update a pipeline [with random "Instill-User-Uid" header]`,
     () => {
       client.connect(constant.pipelineGRPCPublicHost, {
         plaintext: true,
@@ -182,7 +182,7 @@ export function CheckUpdate(metadata) {
           constant.paramsGRPCWithJwt
         ),
         {
-          [`[with random "jwt-sub" header] vdp.pipeline.v1beta.PipelinePublicService/UpdateUserPipeline response StatusUnauthenticated`]:
+          [`[with random "Instill-User-Uid" header] vdp.pipeline.v1beta.PipelinePublicService/UpdateUserPipeline response StatusUnauthenticated`]:
             (r) => r.status === grpc.StatusUnauthenticated,
         }
       );
@@ -209,7 +209,7 @@ export function CheckUpdate(metadata) {
 
 export function CheckRename(metadata) {
   group(
-    `Pipelines API: Rename a pipeline [with random "jwt-sub" header]`,
+    `Pipelines API: Rename a pipeline [with random "Instill-User-Uid" header]`,
     () => {
       client.connect(constant.pipelineGRPCPublicHost, {
         plaintext: true,
@@ -253,7 +253,7 @@ export function CheckRename(metadata) {
           constant.paramsGRPCWithJwt
         ),
         {
-          [`[with random "jwt-sub" header] vdp.pipeline.v1beta.PipelinePublicService/RenameUserPipeline response StatusUnauthenticated`]:
+          [`[with random "Instill-User-Uid" header] vdp.pipeline.v1beta.PipelinePublicService/RenameUserPipeline response StatusUnauthenticated`]:
             (r) => r.status === grpc.StatusUnauthenticated,
         }
       );
@@ -280,7 +280,7 @@ export function CheckRename(metadata) {
 
 export function CheckLookUp(metadata) {
   group(
-    `Pipelines API: Look up a pipeline by uid [with random "jwt-sub" header]`,
+    `Pipelines API: Look up a pipeline by uid [with random "Instill-User-Uid" header]`,
     () => {
       client.connect(constant.pipelineGRPCPublicHost, {
         plaintext: true,
@@ -319,7 +319,7 @@ export function CheckLookUp(metadata) {
           constant.paramsGRPCWithJwt
         ),
         {
-          [`[with random "jwt-sub" header] vdp.pipeline.v1beta.PipelinePublicService/LookUpPipeline response StatusUnauthenticated`]:
+          [`[with random "Instill-User-Uid" header] vdp.pipeline.v1beta.PipelinePublicService/LookUpPipeline response StatusUnauthenticated`]:
             (r) => r.status === grpc.StatusUnauthenticated,
         }
       );

--- a/integration-test/pipeline/rest-pipeline-public-with-jwt.js
+++ b/integration-test/pipeline/rest-pipeline-public-with-jwt.js
@@ -8,7 +8,7 @@ import * as constant from "./const.js";
 
 export function CheckCreate(header) {
   group(
-    `Pipelines API: Create a pipeline [with random "jwt-sub" header]`,
+    `Pipelines API: Create a pipeline [with random "Instill-User-Uid" header]`,
     () => {
       var reqBody = Object.assign(
         {
@@ -27,7 +27,7 @@ export function CheckCreate(header) {
           constant.paramsHTTPWithJwt
         ),
         {
-          [`[with random "jwt-sub" header] POST /v1beta/${constant.namespace}/pipelines response status is 401`]:
+          [`[with random "Instill-User-Uid" header] POST /v1beta/${constant.namespace}/pipelines response status is 401`]:
             (r) => r.status === 401,
         }
       );
@@ -36,7 +36,7 @@ export function CheckCreate(header) {
 }
 
 export function CheckList(header) {
-  group(`Pipelines API: List pipelines [with random "jwt-sub" header]`, () => {
+  group(`Pipelines API: List pipelines [with random "Instill-User-Uid" header]`, () => {
     // Cannot list pipelines of a non-exist user
     check(
       http.request(
@@ -46,7 +46,7 @@ export function CheckList(header) {
         constant.paramsHTTPWithJwt
       ),
       {
-        [`[with random "jwt-sub" header] GET /v1beta/${constant.namespace}/pipelines response status is 200`]:
+        [`[with random "Instill-User-Uid" header] GET /v1beta/${constant.namespace}/pipelines response status is 200`]:
           (r) => r.status === 200,
       }
     );
@@ -54,7 +54,7 @@ export function CheckList(header) {
 }
 
 export function CheckGet(header) {
-  group(`Pipelines API: Get a pipeline [with random "jwt-sub" header]`, () => {
+  group(`Pipelines API: Get a pipeline [with random "Instill-User-Uid" header]`, () => {
     var reqBody = Object.assign(
       {
         id: randomString(10),
@@ -86,7 +86,7 @@ export function CheckGet(header) {
         constant.paramsHTTPWithJwt
       ),
       {
-        [`[with random "jwt-sub" header] GET /v1beta/${constant.namespace}/pipelines/${reqBody.id} response status is 404`]:
+        [`[with random "Instill-User-Uid" header] GET /v1beta/${constant.namespace}/pipelines/${reqBody.id} response status is 404`]:
           (r) => r.status === 404,
       }
     );
@@ -109,7 +109,7 @@ export function CheckGet(header) {
 
 export function CheckUpdate(header) {
   group(
-    `Pipelines API: Update a pipeline [with random "jwt-sub" header]`,
+    `Pipelines API: Update a pipeline [with random "Instill-User-Uid" header]`,
     () => {
       var reqBody = Object.assign(
         {
@@ -146,7 +146,7 @@ export function CheckUpdate(header) {
           constant.paramsHTTPWithJwt
         ),
         {
-          [`[with random "jwt-sub" header] PATCH /v1beta/${constant.namespace}/pipelines/${reqBody.id} response status is 401`]:
+          [`[with random "Instill-User-Uid" header] PATCH /v1beta/${constant.namespace}/pipelines/${reqBody.id} response status is 401`]:
             (r) => r.status === 401,
         }
       );
@@ -171,7 +171,7 @@ export function CheckUpdate(header) {
 
 export function CheckRename(header) {
   group(
-    `Pipelines API: Rename a pipeline [with random "jwt-sub" header]`,
+    `Pipelines API: Rename a pipeline [with random "Instill-User-Uid" header]`,
     () => {
       var id = randomString(10);
       var reqBody = Object.assign(
@@ -208,7 +208,7 @@ export function CheckRename(header) {
           constant.paramsHTTPWithJwt
         ),
         {
-          [`[with random "jwt-sub" header] POST /v1beta/${constant.namespace}/pipelines/${res.json().pipeline.id
+          [`[with random "Instill-User-Uid" header] POST /v1beta/${constant.namespace}/pipelines/${res.json().pipeline.id
             }/rename response status is 401`]: (r) => r.status === 401,
         }
       );
@@ -232,7 +232,7 @@ export function CheckRename(header) {
 
 export function CheckLookUp(header) {
   group(
-    `Pipelines API: Look up a pipeline by uid [with random "jwt-sub" header]`,
+    `Pipelines API: Look up a pipeline by uid [with random "Instill-User-Uid" header]`,
     () => {
       var reqBody = Object.assign(
         {
@@ -264,7 +264,7 @@ export function CheckLookUp(header) {
           constant.paramsHTTPWithJwt
         ),
         {
-          [`[with random "jwt-sub" header] POST /v1beta/pipelines/${res.json().pipeline.id
+          [`[with random "Instill-User-Uid" header] POST /v1beta/pipelines/${res.json().pipeline.id
             }/lookUp response status is 401`]: (r) => r.status === 401,
         }
       );

--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -13,8 +13,10 @@ const MaxPayloadSize = 1024 * 1024 * 32
 
 // Constants for resource owner
 const DefaultUserID string = "admin"
-const HeaderUserUIDKey = "jwt-sub"
-const HeaderInstillCodeKey = "instill-share-code"
+const HeaderUserUIDKey = "Instill-User-Uid"
+const HeaderVisitorUIDKey = "Instill-Visitor-Uid"
+const HeaderAuthTypeKey = "Instill-Auth-Type"
+const HeaderInstillCodeKey = "Instill-Share-Code"
 const StartConnectorId = "start"
 const EndConnectorId = "end"
 const ReturnTracesKey = "instill-return-traces"

--- a/pkg/middleware/misc.go
+++ b/pkg/middleware/misc.go
@@ -150,11 +150,12 @@ func CustomMatcher(key string) (string, bool) {
 	if strings.HasPrefix(strings.ToLower(key), "jwt-") {
 		return key, true
 	}
+	if strings.HasPrefix(strings.ToLower(key), "instill-") {
+		return key, true
+	}
 
 	switch key {
 	case "request-id":
-		return key, true
-	case "Instill-Return-Traces", "Instill-Share-Code":
 		return key, true
 	case "X-B3-Traceid", "X-B3-Spanid", "X-B3-Sampled":
 		return key, true

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -238,7 +238,7 @@ func (a AuthUser) Permalink() string {
 }
 
 func (s *service) AuthenticateUser(ctx context.Context, allowVisitor bool) (authUser *AuthUser, err error) {
-	// Verify if "jwt-sub" is in the header
+	// Verify if "Instill-User-Uid" is in the header
 	authType := resource.GetRequestSingleHeader(ctx, constant.HeaderAuthTypeKey)
 	if authType == "user" {
 		headerCtxUserUID := resource.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey)
@@ -470,7 +470,7 @@ func (s *service) CreateNamespacePipeline(ctx context.Context, ns resource.Names
 
 	if ns.NsType == resource.Organization {
 		resp, err := s.mgmtPublicServiceClient.GetOrganizationSubscription(
-			metadata.AppendToOutgoingContext(ctx, "Jwt-Sub", resource.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey)),
+			metadata.AppendToOutgoingContext(ctx, "Instill-User-Uid", resource.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey)),
 			&mgmtPB.GetOrganizationSubscriptionRequest{Parent: fmt.Sprintf("organizations/%s", ns.NsID)})
 		if err != nil {
 			s, ok := status.FromError(err)
@@ -800,7 +800,7 @@ func (s *service) preTriggerPipeline(ctx context.Context, isAdmin bool, ns resou
 	if !checkRateLimited {
 		if ns.NsType == resource.Organization {
 			resp, err := s.mgmtPublicServiceClient.GetOrganizationSubscription(
-				metadata.AppendToOutgoingContext(ctx, "Jwt-Sub", resource.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey)),
+				metadata.AppendToOutgoingContext(ctx, "Instill-User-Uid", resource.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey)),
 				&mgmtPB.GetOrganizationSubscriptionRequest{Parent: fmt.Sprintf("%s/%s", ns.NsType, ns.NsID)},
 			)
 			if err != nil {
@@ -819,7 +819,7 @@ func (s *service) preTriggerPipeline(ctx context.Context, isAdmin bool, ns resou
 
 		} else {
 			resp, err := s.mgmtPublicServiceClient.GetUserSubscription(
-				metadata.AppendToOutgoingContext(ctx, "Jwt-Sub", resource.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey)),
+				metadata.AppendToOutgoingContext(ctx, "Instill-User-Uid", resource.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey)),
 				&mgmtPB.GetUserSubscriptionRequest{Parent: fmt.Sprintf("%s/%s", ns.NsType, ns.NsID)},
 			)
 			if err != nil {
@@ -1635,7 +1635,7 @@ func (s *service) TriggerNamespacePipelineReleaseByID(ctx context.Context, ns re
 	plan := ""
 	if ns.NsType == resource.Organization {
 		resp, err := s.mgmtPublicServiceClient.GetOrganizationSubscription(
-			metadata.AppendToOutgoingContext(ctx, "Jwt-Sub", resource.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey)),
+			metadata.AppendToOutgoingContext(ctx, "Instill-User-Uid", resource.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey)),
 			&mgmtPB.GetOrganizationSubscriptionRequest{Parent: fmt.Sprintf("%s/%s", ns.NsType, ns.NsID)},
 		)
 		if err != nil {
@@ -1651,7 +1651,7 @@ func (s *service) TriggerNamespacePipelineReleaseByID(ctx context.Context, ns re
 		}
 	} else {
 		resp, err := s.mgmtPublicServiceClient.GetUserSubscription(
-			metadata.AppendToOutgoingContext(ctx, "Jwt-Sub", resource.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey)),
+			metadata.AppendToOutgoingContext(ctx, "Instill-User-Uid", resource.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey)),
 			&mgmtPB.GetUserSubscriptionRequest{Parent: fmt.Sprintf("%s/%s", ns.NsType, ns.NsID)},
 		)
 		if err != nil {
@@ -1711,7 +1711,7 @@ func (s *service) TriggerAsyncNamespacePipelineReleaseByID(ctx context.Context, 
 	plan := ""
 	if ns.NsType == resource.Organization {
 		resp, err := s.mgmtPublicServiceClient.GetOrganizationSubscription(
-			metadata.AppendToOutgoingContext(ctx, "Jwt-Sub", resource.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey)),
+			metadata.AppendToOutgoingContext(ctx, "Instill-User-Uid", resource.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey)),
 			&mgmtPB.GetOrganizationSubscriptionRequest{Parent: fmt.Sprintf("%s/%s", ns.NsType, ns.NsID)},
 		)
 		if err != nil {
@@ -1727,7 +1727,7 @@ func (s *service) TriggerAsyncNamespacePipelineReleaseByID(ctx context.Context, 
 		}
 	} else {
 		resp, err := s.mgmtPublicServiceClient.GetUserSubscription(
-			metadata.AppendToOutgoingContext(ctx, "Jwt-Sub", resource.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey)),
+			metadata.AppendToOutgoingContext(ctx, "Instill-User-Uid", resource.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey)),
 			&mgmtPB.GetUserSubscriptionRequest{Parent: fmt.Sprintf("%s/%s", ns.NsType, ns.NsID)},
 		)
 		if err != nil {
@@ -1920,7 +1920,7 @@ func (s *service) CreateNamespaceConnector(ctx context.Context, ns resource.Name
 
 	if ns.NsType == resource.Organization {
 		resp, err := s.mgmtPublicServiceClient.GetOrganizationSubscription(
-			metadata.AppendToOutgoingContext(ctx, "Jwt-Sub", resource.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey)),
+			metadata.AppendToOutgoingContext(ctx, "Instill-User-Uid", resource.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey)),
 			&mgmtPB.GetOrganizationSubscriptionRequest{Parent: fmt.Sprintf("organizations/%s", ns.NsID)})
 		if err != nil {
 			s, ok := status.FromError(err)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -9,7 +8,6 @@ import (
 
 	"github.com/gofrs/uuid"
 	"github.com/influxdata/influxdb-client-go/v2/api/write"
-	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
 
@@ -25,24 +23,6 @@ import (
 	mgmtPB "github.com/instill-ai/protogen-go/core/mgmt/v1beta"
 	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
-
-func GenOwnerPermalink(owner *mgmtPB.User) string {
-	return "users/" + owner.GetUid()
-}
-
-func InjectOwnerToContext(ctx context.Context, owner *mgmtPB.User) context.Context {
-	ctx = metadata.AppendToOutgoingContext(ctx, "Jwt-Sub", owner.GetUid())
-	return ctx
-}
-func InjectOwnerToContextWithOwnerPermalink(ctx context.Context, permalink string) context.Context {
-	uid, _ := resource.GetRscPermalinkUID(permalink)
-	ctx = metadata.AppendToOutgoingContext(ctx, "Jwt-Sub", uid.String())
-	return ctx
-}
-func InjectOwnerToContextWithUserUid(ctx context.Context, userUid uuid.UUID) context.Context {
-	ctx = metadata.AppendToOutgoingContext(ctx, "Jwt-Sub", userUid.String())
-	return ctx
-}
 
 const (
 	CreateEvent          string = "Create"

--- a/pkg/worker/workflow.go
+++ b/pkg/worker/workflow.go
@@ -637,7 +637,7 @@ func (w *worker) ConnectorActivity(ctx context.Context, param *ExecuteConnectorA
 				logger.Fatal(err.Error())
 			}
 			// TODO: optimize this
-			str.Fields["instill_jwt_sub"] = structpb.NewStringValue(param.PipelineMetadata.UserUid)
+			str.Fields["instill_user_uid"] = structpb.NewStringValue(param.PipelineMetadata.UserUid)
 			str.Fields["instill_model_backend"] = structpb.NewStringValue(fmt.Sprintf("%s:%d", config.Config.ModelBackend.Host, config.Config.ModelBackend.PublicPort))
 			return &str
 		}


### PR DESCRIPTION
Because

- we want to remove unnecessary request to improve the performance
- need to standardize the naming convention of our headers 

This commit

- remove unnecessary mgmt-backend request
- change header `jwt-sub` to `Instill-User-Uid`
