### PR TITLE
chore(usage): add pipeline id in usage data

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,8 +19,8 @@ require (
 	github.com/instill-ai/component v0.9.0-beta
 	github.com/instill-ai/connector v0.10.0-beta
 	github.com/instill-ai/operator v0.6.1-beta
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240105094938-3a71d8f7a812
-	github.com/instill-ai/usage-client v0.2.4-alpha.0.20231206162018-6ccbff13136b
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240122214718-7d090df83765
+	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.3.0-alpha.0.20231219052200-6230a89e386c
 	github.com/knadh/koanf v1.5.0
 	github.com/mennanov/fieldmask-utils v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1191,10 +1191,10 @@ github.com/instill-ai/connector v0.10.0-beta h1:Xuio1tBKzaS7n7x6rudKxdt1kysJEFWy
 github.com/instill-ai/connector v0.10.0-beta/go.mod h1:+umF+6jNQ4iP4djxJHT7u/yDErJesMuWI6wt8fqP+Lc=
 github.com/instill-ai/operator v0.6.1-beta h1:RoEXiwXs0mYPq7VcAAZxv4S1P+Ybsv7Nt2HEihjGQSs=
 github.com/instill-ai/operator v0.6.1-beta/go.mod h1:ROHmvSRF7lQD6/7uOHeBVNcsuQqxPoMtDc6so8XNFwU=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240105094938-3a71d8f7a812 h1:n1EQFT0NeXkmiCD/YtoLG+b/OPo2tNg7MVK0dHNFlvk=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240105094938-3a71d8f7a812/go.mod h1:jhEL0SauySMoPLVvx105DWyThju9sYTbsXIySVCArmM=
-github.com/instill-ai/usage-client v0.2.4-alpha.0.20231206162018-6ccbff13136b h1:YwXracXgTWxaPfIsbC3uaZFjGO0E2y1e3hK9ZUq7ipE=
-github.com/instill-ai/usage-client v0.2.4-alpha.0.20231206162018-6ccbff13136b/go.mod h1:4uTzVtcC+UVKhRaNvJc2+LFLcr/fv3vsYE5QCWu6TQ0=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240122214718-7d090df83765 h1:nFS0byEkAMloOQq9ULBKF3WDvTv5cfvv12BrRgaGwcU=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240122214718-7d090df83765/go.mod h1:jhEL0SauySMoPLVvx105DWyThju9sYTbsXIySVCArmM=
+github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=
+github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a/go.mod h1:EpX3Yr661uWULtZf5UnJHfr5rw2PDyX8ku4Kx0UtYFw=
 github.com/instill-ai/x v0.3.0-alpha.0.20231219052200-6230a89e386c h1:a2RVkpIV2QcrGnSHAou+t/L+vBsaIfFvk5inVg5Uh4s=
 github.com/instill-ai/x v0.3.0-alpha.0.20231219052200-6230a89e386c/go.mod h1:L6jmDPrUou6XskaLXZuK/gDeitdoPa9yE8ONKt1ZwCw=
 github.com/intel/goresctrl v0.2.0/go.mod h1:+CZdzouYFn5EsxgqAQTEzMfwKwuc0fVdMrT9FCCAVRQ=

--- a/pkg/usage/usage.go
+++ b/pkg/usage/usage.go
@@ -121,6 +121,7 @@ func (u *usage) RetrievePipelineUsageData() interface{} {
 					triggerDataList = append(
 						triggerDataList,
 						&usagePB.PipelineUsageData_UserUsageData_PipelineTriggerData{
+							PipelineId:         triggerData.PipelineID,
 							PipelineUid:        triggerData.PipelineUID,
 							PipelineReleaseId:  triggerData.PipelineReleaseID,
 							PipelineReleaseUid: triggerData.PipelineReleaseUID,


### PR DESCRIPTION
Because

- pipeline_id is more informative in the context of grafana dashboard

This commit

- add pipeline_id in PipelineUsageData

resolves INS-3467