### PR TITLE
chore: update test-cases for Airbyte connector

### DIFF
--- a/cmd/init/main.go
+++ b/cmd/init/main.go
@@ -25,7 +25,6 @@ import (
 	"github.com/instill-ai/pipeline-backend/pkg/utils"
 
 	connector "github.com/instill-ai/connector/pkg"
-	connectorAirbyte "github.com/instill-ai/connector/pkg/airbyte"
 	database "github.com/instill-ai/pipeline-backend/pkg/db"
 )
 
@@ -79,30 +78,6 @@ func main() {
 	defer database.Close(db)
 
 	repository := repository.NewRepository(db)
-
-	airbyte := connectorAirbyte.Init(logger, utils.GetConnectorOptions().Airbyte)
-
-	// TODO: use pagination
-	conns, _, _, err := repository.ListConnectorsAdmin(ctx, 1000, "", false, filtering.Filter{}, false)
-	if err != nil {
-		panic(err)
-	}
-
-	airbyteConnector := airbyte.(*connectorAirbyte.Connector)
-	var uids []uuid.UUID
-	for idx := range conns {
-		uid := conns[idx].ConnectorDefinitionUID
-		if _, err = airbyteConnector.GetConnectorDefinitionByUID(uid); err == nil {
-			uids = append(uids, uid)
-
-		}
-	}
-
-	err = airbyteConnector.PreDownloadImage(logger, uids)
-
-	if err != nil {
-		panic(err)
-	}
 
 	// Set tombstone based on definition
 	connector := connector.Init(logger, utils.GetConnectorOptions())

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/iancoleman/strcase v0.2.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
 	github.com/instill-ai/component v0.8.0-beta
-	github.com/instill-ai/connector v0.8.1-beta.0.20240101141631-464258f56792
+	github.com/instill-ai/connector v0.8.1-beta.0.20240101145810-52e840952243
 	github.com/instill-ai/operator v0.6.0-beta
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231214110613-21be2ae5d3e9
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20231206162018-6ccbff13136b

--- a/go.sum
+++ b/go.sum
@@ -1187,8 +1187,8 @@ github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
 github.com/instill-ai/component v0.8.0-beta h1:xXePzuaKhh9RjSnmo6mZE4QD8OkaAuWVxxero6b4Kyo=
 github.com/instill-ai/component v0.8.0-beta/go.mod h1:fWyVPJVJ4WyFSQMgWCc7KvcS7m9QpdS3VXCL2CZE8OY=
-github.com/instill-ai/connector v0.8.1-beta.0.20240101141631-464258f56792 h1:nvWPt8jmVeuYwxuto/ClxFidxULi9Q/te9IS+WdeSec=
-github.com/instill-ai/connector v0.8.1-beta.0.20240101141631-464258f56792/go.mod h1:QgaSVMIVkqZS4y5TGMrfk01h6dDVTGAZxVCRncA2grs=
+github.com/instill-ai/connector v0.8.1-beta.0.20240101145810-52e840952243 h1:UQBN4nMmsdBeaVkRdxG2NyhRy8TFwDUtUED77xo7NOc=
+github.com/instill-ai/connector v0.8.1-beta.0.20240101145810-52e840952243/go.mod h1:QgaSVMIVkqZS4y5TGMrfk01h6dDVTGAZxVCRncA2grs=
 github.com/instill-ai/operator v0.6.0-beta h1:G3imamqb9tDmOKYwzKqbvnKRaseX+PcNXpUJKu03lv8=
 github.com/instill-ai/operator v0.6.0-beta/go.mod h1:exFYtKdZFyzAczduFxQlD4X7+/B4OLYJ3ihA7j8Kcsg=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231214110613-21be2ae5d3e9 h1:Yv0wikxsdNbvyQSk1gsiUXTRlWDmh7+Qqb3mGy2qw80=

--- a/integration-test/connector/const.js
+++ b/integration-test/connector/const.js
@@ -30,11 +30,11 @@ export const mgmtPublicHost = apiGatewayMode ? `${proto}://${__ENV.API_GATEWAY_U
 export const pipelineGRPCPrivateHost = `pipeline-backend:3081`;
 export const pipelineGRPCPublicHost = apiGatewayMode ? `${__ENV.API_GATEWAY_URL}` : `api-gateway:8080`
 
-export const csvDstDefRscName = "connector-definitions/airbyte-destination-csv"
-export const csvDstDefRscPermalink = "connector-definitions/8be1cf83-fde1-477f-a4ad-318d23c9f3c6"
+export const csvDstDefRscName = "connector-definitions/airbyte-destination"
+export const csvDstDefRscPermalink = "connector-definitions/975678a2-5117-48a4-a135-019619dee18e"
 
-export const mySQLDstDefRscName = "connector-definitions/airbyte-destination-mysql"
-export const mySQLDstDefRscPermalink = "connector-definitions/ca81ee7c-3163-4246-af40-094cc31e5e42"
+export const mySQLDstDefRscName = "connector-definitions/airbyte-destination"
+export const mySQLDstDefRscPermalink = "connector-definitions/975678a2-5117-48a4-a135-019619dee18e"
 
 export const namespace = "users/admin"
 export const defaultUsername = "admin"
@@ -42,6 +42,7 @@ export const defaultPassword = "password"
 
 
 export const csvDstConfig = {
+  "destination": "airbyte-destination-csv",
   "destination_path": "/local/test"
 };
 

--- a/integration-test/connector/grpc-data-connector-public-with-jwt.js
+++ b/integration-test/connector/grpc-data-connector-public-with-jwt.js
@@ -43,6 +43,7 @@ export function CheckCreate(metadata) {
             "id": randomString(10),
             "connector_definition_name": constant.mySQLDstDefRscName,
             "configuration": {
+                "destination": "airbyte-destiniation-mysql",
                 "host": randomString(10),
                 "port": 3306,
                 "username": randomString(10),
@@ -366,6 +367,7 @@ export function CheckExecute(metadata) {
             "connector_definition_name": constant.csvDstDefRscName,
             "description": randomString(50),
             "configuration": {
+                "destination": "airbyte-destination-csv",
                 "destination_path": "/local/test-classification"
             },
         }

--- a/integration-test/connector/grpc-data-connector-public.js
+++ b/integration-test/connector/grpc-data-connector-public.js
@@ -59,6 +59,7 @@ export function CheckCreate(metadata) {
             "id": randomString(10),
             "connector_definition_name": constant.mySQLDstDefRscName,
             "configuration": {
+                "destination": "airbyte-destiniation-mysql",
                 "host": randomString(10),
                 "port": 3306,
                 "username": randomString(10),
@@ -620,6 +621,7 @@ export function CheckExecute(metadata) {
             "connector_definition_name": constant.csvDstDefRscName,
             "description": randomString(50),
             "configuration": {
+                "destination": "airbyte-destination-csv",
                 "destination_path": "/local/test-classification"
             },
         }
@@ -661,6 +663,7 @@ export function CheckExecute(metadata) {
             "connector_definition_name": constant.csvDstDefRscName,
             "description": randomString(50),
             "configuration": {
+                "destination": "airbyte-destination-csv",
                 "destination_path": "/local/test-detection-empty-bounding-boxes"
             },
         }
@@ -701,6 +704,7 @@ export function CheckExecute(metadata) {
             "connector_definition_name": constant.csvDstDefRscName,
             "description": randomString(50),
             "configuration": {
+                "destination": "airbyte-destination-csv",
                 "destination_path": "/local/test-detection-multi-models"
             },
         }
@@ -741,6 +745,7 @@ export function CheckExecute(metadata) {
             "connector_definition_name": constant.csvDstDefRscName,
             "description": randomString(50),
             "configuration": {
+                "destination": "airbyte-destination-csv",
                 "destination_path": "/local/test-keypoint"
             },
         }
@@ -782,6 +787,7 @@ export function CheckExecute(metadata) {
             "connector_definition_name": constant.csvDstDefRscName,
             "description": randomString(50),
             "configuration": {
+                "destination": "airbyte-destination-csv",
                 "destination_path": "/local/test-ocr"
             },
         }
@@ -822,6 +828,7 @@ export function CheckExecute(metadata) {
             "connector_definition_name": constant.csvDstDefRscName,
             "description": randomString(50),
             "configuration": {
+                "destination": "airbyte-destination-csv",
                 "destination_path": "/local/test-semantic-segmentation"
             },
         }
@@ -862,6 +869,7 @@ export function CheckExecute(metadata) {
             "connector_definition_name": constant.csvDstDefRscName,
             "description": randomString(50),
             "configuration": {
+                "destination": "airbyte-destination-csv",
                 "destination_path": "/local/test-instance-segmentation"
             },
         }
@@ -902,6 +910,7 @@ export function CheckExecute(metadata) {
             "connector_definition_name": constant.csvDstDefRscName,
             "description": randomString(50),
             "configuration": {
+                "destination": "airbyte-destination-csv",
                 "destination_path": "/local/test-text-to-image"
             },
         }
@@ -942,6 +951,7 @@ export function CheckExecute(metadata) {
             "connector_definition_name": constant.csvDstDefRscName,
             "description": randomString(50),
             "configuration": {
+                "destination": "airbyte-destination-csv",
                 "destination_path": "/local/test-unspecified"
             },
         }

--- a/integration-test/connector/rest-data-connector-public-with-jwt.js
+++ b/integration-test/connector/rest-data-connector-public-with-jwt.js
@@ -207,6 +207,7 @@ export function CheckExecute(header) {
             "connector_definition_name": constant.csvDstDefRscName,
             "description": randomString(50),
             "configuration": {
+                "destination": "airbyte-destination-csv",
                 "destination_path": "/local/test-classification"
             },
         }

--- a/integration-test/connector/rest-data-connector-public.js
+++ b/integration-test/connector/rest-data-connector-public.js
@@ -276,7 +276,9 @@ export function CheckConnect(header) {
             "id": randomString(10),
             "connector_definition_name": constant.csvDstDefRscName,
             "description": randomString(50),
-            "configuration": {}
+            "configuration": {
+                "destination": "airbyte-destination-csv",
+            }
         }
 
         // Cannot connect with unfinished config
@@ -434,6 +436,7 @@ export function CheckExecute(header) {
             "connector_definition_name": constant.csvDstDefRscName,
             "description": randomString(50),
             "configuration": {
+                "destination": "airbyte-destination-csv",
                 "destination_path": "/local/test-classification"
             },
         }
@@ -468,6 +471,7 @@ export function CheckExecute(header) {
             "connector_definition_name": constant.csvDstDefRscName,
             "description": randomString(50),
             "configuration": {
+                "destination": "airbyte-destination-csv",
                 "destination_path": "/local/test-detection-empty-bounding-boxes"
             },
 
@@ -502,6 +506,7 @@ export function CheckExecute(header) {
             "connector_definition_name": constant.csvDstDefRscName,
             "description": randomString(50),
             "configuration": {
+                "destination": "airbyte-destination-csv",
                 "destination_path": "/local/test-detection-multi-models"
             },
 
@@ -536,6 +541,7 @@ export function CheckExecute(header) {
             "connector_definition_name": constant.csvDstDefRscName,
             "description": randomString(50),
             "configuration": {
+                "destination": "airbyte-destination-csv",
                 "destination_path": "/local/test-keypoint"
             },
         }
@@ -568,6 +574,7 @@ export function CheckExecute(header) {
             "connector_definition_name": constant.csvDstDefRscName,
             "description": randomString(50),
             "configuration": {
+                "destination": "airbyte-destination-csv",
                 "destination_path": "/local/test-ocr"
             },
         }
@@ -601,6 +608,7 @@ export function CheckExecute(header) {
             "connector_definition_name": constant.csvDstDefRscName,
             "description": randomString(50),
             "configuration": {
+                "destination": "airbyte-destination-csv",
                 "destination_path": "/local/test-semantic-segmentation"
             }
         }
@@ -635,6 +643,7 @@ export function CheckExecute(header) {
             "connector_definition_name": constant.csvDstDefRscName,
             "description": randomString(50),
             "configuration": {
+                "destination": "airbyte-destination-csv",
                 "destination_path": "/local/test-instance-segmentation"
             },
 
@@ -669,6 +678,7 @@ export function CheckExecute(header) {
             "connector_definition_name": constant.csvDstDefRscName,
             "description": randomString(50),
             "configuration": {
+                "destination": "airbyte-destination-csv",
                 "destination_path": "/local/test-text-to-image"
             }
         }
@@ -702,6 +712,7 @@ export function CheckExecute(header) {
             "connector_definition_name": constant.csvDstDefRscName,
             "description": randomString(50),
             "configuration": {
+                "destination": "airbyte-destination-csv",
                 "destination_path": "/local/test-unspecified"
             }
         }

--- a/integration-test/pipeline/const.js
+++ b/integration-test/pipeline/const.js
@@ -113,7 +113,7 @@ export const simpleRecipe = {
       {
         id: "d01",
         resource_name: `users/instill-ai/connectors/${dstCSVConnID1}`,
-        definition_name: "connector-definitions/airbyte-destination-csv",
+        definition_name: "connector-definitions/airbyte-destination",
         configuration: {
           input: {
             data: {
@@ -125,7 +125,7 @@ export const simpleRecipe = {
       {
         id: "d02",
         resource_name: `users/instill-ai/connectors/${dstCSVConnID2}`,
-        definition_name: "connector-definitions/airbyte-destination-csv",
+        definition_name: "connector-definitions/airbyte-destination",
         configuration: {
           input: {
             data: {
@@ -207,7 +207,7 @@ export const simpleRecipeDupId = {
       {
         id: "d01",
         resource_name: `users/instill-ai/connectors/${dstCSVConnID1}`,
-        definition_name: "connector-definitions/airbyte-destination-csv",
+        definition_name: "connector-definitions/airbyte-destination",
         configuration: {
           input: {
             data: {
@@ -219,7 +219,7 @@ export const simpleRecipeDupId = {
       {
         id: "d01",
         resource_name: `users/instill-ai/connectors/${dstCSVConnID2}`,
-        definition_name: "connector-definitions/airbyte-destination-csv",
+        definition_name: "connector-definitions/airbyte-destination",
         configuration: {
           input: {
             data: {

--- a/integration-test/pipeline/grpc.js
+++ b/integration-test/pipeline/grpc.js
@@ -58,8 +58,9 @@ export function setup() {
             connector: {
               id: constant.dstCSVConnID1,
               connector_definition_name:
-                "connector-definitions/airbyte-destination-csv",
+                "connector-definitions/airbyte-destination",
               configuration: {
+                destination: "airbyte-destination-csv",
                 destination_path: "/local/pipeline-backend-test-1",
               },
             },
@@ -91,8 +92,9 @@ export function setup() {
             connector: {
               id: constant.dstCSVConnID2,
               connector_definition_name:
-                "connector-definitions/airbyte-destination-csv",
+                "connector-definitions/airbyte-destination",
               configuration: {
+                destination: "airbyte-destination-csv",
                 destination_path: "/local/pipeline-backend-test-2",
               },
             },

--- a/integration-test/pipeline/rest.js
+++ b/integration-test/pipeline/rest.js
@@ -51,8 +51,9 @@ export function setup() {
     var res = http.request("POST", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors`,
       JSON.stringify({
         "id": constant.dstCSVConnID1,
-        "connector_definition_name": "connector-definitions/airbyte-destination-csv",
+        "connector_definition_name": "connector-definitions/airbyte-destination",
         "configuration": {
+          "destination": "airbyte-destination-csv",
           "destination_path": "/local/pipeline-backend-test-1"
         }
       }), header)
@@ -70,8 +71,9 @@ export function setup() {
     var res = http.request("POST", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors`,
       JSON.stringify({
         "id": constant.dstCSVConnID2,
-        "connector_definition_name": "connector-definitions/airbyte-destination-csv",
+        "connector_definition_name": "connector-definitions/airbyte-destination",
         "configuration": {
+          "destination": "airbyte-destination-csv",
           "destination_path": "/local/pipeline-backend-test-2"
         }
       }), header)


### PR DESCRIPTION
Because

- Airbyte connectors have been merged into one

This commit

- update test-cases for Airbyte connector
- remove `PreDownloadImage()`
