### PR TITLE
fix: duplicated values in component list

### DIFF
--- a/integration-test/pipeline/rest-component-definition.js
+++ b/integration-test/pipeline/rest-component-definition.js
@@ -45,18 +45,18 @@ export function CheckList() {
     });
 
     // Access non-first page.
-    check(http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?page_size=3&page=2`, null, null), {
-      "GET /v1beta/component-definitions?page_size=3&page=2 response status is 200": (r) => r.status === 200,
-      "GET /v1beta/component-definitions?page_size=3&page=2 response component_definitions size 3": (r) => r.json().component_definitions.length === 3,
-      "GET /v1beta/component-definitions?page_size=3&page=2 response page 0": (r) => r.json().page === 2,
-      "GET /v1beta/component-definitions?page_size=3&page=2 receives a different page": (r) => r.json().component_definitions[0].connector_definition.id != limitedRecords.json().component_definitions[0].connector_definition.id,
+    check(http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?page_size=2&page=2`, null, null), {
+      "GET /v1beta/component-definitions?page_size=2&page=2 response status is 200": (r) => r.status === 200,
+      "GET /v1beta/component-definitions?page_size=2&page=2 response component_definitions size 3": (r) => r.json().component_definitions.length === 2,
+      "GET /v1beta/component-definitions?page_size=2&page=2 response page 0": (r) => r.json().page === 2,
+      "GET /v1beta/component-definitions?page_size=2&page=2 receives a different page": (r) => r.json().component_definitions[0].connector_definition.id != limitedRecords.json().component_definitions[0].connector_definition.id,
     });
 
     // Negative page index yields page 0.
-    check(http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?page_size=3&page=-2`, null, null), {
-      "GET /v1beta/component-definitions?page_size=3&page=-2 response status is 200": (r) => r.status === 200,
-      "GET /v1beta/component-definitions?page_size=3&page=-2 response component_definitions size 3": (r) => r.json().component_definitions.length === 3,
-      "GET /v1beta/component-definitions?page_size=3&page=-2 response page 0": (r) => r.json().page === 0,
+    check(http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?page_size=2&page=-2`, null, null), {
+      "GET /v1beta/component-definitions?page_size=2&page=-2 response status is 200": (r) => r.status === 200,
+      "GET /v1beta/component-definitions?page_size=2&page=-2 response component_definitions size 3": (r) => r.json().component_definitions.length === 2,
+      "GET /v1beta/component-definitions?page_size=2&page=-2 response page 0": (r) => r.json().page === 0,
     });
 
     // Page index beyond last page.

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -783,7 +783,11 @@ func (r *repository) ListComponentDefinitionUIDs(_ context.Context, p ListCompon
 
 	queryBuilder.Count(&totalSize)
 
-	rows, err := queryBuilder.Order("feature_score DESC").Limit(p.Limit).Offset(p.Offset).Rows()
+	// Several results might have the same score and release stage. We need to
+	// sort by at least one unique field so the pagination results aren't
+	// arbitrary.
+	orderBy := "feature_score DESC, release_stage DESC, uid DESC"
+	rows, err := queryBuilder.Order(orderBy).Limit(p.Limit).Offset(p.Offset).Rows()
 	if err != nil {
 		return nil, 0, err
 	}


### PR DESCRIPTION
Because

- Some results were repeated across pages in the component definitions endpoint

![CleanShot 2024-03-19 at 11 38 04](https://github.com/instill-ai/pipeline-backend/assets/3977183/aef75c64-6b5f-4c45-9069-f8db8ee0cc4d)

This happens because the results were sorted by `feature_score` at the database level before paginating. The rest of the results (score 0) were unsorted, which causes an arbitrary order in each query.

This commit

- Sorts the results by UID before paginating
- Additionally, it sorts them by release stage (given the same score, we'll want to have the more stable components first).
