### PR TITLE
feat: support unimplemented release stages in component definitions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,9 +18,9 @@ require (
 	github.com/iancoleman/strcase v0.2.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
 	github.com/instill-ai/component v0.12.0-beta.0.20240307023544-7c27d15e4e01
-	github.com/instill-ai/connector v0.13.0-beta.0.20240307141856-4560e035c92e
-	github.com/instill-ai/operator v0.9.0-beta.0.20240304112014-043d5e3b0ebd
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240306151355-4398dad0ba73
+	github.com/instill-ai/connector v0.13.0-beta.0.20240308162446-7cfb11b5cf1f
+	github.com/instill-ai/operator v0.9.0-beta.0.20240308162331-d3a710391231
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240308151517-4b0523c184d1
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha
 	github.com/knadh/koanf v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -1194,10 +1194,16 @@ github.com/instill-ai/component v0.12.0-beta.0.20240307023544-7c27d15e4e01 h1:sf
 github.com/instill-ai/component v0.12.0-beta.0.20240307023544-7c27d15e4e01/go.mod h1:Zr3ej9EbkCe+lgSyzKhaqq8+mq84LGGP2F3OWOr/l3c=
 github.com/instill-ai/connector v0.13.0-beta.0.20240307141856-4560e035c92e h1:Tcq107yjXu/C5llpdHi2OsgIPX3OE4fx3raHQ1Iz5Wk=
 github.com/instill-ai/connector v0.13.0-beta.0.20240307141856-4560e035c92e/go.mod h1:cnvYWlUm35+hHkCh1EhNUfpTMqn6ZzlN5SsgxHC8+Gk=
+github.com/instill-ai/connector v0.13.0-beta.0.20240308162446-7cfb11b5cf1f h1:Dxtl3QaWZGlU0KRb/hR0ZXYDswiswYZs0Fp50CUGlig=
+github.com/instill-ai/connector v0.13.0-beta.0.20240308162446-7cfb11b5cf1f/go.mod h1:cnvYWlUm35+hHkCh1EhNUfpTMqn6ZzlN5SsgxHC8+Gk=
 github.com/instill-ai/operator v0.9.0-beta.0.20240304112014-043d5e3b0ebd h1:DnTC/0IiHDDSPE8idE3LYJFtEsK6O1kl8cRZroNkMNg=
 github.com/instill-ai/operator v0.9.0-beta.0.20240304112014-043d5e3b0ebd/go.mod h1:69LCxn3s4nl7+sUwsHx8hI6kkR0MyyQ59MUKhWVPw7Y=
+github.com/instill-ai/operator v0.9.0-beta.0.20240308162331-d3a710391231 h1:aG9GNCJiB7ZUlMVwnrTvdDGOTdqe3X1B4nYLhGrQ/9Y=
+github.com/instill-ai/operator v0.9.0-beta.0.20240308162331-d3a710391231/go.mod h1:69LCxn3s4nl7+sUwsHx8hI6kkR0MyyQ59MUKhWVPw7Y=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240306151355-4398dad0ba73 h1:3YT3WV9F1eltn5x3AhtOuRDO2zY3Aud6nk/som9YQvs=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240306151355-4398dad0ba73/go.mod h1:jhEL0SauySMoPLVvx105DWyThju9sYTbsXIySVCArmM=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240308151517-4b0523c184d1 h1:8bhIcJZcUMKvZas2L0uyaVt/V+Tzw0OSR8GtdcFflMo=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240308151517-4b0523c184d1/go.mod h1:jhEL0SauySMoPLVvx105DWyThju9sYTbsXIySVCArmM=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a/go.mod h1:EpX3Yr661uWULtZf5UnJHfr5rw2PDyX8ku4Kx0UtYFw=
 github.com/instill-ai/x v0.4.0-alpha h1:zQV2VLbSHjMv6gyBN/2mwwrvWk0/mJM6ZKS12AzjfQg=

--- a/integration-test/pipeline/rest-component-definition.js
+++ b/integration-test/pipeline/rest-component-definition.js
@@ -111,12 +111,11 @@ export function CheckList() {
     });
 
     // Filter release stage
