### PR TITLE
chore(worker): use config temporal namespace

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -26,8 +26,6 @@ import (
 	pipelineWorker "github.com/instill-ai/pipeline-backend/pkg/worker"
 )
 
-const namespace = "pipeline-backend"
-
 func initTemporalNamespace(ctx context.Context, client client.Client) {
 	logger, _ := logger.GetZapLogger(ctx)
 
@@ -38,7 +36,7 @@ func initTemporalNamespace(ctx context.Context, client client.Client) {
 
 	found := false
 	for _, n := range resp.GetNamespaces() {
-		if n.NamespaceInfo.Name == namespace {
+		if n.NamespaceInfo.Name == config.Config.Temporal.Namespace {
 			found = true
 		}
 	}
@@ -46,7 +44,7 @@ func initTemporalNamespace(ctx context.Context, client client.Client) {
 	if !found {
 		if _, err := client.WorkflowService().RegisterNamespace(ctx,
 			&workflowservice.RegisterNamespaceRequest{
-				Namespace: namespace,
+				Namespace: config.Config.Temporal.Namespace,
 				WorkflowExecutionRetentionPeriod: func() *time.Duration {
 					// Check if the string ends with "d" for day.
 					s := config.Config.Temporal.Retention


### PR DESCRIPTION
Because

- config has the temporal namespace set

This commit

- replace the const namespace variable with the configured one
