### PR TITLE
fix: fix the wrong Temporal workflow retry setting

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -14,8 +14,8 @@ server:
   maxdatasize: 12 # MB in unit
   workflow:
     maxworkflowtimeout: 3600 # in seconds
-    maxworkflowretry: 3
-    maxactivityretry: 1
+    maxworkflowretry: 1
+    maxactivityretry: 3
 connector:
   airbyte:
     mountsource:


### PR DESCRIPTION
Because

- We only need retry for component execution, which is served by Temporal Activity. The Workflow retry is not needed since the recipe is the same, if it fail, it should fail forever.

This commit

- fix the wrong Temporal workflow retry setting
