### PR TITLE
refactor: refactor pipeline activities

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -157,9 +157,9 @@ func main() {
 	})
 
 	w.RegisterWorkflow(cw.TriggerPipelineWorkflow)
-	w.RegisterActivity(cw.PipelineActivity)
-	w.RegisterActivity(cw.ConnectorActivity)
-	w.RegisterActivity(cw.OperatorActivity)
+	w.RegisterActivity(cw.TriggerStartActivity)
+	w.RegisterActivity(cw.TriggerEndActivity)
+	w.RegisterActivity(cw.DAGActivity)
 
 	span.End()
 	err = w.Run(worker.InterruptCh())

--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	go.uber.org/zap v1.26.0
 	golang.org/x/mod v0.12.0
 	golang.org/x/net v0.21.0
+	golang.org/x/sync v0.5.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20231016165738-49dd2c1f3d0b
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231030173426-d783a09b4405
 	google.golang.org/grpc v1.59.0
@@ -110,7 +111,6 @@ require (
 	go.opencensus.io v0.24.0 // indirect
 	golang.org/x/image v0.13.0 // indirect
 	golang.org/x/oauth2 v0.13.0 // indirect
-	golang.org/x/sync v0.5.0 // indirect
 	golang.org/x/tools v0.10.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	google.golang.org/api v0.150.0 // indirect

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -22,7 +22,9 @@ const TaskQueue = "pipeline-backend"
 // Worker interface
 type Worker interface {
 	TriggerPipelineWorkflow(ctx workflow.Context, param *TriggerPipelineWorkflowRequest) (*TriggerPipelineWorkflowResponse, error)
-	PipelineActivity(ctx workflow.Context, ao workflow.ActivityOptions, param *ExecutePipelineActivityRequest) error
+	TriggerStartActivity(ctx context.Context, param *ExecuteTriggerStartActivityRequest) (*ExecuteTriggerStartActivityResponse, error)
+	TriggerEndActivity(ctx context.Context, param *ExecuteTriggerEndActivityRequest) (*ExecuteTriggerEndActivityResponse, error)
+	DAGActivity(ctx context.Context, param *ExecuteDAGActivityRequest) (*ExecuteDAGActivityResponse, error)
 	ConnectorActivity(ctx context.Context, param *ExecuteConnectorActivityRequest) (*ExecuteActivityResponse, error)
 	OperatorActivity(ctx context.Context, param *ExecuteOperatorActivityRequest) (*ExecuteActivityResponse, error)
 }


### PR DESCRIPTION
Because

- We encountered bugs that Temporal will complain about, stating "potential deadlock detected." This is a Temporal workflow mechanism designed to detect problematic workflows. We cannot have blocking functions or code in the Temporal workflow for more than 1 second. We must move those time-consuming implementations into Temporal activities.

This commit

- Refactors pipeline activities. Adds new TriggerStart and TriggerEnd activities for pre and post-processing. Flattens the connector and operator activities into DAG activities.

Note:

- This is a quick fix for functionality. The codebases will be further refactored soon.