### PR TITLE
feat: revamp recipe format and implement iterator

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -157,6 +157,7 @@ func main() {
 	})
 
 	w.RegisterWorkflow(cw.TriggerPipelineWorkflow)
+	w.RegisterActivity(cw.PipelineActivity)
 	w.RegisterActivity(cw.ConnectorActivity)
 	w.RegisterActivity(cw.OperatorActivity)
 

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/instill-ai/component v0.12.0-beta
 	github.com/instill-ai/connector v0.13.0-beta
 	github.com/instill-ai/operator v0.9.0-beta
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240229093826-e5102a60f80e
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240305055434-f65d3c697ec8
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha
 	github.com/knadh/koanf v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -1196,8 +1196,8 @@ github.com/instill-ai/connector v0.13.0-beta h1:lzJewnUPKN54t43lfQ0vCKwMq0MMk7xs
 github.com/instill-ai/connector v0.13.0-beta/go.mod h1:RyTtDP/fcFab7P4k3Z4PEGSlvEBz1/cnz6zqEZKenZ0=
 github.com/instill-ai/operator v0.9.0-beta h1:TSGpKTO2r2yugrTfVAw5ce4T2urMnriNChCb/1Ng5/g=
 github.com/instill-ai/operator v0.9.0-beta/go.mod h1:Nu2DPiWyi5uWpBwckV9bE2xPiWpPkJ3konbXINkRJXs=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240229093826-e5102a60f80e h1:QWwjc4KAnzFrx9Zi/xPGwlvbT5DgT1Qf7D/z5u9JJCk=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240229093826-e5102a60f80e/go.mod h1:jhEL0SauySMoPLVvx105DWyThju9sYTbsXIySVCArmM=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240305055434-f65d3c697ec8 h1:3Nw+/qThtXY5sySXpS6nymNVMkwB8JkkWhtnq27muiY=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240305055434-f65d3c697ec8/go.mod h1:jhEL0SauySMoPLVvx105DWyThju9sYTbsXIySVCArmM=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a/go.mod h1:EpX3Yr661uWULtZf5UnJHfr5rw2PDyX8ku4Kx0UtYFw=
 github.com/instill-ai/x v0.4.0-alpha h1:zQV2VLbSHjMv6gyBN/2mwwrvWk0/mJM6ZKS12AzjfQg=

