### PR TITLE
feat: support dynamic connector and operator definition

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,8 +16,8 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0
 	github.com/iancoleman/strcase v0.2.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/component v0.8.0-beta.0.20240110183225-60b21171a6ab
-	github.com/instill-ai/connector v0.9.0-beta.0.20240110040755-9bc404800d3e
+	github.com/instill-ai/component v0.8.0-beta.0.20240112032605-792559e0b538
+	github.com/instill-ai/connector v0.9.0-beta.0.20240112034820-bd68d14da5ce
 	github.com/instill-ai/operator v0.6.0-beta.0.20240108023644-8644208adde4
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240105094938-3a71d8f7a812
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20231206162018-6ccbff13136b

--- a/go.sum
+++ b/go.sum
@@ -1185,11 +1185,8 @@ github.com/influxdata/influxdb-client-go/v2 v2.12.3 h1:28nRlNMRIV4QbtIUvxhWqaxn0
 github.com/influxdata/influxdb-client-go/v2 v2.12.3/go.mod h1:IrrLUbCjjfkmRuaCiGQg4m2GbkaeJDcuWoxiWdQEbA0=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/instill-ai/component v0.8.0-beta.0.20240110183225-60b21171a6ab h1:HeP0cDDmgvHcBq08NIruXJ36pVtThBaahI1MFUSjunU=
-github.com/instill-ai/component v0.8.0-beta.0.20240110183225-60b21171a6ab/go.mod h1:fWyVPJVJ4WyFSQMgWCc7KvcS7m9QpdS3VXCL2CZE8OY=
+github.com/instill-ai/component v0.8.0-beta.0.20240112032605-792559e0b538 h1:wHkWugd03PwOrupcwrd8/FBaeQhKyvK0xmEK6vwmZVM=
 github.com/instill-ai/component v0.8.0-beta.0.20240112032605-792559e0b538/go.mod h1:fWyVPJVJ4WyFSQMgWCc7KvcS7m9QpdS3VXCL2CZE8OY=
-github.com/instill-ai/connector v0.9.0-beta.0.20240110040755-9bc404800d3e h1:0s6UEpn8f5eIcmbyJVtimbLP7pHvRt6duWI2k1+q2Y4=
-github.com/instill-ai/connector v0.9.0-beta.0.20240110040755-9bc404800d3e/go.mod h1:5KQ7C4E8t9KPr3GmpWVPIyy0i16JwZgaYclDcLCVNBo=
 github.com/instill-ai/connector v0.9.0-beta.0.20240112034820-bd68d14da5ce h1:nP01eO8lkOB0ig1zK9NLqVzUumc80K6T2UNujgcZS5w=
 github.com/instill-ai/connector v0.9.0-beta.0.20240112034820-bd68d14da5ce/go.mod h1:meUwooBcW0NQqNA/9cfdrDGWA9VqK5hjLIvjtBxK4bg=
 github.com/instill-ai/operator v0.6.0-beta.0.20240108023644-8644208adde4 h1:gNxhkOnemxPMpN4vUkOXf1TilyN1kJUK6QQijoaboHg=

--- a/go.sum
+++ b/go.sum
@@ -1187,8 +1187,11 @@ github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
 github.com/instill-ai/component v0.8.0-beta.0.20240110183225-60b21171a6ab h1:HeP0cDDmgvHcBq08NIruXJ36pVtThBaahI1MFUSjunU=
 github.com/instill-ai/component v0.8.0-beta.0.20240110183225-60b21171a6ab/go.mod h1:fWyVPJVJ4WyFSQMgWCc7KvcS7m9QpdS3VXCL2CZE8OY=
