### PR TITLE
feat: add end-user errors on CreateExecution error

### DIFF
--- a/pkg/worker/workflow.go
+++ b/pkg/worker/workflow.go
@@ -631,7 +631,7 @@ func (w *worker) OperatorActivity(ctx context.Context, param *ExecuteOperatorAct
 
 	execution, err := w.operator.CreateExecution(uuid.FromStringOrNil(op.Uid), param.Task, nil, logger)
 	if err != nil {
-		return nil, err
+		return nil, w.toApplicationError(err, param.ID, OperatorActivityError)
 	}
 	compOutputs, err := execution.ExecuteWithValidation(compInputs)
 	if err != nil {


### PR DESCRIPTION
Because

- As in b72ac08, operators may return end-user errors during execution creation.

This commit

- Captures error messages in `operator.CreateExecution`.