--- a/integration-test/pipeline/const.js
+++ b/integration-test/pipeline/const.js
@@ -86,12 +86,10 @@ export const simpleRecipe = {
     components: [
       {
         id: "start",
-        definition_name: "operator-definitions/start",
-        configuration: {
-          metadata: {
+        start_component: {
+          fields: {
             input: {
               title: "Input",
-              type: "string",
               instillFormat: "string"
             }
           }
@@ -99,35 +97,33 @@ export const simpleRecipe = {
       },
       {
         id: "end",
-        definition_name: "operator-definitions/end",
-        configuration: {
-          metadata: {
+        end_component: {
+          fields: {
             answer: {
-              title: "Answer"
+              title: "Answer",
+              value: "${start.input}"
             }
-          },
-          input: {
-            answer: "${start.input}"
           }
         }
       },
       {
         id: "d01",
-        resource_name: `users/admin/connectors/${dstCSVConnID1}`,
-        definition_name: "connector-definitions/airbyte-destination",
-        configuration: {
+        connector_component: {
+          resource_name: `users/admin/connectors/${dstCSVConnID1}`,
+          definition_name: "connector-definitions/airbyte-destination",
           input: {
             data: {
               text: "${start.input}"
             }
           }
+
         }
       },
       {
         id: "d02",
-        resource_name: `users/admin/connectors/${dstCSVConnID2}`,
-        definition_name: "connector-definitions/airbyte-destination",
-        configuration: {
+        connector_component: {
+          resource_name: `users/admin/connectors/${dstCSVConnID2}`,
+          definition_name: "connector-definitions/airbyte-destination",
           input: {
             data: {
               text: "${start.input}"
@@ -145,12 +141,10 @@ export const simpleRecipeWithoutCSV = {
     components: [
       {
         id: "start",
-        definition_name: "operator-definitions/start",
-        configuration: {
-          metadata: {
+        start_component: {
+          fields: {
             input: {
               title: "Input",
-              type: "string",
               instillFormat: "string"
             }
           }
@@ -158,15 +152,12 @@ export const simpleRecipeWithoutCSV = {
       },
       {
         id: "end",
-        definition_name: "operator-definitions/end",
-        configuration: {
-          metadata: {
+        end_component: {
+          fields: {
             answer: {
-              title: "Answer"
+              title: "Answer",
+              value: "${start.input}"
             }
-          },
-          input: {
-            answer: "${start.input}"
           }
         }
       },
@@ -180,12 +171,10 @@ export const simpleRecipeDupId = {
     components: [
       {
         id: "start",
-        definition_name: "operator-definitions/start",
-        configuration: {
-          metadata: {
+        start_component: {
+          fields: {
             input: {
               title: "Input",
-              type: "string",
               instillFormat: "string"
             }
           }
@@ -193,23 +182,20 @@ export const simpleRecipeDupId = {
       },
       {
         id: "end",
-        definition_name: "operator-definitions/end",
-        configuration: {
-          metadata: {
+        end_component: {
+          fields: {
             answer: {
-              title: "Answer"
+              title: "Answer",
+              value: "${start.input}"
             }
-          },
-          input: {
-            answer: "${start.input}"
           }
         }
       },
       {
         id: "d01",
-        resource_name: `users/admin/connectors/${dstCSVConnID1}`,
-        definition_name: "connector-definitions/airbyte-destination",
-        configuration: {
+        connector_component: {
+          resource_name: `users/admin/connectors/${dstCSVConnID1}`,
+          definition_name: "connector-definitions/airbyte-destination",
           input: {
             data: {
               text: "${start.input}"
@@ -219,9 +205,9 @@ export const simpleRecipeDupId = {
       },
       {
         id: "d01",
-        resource_name: `users/admin/connectors/${dstCSVConnID2}`,
-        definition_name: "connector-definitions/airbyte-destination",
-        configuration: {
+        connector_component: {
+          resource_name: `users/admin/connectors/${dstCSVConnID2}`,
+          definition_name: "connector-definitions/airbyte-destination",
           input: {
             data: {
               text: "${start.input}"

--- a/integration-test/pipeline/const.js
+++ b/integration-test/pipeline/const.js
@@ -90,7 +90,7 @@ export const simpleRecipe = {
           fields: {
             input: {
               title: "Input",
-              instillFormat: "string"
+              instill_format: "string"
             }
           }
         }
@@ -109,7 +109,7 @@ export const simpleRecipe = {
       {
         id: "d01",
         connector_component: {
-          resource_name: `users/admin/connectors/${dstCSVConnID1}`,
+          connector_name: `users/admin/connectors/${dstCSVConnID1}`,
           definition_name: "connector-definitions/airbyte-destination",
           input: {
             data: {
@@ -122,7 +122,7 @@ export const simpleRecipe = {
       {
         id: "d02",
         connector_component: {
-          resource_name: `users/admin/connectors/${dstCSVConnID2}`,
+          connector_name: `users/admin/connectors/${dstCSVConnID2}`,
           definition_name: "connector-definitions/airbyte-destination",
           input: {
             data: {
@@ -145,7 +145,7 @@ export const simpleRecipeWithoutCSV = {
           fields: {
             input: {
               title: "Input",
-              instillFormat: "string"
+              instill_format: "string"
             }
           }
         }
@@ -175,7 +175,7 @@ export const simpleRecipeDupId = {
           fields: {
             input: {
               title: "Input",
-              instillFormat: "string"
+              instill_format: "string"
             }
           }
         }
@@ -194,7 +194,7 @@ export const simpleRecipeDupId = {
       {
         id: "d01",
         connector_component: {
-          resource_name: `users/admin/connectors/${dstCSVConnID1}`,
+          connector_name: `users/admin/connectors/${dstCSVConnID1}`,
           definition_name: "connector-definitions/airbyte-destination",
           input: {
             data: {
@@ -206,7 +206,7 @@ export const simpleRecipeDupId = {
       {
         id: "d01",
         connector_component: {
-          resource_name: `users/admin/connectors/${dstCSVConnID2}`,
+          connector_name: `users/admin/connectors/${dstCSVConnID2}`,
           definition_name: "connector-definitions/airbyte-destination",
           input: {
             data: {

--- a/integration-test/pipeline/grpc-pipeline-private.js
+++ b/integration-test/pipeline/grpc-pipeline-private.js
@@ -194,23 +194,6 @@ export function CheckList(data) {
       }
     );
 
-    var srcConnPermalink = "operator-definitions/2ac8be70-0f7a-4b61-a33d-098b8acfa6f3"
-
-    check(
-      clientPrivate.invoke(
-        "vdp.pipeline.v1beta.PipelinePrivateService/ListPipelinesAdmin",
-        {
-          filter: `recipe.components.definition_name:"${srcConnPermalink}"`,
-        },
-        {}
-      ),
-      {
-        [`vdp.pipeline.v1beta.PipelinePrivateService/ListPipelinesAdmin filter: recipe.components.definition_name:"${srcConnPermalink}" response StatusOK`]:
-          (r) => r.status === grpc.StatusOK,
-        [`vdp.pipeline.v1beta.PipelinePrivateService/ListPipelinesAdmin filter: recipe.components.definition_name:"${srcConnPermalink}" response pipelines.length`]:
-          (r) => r.message.pipelines.length > 0,
-      }
-    );
 
     // Delete the pipelines
     for (const reqBody of reqBodies) {

--- a/integration-test/pipeline/grpc-pipeline-public.js
+++ b/integration-test/pipeline/grpc-pipeline-public.js
@@ -401,26 +401,6 @@ export function CheckList(data) {
       }
     );
 
-    // Get UUID for foreign resources
-    var srcConnPermalink = "operator-definitions/2ac8be70-0f7a-4b61-a33d-098b8acfa6f3"
-
-    check(
-      client.invoke(
-        "vdp.pipeline.v1beta.PipelinePublicService/ListUserPipelines",
-        {
-          parent: `${constant.namespace}`,
-          filter: `recipe.components.definition_name:"${srcConnPermalink}"`,
-        },
-        data.metadata
-      ),
-      {
-        [`vdp.pipeline.v1beta.PipelinePublicService/ListUserPipelines filter: recipe.components.definition_name:"${srcConnPermalink}" response StatusOK`]:
-          (r) => r.status === grpc.StatusOK,
-        [`vdp.pipeline.v1beta.PipelinePublicService/ListUserPipelines filter: recipe.components.definition_name:"${srcConnPermalink}" response pipelines.length`]:
-          (r) => r.message.pipelines.length > 0,
-      }
-    );
-
     // Delete the pipelines
     for (const reqBody of reqBodies) {
       check(

--- a/integration-test/pipeline/rest-pipeline-private.js
+++ b/integration-test/pipeline/rest-pipeline-private.js
@@ -176,26 +176,6 @@ export function CheckList(data) {
       }
     );
 
-    var srcConnPermalink = "operator-definitions/2ac8be70-0f7a-4b61-a33d-098b8acfa6f3"
-
-    // var modelUid = http.get(`${modelPublicHost}/v1beta/models/${constant.model_id}`, {}, constant.params).json().model.uid
-    // var modelPermalink = `models/${modelUid}`
-
-    check(
-      http.request(
-        "GET",
-        `${pipelinePrivateHost}/v1beta/admin/pipelines?filter=recipe.components.definition_name:%22${srcConnPermalink}%22`,
-        null,
-        constant.params
-      ),
-      {
-        [`GET /v1beta/admin/pipelines?filter=recipe.components.definition_name:%22${srcConnPermalink}%22 response 200`]:
-          (r) => r.status == 200,
-        [`GET /v1beta/admin/pipelines?filter=recipe.components.definition_name:%22${srcConnPermalink}%22 response pipelines.length > 0`]:
-          (r) => r.json().pipelines.length > 0,
-      }
-    );
-
     // Delete the pipelines
     for (const reqBody of reqBodies) {
       check(

--- a/integration-test/pipeline/rest-pipeline-public.js
+++ b/integration-test/pipeline/rest-pipeline-public.js
@@ -368,23 +368,6 @@ export function CheckList(data) {
       }
     );
 
-    var srcConnPermalink = "operator-definitions/2ac8be70-0f7a-4b61-a33d-098b8acfa6f3"
-
-    check(
-      http.request(
-        "GET",
-        `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines?filter=recipe.components.definition_name:%22${srcConnPermalink}%22`,
-        null,
-        data.header
-      ),
-      {
-        [`GET /v1beta/${constant.namespace}/pipelines?filter=recipe.components.definition_name:%22${srcConnPermalink}%22 response 200`]:
-          (r) => r.status == 200,
-        [`GET /v1beta/${constant.namespace}/pipelines?filter=recipe.components.definition_name:%22${srcConnPermalink}%22 response pipelines.length > 0`]:
-          (r) => r.json().pipelines.length > 0,
-      }
-    );
-
     // Delete the pipelines
     for (const reqBody of reqBodies) {
       check(

--- a/integration-test/proto/vdp/pipeline/v1beta/pipeline.proto
+++ b/integration-test/proto/vdp/pipeline/v1beta/pipeline.proto
@@ -44,34 +44,145 @@ message ReadinessResponse {
   common.healthcheck.v1beta.HealthCheckResponse health_check_response = 1;
 }
 
-// Component is the fundamental building block in pipelines.
+// StartComponent
+// Configures the starting point for pipeline triggering.
+message StartComponent {
+  // Represents a field within the start component.
+  message Field {
+    // Title of the field.
+    string title = 1 [(google.api.field_behavior) = OPTIONAL];
+    // Description of the field.
+    string description = 2 [(google.api.field_behavior) = OPTIONAL];
+    // Instill format.
+    string instill_format = 3 [(google.api.field_behavior) = OPTIONAL];
+    // Instill UI order.
+    int32 instill_ui_order = 4 [(google.api.field_behavior) = OPTIONAL];
+  }
+  // Fields configuration.
+  // Key: Key in the request body.
+  // Field: Field settings of the value.
+  map<string, Field> fields = 1 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// EndComponent
+// Configures the ending point for pipeline triggering.
+message EndComponent {
+  // Represents a field within the end component.
+  message Field {
+    // Title of the field.
+    string title = 1 [(google.api.field_behavior) = OPTIONAL];
+    // Description of the field.
+    string description = 2 [(google.api.field_behavior) = OPTIONAL];
+    // Value of the field.
+    string value = 3 [(google.api.field_behavior) = OPTIONAL];
+    // Instill UI order.
+    int32 instill_ui_order = 4 [(google.api.field_behavior) = OPTIONAL];
+  }
+  // Fields configuration.
+  // Key: Key in the request body.
+  // Field: Field settings of the value.
+  map<string, Field> fields = 1 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// ConnectorComponent
+// Configures a connector component. Requires the creation of a connector resource first.
+message ConnectorComponent {
+  // Definition name.
+  string definition_name = 1 [(google.api.field_behavior) = OPTIONAL];
+  // Connector definition.
+  ConnectorDefinition definition = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Resource name. Leave empty if not created.
+  string resource_name = 3 [(google.api.field_behavior) = OPTIONAL];
+  // Describes the connector resource details (e.g., configuration to connect with the vendor service).
+  Connector resource = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Task.
+  string task = 5 [(google.api.field_behavior) = OPTIONAL];
+  // Input configuration of the component. JSON schema described in the connector definition.
+  google.protobuf.Struct input = 6 [(google.api.field_behavior) = OPTIONAL];
+  // Condition statement determining whether the component is executed or not.
+  string condition = 7 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// OperatorComponent
+// Configures an operator component.
+message OperatorComponent {
+  // Definition name.
+  string definition_name = 1 [(google.api.field_behavior) = OPTIONAL];
+  // Operator definition.
+  OperatorDefinition definition = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Task.
+  string task = 3 [(google.api.field_behavior) = OPTIONAL];
+  // Input configuration of the component. JSON schema described in the operator definition.
+  google.protobuf.Struct input = 4 [(google.api.field_behavior) = OPTIONAL];
+  // Condition statement determining whether the component is executed or not.
+  string condition = 5 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// IteratorComponent
+// Configures an iterator component for iteration.
+message IteratorComponent {
+  // Input array: The iterator will iterate over the elements of the input array.
+  string input_array = 1 [(google.api.field_behavior) = OPTIONAL];
+
+  // Output elements: Configure the output arrays of the map iterator.
+  // The key is the output element variable name, and the value is the data reference of the template.
+  // Example:
+  // output_elements: {
+  //   "key1": "${element.output.a}",
+  //   "key2": "${element.output.b}",
+  // }
+  // This will create the results:
+  // output: {
+  //   "key1": [ ${element1.output.a},  ${element2.output.a} ... ],
+  //   "key2": [ ${element1.output.b},  ${element2.output.b} ... ],
+  // }
+  map<string, string> output_elements = 2 [(google.api.field_behavior) = OPTIONAL];
+
+  // Components: These components will be executed for each input element.
+  repeated NestedComponent components = 3 [(google.api.field_behavior) = OPTIONAL];
+
+  // Condition statement determining whether the component is executed or not.
+  string condition = 4 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// Component
+// Fundamental building block in pipelines.
 //
 // For more information, see [Pipeline
 // Component](https://www.instill.tech/docs/latest/core/concepts/pipeline#pipeline-component)
 message Component {
   // Component ID, provided by the user on creation.
   string id = 1 [(google.api.field_behavior) = REQUIRED];
-  // Resource name.
-  string resource_name = 2 [(google.api.resource_reference).type = "*"];
-  // If the component is a connector, describes the connector details (e.g. the
-  // configuration to connect with an AI model).
-  Connector resource = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Describes the component configuration.
-  google.protobuf.Struct configuration = 4;
-  // Defines the type of task the component will perform.
-  ComponentType type = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // The name of the component definition. It references the connector or
-  // operator definition on top of which a connector is built.
-  string definition_name = 7 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "*"
-  ];
-  // The component definition details.
-  oneof definition {
-    // operator definition detail
-    OperatorDefinition operator_definition = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
-    // connector definition detail
-    ConnectorDefinition connector_definition = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Metadata of the component.
+  google.protobuf.Struct metadata = 10 [(google.api.field_behavior) = OPTIONAL];
+  // The component configuration.
+  oneof component {
+    // StartComponent
+    StartComponent start_component = 11;
+    // EndComponent
+    EndComponent end_component = 12;
+    // ConnectorComponent
+    ConnectorComponent connector_component = 13;
+    // OperatorComponent
+    OperatorComponent operator_component = 14;
+    // IteratorComponent
+    IteratorComponent iterator_component = 15;
+  }
+}
+
+// NestedComponent
+// Fundamental building block in iterator component.
+message NestedComponent {
+  // Component ID, provided by the user on creation.
+  string id = 1 [(google.api.field_behavior) = REQUIRED];
+  // Metadata of the component.
+  google.protobuf.Struct metadata = 2;
+  // The component configuration.
+  oneof component {
+    // ConnectorConfiguration
+    ConnectorComponent connector_component = 3;
+    // OperatorConfiguration
+    OperatorComponent operator_component = 4;
   }
 }
 

--- a/pkg/datamodel/datamodel.go
+++ b/pkg/datamodel/datamodel.go
@@ -75,10 +75,82 @@ type Recipe struct {
 }
 
 type Component struct {
-	ID             string           `json:"id"`
+	ID       string         `json:"id"`
+	Metadata datatypes.JSON `json:"metadata"`
+	// TODO: validate oneof
+	StartComponent     *StartComponent     `json:"start_component,omitempty"`
+	EndComponent       *EndComponent       `json:"end_component,omitempty"`
+	ConnectorComponent *ConnectorComponent `json:"connector_component,omitempty"`
+	OperatorComponent  *OperatorComponent  `json:"operator_component,omitempty"`
+	IteratorComponent  *IteratorComponent  `json:"iterator_component,omitempty"`
+}
+
+func (c *Component) IsStartComponent() bool {
+	return c.StartComponent != nil
+}
+func (c *Component) IsEndComponent() bool {
+	return c.EndComponent != nil
+}
+func (c *Component) IsConnectorComponent() bool {
+	return c.ConnectorComponent != nil
+}
+func (c *Component) IsOperatorComponent() bool {
+	return c.OperatorComponent != nil
+}
+func (c *Component) IsIteratorComponent() bool {
+	return c.IteratorComponent != nil
+}
+func (c *Component) GetCondition() *string {
+	if c.IsConnectorComponent() {
+		return c.ConnectorComponent.Condition
+	}
+	if c.IsOperatorComponent() {
+		return c.OperatorComponent.Condition
+	}
+	if c.IsIteratorComponent() {
+		return c.IteratorComponent.Condition
+	}
+	return nil
+}
+
+type StartComponent struct {
+	Fields map[string]struct {
+		Title          string `json:"title"`
+		Description    string `json:"description"`
+		InstillFormat  string `json:"instill_format"`
+		InstillUIOrder int32  `json:"instill_ui_order"`
+	} `json:"fields"`
+}
+
+type EndComponent struct {
+	Fields map[string]struct {
+		Title          string `json:"title"`
+		Description    string `json:"description"`
+		Value          string `json:"value"`
+		InstillUIOrder int32  `json:"instill_ui_order"`
+	} `json:"fields"`
+}
+
+type ConnectorComponent struct {
 	DefinitionName string           `json:"definition_name"`
-	ResourceName   string           `json:"resource_name"`
-	Configuration  *structpb.Struct `json:"configuration"`
+	ConnectorName  string           `json:"connector_name"`
+	Task           string           `json:"task"`
+	Input          *structpb.Struct `json:"input"`
+	Condition      *string          `json:"condition,omitempty"`
+}
+
+type OperatorComponent struct {
+	DefinitionName string           `json:"definition_name"`
+	Task           string           `json:"task"`
+	Input          *structpb.Struct `json:"input"`
+	Condition      *string          `json:"condition,omitempty"`
+}
+
+type IteratorComponent struct {
+	Input          string            `json:"input"`
+	OutputElements map[string]string `json:"output_elements"`
+	Condition      *string           `json:"condition,omitempty"`
+	Components     []*Component      `json:"components"`
 }
 
 type Sharing struct {

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -22,6 +22,7 @@ const TaskQueue = "pipeline-backend"
 // Worker interface
 type Worker interface {
 	TriggerPipelineWorkflow(ctx workflow.Context, param *TriggerPipelineWorkflowRequest) (*TriggerPipelineWorkflowResponse, error)
+	PipelineActivity(ctx workflow.Context, ao workflow.ActivityOptions, param *ExecutePipelineActivityRequest) error
 	ConnectorActivity(ctx context.Context, param *ExecuteConnectorActivityRequest) (*ExecuteActivityResponse, error)
 	OperatorActivity(ctx context.Context, param *ExecuteOperatorActivityRequest) (*ExecuteActivityResponse, error)
 }


### PR DESCRIPTION
Because:

- The original recipe message utilized `structpb` to encapsulate every configuration, creating an implicit structure that posed a challenge for users or developers to comprehend the data structure. Given the distinct structures associated with various components, it is essential to explicitly expose them to the user.
- A special iterator component for array data iteration is desired.

This commit:

- Revamped the recipe with new Protobuf messages: `StartComponent`, `EndComponent`, `OperatorComponent`, `ConnectorComponent`, and `IteratorComponent`.
- Implements iterator.

Note:

- This is a breaking change in the interface, requiring an update to the implementation on the client-side.