### PR TITLE
feat: support `q` filter for fuzzy search on `id`

### DIFF
--- a/pkg/handler/pipeline.go
+++ b/pkg/handler/pipeline.go
@@ -39,6 +39,7 @@ func (h *PrivateHandler) ListPipelinesAdmin(ctx context.Context, req *pipelinePB
 	declarations, err := filtering.NewDeclarations([]filtering.DeclarationOption{
 		filtering.DeclareStandardFunctions(),
 		filtering.DeclareFunction("time.now", filtering.NewFunctionOverload("time.now", filtering.TypeTimestamp)),
+		filtering.DeclareIdent("q", filtering.TypeString),
 		filtering.DeclareIdent("uid", filtering.TypeString),
 		filtering.DeclareIdent("id", filtering.TypeString),
 		filtering.DeclareIdent("description", filtering.TypeString),
@@ -104,6 +105,7 @@ func (h *PrivateHandler) ListPipelineReleasesAdmin(ctx context.Context, req *pip
 	declarations, err := filtering.NewDeclarations([]filtering.DeclarationOption{
 		filtering.DeclareStandardFunctions(),
 		filtering.DeclareFunction("time.now", filtering.NewFunctionOverload("time.now", filtering.TypeTimestamp)),
+		filtering.DeclareIdent("q", filtering.TypeString),
 		filtering.DeclareIdent("uid", filtering.TypeString),
 		filtering.DeclareIdent("id", filtering.TypeString),
 		filtering.DeclareIdent("description", filtering.TypeString),
@@ -157,6 +159,7 @@ func (h *PublicHandler) ListPipelines(ctx context.Context, req *pipelinePB.ListP
 	declarations, err := filtering.NewDeclarations([]filtering.DeclarationOption{
 		filtering.DeclareStandardFunctions(),
 		filtering.DeclareFunction("time.now", filtering.NewFunctionOverload("time.now", filtering.TypeTimestamp)),
+		filtering.DeclareIdent("q", filtering.TypeString),
 		filtering.DeclareIdent("uid", filtering.TypeString),
 		filtering.DeclareIdent("id", filtering.TypeString),
 		filtering.DeclareIdent("description", filtering.TypeString),
@@ -349,6 +352,7 @@ func (h *PublicHandler) listNamespacePipelines(ctx context.Context, req ListName
 	declarations, err := filtering.NewDeclarations([]filtering.DeclarationOption{
 		filtering.DeclareStandardFunctions(),
 		filtering.DeclareFunction("time.now", filtering.NewFunctionOverload("time.now", filtering.TypeTimestamp)),
+		filtering.DeclareIdent("q", filtering.TypeString),
 		filtering.DeclareIdent("uid", filtering.TypeString),
 		filtering.DeclareIdent("id", filtering.TypeString),
 		filtering.DeclareIdent("description", filtering.TypeString),
@@ -1077,6 +1081,7 @@ func (h *PublicHandler) listNamespacePipelineReleases(ctx context.Context, req L
 	declarations, err := filtering.NewDeclarations([]filtering.DeclarationOption{
 		filtering.DeclareStandardFunctions(),
 		filtering.DeclareFunction("time.now", filtering.NewFunctionOverload("time.now", filtering.TypeTimestamp)),
+		filtering.DeclareIdent("q", filtering.TypeString),
 		filtering.DeclareIdent("uid", filtering.TypeString),
 		filtering.DeclareIdent("id", filtering.TypeString),
 		filtering.DeclareIdent("description", filtering.TypeString),

--- a/pkg/repository/transpiler.go
+++ b/pkg/repository/transpiler.go
@@ -179,8 +179,13 @@ func (t *Transpiler) transpileComparisonCallExpr(e *expr.Expr, op interface{}) (
 	var vars []interface{}
 	switch op.(type) {
 	case clause.Eq:
-		sql = fmt.Sprintf("%s = ?", ident.SQL)
-		vars = append(vars, con.Vars...)
+		if ident.SQL == "q" {
+			sql = fmt.Sprintf("%s LIKE ?", "id")
+			vars = append(vars, fmt.Sprintf("%%%s%%", con.Vars[0]))
+		} else {
+			sql = fmt.Sprintf("%s = ?", ident.SQL)
+			vars = append(vars, con.Vars...)
+		}
 	case clause.Neq:
 		sql = fmt.Sprintf("%s <> ?", ident.SQL)
 		vars = append(vars, con.Vars...)


### PR DESCRIPTION
Because

- We want to introduce a feature that allows users to search for pipelines by `id` using fuzzy search instead of exact matching.

This commit

- Supports the `q` filter for fuzzy searching on `id`.