+github.com/instill-ai/component v0.8.0-beta.0.20240112032605-792559e0b538/go.mod h1:fWyVPJVJ4WyFSQMgWCc7KvcS7m9QpdS3VXCL2CZE8OY=
 github.com/instill-ai/connector v0.9.0-beta.0.20240110040755-9bc404800d3e h1:0s6UEpn8f5eIcmbyJVtimbLP7pHvRt6duWI2k1+q2Y4=
 github.com/instill-ai/connector v0.9.0-beta.0.20240110040755-9bc404800d3e/go.mod h1:5KQ7C4E8t9KPr3GmpWVPIyy0i16JwZgaYclDcLCVNBo=
+github.com/instill-ai/connector v0.9.0-beta.0.20240112034820-bd68d14da5ce h1:nP01eO8lkOB0ig1zK9NLqVzUumc80K6T2UNujgcZS5w=
+github.com/instill-ai/connector v0.9.0-beta.0.20240112034820-bd68d14da5ce/go.mod h1:meUwooBcW0NQqNA/9cfdrDGWA9VqK5hjLIvjtBxK4bg=
 github.com/instill-ai/operator v0.6.0-beta.0.20240108023644-8644208adde4 h1:gNxhkOnemxPMpN4vUkOXf1TilyN1kJUK6QQijoaboHg=
 github.com/instill-ai/operator v0.6.0-beta.0.20240108023644-8644208adde4/go.mod h1:exFYtKdZFyzAczduFxQlD4X7+/B4OLYJ3ihA7j8Kcsg=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240105094938-3a71d8f7a812 h1:n1EQFT0NeXkmiCD/YtoLG+b/OPo2tNg7MVK0dHNFlvk=

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -414,7 +414,7 @@ func (s *service) ConvertReleaseIdAlias(ctx context.Context, ns resource.Namespa
 }
 
 func (s *service) GetOperatorDefinitionById(ctx context.Context, defId string) (*pipelinePB.OperatorDefinition, error) {
-	return s.operator.GetOperatorDefinitionByID(defId)
+	return s.operator.GetOperatorDefinitionByID(defId, nil)
 }
 
 func (s *service) ListOperatorDefinitions(ctx context.Context) []*pipelinePB.OperatorDefinition {
@@ -1853,7 +1853,7 @@ func (s *service) GetConnectorByUID(ctx context.Context, authUser *AuthUser, uid
 
 func (s *service) GetConnectorDefinitionByID(ctx context.Context, id string, view View) (*pipelinePB.ConnectorDefinition, error) {
 
-	def, err := s.connector.GetConnectorDefinitionByID(id)
+	def, err := s.connector.GetConnectorDefinitionByID(id, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1867,7 +1867,7 @@ func (s *service) GetConnectorDefinitionByID(ctx context.Context, id string, vie
 }
 func (s *service) GetConnectorDefinitionByUIDAdmin(ctx context.Context, uid uuid.UUID, view View) (*pipelinePB.ConnectorDefinition, error) {
 
-	def, err := s.connector.GetConnectorDefinitionByUID(uid)
+	def, err := s.connector.GetConnectorDefinitionByUID(uid, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1936,7 +1936,7 @@ func (s *service) CreateNamespaceConnector(ctx context.Context, ns resource.Name
 		}
 	}
 
-	connDefResp, err := s.connector.GetConnectorDefinitionByID(strings.Split(connector.ConnectorDefinitionName, "/")[1])
+	connDefResp, err := s.connector.GetConnectorDefinitionByID(strings.Split(connector.ConnectorDefinitionName, "/")[1], nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/service/validator.go
+++ b/pkg/service/validator.go
@@ -41,11 +41,11 @@ func (s *service) checkRecipe(ownerPermalink string, recipePermalink *datamodel.
 		componentIdMap[recipePermalink.Components[idx].Id] = recipePermalink.Components[idx]
 	}
 
-	startOpDef, err := s.operator.GetOperatorDefinitionByID("start")
+	startOpDef, err := s.operator.GetOperatorDefinitionByID("start", nil)
 	if err != nil {
 		return fmt.Errorf("operator-definitions/start not found")
 	}
-	endOpDef, err := s.operator.GetOperatorDefinitionByID("end")
+	endOpDef, err := s.operator.GetOperatorDefinitionByID("end", nil)
 	if err != nil {
 		return fmt.Errorf("operator-definitions/end not found")
 	}
@@ -67,7 +67,7 @@ func (s *service) checkRecipe(ownerPermalink string, recipePermalink *datamodel.
 				return fmt.Errorf("operator definition for component %s is not found", recipePermalink.Components[idx].Id)
 			}
 
-			def, err := s.connector.GetConnectorDefinitionByUID(uid)
+			def, err := s.connector.GetConnectorDefinitionByUID(uid, nil, nil)
 			if err != nil {
 				return fmt.Errorf("operator definition for component %s is not found", recipePermalink.Components[idx].Id)
 			}
@@ -86,7 +86,7 @@ func (s *service) checkRecipe(ownerPermalink string, recipePermalink *datamodel.
 				return fmt.Errorf("operator definition for component %s is not found", recipePermalink.Components[idx].Id)
 			}
 
-			def, err := s.operator.GetOperatorDefinitionByUID(uid)
+			def, err := s.operator.GetOperatorDefinitionByUID(uid, nil)
 			if err != nil {
 				return fmt.Errorf("operator definition for component %s is not found", recipePermalink.Components[idx].Id)
 			}

--- a/pkg/utils/dag.go
+++ b/pkg/utils/dag.go
@@ -172,7 +172,7 @@ func RenderInput(input interface{}, bindings map[string]interface{}) (interface{
 		if strings.HasPrefix(input, "${") && strings.HasSuffix(input, "}") && strings.Count(input, "${") == 1 {
 			input = input[2:]
 			input = input[:len(input)-1]
-			input = strings.ReplaceAll(input, " ", "")
+			input = strings.TrimSpace(input)
 			if input[0] == '[' && input[len(input)-1] == ']' {
 				outs := []interface{}{}
 				subInputs := strings.Split(input[1:len(input)-1], ",")
@@ -549,7 +549,7 @@ func FindReferenceParent(input string) []string {
 
 			parsed = parsed[2:]
 			parsed = parsed[:len(parsed)-1]
-			parsed = strings.ReplaceAll(parsed, " ", "")
+			parsed = strings.TrimSpace(parsed)
 			if parsed[0] == '[' && parsed[len(parsed)-1] == ']' {
 				parents := []string{}
 				subStrs := strings.Split(parsed[1:len(parsed)-1], ",")

--- a/pkg/worker/workflow.go
+++ b/pkg/worker/workflow.go
@@ -622,7 +622,7 @@ func (w *worker) ConnectorActivity(ctx context.Context, param *ExecuteConnectorA
 		return nil, err
 	}
 
-	con, err := w.connector.GetConnectorDefinitionByUID(uuid.FromStringOrNil(strings.Split(param.DefinitionName, "/")[1]))
+	con, err := w.connector.GetConnectorDefinitionByUID(uuid.FromStringOrNil(strings.Split(param.DefinitionName, "/")[1]), nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -680,7 +680,7 @@ func (w *worker) OperatorActivity(ctx context.Context, param *ExecuteOperatorAct
 		return nil, err
 	}
 
-	op, err := w.operator.GetOperatorDefinitionByUID(uuid.FromStringOrNil(strings.Split(param.DefinitionName, "/")[1]))
+	op, err := w.operator.GetOperatorDefinitionByUID(uuid.FromStringOrNil(strings.Split(param.DefinitionName, "/")[1]), nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Because

Originally, our connector definitions are fixed. However, in some scenarios, the definition will be dynamic.

The component JSON schema can be influenced by connector configuration. For example, the Instill Model Connector can retrieve the model list and incorporate it into the component JSON schema as an enumeration.

The OpenAPI schema can be influenced by both connector and component configuration. For example, we can let user define the JSON schema of the output body in the RestAPI connector and utilize it to generate the OpenAPI schema of the RestAPI connector.

Therefore, we would like to make these connector definitions dynamically generated.

This commit

- support dynamic connector and operator definition
