### PR TITLE
ci(Dockerfile): add curl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN mkdir /airbyte
 
 FROM alpine:3.16
 
-RUN apk add poppler-utils wv tidyhtml libc6-compat tesseract-ocr
+RUN apk add curl poppler-utils wv tidyhtml libc6-compat tesseract-ocr
 
 ARG TARGETARCH
 ARG BUILDARCH


### PR DESCRIPTION
Because

- we want to make the backend container self-healthcheck so the other dependencies can precisely know the container health status

This commit

- add `curl` for running `curl -f http://${PIPELINE_BACKEND_HOST}:${PIPELINE_BACKEND_PUBLICPORT}/v1beta/health/pipeline` in docker compose `healthcheck`
