### PR TITLE
feat: sort component list by score

### DIFF
--- a/cmd/init/main.go
+++ b/cmd/init/main.go
@@ -26,7 +26,7 @@ import (
 	"github.com/instill-ai/pipeline-backend/pkg/repository"
 	"github.com/instill-ai/pipeline-backend/pkg/service"
 	"github.com/instill-ai/pipeline-backend/pkg/utils"
-	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
+	pb "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 
 	connector "github.com/instill-ai/connector/pkg"
 	operator "github.com/instill-ai/operator/pkg"
@@ -92,9 +92,9 @@ func main() {
 			db.Unscoped().Model(&datamodel.Connector{}).Where("connector_definition_uid = ?", connDef.Uid).Update("tombstone", true)
 		}
 
-		cd := &pipelinePB.ComponentDefinition{
+		cd := &pb.ComponentDefinition{
 			Type: service.ConnectorTypeToComponentType[connDef.Type],
-			Definition: &pipelinePB.ComponentDefinition_ConnectorDefinition{
+			Definition: &pb.ComponentDefinition_ConnectorDefinition{
 				ConnectorDefinition: connDef,
 			},
 		}
@@ -106,9 +106,9 @@ func main() {
 
 	opDefs := operator.Init(logger).ListOperatorDefinitions()
 	for _, opDef := range opDefs {
-		cd := &pipelinePB.ComponentDefinition{
-			Type: pipelinePB.ComponentType_COMPONENT_TYPE_OPERATOR,
-			Definition: &pipelinePB.ComponentDefinition_OperatorDefinition{
+		cd := &pb.ComponentDefinition{
+			Type: pb.ComponentType_COMPONENT_TYPE_OPERATOR,
+			Definition: &pb.ComponentDefinition_OperatorDefinition{
 				OperatorDefinition: opDef,
 			},
 		}
@@ -191,53 +191,79 @@ func main() {
 
 }
 
-func updateComponentDefinition(ctx context.Context, cd *pipelinePB.ComponentDefinition, repo repository.Repository) error {
-	var id, uniqueID, version string
+type definition interface {
+	GetUid() string
+	GetId() string
+	GetVersion() string
+}
+
+func updateComponentDefinition(ctx context.Context, cd *pb.ComponentDefinition, repo repository.Repository) error {
+	var def definition
 	switch cd.Type {
-	case pipelinePB.ComponentType_COMPONENT_TYPE_OPERATOR:
-		d := cd.GetOperatorDefinition()
-		id, uniqueID, version = d.GetId(), d.GetUid(), d.GetVersion()
+	case pb.ComponentType_COMPONENT_TYPE_OPERATOR:
+		def = cd.GetOperatorDefinition()
 
-	case pipelinePB.ComponentType_COMPONENT_TYPE_CONNECTOR_AI,
-		pipelinePB.ComponentType_COMPONENT_TYPE_CONNECTOR_DATA,
-		pipelinePB.ComponentType_COMPONENT_TYPE_CONNECTOR_APPLICATION:
+	case pb.ComponentType_COMPONENT_TYPE_CONNECTOR_AI,
+		pb.ComponentType_COMPONENT_TYPE_CONNECTOR_DATA,
+		pb.ComponentType_COMPONENT_TYPE_CONNECTOR_APPLICATION:
 
-		d := cd.GetConnectorDefinition()
-		id, uniqueID, version = d.GetId(), d.GetUid(), d.GetVersion()
+		def = cd.GetConnectorDefinition()
 	default:
 		return fmt.Errorf("unsupported component definition type")
 	}
 
-	uid, err := uuid.FromString(uniqueID)
+	uid, err := uuid.FromString(def.GetUid())
 	if err != nil {
-		return fmt.Errorf("invalid UID in component definition %s: %w", id, err)
-	}
-
-	v, err := semver.Parse(version)
-	if err != nil {
-		return fmt.Errorf("failed to parse version from component definition %s: %w", id, err)
+		return fmt.Errorf("invalid UID in component definition %s: %w", def.GetId(), err)
 	}
 
 	inDB, err := repo.GetComponentDefinitionByUID(ctx, uid)
 	if err != nil && !errors.Is(err, repository.ErrNotFound) {
-		return fmt.Errorf("error fetching component definition %s from DB: %w", id, err)
+		return fmt.Errorf("error fetching component definition %s from DB: %w", def.GetId(), err)
 	}
 
-	// Component definitions are only updated when there's a version bump.
-	if inDB != nil {
-		vInDB, err := semver.Parse(inDB.Version)
-		if err != nil {
-			return fmt.Errorf("failed to parse version from DB component definition %s: %w", id, err)
-		}
-
-		if v.ComparePrecedence(vInDB) <= 0 {
-			return nil
-		}
+	shouldSkip, err := shouldSkipUpsert(def, inDB)
+	if err != nil {
+		return err
+	}
+	if shouldSkip {
+		return nil
 	}
 
 	if err := repo.UpsertComponentDefinition(ctx, cd); err != nil {
-		return fmt.Errorf("failed to upsert component definition %s: %w", id, err)
+		return fmt.Errorf("failed to upsert component definition %s: %w", def.GetId(), err)
 	}
 
 	return nil
+}
+
+// A component definition is only upserted when either of these conditions is
+// satisfied:
+//   - There's a version bump in the definition.
+//   - The feature score of the component (defined in the codebase as this isn't
+//     a public property of the definition) has changed.
+func shouldSkipUpsert(def definition, inDB *datamodel.ComponentDefinition) (bool, error) {
+	if inDB == nil {
+		return false, nil
+	}
+
+	if inDB.FeatureScore != datamodel.FeatureScores[def.GetId()] {
+		return false, nil
+	}
+
+	v, err := semver.Parse(def.GetVersion())
+	if err != nil {
+		return false, fmt.Errorf("failed to parse version from component definition %s: %w", def.GetId(), err)
+	}
+
+	vInDB, err := semver.Parse(inDB.Version)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse version from DB component definition %s: %w", def.GetId(), err)
+	}
+
+	isDBVersionOutdated := v.ComparePrecedence(vInDB) > 0
+	if isDBVersionOutdated {
+		return false, nil
+	}
+	return true, nil
 }

--- a/cmd/init/main_test.go
+++ b/cmd/init/main_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/instill-ai/pipeline-backend/pkg/datamodel"
+	pb "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
+)
+
+func Test_ShouldSkipUpsert(t *testing.T) {
+	c := qt.New(t)
+
+	v := "0.1.0-alpha"
+	d := &pb.ConnectorDefinition{
+		Id:      "my-conn",
+		Version: v,
+	}
+
+	db := &datamodel.ComponentDefinition{
+		Version: v,
+	}
+
+	testcases := []struct {
+		name string
+
+		def  definition
+		inDB *datamodel.ComponentDefinition
+
+		want    bool
+		wantErr string
+	}{
+		{
+			name: "don't skip - no record in DB",
+			def:  d,
+			want: false,
+		},
+		{
+			name: "skip - same version",
+			def:  d,
+			inDB: db,
+			want: true,
+		},
+		{
+			name: "skip - older version",
+			def:  d,
+			inDB: &datamodel.ComponentDefinition{Version: "0.1.0-alpha.1"},
+			want: true,
+		},
+		{
+			name: "don't skip - newer version",
+			def:  &pb.ConnectorDefinition{Id: "my-conn", Version: "0.1.0-alpha.1"},
+			inDB: db,
+			want: false,
+		},
+		{
+			name: "don't skip - score change",
+			def:  d,
+			inDB: &datamodel.ComponentDefinition{Version: v, FeatureScore: 10},
+			want: false,
+		},
+		{
+			name:    "err - malformed version",
+			def:     &pb.ConnectorDefinition{Id: "my-conn", Version: "v0.1.0-alpha"},
+			inDB:    db,
+			wantErr: "failed to parse version.*",
+		},
+		{
+			name:    "err - malformed version in DB",
+			def:     d,
+			inDB:    &datamodel.ComponentDefinition{Version: "v0.1.0-alpha"},
+			wantErr: "failed to parse version.*",
+		},
+	}
+
+	for _, tc := range testcases {
+		c.Run(tc.name, func(c *qt.C) {
+			got, err := shouldSkipUpsert(tc.def, tc.inDB)
+			if tc.wantErr != "" {
+				c.Check(err, qt.ErrorMatches, tc.wantErr)
+				return
+			}
+			c.Check(err, qt.IsNil)
+			c.Check(got, qt.Equals, tc.want)
+		})
+	}
+}

--- a/integration-test/pipeline/rest-component-definition.js
+++ b/integration-test/pipeline/rest-component-definition.js
@@ -13,7 +13,8 @@ export function CheckList() {
       "GET /v1beta/component-definitions response total_size > 0": (r) => r.json().total_size > 0,
       "GET /v1beta/component-definitions response page 0": (r) => r.json().page === 0,
       [`GET /v1beta/component-definitions response default page size ${defaultPageSize}`]: (r) => r.json().component_definitions.length === defaultPageSize,
-      [`GET /v1beta/component-definitions response page size in response ${defaultPageSize}`]: (r) => r.json().page_size === defaultPageSize
+      [`GET /v1beta/component-definitions response page size in response ${defaultPageSize}`]: (r) => r.json().page_size === defaultPageSize,
+      "GET /v1beta/component-definitions response features Instill Model on top": (r) => r.json().component_definitions[0].connector_definition.id === "instill-model",
     });
 
     var limitedRecords = http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions`, null, null)


### PR DESCRIPTION
Because

- We want a way to feature / promote some components in the component page.

This commit

- Adds a map with the component ID -> component score, which will be used in the component definition table in DB to sort the filtered / paginated results.
- Because this is decoupled from the `definitions.json` file (reasoning [here](https://linear.app/instill-ai/issue/INS-3738/sort-component-lists-by-score#comment-9f1a1f51)), changes in these scores will trigger a database component definition update. The init logic that keeps the table up to date is refactored a little bit.
