### PR TITLE
test: use owner profile from mgmtdb as expected result

### DIFF
--- a/integration-test/connector/const.js
+++ b/integration-test/connector/const.js
@@ -26,6 +26,7 @@ if (__ENV.API_GATEWAY_PROTOCOL) {
 export const pipelinePrivateHost = `http://pipeline-backend:3081`;
 export const pipelinePublicHost = apiGatewayMode ? `${proto}://${__ENV.API_GATEWAY_URL}/vdp` : `http://api-gateway:8080/vdp`
 export const mgmtPublicHost = apiGatewayMode ? `${proto}://${__ENV.API_GATEWAY_URL}/core` : `http://api-gateway:8080/core`
+export const mgmtGRPCPublicHost = apiGatewayMode ? `${__ENV.API_GATEWAY_URL}` : `api-gateway:8080`;
 
 export const pipelineGRPCPrivateHost = `pipeline-backend:3081`;
 export const pipelineGRPCPublicHost = apiGatewayMode ? `${__ENV.API_GATEWAY_URL}` : `api-gateway:8080`

--- a/integration-test/connector/grpc-data-connector-definition.js
+++ b/integration-test/connector/grpc-data-connector-definition.js
@@ -13,7 +13,7 @@ import {
 const client = new grpc.Client();
 client.load(['../proto/vdp/pipeline/v1beta'], 'pipeline_public_service.proto');
 
-export function CheckList(metadata) {
+export function CheckList(data) {
 
     group("Connector API: List data connector definitions", () => {
 
@@ -23,7 +23,7 @@ export function CheckList(metadata) {
 
         check(client.invoke('vdp.pipeline.v1beta.PipelinePublicService/ListConnectorDefinitions', {
             filter: "connector_type=CONNECTOR_TYPE_DATA"
-        }, metadata), {
+        }, data.metadata), {
             [`vdp.pipeline.v1beta.PipelinePublicService/ListConnectorDefinitions response StatusOK`]: (r) => r.status === grpc.StatusOK,
             [`vdp.pipeline.v1beta.PipelinePublicService/ListConnectorDefinitions response connectorDefinitions array`]: (r) => Array.isArray(r.message.connectorDefinitions),
             [`vdp.pipeline.v1beta.PipelinePublicService/ListConnectorDefinitions response totalSize > 0`]: (r) => r.message.totalSize > 0,
@@ -35,7 +35,7 @@ export function CheckList(metadata) {
         check(client.invoke('vdp.pipeline.v1beta.PipelinePublicService/ListConnectorDefinitions', {
             filter: "connector_type=CONNECTOR_TYPE_DATA",
             pageSize: 0
-        }, metadata), {
+        }, data.metadata), {
             [`vdp.pipeline.v1beta.PipelinePublicService/ListConnectorDefinitions pageSize=0 response StatusOK`]: (r) => r.status === grpc.StatusOK,
             [`vdp.pipeline.v1beta.PipelinePublicService/ListConnectorDefinitions pageSize=0 response connectorDefinitions length = 1`]: (r) => r.message.connectorDefinitions.length === limitedRecords.message.connectorDefinitions.length,
         });
@@ -43,7 +43,7 @@ export function CheckList(metadata) {
         check(client.invoke('vdp.pipeline.v1beta.PipelinePublicService/ListConnectorDefinitions', {
             filter: "connector_type=CONNECTOR_TYPE_DATA",
             pageSize: 1
-        }, metadata), {
+        }, data.metadata), {
             [`vdp.pipeline.v1beta.PipelinePublicService/ListConnectorDefinitions pageSize=1 response StatusOK`]: (r) => r.status === grpc.StatusOK,
             [`vdp.pipeline.v1beta.PipelinePublicService/ListConnectorDefinitions pageSize=1 response connectorDefinitions length = 1`]: (r) => r.message.connectorDefinitions.length === 1,
         });
@@ -51,7 +51,7 @@ export function CheckList(metadata) {
         var pageRes = client.invoke('vdp.pipeline.v1beta.PipelinePublicService/ListConnectorDefinitions', {
             filter: "connector_type=CONNECTOR_TYPE_DATA",
             pageSize: 1
-        }, metadata)
+        }, data.metadata)
         check(client.invoke('vdp.pipeline.v1beta.PipelinePublicService/ListConnectorDefinitions', {
             filter: "connector_type=CONNECTOR_TYPE_DATA",
             pageSize: 1,
@@ -65,7 +65,7 @@ export function CheckList(metadata) {
             filter: "connector_type=CONNECTOR_TYPE_DATA",
             pageSize: 1,
             view: "VIEW_BASIC"
-        }, metadata), {
+        }, data.metadata), {
             [`vdp.pipeline.v1beta.PipelinePublicService/ListConnectorDefinitions pageSize=1 view=VIEW_BASIC response StatusOK`]: (r) => r.status === grpc.StatusOK,
             [`vdp.pipeline.v1beta.PipelinePublicService/ListConnectorDefinitions pageSize=1 view=VIEW_BASIC response connectorDefinitions connectorDefinition spec is null`]: (r) => r.message.connectorDefinitions[0].spec === null,
         });
@@ -74,7 +74,7 @@ export function CheckList(metadata) {
             filter: "connector_type=CONNECTOR_TYPE_DATA",
             pageSize: 1,
             view: "VIEW_FULL"
-        }, metadata), {
+        }, data.metadata), {
             [`vdp.pipeline.v1beta.PipelinePublicService/ListConnectorDefinitions pageSize=1 view=VIEW_FULL response StatusOK`]: (r) => r.status === grpc.StatusOK,
             [`vdp.pipeline.v1beta.PipelinePublicService/ListConnectorDefinitions pageSize=1 view=VIEW_FULL response connectorDefinitions connectorDefinition spec is not null`]: (r) => r.message.connectorDefinitions[0].spec !== null,
         });
@@ -82,7 +82,7 @@ export function CheckList(metadata) {
         check(client.invoke('vdp.pipeline.v1beta.PipelinePublicService/ListConnectorDefinitions', {
             filter: "connector_type=CONNECTOR_TYPE_DATA",
             pageSize: 1,
-        }, metadata), {
+        }, data.metadata), {
             [`vdp.pipeline.v1beta.PipelinePublicService/ListConnectorDefinitions pageSize=1 response StatusOK`]: (r) => r.status === grpc.StatusOK,
             [`vdp.pipeline.v1beta.PipelinePublicService/ListConnectorDefinitions pageSize=1 response connectorDefinitions connectorDefinition spec is null`]: (r) => r.message.connectorDefinitions[0].spec === null,
         });
@@ -90,7 +90,7 @@ export function CheckList(metadata) {
         check(client.invoke('vdp.pipeline.v1beta.PipelinePublicService/ListConnectorDefinitions', {
             filter: "connector_type=CONNECTOR_TYPE_DATA",
             pageSize: limitedRecords.message.totalSize,
-        }, metadata), {
+        }, data.metadata), {
             [`vdp.pipeline.v1beta.PipelinePublicService/ListConnectorDefinitions pageSize=${limitedRecords.message.totalSize} response StatusOK`]: (r) => r.status === grpc.StatusOK,
             [`vdp.pipeline.v1beta.PipelinePublicService/ListConnectorDefinitions pageSize=${limitedRecords.message.totalSize} response nextPageToken is null`]: (r) => r.message.nextPageToken === "",
         });
@@ -99,7 +99,7 @@ export function CheckList(metadata) {
     });
 }
 
-export function CheckGet(metadata) {
+export function CheckGet(data) {
     group("Connector API: Get data connector definition", () => {
         client.connect(constant.pipelineGRPCPublicHost, {
             plaintext: true
@@ -107,12 +107,12 @@ export function CheckGet(metadata) {
 
         var allRes = client.invoke('vdp.pipeline.v1beta.PipelinePublicService/ListConnectorDefinitions', {
             filter: "connector_type=CONNECTOR_TYPE_DATA",
-        }, metadata)
+        }, data.metadata)
         var def = allRes.message.connectorDefinitions[0]
 
         check(client.invoke('vdp.pipeline.v1beta.PipelinePublicService/GetConnectorDefinition', {
             name: `connector-definitions/${def.id}`
-        }, metadata), {
+        }, data.metadata), {
             [`vdp.pipeline.v1beta.PipelinePublicService/GetConnectorDefinition id=${def.id}} response StatusOK`]: (r) => r.status === grpc.StatusOK,
             [`vdp.pipeline.v1beta.PipelinePublicService/GetConnectorDefinition id=${def.id} response has the exact record`]: (r) => deepEqual(r.message.connectorDefinition, def),
             [`vdp.pipeline.v1beta.PipelinePublicService/GetConnectorDefinition id=${def.id} has the non-empty resource name ${def.name}`]: (r) => r.message.connectorDefinition.name != "",
@@ -122,7 +122,7 @@ export function CheckGet(metadata) {
         check(client.invoke('vdp.pipeline.v1beta.PipelinePublicService/GetConnectorDefinition', {
             name: `connector-definitions/${def.id}`,
             view: "VIEW_BASIC"
-        }, metadata), {
+        }, data.metadata), {
             [`vdp.pipeline.v1beta.PipelinePublicService/GetConnectorDefinition id=${def.id}} view=VIEW_BASIC response StatusOK`]: (r) => r.status === grpc.StatusOK,
             [`vdp.pipeline.v1beta.PipelinePublicService/GetConnectorDefinition id=${def.id} view=VIEW_BASIC response connectorDefinition.spec is null`]: (r) => r.message.connectorDefinition.spec === null,
         });
@@ -130,14 +130,14 @@ export function CheckGet(metadata) {
         check(client.invoke('vdp.pipeline.v1beta.PipelinePublicService/GetConnectorDefinition', {
             name: `connector-definitions/${def.id}`,
             view: "VIEW_FULL"
-        }, metadata), {
+        }, data.metadata), {
             [`vdp.pipeline.v1beta.PipelinePublicService/GetConnectorDefinition id=${def.id}} view=VIEW_FULL response StatusOK`]: (r) => r.status === grpc.StatusOK,
             [`vdp.pipeline.v1beta.PipelinePublicService/GetConnectorDefinition id=${def.id} view=VIEW_FULL response connectorDefinition.spec is not null`]: (r) => r.message.connectorDefinition.spec !== null,
         });
 
         check(client.invoke('vdp.pipeline.v1beta.PipelinePublicService/GetConnectorDefinition', {
             name: `connector-definitions/${def.id}`,
-        }, metadata), {
+        }, data.metadata), {
             [`vdp.pipeline.v1beta.PipelinePublicService/GetConnectorDefinition id=${def.id}} response StatusOK`]: (r) => r.status === grpc.StatusOK,
             [`vdp.pipeline.v1beta.PipelinePublicService/GetConnectorDefinition id=${def.id} response connectorDefinition.spec is null`]: (r) => r.message.connectorDefinition.spec === null,
         });

--- a/integration-test/connector/grpc-data-connector-private.js
+++ b/integration-test/connector/grpc-data-connector-private.js
@@ -16,7 +16,7 @@ const clientPublic = new grpc.Client();
 clientPrivate.load(['../proto/vdp/pipeline/v1beta'], 'pipeline_private_service.proto');
 clientPublic.load(['../proto/vdp/pipeline/v1beta'], 'pipeline_public_service.proto');
 
-export function CheckList(metadata) {
+export function CheckList(data) {
 
     group("Connector API: List data connectors by admin", () => {
 
@@ -51,10 +51,10 @@ export function CheckList(metadata) {
             var resDst = clientPublic.invoke('vdp.pipeline.v1beta.PipelinePublicService/CreateUserConnector', {
                 parent: `${constant.namespace}`,
                 connector: reqBody
-            }, metadata)
+            }, data.metadata)
             clientPublic.invoke('vdp.pipeline.v1beta.PipelinePublicService/ConnectUserConnector', {
                 name: `${constant.namespace}/connectors/${resDst.message.connector.id}`
-            }, metadata)
+            }, data.metadata)
 
             check(resDst, {
                 [`vdp.pipeline.v1beta.PipelinePublicService/CreateUserConnector x${reqBodies.length} HTTP response StatusOK`]: (r) => r.status === grpc.StatusOK,
@@ -110,7 +110,7 @@ export function CheckList(metadata) {
             [`vdp.pipeline.v1beta.PipelinePrivateService/ListConnectorsAdmin pageSize=1 view=VIEW_FULL response StatusOK`]: (r) => r.status === grpc.StatusOK,
             [`vdp.pipeline.v1beta.PipelinePrivateService/ListConnectorsAdmin pageSize=1 view=VIEW_FULL response connectors[0].configuration is not null`]: (r) => r.message.connectors[0].configuration !== null,
             [`vdp.pipeline.v1beta.PipelinePrivateService/ListConnectorsAdmin pageSize=1 view=VIEW_FULL response connectors[0].connectorDefinitionDetail is not null`]: (r) => r.message.connectors[0].connectorDefinitionDetail !== null,
-            [`vdp.pipeline.v1beta.PipelinePrivateService/ListConnectorsAdmin pageSize=1 view=VIEW_FULL response connectors[0].owner is valid`]: (r) => helper.isValidOwnerGRPC(r.message.connectors[0].owner),
+            [`vdp.pipeline.v1beta.PipelinePrivateService/ListConnectorsAdmin pageSize=1 view=VIEW_FULL response connectors[0].owner is valid`]: (r) => helper.isValidOwner(r.message.connectors[0].owner, data.expectedOwner),
         });
 
 
@@ -133,7 +133,7 @@ export function CheckList(metadata) {
         for (const reqBody of reqBodies) {
             check(clientPublic.invoke(`vdp.pipeline.v1beta.PipelinePublicService/DeleteUserConnector`, {
                 name: `${constant.namespace}/connectors/${reqBody.id}`
-            }, metadata), {
+            }, data.metadata), {
                 [`vdp.pipeline.v1beta.PipelinePublicService/DeleteUserConnector x${reqBodies.length} response StatusOK`]: (r) => r.status === grpc.StatusOK,
             });
         }
@@ -143,7 +143,7 @@ export function CheckList(metadata) {
     });
 }
 
-export function CheckLookUp(metadata) {
+export function CheckLookUp(data) {
 
     group("Connector API: Look up data connectors by UID by admin", () => {
 
@@ -165,11 +165,11 @@ export function CheckLookUp(metadata) {
         var resCSVDst = clientPublic.invoke('vdp.pipeline.v1beta.PipelinePublicService/CreateUserConnector', {
             parent: `${constant.namespace}`,
             connector: csvDstConnector
-        }, metadata)
+        }, data.metadata)
 
         clientPublic.invoke('vdp.pipeline.v1beta.PipelinePublicService/ConnectUserConnector', {
             name: `${constant.namespace}/connectors/${csvDstConnector.id}`
-        }, metadata)
+        }, data.metadata)
 
         check(clientPrivate.invoke('vdp.pipeline.v1beta.PipelinePrivateService/LookUpConnectorAdmin', {
             permalink: `connectors/${resCSVDst.message.connector.uid}`
@@ -182,7 +182,7 @@ export function CheckLookUp(metadata) {
 
         check(clientPublic.invoke(`vdp.pipeline.v1beta.PipelinePublicService/DeleteUserConnector`, {
             name: `${constant.namespace}/connectors/${csvDstConnector.id}`
-        }, metadata), {
+        }, data.metadata), {
             [`vdp.pipeline.v1beta.PipelinePublicService/DeleteUserConnector ${csvDstConnector.id} response StatusOK`]: (r) => r.status === grpc.StatusOK,
         });
 

--- a/integration-test/connector/grpc-data-connector-public-with-jwt.js
+++ b/integration-test/connector/grpc-data-connector-public-with-jwt.js
@@ -14,7 +14,7 @@ import * as helper from "./helper.js"
 const client = new grpc.Client();
 client.load(['../proto/vdp/pipeline/v1beta'], 'pipeline_public_service.proto');
 
-export function CheckCreate(metadata) {
+export function CheckCreate(data) {
 
     group(`Connector API: Create destination connectors [with random "Instill-User-Uid" header]`, () => {
 
@@ -64,7 +64,7 @@ export function CheckCreate(metadata) {
 
 }
 
-export function CheckList(metadata) {
+export function CheckList(data) {
 
     group(`Connector API: List destination connectors [with random "Instill-User-Uid" header]`, () => {
 
@@ -84,7 +84,7 @@ export function CheckList(metadata) {
     });
 }
 
-export function CheckGet(metadata) {
+export function CheckGet(data) {
 
     group(`Connector API: Get destination connectors by ID [with random "Instill-User-Uid" header]`, () => {
 
@@ -102,7 +102,7 @@ export function CheckGet(metadata) {
         var resCSVDst = client.invoke('vdp.pipeline.v1beta.PipelinePublicService/CreateUserConnector', {
             parent: `${constant.namespace}`,
             connector: csvDstConnector
-        }, metadata)
+        }, data.metadata)
 
         // client.invoke('vdp.pipeline.v1beta.PipelinePublicService/ConnectUserConnector', {
         //     name: `${constant.namespace}/connectors/${csvDstConnector.id}`
@@ -123,7 +123,7 @@ export function CheckGet(metadata) {
 
         check(client.invoke(`vdp.pipeline.v1beta.PipelinePublicService/DeleteUserConnector`, {
             name: `${constant.namespace}/connectors/${resCSVDst.message.connector.id}`
-        }, metadata), {
+        }, data.metadata), {
             [`vdp.pipeline.v1beta.PipelinePublicService/DeleteUserConnector ${resCSVDst.message.connector.id} response StatusOK`]: (r) => r.status === grpc.StatusOK,
         });
 
@@ -131,7 +131,7 @@ export function CheckGet(metadata) {
     });
 }
 
-export function CheckUpdate(metadata) {
+export function CheckUpdate(data) {
 
     group(`Connector API: Update destination connectors [with random "Instill-User-Uid" header]`, () => {
 
@@ -149,11 +149,11 @@ export function CheckUpdate(metadata) {
         client.invoke('vdp.pipeline.v1beta.PipelinePublicService/CreateUserConnector', {
             parent: `${constant.namespace}`,
             connector: csvDstConnector
-        }, metadata)
+        }, data.metadata)
 
         client.invoke('vdp.pipeline.v1beta.PipelinePublicService/ConnectUserConnector', {
             name: `${constant.namespace}/connectors/${csvDstConnector.id}`
-        }, metadata)
+        }, data.metadata)
 
         var csvDstConnectorUpdate = {
             "id": csvDstConnector.id,
@@ -176,7 +176,7 @@ export function CheckUpdate(metadata) {
 
         check(client.invoke(`vdp.pipeline.v1beta.PipelinePublicService/DeleteUserConnector`, {
             name: `${constant.namespace}/connectors/${csvDstConnector.id}`
-        }, metadata), {
+        }, data.metadata), {
             [`vdp.pipeline.v1beta.PipelinePublicService/DeleteUserConnector ${csvDstConnector.id} response StatusOK`]: (r) => r.status === grpc.StatusOK,
         });
 
@@ -184,7 +184,7 @@ export function CheckUpdate(metadata) {
     });
 }
 
-export function CheckLookUp(metadata) {
+export function CheckLookUp(data) {
 
     group(`Connector API: Look up destination connectors by UID [with random "Instill-User-Uid" header]`, () => {
 
@@ -202,11 +202,11 @@ export function CheckLookUp(metadata) {
         var resCSVDst = client.invoke('vdp.pipeline.v1beta.PipelinePublicService/CreateUserConnector', {
             parent: `${constant.namespace}`,
             connector: csvDstConnector
-        }, metadata)
+        }, data.metadata)
 
         client.invoke('vdp.pipeline.v1beta.PipelinePublicService/ConnectUserConnector', {
             name: `${constant.namespace}/connectors/${csvDstConnector.id}`
-        }, metadata)
+        }, data.metadata)
 
         // Cannot look up destination connector of a non-exist user
         check(client.invoke('vdp.pipeline.v1beta.PipelinePublicService/LookUpConnector', {
@@ -217,7 +217,7 @@ export function CheckLookUp(metadata) {
 
         check(client.invoke(`vdp.pipeline.v1beta.PipelinePublicService/DeleteUserConnector`, {
             name: `${constant.namespace}/connectors/${csvDstConnector.id}`
-        }, metadata), {
+        }, data.metadata), {
             [`vdp.pipeline.v1beta.PipelinePublicService/DeleteUserConnector ${csvDstConnector.id} response StatusOK`]: (r) => r.status === grpc.StatusOK,
         });
 
@@ -225,7 +225,7 @@ export function CheckLookUp(metadata) {
     });
 }
 
-export function CheckState(metadata) {
+export function CheckState(data) {
 
     group(`Connector API: Change state destination connectors [with random "Instill-User-Uid" header]`, () => {
 
@@ -243,11 +243,11 @@ export function CheckState(metadata) {
         var resCSVDst = client.invoke('vdp.pipeline.v1beta.PipelinePublicService/CreateUserConnector', {
             parent: `${constant.namespace}`,
             connector: csvDstConnector
-        }, metadata)
+        }, data.metadata)
 
         client.invoke('vdp.pipeline.v1beta.PipelinePublicService/ConnectUserConnector', {
             name: `${constant.namespace}/connectors/${csvDstConnector.id}`
-        }, metadata)
+        }, data.metadata)
 
         // Cannot connect destination connector of a non-exist user
         check(client.invoke('vdp.pipeline.v1beta.PipelinePublicService/ConnectUserConnector', {
@@ -265,7 +265,7 @@ export function CheckState(metadata) {
 
         check(client.invoke('vdp.pipeline.v1beta.PipelinePublicService/WatchUserConnector', {
             name: `${constant.namespace}/connectors/${resCSVDst.message.connector.id}`
-        }, metadata), {
+        }, data.metadata), {
             "vdp.pipeline.v1beta.PipelinePublicService/CreateUserConnector CSV destination connector STATE_CONNECTED": (r) => r.message.state === "STATE_CONNECTED",
         })
 
@@ -299,7 +299,7 @@ export function CheckState(metadata) {
 
         check(client.invoke(`vdp.pipeline.v1beta.PipelinePublicService/DeleteUserConnector`, {
             name: `${constant.namespace}/connectors/${csvDstConnector.id}`
-        }, metadata), {
+        }, data.metadata), {
             [`vdp.pipeline.v1beta.PipelinePublicService/DeleteUserConnector ${csvDstConnector.id} response StatusOK`]: (r) => r.status === grpc.StatusOK,
         });
 
@@ -307,7 +307,7 @@ export function CheckState(metadata) {
     });
 }
 
-export function CheckRename(metadata) {
+export function CheckRename(data) {
 
     group(`Connector API: Rename destination connectors [with random "Instill-User-Uid" header]`, () => {
 
@@ -325,11 +325,11 @@ export function CheckRename(metadata) {
         var resCSVDst = client.invoke('vdp.pipeline.v1beta.PipelinePublicService/CreateUserConnector', {
             parent: `${constant.namespace}`,
             connector: csvDstConnector
-        }, metadata)
+        }, data.metadata)
 
         client.invoke('vdp.pipeline.v1beta.PipelinePublicService/ConnectUserConnector', {
             name: `${constant.namespace}/connectors/${csvDstConnector.id}`
-        }, metadata)
+        }, data.metadata)
 
         let new_id = `some_id_not_${resCSVDst.message.connector.id}`
 
@@ -343,7 +343,7 @@ export function CheckRename(metadata) {
 
         check(client.invoke(`vdp.pipeline.v1beta.PipelinePublicService/DeleteUserConnector`, {
             name: `${constant.namespace}/connectors/${csvDstConnector.id}`
-        }, metadata), {
+        }, data.metadata), {
             [`vdp.pipeline.v1beta.PipelinePublicService/DeleteUserConnector ${csvDstConnector.id} response StatusOK`]: (r) => r.status === grpc.StatusOK,
         });
 
@@ -351,7 +351,7 @@ export function CheckRename(metadata) {
     });
 }
 
-export function CheckExecute(metadata) {
+export function CheckExecute(data) {
 
     group(`Connector API: Write destination connectors [with random "Instill-User-Uid" header]`, () => {
 
@@ -375,15 +375,15 @@ export function CheckExecute(metadata) {
         resCSVDst = client.invoke('vdp.pipeline.v1beta.PipelinePublicService/CreateUserConnector', {
             parent: `${constant.namespace}`,
             connector: csvDstConnector
-        }, metadata)
+        }, data.metadata)
 
         client.invoke('vdp.pipeline.v1beta.PipelinePublicService/ConnectUserConnector', {
             name: `${constant.namespace}/connectors/${csvDstConnector.id}`
-        }, metadata)
+        }, data.metadata)
 
         check(client.invoke('vdp.pipeline.v1beta.PipelinePublicService/WatchUserConnector', {
             name: `${constant.namespace}/connectors/${resCSVDst.message.connector.id}`
-        }, metadata), {
+        }, data.metadata), {
             "vdp.pipeline.v1beta.PipelinePublicService/CreateUserConnector CSV destination connector STATE_CONNECTED": (r) => r.message.state === "STATE_CONNECTED",
         })
 
@@ -400,7 +400,7 @@ export function CheckExecute(metadata) {
 
         check(client.invoke(`vdp.pipeline.v1beta.PipelinePublicService/DeleteUserConnector`, {
             name: `${constant.namespace}/connectors/${resCSVDst.message.connector.id}`
-        }, metadata), {
+        }, data.metadata), {
             [`vdp.pipeline.v1beta.PipelinePublicService/DeleteUserConnector ${resCSVDst.message.connector.id} response (classification) StatusOK`]: (r) => r.status === grpc.StatusOK,
         });
 
@@ -408,7 +408,7 @@ export function CheckExecute(metadata) {
     });
 }
 
-export function CheckTest(metadata) {
+export function CheckTest(data) {
 
     group(`Connector API: Test destination connectors' connection [with random "Instill-User-Uid" header]`, () => {
 
@@ -426,11 +426,11 @@ export function CheckTest(metadata) {
         var resCSVDst = client.invoke('vdp.pipeline.v1beta.PipelinePublicService/CreateUserConnector', {
             parent: `${constant.namespace}`,
             connector: csvDstConnector
-        }, metadata)
+        }, data.metadata)
 
         client.invoke('vdp.pipeline.v1beta.PipelinePublicService/ConnectUserConnector', {
             name: `${constant.namespace}/connectors/${csvDstConnector.id}`
-        }, metadata)
+        }, data.metadata)
 
         // Cannot test destination connector of a non-exist user
         check(client.invoke('vdp.pipeline.v1beta.PipelinePublicService/TestUserConnector', {
@@ -441,7 +441,7 @@ export function CheckTest(metadata) {
 
         check(client.invoke(`vdp.pipeline.v1beta.PipelinePublicService/DeleteUserConnector`, {
             name: `${constant.namespace}/connectors/${csvDstConnector.id}`
-        }, metadata), {
+        }, data.metadata), {
             [`vdp.pipeline.v1beta.PipelinePublicService/DeleteUserConnector ${csvDstConnector.id} response StatusOK`]: (r) => r.status === grpc.StatusOK,
         });
 

--- a/integration-test/connector/helper.js
+++ b/integration-test/connector/helper.js
@@ -12,35 +12,12 @@ export function isUUID(uuid) {
 }
 
 
-export function isValidOwnerHTTP(owner) {
-    const expectedProfile = {
-        "display_name": "Instill",
-        "bio": "",
-        "avatar": "",
-        "public_email": "",
-        "company_name": "Instill AI",
-        "social_profile_links": {}
-    }
+export function isValidOwner(owner, expectedOwner) {
     if (owner === null || owner === undefined) return false;
     if (owner.user === null || owner.user === undefined) return false;
-    if (owner.user.id !== "admin") return false;
-    return deepEqual(owner.user.profile, expectedProfile)
+    if (owner.user.id !== expectedOwner.id) return false;
+    return deepEqual(owner.user.profile, expectedOwner.profile)
   }
-
-export function isValidOwnerGRPC(owner) {
-    const expectedProfile = {
-        "displayName": "Instill",
-        "bio": "",
-        "avatar": "",
-        "publicEmail": "",
-        "companyName": "Instill AI",
-        "socialProfileLinks": {}
-    }
-    if (owner === null || owner === undefined) return false;
-    if (owner.user === null || owner.user === undefined) return false;
-    if (owner.user.id !== "admin") return false;
-    return deepEqual(owner.user.profile, expectedProfile)
-}
 
 export function genHeader(contentType) {
     return {

--- a/integration-test/connector/rest-data-connector-definition.js
+++ b/integration-test/connector/rest-data-connector-definition.js
@@ -4,77 +4,77 @@ import { check, group } from "k6";
 import { pipelinePublicHost } from "./const.js"
 import { deepEqual } from "./helper.js"
 
-export function CheckList(header) {
+export function CheckList(data) {
 
     group("Connector API: List destination connector definitions", () => {
 
-        check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions`, null, header), {
+        check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions`, null, data.header), {
             "GET /v1beta/connector-definitions response status is 200": (r) => r.status === 200,
             "GET /v1beta/connector-definitions response has connector_definitions array": (r) => Array.isArray(r.json().connector_definitions),
             "GET /v1beta/connector-definitions response total_size > 0": (r) => r.json().total_size > 0
         });
 
-        var limitedRecords = http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions`, null, header)
-        check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions?page_size=0`, null, header), {
+        var limitedRecords = http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions`, null, data.header)
+        check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions?page_size=0`, null, data.header), {
             "GET /v1beta/connector-definitions?page_size=0 response status is 200": (r) => r.status === 200,
             "GET /v1beta/connector-definitions?page_size=0 response limited records for 10": (r) => r.json().connector_definitions.length === limitedRecords.json().connector_definitions.length,
         });
 
-        check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions?page_size=1`, null, header), {
+        check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions?page_size=1`, null, data.header), {
             "GET /v1beta/connector-definitions?page_size=1 response status is 200": (r) => r.status === 200,
             "GET /v1beta/connector-definitions?page_size=1 response connector_definitions size 1": (r) => r.json().connector_definitions.length === 1,
         });
 
-        var pageRes = http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions?page_size=1`, null, header)
-        check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions?page_size=1&page_token=${pageRes.json().next_page_token}`, null, header), {
+        var pageRes = http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions?page_size=1`, null, data.header)
+        check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions?page_size=1&page_token=${pageRes.json().next_page_token}`, null, data.header), {
             [`GET /v1beta/connector-definitions?page_size=1&page_token=${pageRes.json().next_page_token} response status is 200`]: (r) => r.status === 200,
             [`GET /v1beta/connector-definitions?page_size=1&page_token=${pageRes.json().next_page_token} response connector_definitions size 1`]: (r) => r.json().connector_definitions.length === 1,
         });
 
-        check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions?page_size=1&view=VIEW_BASIC`, null, header), {
+        check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions?page_size=1&view=VIEW_BASIC`, null, data.header), {
             "GET /v1beta/connector-definitions?page_size=1&view=VIEW_BASIC response status 200": (r) => r.status === 200,
             "GET /v1beta/connector-definitions?page_size=1&view=VIEW_BASIC response connector_definitions[0].spec is null": (r) => r.json().connector_definitions[0].spec === null,
         });
 
-        check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions?page_size=1&view=VIEW_FULL`, null, header), {
+        check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions?page_size=1&view=VIEW_FULL`, null, data.header), {
             "GET /v1beta/connector-definitions?page_size=1&view=VIEW_FULL response status 200": (r) => r.status === 200,
             "GET /v1beta/connector-definitions?page_size=1&view=VIEW_FULL response connector_definitions[0].spec is not null": (r) => r.json().connector_definitions[0].spec !== null,
         });
 
-        check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions?page_size=1`, null, header), {
+        check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions?page_size=1`, null, data.header), {
             "GET /v1beta/connector-definitions?page_size=1 response status 200": (r) => r.status === 200,
             "GET /v1beta/connector-definitions?page_size=1 response connector_definitions[0].spec is null": (r) => r.json().connector_definitions[0].spec === null,
         });
 
-        check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions?page_size=${limitedRecords.json().total_size}`, null, header), {
+        check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions?page_size=${limitedRecords.json().total_size}`, null, data.header), {
             [`GET /v1beta/connector-definitions?page_size=${limitedRecords.json().total_size} response status 200`]: (r) => r.status === 200,
             [`GET /v1beta/connector-definitions?page_size=${limitedRecords.json().total_size} response next_page_token is empty`]: (r) => r.json().next_page_token === "",
         });
     });
 }
 
-export function CheckGet(header) {
+export function CheckGet(data) {
     group("Connector API: Get destination connector definition", () => {
-        var allRes = http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions`, null, header)
+        var allRes = http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions`, null, data.header)
         var def = allRes.json().connector_definitions[0]
-        check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions/${def.id}`, null, header), {
+        check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions/${def.id}`, null, data.header), {
             [`GET /v1beta/connector-definitions/${def.id} response status is 200`]: (r) => r.status === 200,
             [`GET /v1beta/connector-definitions/${def.id} response has the exact record`]: (r) => deepEqual(r.json().connector_definition, def),
             [`GET /v1beta/connector-definitions/${def.id} response has the non-empty resource name ${def.name}`]: (r) => r.json().connector_definition.name != "",
             [`GET /v1beta/connector-definitions/${def.id} response has the resource name ${def.name}`]: (r) => r.json().connector_definition.name === def.name,
         });
 
-        check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions/${def.id}?view=VIEW_BASIC`, null, header), {
+        check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions/${def.id}?view=VIEW_BASIC`, null, data.header), {
             [`GET /v1beta/connector-definitions/${def.id}?view=VIEW_BASIC response status 200`]: (r) => r.status === 200,
             [`GET /v1beta/connector-definitions/${def.id}?view=VIEW_BASIC response connector_definition.spec is null`]: (r) => r.json().connector_definition.spec === null,
         });
 
-        check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions/${def.id}?view=VIEW_FULL`, null, header), {
+        check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions/${def.id}?view=VIEW_FULL`, null, data.header), {
             [`GET /v1beta/connector-definitions/${def.id}?view=VIEW_FULL response status 200`]: (r) => r.status === 200,
             [`GET /v1beta/connector-definitions/${def.id}?view=VIEW_FULL response connector_definition.spec is not null`]: (r) => r.json().connector_definition.spec !== null,
         });
 
-        check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions/${def.id}`, null, header), {
+        check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions/${def.id}`, null, data.header), {
             [`GET /v1beta/connector-definitions/${def.id} response status 200`]: (r) => r.status === 200,
             [`GET /v1beta/connector-definitions/${def.id} response connector_definition.spec is null`]: (r) => r.json().connector_definition.spec === null,
         });

--- a/integration-test/connector/rest-data-connector-private.js
+++ b/integration-test/connector/rest-data-connector-private.js
@@ -16,7 +16,7 @@ import {
 import * as constant from "./const.js"
 import * as helper from "./helper.js"
 
-export function CheckList(header) {
+export function CheckList(data) {
 
     group("Connector API: List destination connectors by admin", () => {
 
@@ -41,7 +41,7 @@ export function CheckList(header) {
         // Create connectors
         for (const reqBody of reqBodies) {
             var resCSVDst = http.request("POST", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors`,
-                JSON.stringify(reqBody), header)
+                JSON.stringify(reqBody), data.header)
             check(resCSVDst, {
                 [`POST /v1beta/${constant.namespace}/connectors x${reqBodies.length} response status 201`]: (r) => r.status === 201,
             });
@@ -54,7 +54,7 @@ export function CheckList(header) {
         });
 
         var limitedRecords = http.request("GET", `${pipelinePrivateHost}/v1beta/admin/connectors?filter=connector_type=CONNECTOR_TYPE_DATA`)
-        check(http.request("GET", `${pipelinePrivateHost}/v1beta/admin/connectors?page_size=0`, null, header), {
+        check(http.request("GET", `${pipelinePrivateHost}/v1beta/admin/connectors?page_size=0`, null, data.header), {
             "GET /v1beta/admin/connectors?page_size=0 response status is 200": (r) => r.status === 200,
             "GET /v1beta/admin/connectors?page_size=0 response all records": (r) => r.json().connectors.length === limitedRecords.json().connectors.length,
         });
@@ -65,7 +65,7 @@ export function CheckList(header) {
         });
 
         var pageRes = http.request("GET", `${pipelinePrivateHost}/v1beta/admin/connectors?filter=connector_type=CONNECTOR_TYPE_DATA&page_size=1`)
-        check(http.request("GET", `${pipelinePrivateHost}/v1beta/admin/connectors?page_size=1&page_token=${pageRes.json().next_page_token}`, null, header), {
+        check(http.request("GET", `${pipelinePrivateHost}/v1beta/admin/connectors?page_size=1&page_token=${pageRes.json().next_page_token}`, null, data.header), {
             [`GET /v1beta/admin/connectors?page_size=1&page_token=${pageRes.json().next_page_token} response status is 200`]: (r) => r.status === 200,
             [`GET /v1beta/admin/connectors?page_size=1&page_token=${pageRes.json().next_page_token} response connectors size 1`]: (r) => r.json().connectors.length === 1,
         });
@@ -80,7 +80,7 @@ export function CheckList(header) {
             "GET /v1beta/admin/connectors?page_size=1&view=VIEW_FULL response status 200": (r) => r.status === 200,
             "GET /v1beta/admin/connectors?page_size=1&view=VIEW_FULL response connectors[0].configuration is not null": (r) => r.json().connectors[0].configuration !== null,
             "GET /v1beta/admin/connectors?page_size=1&view=VIEW_FULL response connectors[0].connector_definition_detail is not null": (r) => r.json().connectors[0].connector_definition_detail !== null,
-            "GET /v1beta/admin/connectors?page_size=1&view=VIEW_FULL response connectors[0].owner is valid": (r) => helper.isValidOwnerHTTP(r.json().connectors[0].owner ),
+            "GET /v1beta/admin/connectors?page_size=1&view=VIEW_FULL response connectors[0].owner is valid": (r) => helper.isValidOwner(r.json().connectors[0].owner, data.expectedOwner),
         });
 
         check(http.request("GET", `${pipelinePrivateHost}/v1beta/admin/connectors?filter=connector_type=CONNECTOR_TYPE_DATA&page_size=1`), {
@@ -96,14 +96,14 @@ export function CheckList(header) {
 
         // Delete the destination connectors
         for (const reqBody of reqBodies) {
-            check(http.request("DELETE", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors/${reqBody.id}`, null, header), {
+            check(http.request("DELETE", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors/${reqBody.id}`, null, data.header), {
                 [`DELETE /v1beta/admin/connectors x${reqBodies.length} response status is 204`]: (r) => r.status === 204,
             });
         }
     });
 }
 
-export function CheckLookUp(header) {
+export function CheckLookUp(data) {
 
     group("Connector API: Look up destination connectors by UID by admin", () => {
 
@@ -115,7 +115,7 @@ export function CheckLookUp(header) {
         }
 
         var resCSVDst = http.request("POST", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors`,
-            JSON.stringify(csvDstConnector), header)
+            JSON.stringify(csvDstConnector), data.header)
 
         check(http.request("GET", `${pipelinePrivateHost}/v1beta/admin/connectors/${resCSVDst.json().connector.uid}/lookUp`), {
             [`GET /v1beta/admin/connectors/${resCSVDst.json().connector.uid}/lookUp response status 200`]: (r) => r.status === 200,
@@ -124,7 +124,7 @@ export function CheckLookUp(header) {
             [`GET /v1beta/admin/connectors/${resCSVDst.json().connector.uid}/lookUp response connector owner is invalid`]: (r) => r.json().connector.owner === undefined,
         });
 
-        check(http.request("DELETE", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id}`, null, header), {
+        check(http.request("DELETE", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id}`, null, data.header), {
             [`DELETE /v1beta/admin/connectors/${resCSVDst.json().connector.id} response status 204`]: (r) => r.status === 204,
         });
 

--- a/integration-test/connector/rest-data-connector-public-with-jwt.js
+++ b/integration-test/connector/rest-data-connector-public-with-jwt.js
@@ -7,7 +7,7 @@ import { pipelinePublicHost } from "./const.js"
 import * as constant from "./const.js"
 import * as helper from "./helper.js"
 
-export function CheckCreate(header) {
+export function CheckCreate(data) {
 
     group(`Connector API: Create destination connectors [with random "Instill-User-Uid" header]`, () => {
 
@@ -31,7 +31,7 @@ export function CheckCreate(header) {
 
 }
 
-export function CheckList(header) {
+export function CheckList(data) {
 
     group(`Connector API: List destination connectors [with random "Instill-User-Uid" header]`, () => {
 
@@ -42,7 +42,7 @@ export function CheckList(header) {
     });
 }
 
-export function CheckGet(header) {
+export function CheckGet(data) {
 
     group(`Connector API: Get destination connectors by ID [with random "Instill-User-Uid" header]`, () => {
 
@@ -54,12 +54,12 @@ export function CheckGet(header) {
         }
 
         var resCSVDst = http.request("POST", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors`,
-            JSON.stringify(csvDstConnector), header)
+            JSON.stringify(csvDstConnector), data.header)
 
         http.request("POST", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors/${csvDstConnector.id}/connect`,
-            {}, header)
+            {}, data.header)
 
-        check(http.request("GET", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id}/watch`, null, header), {
+        check(http.request("GET", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id}/watch`, null, data.header), {
             [`GET /v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id}/watch response connector state is STATE_CONNECTED`]: (r) => r.json().state === "STATE_CONNECTED",
         })
 
@@ -68,13 +68,13 @@ export function CheckGet(header) {
             [`[with random "Instill-User-Uid" header] GET /v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id} response status is 401`]: (r) => r.status === 401,
         });
 
-        check(http.request("DELETE", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id}`, null, header), {
+        check(http.request("DELETE", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id}`, null, data.header), {
             [`DELETE /v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id} response status 204`]: (r) => r.status === 204,
         });
     });
 }
 
-export function CheckUpdate(header) {
+export function CheckUpdate(data) {
 
     group(`Connector API: Update destination connectors [with random "Instill-User-Uid" header]`, () => {
 
@@ -86,7 +86,7 @@ export function CheckUpdate(header) {
         }
 
         var resCSVDst = http.request("POST", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors`,
-            JSON.stringify(csvDstConnector), header)
+            JSON.stringify(csvDstConnector), data.header)
 
         var csvDstConnectorUpdate = {
             "id": csvDstConnector.id,
@@ -106,13 +106,13 @@ export function CheckUpdate(header) {
             [`[with random "Instill-User-Uid" header] PATCH /v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id} response status 401`]: (r) => r.status === 401,
         });
 
-        check(http.request("DELETE", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors/${csvDstConnector.id}`, null, header), {
+        check(http.request("DELETE", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors/${csvDstConnector.id}`, null, data.header), {
             [`DELETE /v1beta/${constant.namespace}/connectors/${csvDstConnector.id} response status 204`]: (r) => r.status === 204,
         });
     });
 }
 
-export function CheckLookUp(header) {
+export function CheckLookUp(data) {
 
     group(`Connector API: Look up destination connectors by UID [with random "Instill-User-Uid" header]`, () => {
 
@@ -124,21 +124,21 @@ export function CheckLookUp(header) {
         }
 
         var resCSVDst = http.request("POST", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors`,
-            JSON.stringify(csvDstConnector), header)
+            JSON.stringify(csvDstConnector), data.header)
 
         // Cannot look up a destination connector of a non-exist user
         check(http.request("GET", `${pipelinePublicHost}/v1beta/connectors/${resCSVDst.json().connector.uid}/lookUp`, null, constant.paramsHTTPWithJwt), {
             [`[with random "Instill-User-Uid" header] GET /v1beta/connectors/${resCSVDst.json().connector.uid}/lookUp response status 401`]: (r) => r.status === 401,
         });
 
-        check(http.request("DELETE", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id}`, null, header), {
+        check(http.request("DELETE", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id}`, null, data.header), {
             [`DELETE /v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id} response status 204`]: (r) => r.status === 204,
         });
 
     });
 }
 
-export function CheckState(header) {
+export function CheckState(data) {
 
     group(`Connector API: Change state destination connectors [with random "Instill-User-Uid" header]`, () => {
         var csvDstConnector = {
@@ -149,7 +149,7 @@ export function CheckState(header) {
         }
 
         var resCSVDst = http.request("POST", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors`,
-            JSON.stringify(csvDstConnector), header)
+            JSON.stringify(csvDstConnector), data.header)
 
         check(http.request("POST", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id}/disconnect`, null, constant.paramsHTTPWithJwt), {
             [`[with random "Instill-User-Uid" header] POST /v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id}/disconnect response at UNSPECIFIED state status 401`]: (r) => r.status === 401,
@@ -159,7 +159,7 @@ export function CheckState(header) {
             [`[with random "Instill-User-Uid" header] POST /v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id}/connect response at UNSPECIFIED state status 401`]: (r) => r.status === 401,
         });
 
-        check(http.request("DELETE", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id}`, null, header), {
+        check(http.request("DELETE", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id}`, null, data.header), {
             [`DELETE /v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id} response status 204`]: (r) => r.status === 204,
         });
 
@@ -167,7 +167,7 @@ export function CheckState(header) {
 
 }
 
-export function CheckRename(header) {
+export function CheckRename(data) {
 
     group(`Connector API: Rename destination connectors [with random "Instill-User-Uid" header]`, () => {
 
@@ -179,7 +179,7 @@ export function CheckRename(header) {
         }
 
         var resCSVDst = http.request("POST", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors`,
-            JSON.stringify(csvDstConnector), header)
+            JSON.stringify(csvDstConnector), data.header)
 
         // Cannot rename destination connector of a non-exist user
         check(http.request("POST", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id}/rename`,
@@ -189,13 +189,13 @@ export function CheckRename(header) {
             [`[with random "Instill-User-Uid" header] POST /v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id}/rename response status 401`]: (r) => r.status === 401,
         });
 
-        check(http.request("DELETE", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors/${csvDstConnector.id}`, null, header), {
+        check(http.request("DELETE", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors/${csvDstConnector.id}`, null, data.header), {
             [`DELETE /v1beta/${constant.namespace}/connectors/${csvDstConnector.id} response status 204`]: (r) => r.status === 204,
         });
     });
 }
 
-export function CheckExecute(header) {
+export function CheckExecute(data) {
 
     group(`Connector API: Write destination connectors [with random "Instill-User-Uid" header]`, () => {
 
@@ -213,12 +213,12 @@ export function CheckExecute(header) {
         }
 
         resCSVDst = http.request("POST", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors`,
-            JSON.stringify(csvDstConnector), header)
+            JSON.stringify(csvDstConnector), data.header)
 
         http.request("POST", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors/${csvDstConnector.id}/connect`,
-            {}, header)
+            {}, data.header)
 
-        check(http.request("GET", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id}/watch`, null, header), {
+        check(http.request("GET", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id}/watch`, null, data.header), {
             [`[with random "Instill-User-Uid" header] GET /v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id}/watch response connector state is STATE_CONNECTED`]: (r) => r.json().state === "STATE_CONNECTED",
         })
 
@@ -233,13 +233,13 @@ export function CheckExecute(header) {
         // Wait for 1 sec for the connector writing to the destination-csv before deleting it
         sleep(1)
 
-        check(http.request("DELETE", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id}`, null, header), {
+        check(http.request("DELETE", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id}`, null, data.header), {
             [`DELETE /v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id} response status 204 (classification)`]: (r) => r.status === 204,
         });
     });
 }
 
-export function CheckTest(header) {
+export function CheckTest(data) {
 
     group(`Connector API: Test destination connectors by ID [with random "Instill-User-Uid" header]`, () => {
 
@@ -251,12 +251,12 @@ export function CheckTest(header) {
         }
 
         var resCSVDst = http.request("POST", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors`,
-            JSON.stringify(csvDstConnector), header)
+            JSON.stringify(csvDstConnector), data.header)
 
         http.request("POST", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors/${csvDstConnector.id}/connect`,
-            {}, header)
+            {}, data.header)
 
-        check(http.request("GET", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id}/watch`, null, header), {
+        check(http.request("GET", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id}/watch`, null, data.header), {
             [`GET /v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id}/watch response connector state is STATE_CONNECTED`]: (r) => r.json().state === "STATE_CONNECTED",
         })
 
@@ -265,7 +265,7 @@ export function CheckTest(header) {
             [`[with random "Instill-User-Uid" header] POST /v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id}/testConnection response status is 401`]: (r) => r.status === 401,
         });
 
-        check(http.request("DELETE", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id}`, null, header), {
+        check(http.request("DELETE", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id}`, null, data.header), {
             [`DELETE /v1beta/${constant.namespace}/connectors/${resCSVDst.json().connector.id} response status 204`]: (r) => r.status === 204,
         });
     });

--- a/integration-test/connector/rest.js
+++ b/integration-test/connector/rest.js
@@ -46,10 +46,11 @@ export function setup() {
     }
   });
 
-  return header
+  var resp = http.request("GET", `${constant.mgmtPublicHost}/v1beta/user`, {}, {headers: {"Authorization": `Bearer ${loginResp.json().access_token}`}})
+  return {header: header, expectedOwner: resp.json().user}
 }
 
-export default function (header) {
+export default function (data) {
 
   /*
    * Connector API - API CALLS
@@ -66,38 +67,38 @@ export default function (header) {
   if (!constant.apiGatewayMode) {
 
     // data connectors
-    dataConnectorPrivate.CheckList(header)
-    dataConnectorPrivate.CheckLookUp(header)
+    dataConnectorPrivate.CheckList(data)
+    dataConnectorPrivate.CheckLookUp(data)
 
 
   } else {
 
     // data public with Instill-User-Uid
-    dataConnectorPublicWithJwt.CheckCreate(header)
-    dataConnectorPublicWithJwt.CheckList(header)
-    dataConnectorPublicWithJwt.CheckGet(header)
-    dataConnectorPublicWithJwt.CheckUpdate(header)
-    dataConnectorPublicWithJwt.CheckLookUp(header)
-    dataConnectorPublicWithJwt.CheckState(header)
-    dataConnectorPublicWithJwt.CheckRename(header)
-    dataConnectorPublicWithJwt.CheckExecute(header)
-    dataConnectorPublicWithJwt.CheckTest(header)
+    dataConnectorPublicWithJwt.CheckCreate(data)
+    dataConnectorPublicWithJwt.CheckList(data)
+    dataConnectorPublicWithJwt.CheckGet(data)
+    dataConnectorPublicWithJwt.CheckUpdate(data)
+    dataConnectorPublicWithJwt.CheckLookUp(data)
+    dataConnectorPublicWithJwt.CheckState(data)
+    dataConnectorPublicWithJwt.CheckRename(data)
+    dataConnectorPublicWithJwt.CheckExecute(data)
+    dataConnectorPublicWithJwt.CheckTest(data)
 
     // data connector definitions
-    dataConnectorDefinition.CheckList(header)
-    dataConnectorDefinition.CheckGet(header)
+    dataConnectorDefinition.CheckList(data)
+    dataConnectorDefinition.CheckGet(data)
 
     // data connectors
-    dataConnectorPublic.CheckCreate(header)
-    dataConnectorPublic.CheckList(header)
-    dataConnectorPublic.CheckGet(header)
-    dataConnectorPublic.CheckUpdate(header)
-    dataConnectorPublic.CheckConnect(header)
-    dataConnectorPublic.CheckLookUp(header)
-    dataConnectorPublic.CheckState(header)
-    dataConnectorPublic.CheckRename(header)
-    dataConnectorPublic.CheckExecute(header)
-    dataConnectorPublic.CheckTest(header)
+    dataConnectorPublic.CheckCreate(data)
+    dataConnectorPublic.CheckList(data)
+    dataConnectorPublic.CheckGet(data)
+    dataConnectorPublic.CheckUpdate(data)
+    dataConnectorPublic.CheckConnect(data)
+    dataConnectorPublic.CheckLookUp(data)
+    dataConnectorPublic.CheckState(data)
+    dataConnectorPublic.CheckRename(data)
+    dataConnectorPublic.CheckExecute(data)
+    dataConnectorPublic.CheckTest(data)
   }
 
 
@@ -105,9 +106,9 @@ export default function (header) {
 
 }
 
-export function teardown(header) {
+export function teardown(data) {
   group("Connector API: Delete all pipelines created by this test", () => {
-    for (const pipeline of http.request("GET", `${pipelinePublicHost}/v1beta/pipelines?page_size=100`, null, header).json("pipelines")) {
+    for (const pipeline of http.request("GET", `${pipelinePublicHost}/v1beta/pipelines?page_size=100`, null, data.header).json("pipelines")) {
       check(http.request("DELETE", `${pipelinePublicHost}/v1beta/pipelines/${pipeline.id}`), {
         [`DELETE /v1beta/pipelines response status is 204`]: (r) => r.status === 204,
       });

--- a/integration-test/pipeline/const.js
+++ b/integration-test/pipeline/const.js
@@ -29,6 +29,7 @@ export const pipelinePublicHost = apiGatewayMode ? `${proto}://${__ENV.API_GATEW
 export const mgmtPublicHost = apiGatewayMode ? `${proto}://${__ENV.API_GATEWAY_URL}/core` : `http://api-gateway:8080/core`
 export const pipelineGRPCPrivateHost = apiGatewayMode ? `${__ENV.API_GATEWAY_URL}` : `pipeline-backend:3081`;
 export const pipelineGRPCPublicHost = apiGatewayMode ? `${__ENV.API_GATEWAY_URL}` : `api-gateway:8080`;
+export const mgmtGRPCPublicHost = apiGatewayMode ? `${__ENV.API_GATEWAY_URL}` : `api-gateway:8080`;
 
 export const dogImg = encoding.b64encode(
   open(`${__ENV.TEST_FOLDER_ABS_PATH}/integration-test/data/dog.jpg`, "b")

--- a/integration-test/pipeline/grpc-pipeline-private.js
+++ b/integration-test/pipeline/grpc-pipeline-private.js
@@ -17,7 +17,7 @@ clientPublic.load(
   "pipeline_public_service.proto"
 );
 
-export function CheckList(metadata) {
+export function CheckList(data) {
   group("Pipelines API: List pipelines by admin", () => {
     clientPrivate.connect(constant.pipelineGRPCPrivateHost, {
       plaintext: true,
@@ -64,7 +64,7 @@ export function CheckList(metadata) {
             parent: `${constant.namespace}`,
             pipeline: reqBody,
           },
-          metadata
+          data.metadata
         ),
         {
           [`vdp.pipeline.v1beta.PipelinePublicService/CreateUserPipeline x${reqBodies.length} response StatusOK`]:
@@ -220,7 +220,7 @@ export function CheckList(metadata) {
           {
             name: `${constant.namespace}/pipelines/${reqBody.id}`,
           },
-          metadata
+          data.metadata
         ),
         {
           [`vdp.pipeline.v1beta.PipelinePublicService/DeleteUserPipeline response StatusOK`]:
@@ -234,7 +234,7 @@ export function CheckList(metadata) {
   });
 }
 
-export function CheckLookUp(metadata) {
+export function CheckLookUp(data) {
   group("Pipelines API: Look up a pipeline by uid by admin", () => {
     clientPrivate.connect(constant.pipelineGRPCPrivateHost, {
       plaintext: true,
@@ -258,7 +258,7 @@ export function CheckLookUp(metadata) {
         parent: `${constant.namespace}`,
         pipeline: reqBody,
       },
-      metadata
+      data.metadata
     );
 
     check(res, {
@@ -288,7 +288,7 @@ export function CheckLookUp(metadata) {
         {
           name: `${constant.namespace}/pipelines/${reqBody.id}`,
         },
-        metadata
+        data.metadata
       ),
       {
         [`vdp.pipeline.v1beta.PipelinePublicService/DeleteUserPipeline response StatusOK`]:

--- a/integration-test/pipeline/grpc-pipeline-public-with-jwt.js
+++ b/integration-test/pipeline/grpc-pipeline-public-with-jwt.js
@@ -7,7 +7,7 @@ import * as constant from "./const.js";
 const client = new grpc.Client();
 client.load(["../proto/vdp/pipeline/v1beta"], "pipeline_public_service.proto");
 
-export function CheckCreate(metadata) {
+export function CheckCreate(data) {
   group(
     `Pipelines API: Create a pipeline [with random "Instill-User-Uid" header]`,
     () => {
@@ -44,7 +44,7 @@ export function CheckCreate(metadata) {
   );
 }
 
-export function CheckList(metadata) {
+export function CheckList(data) {
   group(`Pipelines API: List pipelines [with random "Instill-User-Uid" header]`, () => {
     client.connect(constant.pipelineGRPCPublicHost, {
       plaintext: true,
@@ -69,7 +69,7 @@ export function CheckList(metadata) {
   });
 }
 
-export function CheckGet(metadata) {
+export function CheckGet(data) {
   group(`Pipelines API: Get a pipeline [with random "Instill-User-Uid" header]`, () => {
     client.connect(constant.pipelineGRPCPublicHost, {
       plaintext: true,
@@ -90,7 +90,7 @@ export function CheckGet(metadata) {
           parent: `${constant.namespace}`,
           pipeline: reqBody,
         },
-        metadata
+        data.metadata
       ),
       {
         [`vdp.pipeline.v1beta.PipelinePublicService/CreateUserPipeline response StatusOK`]:
@@ -121,7 +121,7 @@ export function CheckGet(metadata) {
         {
           name: `${constant.namespace}/pipelines/${reqBody.id}`,
         },
-        metadata
+        data.metadata
       ),
       {
         [`vdp.pipeline.v1beta.PipelinePublicService/DeleteUserPipeline response StatusOK`]:
@@ -133,7 +133,7 @@ export function CheckGet(metadata) {
   });
 }
 
-export function CheckUpdate(metadata) {
+export function CheckUpdate(data) {
   group(
     `Pipelines API: Update a pipeline [with random "Instill-User-Uid" header]`,
     () => {
@@ -155,7 +155,7 @@ export function CheckUpdate(metadata) {
           parent: `${constant.namespace}`,
           pipeline: reqBody,
         },
-        metadata
+        data.metadata
       );
 
       check(resOrigin, {
@@ -194,7 +194,7 @@ export function CheckUpdate(metadata) {
           {
             name: `${constant.namespace}/pipelines/${reqBody.id}`,
           },
-          metadata
+          data.metadata
         ),
         {
           [`vdp.pipeline.v1beta.PipelinePublicService/DeleteUserPipeline response StatusOK`]:
@@ -207,7 +207,7 @@ export function CheckUpdate(metadata) {
   );
 }
 
-export function CheckRename(metadata) {
+export function CheckRename(data) {
   group(
     `Pipelines API: Rename a pipeline [with random "Instill-User-Uid" header]`,
     () => {
@@ -229,7 +229,7 @@ export function CheckRename(metadata) {
           parent: `${constant.namespace}`,
           pipeline: reqBody,
         },
-        metadata
+        data.metadata
       );
 
       check(res, {
@@ -265,7 +265,7 @@ export function CheckRename(metadata) {
           {
             name: `${constant.namespace}/pipelines/${reqBody.id}`,
           },
-          metadata
+          data.metadata
         ),
         {
           [`vdp.pipeline.v1beta.PipelinePublicService/DeleteUserPipeline response StatusOK`]:
@@ -278,7 +278,7 @@ export function CheckRename(metadata) {
   );
 }
 
-export function CheckLookUp(metadata) {
+export function CheckLookUp(data) {
   group(
     `Pipelines API: Look up a pipeline by uid [with random "Instill-User-Uid" header]`,
     () => {
@@ -300,7 +300,7 @@ export function CheckLookUp(metadata) {
           parent: `${constant.namespace}`,
           pipeline: reqBody,
         },
-        metadata
+        data.metadata
       );
 
       check(res, {
@@ -331,7 +331,7 @@ export function CheckLookUp(metadata) {
           {
             name: `${constant.namespace}/pipelines/${reqBody.id}`,
           },
-          metadata
+          data.metadata
         ),
         {
           [`vdp.pipeline.v1beta.PipelinePublicService/DeleteUserPipeline response StatusOK`]:

--- a/integration-test/pipeline/grpc-pipeline-public.js
+++ b/integration-test/pipeline/grpc-pipeline-public.js
@@ -9,7 +9,7 @@ import * as helper from "./helper.js";
 const client = new grpc.Client();
 client.load(["../proto/vdp/pipeline/v1beta"], "pipeline_public_service.proto");
 
-export function CheckCreate(metadata) {
+export function CheckCreate(data) {
   group("Pipelines API: Create a pipeline", () => {
     client.connect(constant.pipelineGRPCPublicHost, {
       plaintext: true,
@@ -30,7 +30,7 @@ export function CheckCreate(metadata) {
         parent: `${constant.namespace}`,
         pipeline: reqBody,
       },
-      metadata
+      data.metadata
     );
 
     check(resOrigin, {
@@ -47,7 +47,7 @@ export function CheckCreate(metadata) {
       "vdp.pipeline.v1beta.PipelinePublicService/CreateUserPipeline response pipeline recipe is valid":
         (r) => helper.validateRecipeGRPC(r.message.pipeline.recipe, false),
       "vdp.pipeline.v1beta.PipelinePublicService/CreateUserPipeline response pipeline owner is valid":
-        (r) => helper.isValidOwnerGRPC(r.message.pipeline.owner),
+        (r) => helper.isValidOwner(r.message.pipeline.owner, data.expectedOwner),
       "vdp.pipeline.v1beta.PipelinePublicService/CreateUserPipeline response pipeline create_time":
         (r) =>
           new Date(r.message.pipeline.createTime).getTime() >
@@ -65,7 +65,7 @@ export function CheckCreate(metadata) {
         {
           parent: `${constant.namespace}`,
         },
-        metadata
+        data.metadata
       ),
       {
         "vdp.pipeline.v1beta.PipelinePublicService/CreateUserPipeline response StatusInvalidArgument":
@@ -79,7 +79,7 @@ export function CheckCreate(metadata) {
         {
           parent: `${constant.namespace}`,
         },
-        metadata
+        data.metadata
       ),
       {
         "vdp.pipeline.v1beta.PipelinePublicService/CreateUserPipeline response StatusInvalidArgument":
@@ -94,7 +94,7 @@ export function CheckCreate(metadata) {
           parent: `${constant.namespace}`,
           pipeline: reqBody,
         },
-        metadata
+        data.metadata
       ),
       {
         "vdp.pipeline.v1beta.PipelinePublicService/CreateUserPipeline response StatusAlreadyExists":
@@ -108,7 +108,7 @@ export function CheckCreate(metadata) {
         {
           name: `${constant.namespace}/pipelines/${reqBody.id}`,
         },
-        metadata
+        data.metadata
       ),
       {
         [`vdp.pipeline.v1beta.PipelinePublicService/DeleteUserPipeline ${reqBody.id} response StatusOK`]:
@@ -123,7 +123,7 @@ export function CheckCreate(metadata) {
           parent: `${constant.namespace}`,
           pipeline: reqBody,
         },
-        metadata
+        data.metadata
       ),
       {
         "vdp.pipeline.v1beta.PipelinePublicService/CreateUserPipeline response StatusOK":
@@ -139,7 +139,7 @@ export function CheckCreate(metadata) {
           parent: `${constant.namespace}`,
           pipeline: reqBody,
         },
-        metadata
+        data.metadata
       ),
       {
         "vdp.pipeline.v1beta.PipelinePublicService/CreateUserPipeline with null id response StatusInvalidArgument":
@@ -155,7 +155,7 @@ export function CheckCreate(metadata) {
           parent: `${constant.namespace}`,
           pipeline: reqBody,
         },
-        metadata
+        data.metadata
       ),
       {
         "vdp.pipeline.v1beta.PipelinePublicService/CreateUserPipeline with non-RFC-1034 naming id response StatusInvalidArgument":
@@ -171,7 +171,7 @@ export function CheckCreate(metadata) {
           parent: `${constant.namespace}`,
           pipeline: reqBody,
         },
-        metadata
+        data.metadata
       ),
       {
         "vdp.pipeline.v1beta.PipelinePublicService/CreateUserPipeline with > 32-character id response StatusInvalidArgument":
@@ -187,7 +187,7 @@ export function CheckCreate(metadata) {
           parent: `${constant.namespace}`,
           pipeline: reqBody,
         },
-        metadata
+        data.metadata
       ),
       {
         "vdp.pipeline.v1beta.PipelinePublicService/CreateUserPipeline with non-ASCII id response StatusInvalidArgument":
@@ -202,7 +202,7 @@ export function CheckCreate(metadata) {
         {
           name: `${constant.namespace}/pipelines/${resOrigin.message.pipeline.id}`,
         },
-        metadata
+        data.metadata
       ),
       {
         [`vdp.pipeline.v1beta.PipelinePublicService/DeleteUserPipeline response StatusOK`]:
@@ -214,7 +214,7 @@ export function CheckCreate(metadata) {
   });
 }
 
-export function CheckList(metadata) {
+export function CheckList(data) {
   group("Pipelines API: List pipelines", () => {
     client.connect(constant.pipelineGRPCPublicHost, {
       plaintext: true,
@@ -226,7 +226,7 @@ export function CheckList(metadata) {
         {
           parent: `${constant.namespace}`,
         },
-        metadata
+        data.metadata
       ),
       {
         [`vdp.pipeline.v1beta.PipelinePublicService/ListUserPipelines response StatusOK`]:
@@ -259,7 +259,7 @@ export function CheckList(metadata) {
             parent: `${constant.namespace}`,
             pipeline: reqBody,
           },
-          metadata
+          data.metadata
         ),
         {
           [`vdp.pipeline.v1beta.PipelinePublicService/CreateUserPipeline x${reqBodies.length} response StatusOK`]:
@@ -276,7 +276,7 @@ export function CheckList(metadata) {
         {
           parent: `${constant.namespace}`,
         },
-        metadata
+        data.metadata
       ),
       {
         [`vdp.pipeline.v1beta.PipelinePublicService/ListUserPipelines response StatusOK`]:
@@ -297,7 +297,7 @@ export function CheckList(metadata) {
           parent: `${constant.namespace}`,
           view: "VIEW_FULL",
         },
-        metadata
+        data.metadata
       ),
       {
         [`vdp.pipeline.v1beta.PipelinePublicService/ListUserPipelines view=VIEW_FULL response StatusOK`]:
@@ -315,7 +315,7 @@ export function CheckList(metadata) {
           parent: `${constant.namespace}`,
           view: "VIEW_BASIC",
         },
-        metadata
+        data.metadata
       ),
       {
         [`vdp.pipeline.v1beta.PipelinePublicService/ListUserPipelines view=VIEW_BASIC response StatusOK`]:
@@ -332,7 +332,7 @@ export function CheckList(metadata) {
           parent: `${constant.namespace}`,
           pageSize: 3,
         },
-        metadata
+        data.metadata
       ),
       {
         [`vdp.pipeline.v1beta.PipelinePublicService/ListUserPipelines response pipelines.length == 3`]:
@@ -347,7 +347,7 @@ export function CheckList(metadata) {
           parent: `${constant.namespace}`,
           pageSize: 101,
         },
-        metadata
+        data.metadata
       ),
       {
         [`vdp.pipeline.v1beta.PipelinePublicService/ListUserPipelines response pipelines.length == 100`]:
@@ -361,7 +361,7 @@ export function CheckList(metadata) {
         parent: `${constant.namespace}`,
         pageSize: 100,
       },
-      metadata
+      data.metadata
     );
     var resSecond100 = client.invoke(
       "vdp.pipeline.v1beta.PipelinePublicService/ListUserPipelines",
@@ -370,7 +370,7 @@ export function CheckList(metadata) {
         pageSize: 100,
         pageToken: resFirst100.message.nextPageToken,
       },
-      metadata
+      data.metadata
     );
     check(resSecond100, {
       [`vdp.pipeline.v1beta.PipelinePublicService/ListUserPipelines pageSize=100 pageToken=${resFirst100.message.nextPageToken} response StatusOK`]:
@@ -391,7 +391,7 @@ export function CheckList(metadata) {
           filter:
             'create_time>timestamp("2000-06-19T23:31:08.657Z")',
         },
-        metadata
+        data.metadata
       ),
       {
         [`vdp.pipeline.v1beta.PipelinePublicService/ListUserPipelines filter: state=create_time>timestamp("2000-06-19T23:31:08.657Z") response StatusOK`]:
@@ -411,7 +411,7 @@ export function CheckList(metadata) {
           parent: `${constant.namespace}`,
           filter: `recipe.components.definition_name:"${srcConnPermalink}"`,
         },
-        metadata
+        data.metadata
       ),
       {
         [`vdp.pipeline.v1beta.PipelinePublicService/ListUserPipelines filter: recipe.components.definition_name:"${srcConnPermalink}" response StatusOK`]:
@@ -429,7 +429,7 @@ export function CheckList(metadata) {
           {
             name: `${constant.namespace}/pipelines/${reqBody.id}`,
           },
-          metadata
+          data.metadata
         ),
         {
           [`vdp.pipeline.v1beta.PipelinePublicService/DeleteUserPipeline response StatusOK`]:
@@ -442,7 +442,7 @@ export function CheckList(metadata) {
   });
 }
 
-export function CheckGet(metadata) {
+export function CheckGet(data) {
   group("Pipelines API: Get a pipeline", () => {
     client.connect(constant.pipelineGRPCPublicHost, {
       plaintext: true,
@@ -463,7 +463,7 @@ export function CheckGet(metadata) {
           parent: `${constant.namespace}`,
           pipeline: reqBody,
         },
-        metadata
+        data.metadata
       ),
       {
         [`vdp.pipeline.v1beta.PipelinePublicService/CreateUserPipeline response StatusOK`]:
@@ -477,7 +477,7 @@ export function CheckGet(metadata) {
         {
           name: `${constant.namespace}/pipelines/${reqBody.id}`,
         },
-        metadata
+        data.metadata
       ),
       {
         [`vdp.pipeline.v1beta.PipelinePublicService/GetUserPipeline name: pipelines/${reqBody.id} response StatusOK`]:
@@ -497,6 +497,7 @@ export function CheckGet(metadata) {
       }
     );
 
+
     check(
       client.invoke(
         "vdp.pipeline.v1beta.PipelinePublicService/GetUserPipeline",
@@ -504,7 +505,7 @@ export function CheckGet(metadata) {
           name: `${constant.namespace}/pipelines/${reqBody.id}`,
           view: "VIEW_FULL",
         },
-        metadata
+        data.metadata
       ),
       {
         [`vdp.pipeline.v1beta.PipelinePublicService/GetUserPipeline name: pipelines/${reqBody.id} view: "VIEW_FULL" response StatusOK`]:
@@ -512,7 +513,7 @@ export function CheckGet(metadata) {
         [`vdp.pipeline.v1beta.PipelinePublicService/GetUserPipeline name: pipelines/${reqBody.id} view: "VIEW_FULL" response pipeline recipe is null`]:
           (r) => r.message.pipeline.recipe !== null,
         [`vdp.pipeline.v1beta.PipelinePublicService/GetUserPipeline name: pipelines/${reqBody.id} view: "VIEW_FULL" response pipeline owner is valid`]:
-          (r) => helper.isValidOwnerGRPC(r.message.pipeline.owner),
+          (r) => helper.isValidOwner(r.message.pipeline.owner, data.expectedOwner),
       }
     );
 
@@ -522,7 +523,7 @@ export function CheckGet(metadata) {
         {
           name: `${constant.namespace}/pipelines/this-id-does-not-exist`,
         },
-        metadata
+        data.metadata
       ),
       {
         [`vdp.pipeline.v1beta.PipelinePublicService/GetUserPipeline name: this-id-does-not-exist response StatusNotFound`]:
@@ -537,7 +538,7 @@ export function CheckGet(metadata) {
         {
           name: `${constant.namespace}/pipelines/${reqBody.id}`,
         },
-        metadata
+        data.metadata
       ),
       {
         [`vdp.pipeline.v1beta.PipelinePublicService/DeleteUserPipeline response StatusOK`]:
@@ -549,7 +550,7 @@ export function CheckGet(metadata) {
   });
 }
 
-export function CheckUpdate(metadata) {
+export function CheckUpdate(data) {
   group("Pipelines API: Update a pipeline", () => {
     client.connect(constant.pipelineGRPCPublicHost, {
       plaintext: true,
@@ -569,7 +570,7 @@ export function CheckUpdate(metadata) {
         parent: `${constant.namespace}`,
         pipeline: reqBody,
       },
-      metadata
+      data.metadata
     );
 
     check(resOrigin, {
@@ -591,7 +592,7 @@ export function CheckUpdate(metadata) {
           pipeline: reqBodyUpdate,
           update_mask: "description",
         },
-        metadata
+        data.metadata
       ),
       {
         [`vdp.pipeline.v1beta.PipelinePublicService/UpdateUserPipeline response StatusOK`]:
@@ -633,7 +634,7 @@ export function CheckUpdate(metadata) {
           pipeline: reqBodyUpdate,
           update_mask: "description",
         },
-        metadata
+        data.metadata
       ),
       {
         [`vdp.pipeline.v1beta.PipelinePublicService/UpdateUserPipeline response pipeline description empty`]:
@@ -649,7 +650,7 @@ export function CheckUpdate(metadata) {
           pipeline: reqBodyUpdate,
           update_mask: "description",
         },
-        metadata
+        data.metadata
       ),
       {
         [`vdp.pipeline.v1beta.PipelinePublicService/UpdateUserPipeline response pipeline description non-empty`]:
@@ -665,7 +666,7 @@ export function CheckUpdate(metadata) {
           pipeline: reqBodyUpdate,
           update_mask: "id",
         },
-        metadata
+        data.metadata
       ),
       {
         [`vdp.pipeline.v1beta.PipelinePublicService/UpdateUserPipeline updating IMMUTABLE field with different id response StatusInvalidArgument`]:
@@ -681,7 +682,7 @@ export function CheckUpdate(metadata) {
           pipeline: reqBodyUpdate,
           update_mask: "id",
         },
-        metadata
+        data.metadata
       ),
       {
         [`vdp.pipeline.v1beta.PipelinePublicService/UpdateUserPipeline updating IMMUTABLE field with the same id response StatusOK`]:
@@ -696,7 +697,7 @@ export function CheckUpdate(metadata) {
         {
           name: `${constant.namespace}/pipelines/${reqBody.id}`,
         },
-        metadata
+        data.metadata
       ),
       {
         [`vdp.pipeline.v1beta.PipelinePublicService/DeleteUserPipeline response StatusOK`]:
@@ -709,7 +710,7 @@ export function CheckUpdate(metadata) {
 }
 
 
-export function CheckRename(metadata) {
+export function CheckRename(data) {
   group("Pipelines API: Rename a pipeline", () => {
     client.connect(constant.pipelineGRPCPublicHost, {
       plaintext: true,
@@ -729,7 +730,7 @@ export function CheckRename(metadata) {
         parent: `${constant.namespace}`,
         pipeline: reqBody,
       },
-      metadata
+      data.metadata
     );
 
     check(res, {
@@ -748,7 +749,7 @@ export function CheckRename(metadata) {
           name: `${constant.namespace}/pipelines/${reqBody.id}`,
           new_pipeline_id: reqBody.new_pipeline_id,
         },
-        metadata
+        data.metadata
       ),
       {
         [`vdp.pipeline.v1beta.PipelinePublicService/RenameUserPipeline response StatusOK`]:
@@ -768,7 +769,7 @@ export function CheckRename(metadata) {
         {
           name: `${constant.namespace}/pipelines/${reqBody.new_pipeline_id}`,
         },
-        metadata
+        data.metadata
       ),
       {
         [`vdp.pipeline.v1beta.PipelinePublicService/DeleteUserPipeline response StatusOK`]:
@@ -780,7 +781,7 @@ export function CheckRename(metadata) {
   });
 }
 
-export function CheckLookUp(metadata) {
+export function CheckLookUp(data) {
   group("Pipelines API: Look up a pipeline by uid", () => {
     client.connect(constant.pipelineGRPCPublicHost, {
       plaintext: true,
@@ -800,7 +801,7 @@ export function CheckLookUp(metadata) {
         parent: `${constant.namespace}`,
         pipeline: reqBody,
       },
-      metadata
+      data.metadata
     );
 
     check(res, {
@@ -814,7 +815,7 @@ export function CheckLookUp(metadata) {
         {
           permalink: `pipelines/${res.message.pipeline.uid}`,
         },
-        metadata
+        data.metadata
       ),
       {
         [`vdp.pipeline.v1beta.PipelinePublicService/LookUpPipeline response StatusOK`]:
@@ -831,7 +832,7 @@ export function CheckLookUp(metadata) {
         {
           name: `${constant.namespace}/pipelines/${reqBody.id}`,
         },
-        metadata
+        data.metadata
       ),
       {
         [`vdp.pipeline.v1beta.PipelinePublicService/DeleteUserPipeline response StatusOK`]:

--- a/integration-test/pipeline/grpc-pipeline-public.js
+++ b/integration-test/pipeline/grpc-pipeline-public.js
@@ -513,7 +513,7 @@ export function CheckGet(data) {
         [`vdp.pipeline.v1beta.PipelinePublicService/GetUserPipeline name: pipelines/${reqBody.id} view: "VIEW_FULL" response pipeline recipe is null`]:
           (r) => r.message.pipeline.recipe !== null,
         [`vdp.pipeline.v1beta.PipelinePublicService/GetUserPipeline name: pipelines/${reqBody.id} view: "VIEW_FULL" response pipeline owner is valid`]:
-          (r) => helper.isValidOwner(r.message.pipeline.owner, data.expectedOwner),
+          (r) => {console.log(r.message.pipeline.owner); console.log(data.expectedOwner); return helper.isValidOwner(r.message.pipeline.owner, data.expectedOwner)},
       }
     );
 

--- a/integration-test/pipeline/grpc-trigger-async.js
+++ b/integration-test/pipeline/grpc-trigger-async.js
@@ -9,7 +9,7 @@ import * as constant from "./const.js";
 const client = new grpc.Client();
 client.load(["../proto/vdp/pipeline/v1beta"], "pipeline_public_service.proto");
 
-export function CheckTrigger(metadata) {
+export function CheckTrigger(data) {
   group(
     "Pipelines API: Trigger an async pipeline for single image and single model",
     () => {
@@ -32,7 +32,7 @@ export function CheckTrigger(metadata) {
             parent: `${constant.namespace}`,
             pipeline: reqBody,
           },
-          metadata
+          data.metadata
         ),
         {
           "vdp.pipeline.v1beta.PipelinePublicService/CreateUserPipeline Async GRPC pipeline response StatusOK":
@@ -47,7 +47,7 @@ export function CheckTrigger(metadata) {
           name: `${constant.namespace}/pipelines/${reqBody.id}`,
           inputs: constant.simplePayload.inputs,
         },
-        metadata
+        data.metadata
       ),
         {
           [`vdp.pipeline.v1beta.PipelinePublicService/TriggerAsyncUserPipeline (url) response StatusOK`]:
@@ -64,7 +64,7 @@ export function CheckTrigger(metadata) {
           {
             name: `${constant.namespace}/pipelines/${reqBody.id}`,
           },
-          metadata
+          data.metadata
         ),
         {
           [`vdp.pipeline.v1beta.PipelinePublicService/DeleteUserPipeline response StatusOK`]:

--- a/integration-test/pipeline/grpc-trigger.js
+++ b/integration-test/pipeline/grpc-trigger.js
@@ -8,7 +8,7 @@ import * as constant from "./const.js";
 const client = new grpc.Client();
 client.load(["../proto/vdp/pipeline/v1beta"], "pipeline_public_service.proto");
 
-export function CheckTrigger(metadata) {
+export function CheckTrigger(data) {
   group(
     "Pipelines API: Trigger a pipeline for single image and single model",
     () => {
@@ -31,7 +31,7 @@ export function CheckTrigger(metadata) {
             parent: `${constant.namespace}`,
             pipeline: reqGRPC,
           },
-          metadata
+          data.metadata
         ),
         {
           "vdp.pipeline.v1beta.PipelinePublicService/CreateUserPipeline GRPC pipeline response StatusOK":
@@ -46,7 +46,7 @@ export function CheckTrigger(metadata) {
             name: `${constant.namespace}/pipelines/${reqGRPC.id}`,
             inputs: constant.simplePayload.inputs,
           },
-          metadata
+          data.metadata
         ),
         {
           [`vdp.pipeline.v1beta.PipelinePublicService/TriggerUserPipeline (url) response StatusOK`]:
@@ -61,7 +61,7 @@ export function CheckTrigger(metadata) {
           {
             name: `${constant.namespace}/pipelines/${reqGRPC.id}`,
           },
-          metadata
+          data.metadata
         ),
         {
           [`vdp.pipeline.v1beta.PipelinePublicService/DeleteUserPipeline ${reqGRPC.id} response StatusOK`]:

--- a/integration-test/pipeline/helper.js
+++ b/integration-test/pipeline/helper.js
@@ -23,34 +23,11 @@ export function isUUID(uuid) {
   return regexExp.test(uuid);
 }
 
-export function isValidOwnerHTTP(owner) {
-  const expectedProfile = {
-    "display_name": "Instill",
-    "bio": "",
-    "avatar": "",
-    "public_email": "",
-    "company_name": "Instill AI",
-    "social_profile_links": {}
-  }
+export function isValidOwner(owner, expectedOwner) {
   if (owner === null || owner === undefined) return false;
   if (owner.user === null || owner.user === undefined) return false;
   if (owner.user.id !== "admin") return false;
-  return deepEqual(owner.user.profile, expectedProfile)
-}
-
-export function isValidOwnerGRPC(owner) {
-  const expectedProfile = {
-    "displayName": "Instill",
-    "bio": "",
-    "avatar": "",
-    "publicEmail": "",
-    "companyName": "Instill AI",
-    "socialProfileLinks": {}
-  }
-  if (owner === null || owner === undefined) return false;
-  if (owner.user === null || owner.user === undefined) return false;
-  if (owner.user.id !== "admin") return false;
-  return deepEqual(owner.user.profile, expectedProfile)
+  return deepEqual(owner.user.profile, expectedOwner.profile)
 }
 
 export function validateRecipe(recipe, isPrivate) {

--- a/integration-test/pipeline/rest-pipeline-private.js
+++ b/integration-test/pipeline/rest-pipeline-private.js
@@ -10,10 +10,10 @@ import {
 import * as constant from "./const.js";
 import * as helper from "./helper.js";
 
-export function CheckList(header) {
+export function CheckList(data) {
   group("Pipelines API: List pipelines by admin", () => {
     check(
-      http.request("GET", `${pipelinePrivateHost}/v1beta/admin/pipelines`, null, header),
+      http.request("GET", `${pipelinePrivateHost}/v1beta/admin/pipelines`, null, data.header),
       {
         [`GET /v1beta/admin/pipelines response status is 200`]: (r) =>
           r.status === 200,
@@ -44,7 +44,7 @@ export function CheckList(header) {
           "POST",
           `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines`,
           JSON.stringify(reqBody),
-          header
+          data.header
         ),
         {
           [`POST /v1beta/${constant.namespace}/pipelines x${reqBodies.length} response status is 201`]:
@@ -203,7 +203,7 @@ export function CheckList(header) {
           "DELETE",
           `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines/${reqBody.id}`,
           JSON.stringify(reqBody),
-          header
+          data.header
         ),
         {
           [`DELETE /v1beta/${constant.namespace}/pipelines x${reqBodies.length} response status is 204`]:
@@ -214,7 +214,7 @@ export function CheckList(header) {
   });
 }
 
-export function CheckLookUp(header) {
+export function CheckLookUp(data) {
   group("Pipelines API: Look up a pipeline by uid by admin", () => {
     var reqBody = Object.assign(
       {
@@ -228,7 +228,7 @@ export function CheckLookUp(header) {
       "POST",
       `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines`,
       JSON.stringify(reqBody),
-      header
+      data.header
     );
 
     check(res, {
@@ -256,7 +256,7 @@ export function CheckLookUp(header) {
         "DELETE",
         `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines/${reqBody.id}`,
         null,
-        header
+        data.header
       ),
       {
         [`DELETE /v1beta/${constant.namespace}/pipelines/${reqBody.id} response status 204`]: (r) =>

--- a/integration-test/pipeline/rest-pipeline-public-with-jwt.js
+++ b/integration-test/pipeline/rest-pipeline-public-with-jwt.js
@@ -6,7 +6,7 @@ import { pipelinePublicHost } from "./const.js";
 
 import * as constant from "./const.js";
 
-export function CheckCreate(header) {
+export function CheckCreate(data) {
   group(
     `Pipelines API: Create a pipeline [with random "Instill-User-Uid" header]`,
     () => {
@@ -35,7 +35,7 @@ export function CheckCreate(header) {
   );
 }
 
-export function CheckList(header) {
+export function CheckList(data) {
   group(`Pipelines API: List pipelines [with random "Instill-User-Uid" header]`, () => {
     // Cannot list pipelines of a non-exist user
     check(
@@ -53,7 +53,7 @@ export function CheckList(header) {
   });
 }
 
-export function CheckGet(header) {
+export function CheckGet(data) {
   group(`Pipelines API: Get a pipeline [with random "Instill-User-Uid" header]`, () => {
     var reqBody = Object.assign(
       {
@@ -69,7 +69,7 @@ export function CheckGet(header) {
         "POST",
         `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines`,
         JSON.stringify(reqBody),
-        header
+        data.header
       ),
       {
         "POST /v1beta/${constant.namespace}/pipelines response status is 201": (r) =>
@@ -97,7 +97,7 @@ export function CheckGet(header) {
         "DELETE",
         `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines/${reqBody.id}`,
         null,
-        header
+        data.header
       ),
       {
         [`DELETE /v1beta/${constant.namespace}/pipelines/${reqBody.id} response status 204`]: (r) =>
@@ -107,7 +107,7 @@ export function CheckGet(header) {
   });
 }
 
-export function CheckUpdate(header) {
+export function CheckUpdate(data) {
   group(
     `Pipelines API: Update a pipeline [with random "Instill-User-Uid" header]`,
     () => {
@@ -123,7 +123,7 @@ export function CheckUpdate(header) {
         "POST",
         `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines`,
         JSON.stringify(reqBody),
-        header
+        data.header
       );
 
       check(resOrigin, {
@@ -157,7 +157,7 @@ export function CheckUpdate(header) {
           "DELETE",
           `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines/${reqBody.id}`,
           null,
-          header
+          data.header
         ),
         {
           [`DELETE /v1beta/${constant.namespace}/pipelines/${reqBody.id} response status 204`]: (
@@ -169,7 +169,7 @@ export function CheckUpdate(header) {
   );
 }
 
-export function CheckRename(header) {
+export function CheckRename(data) {
   group(
     `Pipelines API: Rename a pipeline [with random "Instill-User-Uid" header]`,
     () => {
@@ -186,7 +186,7 @@ export function CheckRename(header) {
         "POST",
         `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines`,
         JSON.stringify(reqBody),
-        header
+        data.header
       );
 
       check(res, {
@@ -219,7 +219,7 @@ export function CheckRename(header) {
           "DELETE",
           `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines/${id}`,
           null,
-          header
+          data.header
         ),
         {
           [`DELETE /v1beta/${constant.namespace}/pipelines/${id} response status 204`]: (r) =>
@@ -230,7 +230,7 @@ export function CheckRename(header) {
   );
 }
 
-export function CheckLookUp(header) {
+export function CheckLookUp(data) {
   group(
     `Pipelines API: Look up a pipeline by uid [with random "Instill-User-Uid" header]`,
     () => {
@@ -246,7 +246,7 @@ export function CheckLookUp(header) {
         "POST",
         `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines`,
         JSON.stringify(reqBody),
-        header
+        data.header
       );
 
       check(res, {
@@ -275,7 +275,7 @@ export function CheckLookUp(header) {
           "DELETE",
           `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines/${reqBody.id}`,
           null,
-          header
+          data.header
         ),
         {
           [`DELETE /v1beta/${constant.namespace}/pipelines/${reqBody.id} response status 204`]: (

--- a/integration-test/pipeline/rest-pipeline-public.js
+++ b/integration-test/pipeline/rest-pipeline-public.js
@@ -7,7 +7,7 @@ import { pipelinePublicHost } from "./const.js";
 import * as constant from "./const.js";
 import * as helper from "./helper.js";
 
-export function CheckCreate(header) {
+export function CheckCreate(data) {
   group("Pipelines API: Create a pipeline", () => {
 
     var reqBody = Object.assign(
@@ -23,7 +23,7 @@ export function CheckCreate(header) {
       "POST",
       `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines`,
       JSON.stringify(reqBody),
-      header
+      data.header
     );
     check(resOrigin, {
       "POST /v1beta/${constant.namespace}/pipelines response status is 201": (r) => r.status === 201,
@@ -38,7 +38,7 @@ export function CheckCreate(header) {
       "POST /v1beta/${constant.namespace}/pipelines response pipeline recipe is valid": (r) =>
         helper.validateRecipe(r.json().pipeline.recipe, false),
       "POST /v1beta/${constant.namespace}/pipelines response pipeline owner isinvalid": (r) =>
-        helper.isValidOwnerHTTP(r.json().pipeline.owner),
+        helper.isValidOwner(r.json().pipeline.owner, data.expectedOwner),
       "POST /v1beta/${constant.namespace}/pipelines response pipeline create_time": (r) =>
         new Date(r.json().pipeline.create_time).getTime() >
         new Date().setTime(0),
@@ -53,7 +53,7 @@ export function CheckCreate(header) {
         "POST",
         `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines`,
         JSON.stringify({}),
-        header
+        data.header
       ),
       {
         "POST /v1beta/${constant.namespace}/pipelines request body JSON Schema failed status 400": (
@@ -67,7 +67,7 @@ export function CheckCreate(header) {
         "POST",
         `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines`,
         JSON.stringify(reqBody),
-        header
+        data.header
       ),
       {
         "POST /v1beta/${constant.namespace}/pipelines re-create the same id response status is 409":
@@ -80,7 +80,7 @@ export function CheckCreate(header) {
         "DELETE",
         `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines/${reqBody.id}`,
         null,
-        header
+        data.header
       ),
       {
         [`DELETE /v1beta/${constant.namespace}/pipelines/${reqBody.id} response status 204`]: (r) =>
@@ -93,7 +93,7 @@ export function CheckCreate(header) {
         "POST",
         `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines`,
         JSON.stringify(reqBody),
-        header
+        data.header
       ),
       {
         "POST /v1beta/${constant.namespace}/pipelines re-create the same id after deletion response status is 201":
@@ -106,7 +106,7 @@ export function CheckCreate(header) {
         "POST",
         `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines`,
         JSON.stringify({}),
-        header
+        data.header
       ),
       {
         "POST /v1beta/${constant.namespace}/pipelines with empty body response status is 400": (r) =>
@@ -119,7 +119,7 @@ export function CheckCreate(header) {
         "POST",
         `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines`,
         null,
-        header
+        data.header
       ),
       {
         "POST /v1beta/${constant.namespace}/pipelines with null body response status is 400": (r) =>
@@ -133,7 +133,7 @@ export function CheckCreate(header) {
         "POST",
         `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines`,
         JSON.stringify(reqBody),
-        header
+        data.header
       ),
       {
         "POST /v1beta/${constant.namespace}/pipelines with null id response status is 400": (r) =>
@@ -147,7 +147,7 @@ export function CheckCreate(header) {
         "POST",
         `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines`,
         JSON.stringify(reqBody),
-        header
+        data.header
       ),
       {
         "POST /v1beta/${constant.namespace}/pipelines with non-RFC-1034 naming id response status is 400":
@@ -161,7 +161,7 @@ export function CheckCreate(header) {
         "POST",
         `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines`,
         JSON.stringify(reqBody),
-        header
+        data.header
       ),
       {
         "POST /v1beta/${constant.namespace}/pipelines with > 32-character id response status is 400":
@@ -175,7 +175,7 @@ export function CheckCreate(header) {
         "POST",
         `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines`,
         JSON.stringify(reqBody),
-        header
+        data.header
       ),
       {
         "POST /v1beta/${constant.namespace}/pipelines with non-ASCII id response status is 400": (
@@ -191,7 +191,7 @@ export function CheckCreate(header) {
         `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines/${resOrigin.json().pipeline.id
         }`,
         null,
-        header
+        data.header
       ),
       {
         [`DELETE /v1beta/${constant.namespace}/pipelines/${resOrigin.json().pipeline.id
@@ -203,9 +203,9 @@ export function CheckCreate(header) {
 
 
 
-export function CheckList(header) {
+export function CheckList(data) {
   group("Pipelines API: List pipelines", () => {
-    check(http.request("GET", `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines`, null, header), {
+    check(http.request("GET", `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines`, null, data.header), {
       [`GET /v1beta/${constant.namespace}/pipelines response status is 200`]: (r) =>
         r.status === 200,
       [`GET /v1beta/${constant.namespace}/pipelines response next_page_token is empty`]: (r) =>
@@ -233,7 +233,7 @@ export function CheckList(header) {
           "POST",
           `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines`,
           JSON.stringify(reqBody),
-          header
+          data.header
         ),
         {
           [`POST /v1beta/${constant.namespace}/pipelines x${reqBodies.length} response status is 201`]:
@@ -247,7 +247,7 @@ export function CheckList(header) {
         "GET",
         `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines`,
         null,
-        header
+        data.header
       ),
       {
         [`GET /v1beta/${constant.namespace}/pipelines response status is 200`]: (r) =>
@@ -266,7 +266,7 @@ export function CheckList(header) {
         "GET",
         `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines?view=VIEW_FULL`,
         null,
-        header
+        data.header
       ),
       {
         [`GET /v1beta/${constant.namespace}/pipelines?view=VIEW_FULL response pipelines[0] has recipe`]:
@@ -281,7 +281,7 @@ export function CheckList(header) {
         "GET",
         `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines?view=VIEW_BASIC`,
         null,
-        header
+        data.header
       ),
       {
         [`GET /v1beta/${constant.namespace}/pipelines?view=VIEW_BASIC response pipelines[0].recipe is null`]:
@@ -294,7 +294,7 @@ export function CheckList(header) {
         "GET",
         `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines?page_size=3`,
         null,
-        header
+        data.header
       ),
       {
         [`GET /v1beta/${constant.namespace}/pipelines?page_size=3 response pipelines.length == 3`]: (
@@ -308,7 +308,7 @@ export function CheckList(header) {
         "GET",
         `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines?page_size=101`,
         null,
-        header
+        data.header
       ),
       {
         [`GET /v1beta/${constant.namespace}/pipelines?page_size=101 response pipelines.length == 100`]:
@@ -320,13 +320,13 @@ export function CheckList(header) {
       "GET",
       `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines?page_size=100`,
       null,
-      header
+      data.header
     );
     var resSecond100 = http.request(
       "GET",
       `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines?page_size=100&page_token=${resFirst100.json().next_page_token
       }`,
-      null, header
+      null, data.header
     );
     check(resSecond100, {
       [`GET /v1beta/${constant.namespace}/pipelines?page_size=100&page_token=${resFirst100.json().next_page_token
@@ -344,7 +344,7 @@ export function CheckList(header) {
         "GET",
         `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines`,
         null,
-        header
+        data.header
       ),
       {
         [`GET /v1beta/${constant.namespace}/pipelines response 200`]: (r) => r.status == 200,
@@ -358,7 +358,7 @@ export function CheckList(header) {
         "GET",
         `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines?filter=create_time>timestamp%28%222000-06-19T23:31:08.657Z%22%29`,
         null,
-        header
+        data.header
       ),
       {
         [`GET /v1beta/${constant.namespace}/pipelines?filter=create_time%20>%20timestamp%28%222000-06-19T23:31:08.657Z%22%29 response 200`]:
@@ -375,7 +375,7 @@ export function CheckList(header) {
         "GET",
         `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines?filter=recipe.components.definition_name:%22${srcConnPermalink}%22`,
         null,
-        header
+        data.header
       ),
       {
         [`GET /v1beta/${constant.namespace}/pipelines?filter=recipe.components.definition_name:%22${srcConnPermalink}%22 response 200`]:
@@ -392,7 +392,7 @@ export function CheckList(header) {
           "DELETE",
           `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines/${reqBody.id}`,
           JSON.stringify(reqBody),
-          header
+          data.header
         ),
         {
           [`DELETE /v1beta/${constant.namespace}/pipelines x${reqBodies.length} response status is 204`]:
@@ -403,7 +403,7 @@ export function CheckList(header) {
   });
 }
 
-export function CheckGet(header) {
+export function CheckGet(data) {
   group("Pipelines API: Get a pipeline", () => {
     var reqBody = Object.assign(
       {
@@ -419,7 +419,7 @@ export function CheckGet(header) {
         "POST",
         `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines`,
         JSON.stringify(reqBody),
-        header
+        data.header
       ),
       {
         "POST /v1beta/${constant.namespace}/pipelines response status is 201": (r) =>
@@ -432,7 +432,7 @@ export function CheckGet(header) {
         "GET",
         `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines/${reqBody.id}`,
         null,
-        header
+        data.header
       ),
       {
         [`GET /v1beta/${constant.namespace}/pipelines/${reqBody.id} response status is 200`]: (r) =>
@@ -457,7 +457,7 @@ export function CheckGet(header) {
         "GET",
         `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines/${reqBody.id}?view=VIEW_FULL`,
         null,
-        header
+        data.header
       ),
       {
         [`GET /v1beta/${constant.namespace}/pipelines/${reqBody.id} response status is 200`]: (r) =>
@@ -465,7 +465,7 @@ export function CheckGet(header) {
         [`GET /v1beta/${constant.namespace}/pipelines/${reqBody.id} response pipeline recipe is not null`]:
           (r) => r.json().pipeline.recipe !== null,
         [`GET /v1beta/${constant.namespace}/pipelines/${reqBody.id} response pipeline owner isvalid`]:
-          (r) => helper.isValidOwnerHTTP(r.json().pipeline.owner),
+          (r) => helper.isValidOwner(r.json().pipeline.owner, data.expectedOwner),
       }
     );
 
@@ -474,7 +474,7 @@ export function CheckGet(header) {
         "GET",
         `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines/this-id-does-not-exist`,
         null,
-        header
+        data.header
       ),
       {
         "GET /v1beta/${constant.namespace}/pipelines/this-id-does-not-exist response status is 404":
@@ -488,7 +488,7 @@ export function CheckGet(header) {
         "DELETE",
         `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines/${reqBody.id}`,
         null,
-        header
+        data.header
       ),
       {
         [`DELETE /v1beta/${constant.namespace}/pipelines/${reqBody.id} response status 204`]: (r) =>
@@ -498,7 +498,7 @@ export function CheckGet(header) {
   });
 }
 
-export function CheckUpdate(header) {
+export function CheckUpdate(data) {
   group("Pipelines API: Update a pipeline", () => {
     var reqBody = Object.assign(
       {
@@ -512,7 +512,7 @@ export function CheckUpdate(header) {
       "POST",
       `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines`,
       JSON.stringify(reqBody),
-      header
+      data.header
     );
 
     check(resOrigin, {
@@ -530,7 +530,7 @@ export function CheckUpdate(header) {
         "PATCH",
         `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines/${reqBody.id}`,
         JSON.stringify(reqBodyUpdate),
-        header
+        data.header
       ),
       {
         [`PATCH /v1beta/${constant.namespace}/pipelines/${reqBody.id} response status is 200`]: (
@@ -549,7 +549,7 @@ export function CheckUpdate(header) {
         [`PATCH /v1beta/${constant.namespace}/pipelines/${reqBody.id} response pipeline description (OPTIONAL)`]:
           (r) => r.json().pipeline.description === reqBodyUpdate.description,
         [`PATCH /v1beta/${constant.namespace}/pipelines/${reqBody.id} response pipeline owner isvalid`]:
-          (r) => helper.isValidOwnerHTTP(r.json().pipeline.owner),
+          (r) => helper.isValidOwner(r.json().pipeline.owner, data.expectedOwner),
         [`PATCH /v1beta/${constant.namespace}/pipelines/${reqBody.id} response pipeline create_time (OUTPUT_ONLY)`]:
           (r) =>
             new Date(r.json().pipeline.create_time).getTime() >
@@ -571,7 +571,7 @@ export function CheckUpdate(header) {
         "PATCH",
         `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines/${reqBody.id}`,
         JSON.stringify(reqBodyUpdate),
-        header
+        data.header
       ),
       {
         [`PATCH /v1beta/${constant.namespace}/pipelines/${reqBody.id} response pipeline empty description`]:
@@ -585,7 +585,7 @@ export function CheckUpdate(header) {
         "PATCH",
         `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines/${reqBody.id}`,
         JSON.stringify(reqBodyUpdate),
-        header
+        data.header
       ),
       {
         [`PATCH /v1beta/${constant.namespace}/pipelines/${reqBody.id} response pipeline non-empty description`]:
@@ -599,7 +599,7 @@ export function CheckUpdate(header) {
         "PATCH",
         `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines/${reqBody.id}`,
         JSON.stringify(reqBodyUpdate),
-        header
+        data.header
       ),
       {
         [`PATCH /v1beta/${constant.namespace}/pipelines/${reqBody.id} response status for updating IMMUTABLE field with different id is 400`]:
@@ -613,7 +613,7 @@ export function CheckUpdate(header) {
         "PATCH",
         `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines/${reqBody.id}`,
         JSON.stringify(reqBodyUpdate),
-        header
+        data.header
       ),
       {
         [`PATCH /v1beta/${constant.namespace}/pipelines/${reqBody.id} response status for updating IMMUTABLE field with the same id is 200`]:
@@ -626,7 +626,7 @@ export function CheckUpdate(header) {
         "PATCH",
         `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines/this-id-does-not-exist`,
         JSON.stringify(reqBodyUpdate),
-        header
+        data.header
       ),
       {
         "PATCH /v1beta/${constant.namespace}/pipelines/this-id-does-not-exist response status is 404":
@@ -640,7 +640,7 @@ export function CheckUpdate(header) {
         "DELETE",
         `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines/${reqBody.id}`,
         null,
-        header
+        data.header
       ),
       {
         [`DELETE /v1beta/${constant.namespace}/pipelines/${reqBody.id} response status 204`]: (r) =>
@@ -651,7 +651,7 @@ export function CheckUpdate(header) {
 }
 
 
-export function CheckRename(header) {
+export function CheckRename(data) {
   group("Pipelines API: Rename a pipeline", () => {
     var reqBody = Object.assign(
       {
@@ -665,7 +665,7 @@ export function CheckRename(header) {
       "POST",
       `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines`,
       JSON.stringify(reqBody),
-      header
+      data.header
     );
 
     check(res, {
@@ -682,7 +682,7 @@ export function CheckRename(header) {
         `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines/${res.json().pipeline.id
         }/rename`,
         JSON.stringify(reqBody),
-        header
+        data.header
       ),
       {
         [`POST /v1beta/${constant.namespace}/pipelines/${res.json().pipeline.id
@@ -702,7 +702,7 @@ export function CheckRename(header) {
         "DELETE",
         `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines/${reqBody.new_pipeline_id}`,
         null,
-        header
+        data.header
       ),
       {
         [`DELETE /v1beta/${constant.namespace}/pipelines/${reqBody.new_pipeline_id} response status 204`]:
@@ -712,7 +712,7 @@ export function CheckRename(header) {
   });
 }
 
-export function CheckLookUp(header) {
+export function CheckLookUp(data) {
   group("Pipelines API: Look up a pipeline by uid", () => {
     var reqBody = Object.assign(
       {
@@ -726,7 +726,7 @@ export function CheckLookUp(header) {
       "POST",
       `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines`,
       JSON.stringify(reqBody),
-      header
+      data.header
     );
 
     check(res, {
@@ -739,7 +739,7 @@ export function CheckLookUp(header) {
         `${pipelinePublicHost}/v1beta/pipelines/${res.json().pipeline.uid
         }/lookUp`,
         null,
-        header
+        data.header
       ),
       {
         [`GET /v1beta/pipelines/${res.json().pipeline.uid
@@ -756,7 +756,7 @@ export function CheckLookUp(header) {
         "DELETE",
         `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines/${reqBody.id}`,
         null,
-        header
+        data.header
       ),
       {
         [`DELETE /v1beta/${constant.namespace}/pipelines/${reqBody.id} response status 204`]: (r) =>

--- a/integration-test/pipeline/rest-trigger-async.js
+++ b/integration-test/pipeline/rest-trigger-async.js
@@ -7,7 +7,7 @@ import { pipelinePublicHost } from "./const.js";
 
 import * as constant from "./const.js"
 
-export function CheckTrigger(header) {
+export function CheckTrigger(data) {
 
   var reqBody = Object.assign(
     {
@@ -19,12 +19,12 @@ export function CheckTrigger(header) {
 
   group("Pipelines API: Trigger an async pipeline for single image and single model", () => {
 
-    check(http.request("POST", `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines`, JSON.stringify(reqBody), header), {
+    check(http.request("POST", `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines`, JSON.stringify(reqBody), data.header), {
       "POST /v1beta/${constant.namespace}/pipelines response status is 201": (r) => r.status === 201,
     });
 
 
-    check(http.request("POST", `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines/${reqBody.id}/triggerAsync`, JSON.stringify(constant.simplePayload), header), {
+    check(http.request("POST", `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines/${reqBody.id}/triggerAsync`, JSON.stringify(constant.simplePayload), data.header), {
       [`POST /v1beta/${constant.namespace}/pipelines/${reqBody.id}/triggerAsync (url) response status is 200`]: (r) => r.status === 200,
       [`POST /v1beta/${constant.namespace}/pipelines/${reqBody.id}/triggerAsync (url) response status is 200`]: (r) => r.json().operation.name.startsWith("operations/"),
     });
@@ -32,7 +32,7 @@ export function CheckTrigger(header) {
   });
 
   // Delete the pipeline
-  check(http.request("DELETE", `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines/${reqBody.id}`, null, header), {
+  check(http.request("DELETE", `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines/${reqBody.id}`, null, data.header), {
     [`DELETE /v1beta/${constant.namespace}/pipelines/${reqBody.id} response status 204`]: (r) => r.status === 204,
   });
 }

--- a/integration-test/pipeline/rest-trigger.js
+++ b/integration-test/pipeline/rest-trigger.js
@@ -7,7 +7,7 @@ import { pipelinePublicHost } from "./const.js";
 
 import * as constant from "./const.js"
 
-export function CheckTrigger(header) {
+export function CheckTrigger(data) {
 
   group("Pipelines API: Trigger a pipeline for single image and single model", () => {
 
@@ -19,16 +19,16 @@ export function CheckTrigger(header) {
       constant.simpleRecipe
     );
 
-    check(http.request("POST", `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines`, JSON.stringify(reqHTTP), header), {
+    check(http.request("POST", `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines`, JSON.stringify(reqHTTP), data.header), {
       "POST /v1beta/${constant.namespace}/pipelines response status is 201 (HTTP pipeline)": (r) => r.status === 201,
     });
 
-    check(http.request("POST", `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines/${reqHTTP.id}/trigger`, JSON.stringify(constant.simplePayload), header), {
+    check(http.request("POST", `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines/${reqHTTP.id}/trigger`, JSON.stringify(constant.simplePayload), data.header), {
       [`POST /v1beta/${constant.namespace}/pipelines/${reqHTTP.id}/trigger (url) response status is 200`]: (r) => r.status === 200,
     });
 
 
-    check(http.request("DELETE", `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines/${reqHTTP.id}`, null, header), {
+    check(http.request("DELETE", `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines/${reqHTTP.id}`, null, data.header), {
       [`DELETE /v1beta/${constant.namespace}/pipelines/${reqHTTP.id} response status 204`]: (r) => r.status === 204,
     });
 

--- a/integration-test/pipeline/rest.js
+++ b/integration-test/pipeline/rest.js
@@ -85,11 +85,11 @@ export function setup() {
     http.request("POST", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors/${constant.dstCSVConnID2}/connect`, {}, header)
 
   });
-
-  return header
+  var resp = http.request("GET", `${constant.mgmtPublicHost}/v1beta/user`, {}, {headers: {"Authorization": `Bearer ${loginResp.json().access_token}`}})
+  return {header: header, expectedOwner: resp.json().user}
 }
 
-export default function (header) {
+export default function (data) {
 
   /*
    * Pipelines API - API CALLS
@@ -105,46 +105,46 @@ export default function (header) {
   }
 
   if (!constant.apiGatewayMode) {
-    pipelinePrivate.CheckList(header)
-    pipelinePrivate.CheckLookUp(header)
+    pipelinePrivate.CheckList(data)
+    pipelinePrivate.CheckLookUp(data)
 
   } else {
 
-    pipelinePublicWithJwt.CheckCreate(header)
-    pipelinePublicWithJwt.CheckList(header)
-    pipelinePublicWithJwt.CheckGet(header)
-    pipelinePublicWithJwt.CheckUpdate(header)
-    pipelinePublicWithJwt.CheckRename(header)
-    pipelinePublicWithJwt.CheckLookUp(header)
-    pipelinePublic.CheckCreate(header)
-    pipelinePublic.CheckList(header)
-    pipelinePublic.CheckGet(header)
-    pipelinePublic.CheckUpdate(header)
-    pipelinePublic.CheckRename(header)
-    pipelinePublic.CheckLookUp(header)
+    pipelinePublicWithJwt.CheckCreate(data)
+    pipelinePublicWithJwt.CheckList(data)
+    pipelinePublicWithJwt.CheckGet(data)
+    pipelinePublicWithJwt.CheckUpdate(data)
+    pipelinePublicWithJwt.CheckRename(data)
+    pipelinePublicWithJwt.CheckLookUp(data)
+    pipelinePublic.CheckCreate(data)
+    pipelinePublic.CheckList(data)
+    pipelinePublic.CheckGet(data)
+    pipelinePublic.CheckUpdate(data)
+    pipelinePublic.CheckRename(data)
+    pipelinePublic.CheckLookUp(data)
 
-    trigger.CheckTrigger(header)
-    triggerAsync.CheckTrigger(header)
+    trigger.CheckTrigger(data)
+    triggerAsync.CheckTrigger(data)
 
   }
 }
 
-export function teardown(header) {
+export function teardown(data) {
 
   group("Connector API: Delete all pipelines created by this test", () => {
-    for (const pipeline of http.request("GET", `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines?page_size=100`, null, header).json("pipelines")) {
-      check(http.request("DELETE", `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines/${pipeline.id}`, null, header), {
+    for (const pipeline of http.request("GET", `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines?page_size=100`, null, data.header).json("pipelines")) {
+      check(http.request("DELETE", `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines/${pipeline.id}`, null, data.header), {
         [`DELETE /v1beta/${constant.namespace}/pipelines response status is 204`]: (r) => r.status === 204,
       });
     }
   });
   group("Connector Backend API: Delete the csv destination connector", function () {
-    check(http.request("DELETE", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors/${constant.dstCSVConnID1}`, null, header), {
+    check(http.request("DELETE", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors/${constant.dstCSVConnID1}`, null, data.header), {
       [`DELETE /v1beta/${constant.namespace}/connectors/${constant.dstCSVConnID1} response status 204`]: (r) => r.status === 204,
     });
   });
   group("Connector Backend API: Delete the csv destination connector", function () {
-    check(http.request("DELETE", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors/${constant.dstCSVConnID2}`, null, header), {
+    check(http.request("DELETE", `${pipelinePublicHost}/v1beta/${constant.namespace}/connectors/${constant.dstCSVConnID2}`, null, data.header), {
       [`DELETE /v1beta/${constant.namespace}/connectors/${constant.dstCSVConnID2} response status 204`]: (r) => r.status === 204,
     });
   });

--- a/integration-test/proto/core/mgmt/v1beta/metric.proto
+++ b/integration-test/proto/core/mgmt/v1beta/metric.proto
@@ -1,0 +1,285 @@
+syntax = "proto3";
+
+package core.mgmt.v1beta;
+
+// Google API
+import "google/api/field_behavior.proto";
+// Protobuf standard
+import "google/protobuf/timestamp.proto";
+
+// Mode describes the execution mode of the pipeline (sync or async).
+enum Mode {
+  // Unspecified.
+  MODE_UNSPECIFIED = 0;
+  // Synchronous (result is returned in the response).
+  MODE_SYNC = 1;
+  // Asynchronous (response only contains acknowledgement).
+  MODE_ASYNC = 2;
+}
+
+// Status describes the output of an execution.
+enum Status {
+  // Unspecified.
+  STATUS_UNSPECIFIED = 0;
+  // Successfully completed.
+  STATUS_COMPLETED = 1;
+  // Finished with error.
+  STATUS_ERRORED = 2;
+}
+
+// ========== Pipeline endpoints
+
+// PipelineTriggerRecord represents a pipeline execution event.
+message PipelineTriggerRecord {
+  // The moment when the pipeline was triggered.
+  google.protobuf.Timestamp trigger_time = 1;
+  // UUID of the trigger.
+  string pipeline_trigger_id = 2;
+  // Pipeline ID.
+  string pipeline_id = 3;
+  // Pipeline UUID.
+  string pipeline_uid = 4;
+  // Trigger mode.
+  Mode trigger_mode = 5;
+  // Total execution duration.
+  float compute_time_duration = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Final status.
+  Status status = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // If a release of the pipeline was triggered, pipeline version.
+  string pipeline_release_id = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // If a release of the pipeline was triggered, release UUID.
+  string pipeline_release_uid = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// PipelineTriggerTableRecord contains pipeline trigger metrics, aggregated by
+// pipeline ID.
+message PipelineTriggerTableRecord {
+  // Pipeline ID.
+  string pipeline_id = 1;
+  // Pipeline UUID.
+  string pipeline_uid = 2;
+  // Number of triggers with `STATUS_COMPLETED`.
+  int32 trigger_count_completed = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Number of triggers with `STATUS_ERRORED`.
+  int32 trigger_count_errored = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Version for the triggered pipeline if it is a release pipeline.
+  string pipeline_release_id = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Release UUID for the triggered pipeline if it is a release pipeline.
+  string pipeline_release_uid = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// PipelineTriggerChartRecord contains pipeline trigger metrics, aggregated by
+// pipeline ID and time frame.
+message PipelineTriggerChartRecord {
+  // Pipeline ID.
+  string pipeline_id = 1;
+  // Pipeline UUID.
+  string pipeline_uid = 2;
+  // Trigger mode.
+  Mode trigger_mode = 3;
+  // Final status.
+  Status status = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Time buckets.
+  repeated google.protobuf.Timestamp time_buckets = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Aggregated trigger count in each time bucket.
+  repeated int32 trigger_counts = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Total computation time duration in each time bucket.
+  repeated float compute_time_duration = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Version for the triggered pipeline if it is a release pipeline.
+  string pipeline_release_id = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Release UUID for the triggered pipeline if it is a release pipeline.
+  string pipeline_release_uid = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// ListPipelineTriggerRecordsRequest represents a request to list the triggers
+// of a pipeline.
+message ListPipelineTriggerRecordsRequest {
+  // The maximum number of triggers to return. If this parameter is unspecified,
+  // at most 100 pipelines will be returned. The cap value for this parameter is
+  // 1000 (i.e. any value above that will be coerced to 100).
+  optional int32 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
+  // Page token.
+  optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
+  // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
+  // expression.
+  // - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
+  optional string filter = 3 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// ListPipelineTriggerRecordsResponse contains a list of pipeline triggers.
+message ListPipelineTriggerRecordsResponse {
+  // A list of pipeline triggers.
+  repeated PipelineTriggerRecord pipeline_trigger_records = 1;
+  // Next page token.
+  string next_page_token = 2;
+  // Total number of pipeline triggers.
+  int32 total_size = 3;
+}
+
+// ListPipelineTriggerTableRecordsRequest represents a request to list the
+// pipeline triggers metrics, aggregated by pipeline ID.
+message ListPipelineTriggerTableRecordsRequest {
+  // The maximum number of results to return. If this parameter is unspecified,
+  // at most 100 pipelines will be returned. The cap value for this parameter
+  // is 1000 (i.e. any value above that will be coerced to 1000).
+  optional int32 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
+  // Page token.
+  optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
+  // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
+  // expression.
+  // - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
+  optional string filter = 3 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// ListPipelineTriggerTableRecordsResponse contains the pipeline metrics.
+message ListPipelineTriggerTableRecordsResponse {
+  // A list of pipeline trigger tables.
+  repeated PipelineTriggerTableRecord pipeline_trigger_table_records = 1;
+  // Next page token.
+  string next_page_token = 2;
+  // Total number of pipeline trigger records
+  int32 total_size = 3;
+}
+
+// ListPipelineTriggerChartRecordsRequest represents a request to list pipeline
+// trigger metrics, aggregated by pipeline ID and time frame.
+message ListPipelineTriggerChartRecordsRequest {
+  // Aggregation window in nanoseconds.
+  int32 aggregation_window = 1;
+  // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
+  // expression.
+  // - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
+  optional string filter = 2 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// ListPipelineTriggerChartRecordsResponse contains a list of pipeline trigger
+// chart records.
+message ListPipelineTriggerChartRecordsResponse {
+  // A list of pipeline trigger records.
+  repeated PipelineTriggerChartRecord pipeline_trigger_chart_records = 1;
+}
+
+// ========== Connector endpoints
+
+// ConnectorExecuteRecord represents a connector execution event.
+message ConnectorExecuteRecord {
+  // The moment when the connector was executed.
+  google.protobuf.Timestamp execute_time = 1;
+  // UUID of the execution.
+  string connector_execute_id = 2;
+  // Connector ID.
+  string connector_id = 3;
+  // Connector UUID.
+  string connector_uid = 4;
+  // Connector definition UUID.
+  string connector_definition_uid = 5;
+  // Pipeline ID.
+  string pipeline_id = 6;
+  // Pipeline UUID.
+  string pipeline_uid = 7;
+  // UUID of the pipeline trigger.
+  string pipeline_trigger_id = 8;
+  // Total execution time.
+  float compute_time_duration = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Final status for the connector execution.
+  Status status = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// ConnectorExecuteTableRecord contains connector execution metrics, a aggregated by connector ID.
+message ConnectorExecuteTableRecord {
+  // Connector ID.
+  string connector_id = 1;
+  // Connector UUID.
+  string connector_uid = 2;
+  // Number of executions with `STATUS_COMPLETED`.
+  int32 execute_count_completed = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Number of executions with `STATUS_ERRORED`.
+  int32 execute_count_errored = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// ConnectorExecuteChartRecord contains connector execution metrics,
+// agggregated by connector ID and time frame.
+message ConnectorExecuteChartRecord {
+  // Connector ID.
+  string connector_id = 1;
+  // Connector UUID.
+  string connector_uid = 2;
+  // Final status.
+  Status status = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Time buckets.
+  repeated google.protobuf.Timestamp time_buckets = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Aggregated execution count in each time bucket.
+  repeated int32 execute_counts = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Total computation time duration in each time bucket.
+  repeated float compute_time_duration = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// ListConnectorExecuteRecordsRequest represents a request to list connector
+// executions.
+message ListConnectorExecuteRecordsRequest {
+  // The maximum number of executions to return. If this parameter is
+  // unspecified, at most 100 pipelines will be returned. The cap value for
+  // this parameter is 1000 (i.e. any value above that will be coerced to
+  // 1000).
+  optional int32 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
+  // Page token.
+  optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
+  // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
+  // expression.
+  // - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
+  optional string filter = 3 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// ListConnectorExecuteRecordsResponse represents a response for a list
+// of connector execute record
+message ListConnectorExecuteRecordsResponse {
+  // A list of connector execute records
+  repeated ConnectorExecuteRecord connector_execute_records = 1;
+  // Next page token.
+  string next_page_token = 2;
+  // Total count of connector execute records
+  int32 total_size = 3;
+}
+
+// ListConnectorExecuteTableRecordsRequest represents a request to list the
+// connector execution metrics, aggregated by connector.
+message ListConnectorExecuteTableRecordsRequest {
+  // The maximum number of results to return. If this parameter is unspecified,
+  // at most 100 pipelines will be returned. The cap value for this parameter
+  // is 1000 (i.e. any value above that will be coerced to 1000).
+  optional int32 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
+  // Page token.
+  optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
+  // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
+  // expression.
+  // - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
+  optional string filter = 3 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// ListConnectorExecuteTableRecordsResponse contains the connector metrics.
+message ListConnectorExecuteTableRecordsResponse {
+  // A list of connector execution records.
+  repeated ConnectorExecuteTableRecord connector_execute_table_records = 1;
+  // Next page token.
+  string next_page_token = 2;
+  // Total number of connector execution records.
+  int32 total_size = 3;
+}
+
+// ListConnectorExecuteChartRecordsRequest represents a request to list
+// connector execution metrics, aggregated by connector and time frame.
+message ListConnectorExecuteChartRecordsRequest {
+  // Aggregation window in nanoseconds.
+  int32 aggregation_window = 1;
+  // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
+  // expression.
+  // - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
+  optional string filter = 2 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// ListConnectorExecuteChartRecordsResponse contains a list of connector
+// execution chart records.
+message ListConnectorExecuteChartRecordsResponse {
+  // A list of connector execution records.
+  repeated ConnectorExecuteChartRecord connector_execute_chart_records = 1;
+}

--- a/integration-test/proto/core/mgmt/v1beta/mgmt_public_service.proto
+++ b/integration-test/proto/core/mgmt/v1beta/mgmt_public_service.proto
@@ -1,0 +1,389 @@
+syntax = "proto3";
+
+package core.mgmt.v1beta;
+
+// Core definitions
+import "../../../core/mgmt/v1beta/metric.proto";
+import "../../../core/mgmt/v1beta/mgmt.proto";
+// Google API
+import "google/api/annotations.proto";
+import "google/api/client.proto";
+import "google/api/visibility.proto";
+// OpenAPI definition
+import "protoc-gen-openapiv2/options/annotations.proto";
+
+// MGMT
+//
+// MgmtPublicService exposes the public Core endpoints that allow clients to
+// manage user resources.
+service MgmtPublicService {
+  option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_tag) = {description: "Public Core endpoints"};
+
+  // Delete an organization membership
+  //
+  // Deletes a user membership within an organization.
+  rpc DeleteOrganizationMembership(DeleteOrganizationMembershipRequest) returns (DeleteOrganizationMembershipResponse) {
+    option (google.api.http) = {delete: "/v1beta/{name=organizations/*/memberships/*}"};
+    option (google.api.method_signature) = "name";
+  }
+
+  // Check if the MGMT server is alive
+  //
+  // See https://github.com/grpc/grpc/blob/master/doc/health-checking.md.
+  rpc Liveness(LivenessRequest) returns (LivenessResponse) {
+    option (google.api.http) = {
+      get: "/v1beta/__liveness"
+      additional_bindings: [
+        {get: "/v1beta/health/mgmt"}]
+    };
+    option (google.api.method_visibility).restriction = "INTERNAL";
+  }
+
+  // Check if the pipeline server is ready
+  //
+  // See https://github.com/grpc/grpc/blob/master/doc/health-checking.md
+  rpc Readiness(ReadinessRequest) returns (ReadinessResponse) {
+    option (google.api.http) = {
+      get: "/v1beta/__readiness"
+      additional_bindings: [
+        {get: "/v1beta/ready/mgmt"}]
+    };
+    option (google.api.method_visibility).restriction = "INTERNAL";
+  }
+
+  // Check if a namespace is in use
+  //
+  // Returns the availability of a namespace or, alternatively, the type of
+  // resource that is using it.
+  rpc CheckNamespace(CheckNamespaceRequest) returns (CheckNamespaceResponse) {
+    option (google.api.http) = {
+      post: "/v1beta/check-namespace"
+      body: "*"
+    };
+    option (google.api.method_signature) = "namespace";
+    option (google.api.method_visibility).restriction = "INTERNAL";
+  }
+
+  // Get the authenticated user
+  //
+  // Returns the details of the authenticated user.
+  rpc GetAuthenticatedUser(GetAuthenticatedUserRequest) returns (GetAuthenticatedUserResponse) {
+    option (google.api.http) = {get: "/v1beta/user"};
+    option (google.api.method_signature) = "user,update_mask";
+  }
+
+  // Update the authenticated user
+  //
+  // Updates the information of the authenticated user.
+  //
+  // In REST requests, only the supplied user fields will be taken into account
+  // when updating the resource.
+  rpc PatchAuthenticatedUser(PatchAuthenticatedUserRequest) returns (PatchAuthenticatedUserResponse) {
+    option (google.api.http) = {
+      patch: "/v1beta/user"
+      body: "user"
+    };
+    option (google.api.method_signature) = "user,update_mask";
+  }
+
+  // List users
+  //
+  // Returns a paginated list of users.
+  rpc ListUsers(ListUsersRequest) returns (ListUsersResponse) {
+    option (google.api.http) = {get: "/v1beta/users"};
+  }
+
+  // Get a user
+  //
+  // Returns the details of a user by their ID.
+  rpc GetUser(GetUserRequest) returns (GetUserResponse) {
+    option (google.api.http) = {get: "/v1beta/{name=users/*}"};
+    option (google.api.method_signature) = "name";
+    option (google.api.method_visibility).restriction = "INTERNAL";
+  }
+
+  // List user memberships
+  //
+  // Returns the memberships of a user.
+  rpc ListUserMemberships(ListUserMembershipsRequest) returns (ListUserMembershipsResponse) {
+    option (google.api.http) = {get: "/v1beta/{parent=users/*}/memberships"};
+    option (google.api.method_signature) = "parent";
+    option (google.api.method_visibility).restriction = "INTERNAL";
+  }
+
+  // Get a user membership
+  //
+  // Returns the details of the relationship between a user and an
+  // organization. The authenticated must match the membership parent.
+  rpc GetUserMembership(GetUserMembershipRequest) returns (GetUserMembershipResponse) {
+    option (google.api.http) = {get: "/v1beta/{name=users/*/memberships/*}"};
+    option (google.api.method_signature) = "name";
+    option (google.api.method_visibility).restriction = "INTERNAL";
+  }
+
+  // Update a user membership
+  //
+  // Accesses and updates a user membership by parent and membership IDs.
+  rpc UpdateUserMembership(UpdateUserMembershipRequest) returns (UpdateUserMembershipResponse) {
+    option (google.api.http) = {
+      put: "/v1beta/{membership.name=users/*/memberships/*}"
+      body: "membership"
+    };
+    option (google.api.method_signature) = "membership,update_mask";
+    option (google.api.method_visibility).restriction = "INTERNAL";
+  }
+
+  // Delete a user membership
+  //
+  // Accesses and deletes a user membership by parent and membership IDs.
+  rpc DeleteUserMembership(DeleteUserMembershipRequest) returns (DeleteUserMembershipResponse) {
+    option (google.api.http) = {delete: "/v1beta/{name=users/*/memberships/*}"};
+    option (google.api.method_signature) = "name";
+  }
+
+  // List organizations
+  //
+  // Returns a paginated list of organizations.
+  rpc ListOrganizations(ListOrganizationsRequest) returns (ListOrganizationsResponse) {
+    option (google.api.http) = {get: "/v1beta/organizations"};
+    option (google.api.method_visibility).restriction = "INTERNAL";
+  }
+
+  // Create an organization
+  //
+  // Creates an organization.
+  rpc CreateOrganization(CreateOrganizationRequest) returns (CreateOrganizationResponse) {
+    option (google.api.http) = {
+      post: "/v1beta/organizations"
+      body: "organization"
+    };
+    option (google.api.method_signature) = "organization";
+    option (google.api.method_visibility).restriction = "INTERNAL";
+  }
+
+  // Get an organization
+  //
+  // Returns the organization details by its ID.
+  rpc GetOrganization(GetOrganizationRequest) returns (GetOrganizationResponse) {
+    option (google.api.http) = {get: "/v1beta/{name=organizations/*}"};
+    option (google.api.method_signature) = "name";
+    option (google.api.method_visibility).restriction = "INTERNAL";
+  }
+
+  // Update an organization
+  //
+  // Accesses and updates an organization by ID.
+  //
+  // In REST requests, only the supplied organization fields will be taken into
+  // account when updating the resource.
+  rpc UpdateOrganization(UpdateOrganizationRequest) returns (UpdateOrganizationResponse) {
+    option (google.api.http) = {
+      patch: "/v1beta/{organization.name=organizations/*}"
+      body: "organization"
+    };
+    option (google.api.method_signature) = "organization,update_mask";
+    option (google.api.method_visibility).restriction = "INTERNAL";
+  }
+
+  // Delete an organization
+  //
+  // Accesses and deletes an organization by ID.
+  rpc DeleteOrganization(DeleteOrganizationRequest) returns (DeleteOrganizationResponse) {
+    option (google.api.http) = {delete: "/v1beta/{name=organizations/*}"};
+    option (google.api.method_signature) = "name";
+    option (google.api.method_visibility).restriction = "INTERNAL";
+  }
+
+  // List organization memberships
+  //
+  // Returns a paginated list of the user memberships in an organization.
+  rpc ListOrganizationMemberships(ListOrganizationMembershipsRequest) returns (ListOrganizationMembershipsResponse) {
+    option (google.api.http) = {get: "/v1beta/{parent=organizations/*}/memberships"};
+    option (google.api.method_signature) = "parent";
+    option (google.api.method_visibility).restriction = "INTERNAL";
+  }
+
+  // Get a an organization membership
+  //
+  // Returns the details of a user membership within an organization.
+  rpc GetOrganizationMembership(GetOrganizationMembershipRequest) returns (GetOrganizationMembershipResponse) {
+    option (google.api.http) = {get: "/v1beta/{name=organizations/*/memberships/*}"};
+    option (google.api.method_signature) = "name";
+    option (google.api.method_visibility).restriction = "INTERNAL";
+  }
+
+  // Uppdate an organization membership
+  //
+  // Updates a user membership within an organization.
+  rpc UpdateOrganizationMembership(UpdateOrganizationMembershipRequest) returns (UpdateOrganizationMembershipResponse) {
+    option (google.api.http) = {
+      put: "/v1beta/{membership.name=organizations/*/memberships/*}"
+      body: "membership"
+    };
+    option (google.api.method_signature) = "membership,update_mask";
+    option (google.api.method_visibility).restriction = "INTERNAL";
+  }
+
+  // Get the subscription of the authenticated user
+  //
+  // Returns the subscription details of the authenticated user.
+  rpc GetAuthenticatedUserSubscription(GetAuthenticatedUserSubscriptionRequest) returns (GetAuthenticatedUserSubscriptionResponse) {
+    option (google.api.http) = {get: "/v1beta/user/subscription"};
+    option (google.api.method_visibility).restriction = "INTERNAL";
+  }
+
+  // Get an organization subscription
+  //
+  // Returns the subscription details of an organization.
+  rpc GetOrganizationSubscription(GetOrganizationSubscriptionRequest) returns (GetOrganizationSubscriptionResponse) {
+    option (google.api.http) = {get: "/v1beta/{parent=organizations/*}/subscription"};
+    option (google.api.method_signature) = "parent";
+    option (google.api.method_visibility).restriction = "INTERNAL";
+  }
+
+  // Create an API token
+  //
+  // Creates an API token for the authenticated user.
+  rpc CreateToken(CreateTokenRequest) returns (CreateTokenResponse) {
+    option (google.api.http) = {
+      post: "/v1beta/tokens"
+      body: "token"
+    };
+    option (google.api.method_signature) = "token";
+    option (google.api.method_visibility).restriction = "INTERNAL";
+  }
+
+  // List API tokens
+  //
+  // Returns a paginated list of the API tokens of the authenticated user.
+  rpc ListTokens(ListTokensRequest) returns (ListTokensResponse) {
+    option (google.api.http) = {get: "/v1beta/tokens"};
+    option (google.api.method_visibility).restriction = "INTERNAL";
+  }
+
+  // Get an API token
+  //
+  // Returns the details of an API token.
+  rpc GetToken(GetTokenRequest) returns (GetTokenResponse) {
+    option (google.api.http) = {get: "/v1beta/{name=tokens/*}"};
+    option (google.api.method_signature) = "name";
+    option (google.api.method_visibility).restriction = "INTERNAL";
+  }
+
+  // Delete an API token
+  //
+  // Deletes an API token.
+  rpc DeleteToken(DeleteTokenRequest) returns (DeleteTokenResponse) {
+    option (google.api.http) = {delete: "/v1beta/{name=tokens/*}"};
+    option (google.api.method_signature) = "name";
+    option (google.api.method_visibility).restriction = "INTERNAL";
+  }
+
+  // Validate an API token.
+  //
+  // Validates an API token.
+  rpc ValidateToken(ValidateTokenRequest) returns (ValidateTokenResponse) {
+    option (google.api.http) = {post: "/v1beta/validate_token"};
+    option (google.api.method_visibility).restriction = "INTERNAL";
+  }
+
+  // List pipeline triggers
+  //
+  // Returns a paginated list of pipeline executions.
+  rpc ListPipelineTriggerRecords(ListPipelineTriggerRecordsRequest) returns (ListPipelineTriggerRecordsResponse) {
+    option (google.api.http) = {get: "/v1beta/metrics/vdp/pipeline/triggers"};
+    option (google.api.method_visibility).restriction = "INTERNAL";
+  }
+
+  // List pipeline trigger metrics
+  //
+  // Returns a paginated list of pipeline executions aggregated by pipeline ID.
+  rpc ListPipelineTriggerTableRecords(ListPipelineTriggerTableRecordsRequest) returns (ListPipelineTriggerTableRecordsResponse) {
+    option (google.api.http) = {get: "/v1beta/metrics/vdp/pipeline/tables"};
+    option (google.api.method_visibility).restriction = "INTERNAL";
+  }
+
+  // List pipeline trigger computation time charts
+  //
+  // Returns a paginated list with pipeline trigger execution times, aggregated
+  // by pipeline and time frames.
+  rpc ListPipelineTriggerChartRecords(ListPipelineTriggerChartRecordsRequest) returns (ListPipelineTriggerChartRecordsResponse) {
+    option (google.api.http) = {get: "/v1beta/metrics/vdp/pipeline/charts"};
+    option (google.api.method_visibility).restriction = "INTERNAL";
+  }
+
+  // List connector executions
+  //
+  // Returns a paginated list of connector executions.
+  rpc ListConnectorExecuteRecords(ListConnectorExecuteRecordsRequest) returns (ListConnectorExecuteRecordsResponse) {
+    option (google.api.http) = {get: "/v1beta/metrics/vdp/connector/executes"};
+    option (google.api.method_visibility).restriction = "INTERNAL";
+  }
+
+  // List connector execution metrics
+  //
+  // Returns a paginated list of connector executions aggregated by connector.
+  rpc ListConnectorExecuteTableRecords(ListConnectorExecuteTableRecordsRequest) returns (ListConnectorExecuteTableRecordsResponse) {
+    option (google.api.http) = {get: "/v1beta/metrics/vdp/connector/tables"};
+    option (google.api.method_visibility).restriction = "INTERNAL";
+  }
+
+  // List connector execution computation time charts
+  //
+  // Returns a paginated list with connector execution times, aggregated by
+  // connector and time frames.
+  rpc ListConnectorExecuteChartRecords(ListConnectorExecuteChartRecordsRequest) returns (ListConnectorExecuteChartRecordsResponse) {
+    option (google.api.http) = {get: "/v1beta/metrics/vdp/connector/charts"};
+    option (google.api.method_visibility).restriction = "INTERNAL";
+  }
+
+  // Auth endpoints are only used in the community edition and the OpenAPI
+  // documentation references Instill Cloud. Therefore, these endpoints are
+  // hidden.
+
+  // Get Auth token issuer
+  //
+  // Returns the auth token issuer details. This operation requires admin permissions.
+  rpc AuthTokenIssuer(AuthTokenIssuerRequest) returns (AuthTokenIssuerResponse) {
+    option (google.api.http) = {
+      post: "/v1beta/auth/token_issuer",
+      body: "*"
+    };
+    option (google.api.method_visibility).restriction = "INTERNAL";
+  }
+
+  // Log in a user
+  //
+  // Authenticates a user and returns an access token.
+  rpc AuthLogin(AuthLoginRequest) returns (AuthLoginResponse) {
+    option (google.api.http) = {post: "/v1beta/auth/login"};
+    option (google.api.method_visibility).restriction = "INTERNAL";
+  }
+
+  // Log out a user
+  //
+  // Logs out an authenticated user.
+  rpc AuthLogout(AuthLogoutRequest) returns (AuthLogoutResponse) {
+    option (google.api.http) = {post: "/v1beta/auth/logout"};
+    option (google.api.method_visibility).restriction = "INTERNAL";
+  }
+
+  // Change password
+  //
+  // Updates the password of a user.
+  rpc AuthChangePassword(AuthChangePasswordRequest) returns (AuthChangePasswordResponse) {
+    option (google.api.http) = {
+      post: "/v1beta/auth/change_password",
+      body: "*"
+    };
+    option (google.api.method_visibility).restriction = "INTERNAL";
+  }
+
+  // Validate an access token
+  //
+  // Checks the validity of an access token.
+  rpc AuthValidateAccessToken(AuthValidateAccessTokenRequest) returns (AuthValidateAccessTokenResponse) {
+    option (google.api.http) = {post: "/v1beta/auth/validate_access_token"};
+    option (google.api.method_visibility).restriction = "INTERNAL";
+  }
+}


### PR DESCRIPTION
Because

- We will run pipeline integration tests together with other backend tests. The owner profile data might be changed by other backends. We need to use the real data from the database as the expected result instead of using the hardcoded one.

This commit

- Uses owner profile from mgmtdb as the expected result