### PR TITLE
fix(worker): fix temporal cloud namespace init

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -133,7 +133,10 @@ func main() {
 	}
 	defer temporalClient.Close()
 
-	initTemporalNamespace(ctx, temporalClient)
+	// for only local temporal cluster
+	if config.Config.Temporal.Ca == "" && config.Config.Temporal.Cert == "" && config.Config.Temporal.Key == "" {
+		initTemporalNamespace(ctx, temporalClient)
+	}
 
 	redisClient := redis.NewClient(&config.Config.Cache.Redis.RedisOptions)
 	defer redisClient.Close()


### PR DESCRIPTION
Because

- we can't programmatically list namespace in Temporal Cloud (i.e., `tcld` is the current only way to pass the authentication) 

This commit

- bypass the initialisation of namespace for Temporal Cloud route
