### PR TITLE
test: increase timeout

### DIFF
--- a/integration-test/pipeline/const.js
+++ b/integration-test/pipeline/const.js
@@ -51,14 +51,14 @@ export const params = {
   headers: {
     "Content-Type": "application/json",
   },
-  timeout: "10s",
+  timeout: "300s",
 };
 
 export const paramsGrpc = {
   metadata: {
     "Content-Type": "application/json",
   },
-  timeout: "10s",
+  timeout: "300s",
 };
 
 const randomUUID = uuidv4();

--- a/integration-test/pipeline/grpc.js
+++ b/integration-test/pipeline/grpc.js
@@ -26,7 +26,7 @@ export let options = {
 export function setup() {
   client.connect(constant.pipelineGRPCPublicHost, {
     plaintext: true,
-    timeout: "10s",
+    timeout: "300s",
   });
 
   var loginResp = http.request("POST", `${constant.mgmtPublicHost}/v1beta/auth/login`, JSON.stringify({


### PR DESCRIPTION
Because

- Some test-cases are flaky due to timeout.

This commit

- Increase timeout in test