-    check(http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?page_size=1&filter=release_stage="RELEASE_STAGE_ALPHA"`, null, null), {
-      [`GET /v1beta/component-definitions?page_size=1&filter=release_stage="RELEASE_STAGE_ALPHA" response status 200`]: (r) => r.status === 200,
+    check(http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?page_size=1&filter=release_stage=RELEASE_STAGE_ALPHA`, null, null), {
+      [`GET /v1beta/component-definitions?page_size=1&filter=release_stage=RELEASE_STAGE_ALPHA response status 200`]: (r) => r.status === 200,
       // TODO when there are non-alpha components, update expectations.
-      [`GET /v1beta/component-definitions?page_size=1&filter=release_stage="RELEASE_STAGE_ALPHA" number of results`]: (r) => r.json().total_size === limitedRecords.json().total_size,
-      // TODO check only prerelease in semver.
-      [`GET /v1beta/component-definitions?page_size=1&filter=release_stage="RELEASE_STAGE_ALPHA" title is JSON`]: (r) => r.json().component_definitions[0].connector_definition.version === "0.1.0-alpha",
+      [`GET /v1beta/component-definitions?page_size=1&filter=release_stage=RELEASE_STAGE_ALPHA number of results`]: (r) => r.json().total_size === limitedRecords.json().total_size,
+      [`GET /v1beta/component-definitions?page_size=1&filter=release_stage=RELEASE_STAGE_ALPHA release_stage is alpha`]: (r) => r.json().component_definitions[0].connector_definition.release_stage === "RELEASE_STAGE_ALPHA",
     });
   });
 }

--- a/pkg/datamodel/datamodel.go
+++ b/pkg/datamodel/datamodel.go
@@ -255,13 +255,13 @@ func (p *SharingCode) Value() (driver.Value, error) {
 	return string(valueString), err
 }
 
-// Scan function for custom GORM type ReleaseStage
+// Scan function for custom GORM type PipelineRole
 func (p *PipelineRole) Scan(value interface{}) error {
 	*p = PipelineRole(pipelinePB.Role_value[value.(string)])
 	return nil
 }
 
-// Value function for custom GORM type ReleaseStage
+// Value function for custom GORM type PipelineRole
 func (p PipelineRole) Value() (driver.Value, error) {
 	return pipelinePB.Role(p).String(), nil
 }
@@ -318,13 +318,13 @@ func (r ConnectorState) Value() (driver.Value, error) {
 	return pipelinePB.Connector_State(r).String(), nil
 }
 
-// Scan function for custom GORM type ReleaseStage
+// Scan function for custom GORM type ConnectorVisibility
 func (r *ConnectorVisibility) Scan(value interface{}) error {
 	*r = ConnectorVisibility(pipelinePB.Connector_Visibility_value[value.(string)])
 	return nil
 }
 
-// Value function for custom GORM type ReleaseStage
+// Value function for custom GORM type ConnectorVisibility
 func (r ConnectorVisibility) Value() (driver.Value, error) {
 	return pipelinePB.Connector_Visibility(r).String(), nil
 }

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -1887,10 +1887,11 @@ func (s *service) ListComponentDefinitions(ctx context.Context, req *pipelinePB.
 	view := parseView(int32(req.GetView()))
 
 	var compType pipelinePB.ComponentType
+	var releaseStage pipelinePB.ComponentDefinition_ReleaseStage
 	declarations, err := filtering.NewDeclarations(
 		filtering.DeclareStandardFunctions(),
 		filtering.DeclareIdent("q_title", filtering.TypeString),
-		filtering.DeclareIdent("release_stage", filtering.TypeString),
+		filtering.DeclareEnumIdent("release_stage", releaseStage.Type()),
 		filtering.DeclareEnumIdent("component_type", compType.Type()),
 	)
 	if err != nil {


### PR DESCRIPTION
Because

- Component page showcases unimplemented components with the "Open for contribution" and "Coming soon" tags.

This commit

- Uses the new `release_stage` property introduced in https://github.com/instill-ai/protobufs/pull/283

