### PR TITLE
feat: add end-user errors on CreateExecution error

### DIFF
--- a/pkg/worker/workflow.go
+++ b/pkg/worker/workflow.go
@@ -598,7 +598,7 @@ func (w *worker) ConnectorActivity(ctx context.Context, param *ExecuteConnectorA
 
 	execution, err := w.connector.CreateExecution(uuid.FromStringOrNil(con.Uid), param.Task, configuration, logger)
 	if err != nil {
-		return nil, err
+		return nil, w.toApplicationError(err, param.ID, ConnectorActivityError)
 	}
 	compOutputs, err := execution.ExecuteWithValidation(compInputs)
 	if err != nil {


### PR DESCRIPTION
Because

- https://github.com/instill-ai/connector/pull/113 introduced an [end-user error](https://github.com/instill-ai/connector/pull/113/files#diff-ccd0d26c1e8d29bcffb2741e853132db31305425679cdc929b82eb8af6c3824cR79) in a `CreateExecution` function, which isn't displayed correctly in console.

This commit

- Checks the response from `CreateExecution` and adds any potential end-user error as a Temporal error message.
