### PR TITLE
feat: pin the user to read from the primary database for a certain time frame after mutating the data

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -13,8 +13,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/go-redis/redis/v9"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"github.com/redis/go-redis/v9"
 	"go.opentelemetry.io/contrib/propagators/b3"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
@@ -244,9 +244,6 @@ func main() {
 		defer mgmtPublicServiceClientConn.Close()
 	}
 
-	redisClient := redis.NewClient(&config.Config.Cache.Redis.RedisOptions)
-	defer redisClient.Close()
-
 	influxDBClient, influxDBWriteClient := external.InitInfluxDBServiceClient(ctx)
 	defer influxDBClient.Close()
 
@@ -257,7 +254,10 @@ func main() {
 		}
 	}()
 
-	repository := repository.NewRepository(db)
+	redisClient := redis.NewClient(&config.Config.Cache.Redis.RedisOptions)
+	defer redisClient.Close()
+
+	repository := repository.NewRepository(db, redisClient)
 
 	service := service.NewService(
 		repository,

--- a/config/config.go
+++ b/config/config.go
@@ -7,11 +7,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-redis/redis/v9"
 	"github.com/knadh/koanf"
 	"github.com/knadh/koanf/parsers/yaml"
+	"github.com/knadh/koanf/providers/confmap"
 	"github.com/knadh/koanf/providers/env"
 	"github.com/knadh/koanf/providers/file"
+	"github.com/redis/go-redis/v9"
 )
 
 // Config - Global variable to export
@@ -83,10 +84,11 @@ type DatabaseConfig struct {
 	Host     string `koanf:"host"`
 	Port     int    `koanf:"port"`
 	Replica  struct {
-		Username string `koanf:"username"`
-		Password string `koanf:"password"`
-		Host     string `koanf:"host"`
-		Port     int    `koanf:"port"`
+		Username             string `koanf:"username"`
+		Password             string `koanf:"password"`
+		Host                 string `koanf:"host"`
+		Port                 int    `koanf:"port"`
+		ReplicationTimeFrame int    `koanf:"replicationtimeframe"` // in seconds
 	} `koanf:"replica"`
 	Name     string `koanf:"name"`
 	Version  uint   `koanf:"version"`
@@ -163,6 +165,12 @@ type ModelBackendConfig struct {
 func Init() error {
 	k := koanf.New(".")
 	parser := yaml.Parser()
+
+	if err := k.Load(confmap.Provider(map[string]interface{}{
+		"database.replica.replicationtimeframe": 180,
+	}, "."), nil); err != nil {
+		log.Fatal(err.Error())
+	}
 
 	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	fileRelativePath := fs.String("file", "config/config.yaml", "configuration file")

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/PaesslerAG/jsonpath v0.1.1
 	github.com/frankban/quicktest v1.14.6
 	github.com/gabriel-vasile/mimetype v1.4.3
-	github.com/go-redis/redis/v9 v9.0.0-beta.2
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/golang-migrate/migrate/v4 v4.15.2
 	github.com/golang/mock v1.6.0
@@ -25,6 +24,7 @@ require (
 	github.com/launchdarkly/go-semver v1.0.2
 	github.com/mennanov/fieldmask-utils v1.0.0
 	github.com/openfga/go-sdk v0.2.3
+	github.com/redis/go-redis/v9 v9.5.1
 	go.einride.tech/aip v0.60.0
 	go.opentelemetry.io/contrib/propagators/b3 v1.17.0
 	go.opentelemetry.io/otel v1.24.0
@@ -103,7 +103,6 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.15 // indirect
 	github.com/pkoukk/tiktoken-go v0.1.6 // indirect
-	github.com/redis/go-redis/v9 v9.5.1 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
 	github.com/saintfish/chardet v0.0.0-20120816061221-3af4cd4741ca // indirect
 	github.com/temoto/robotstxt v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -897,8 +897,6 @@ github.com/go-openapi/swag v0.0.0-20160704191624-1d0bd113de87/go.mod h1:DXUve3Dp
 github.com/go-openapi/swag v0.19.2/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-openapi/swag v0.19.14/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/eQntq43wQ=
-github.com/go-redis/redis/v9 v9.0.0-beta.2 h1:ZSr84TsnQyKMAg8gnV+oawuQezeJR11/09THcWCQzr4=
-github.com/go-redis/redis/v9 v9.0.0-beta.2/go.mod h1:Bldcd/M/bm9HbnNPi/LUtYBSD8ttcZYBMupwMXhdU0o=
 github.com/go-resty/resty/v2 v2.0.0/go.mod h1:dZGr0i9PLlaaTD4H/hoZIDjQ+r6xq8mgbRzHZf7f2J8=
 github.com/go-resty/resty/v2 v2.12.0 h1:rsVL8P90LFvkUYq/V5BTVe203WfRIU4gvcf+yfzJzGA=
 github.com/go-resty/resty/v2 v2.12.0/go.mod h1:o0yGPrkS3lOe1+eFajk6kBW8ScXzwU3hD69/gt2yB/0=
@@ -1501,7 +1499,6 @@ github.com/neo4j/neo4j-go-driver v1.8.1-0.20200803113522-b626aa943eba/go.mod h1:
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/npillmayer/nestext v0.1.3/go.mod h1:h2lrijH8jpicr25dFY+oAJLyzlya6jhnuG+zWp9L0Uk=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
-github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
@@ -1521,8 +1518,6 @@ github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108
 github.com/onsi/ginkgo v1.13.0/go.mod h1:+REjRxOmWfHCjfv9TTWB1jD1Frx4XydAD3zm1lskyM0=
 github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
-github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
-github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
 github.com/onsi/gomega v0.0.0-20151007035656-2152b45fa28a/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -1532,8 +1527,6 @@ github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoT
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDsH8xc=
 github.com/onsi/gomega v1.15.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+tEHG0=
-github.com/onsi/gomega v1.20.0 h1:8W0cWlwFkflGPLltQvLRB7ZVD5HuP6ng320w2IS245Q=
-github.com/onsi/gomega v1.20.0/go.mod h1:DtrZpjmvpn2mPm4YWQa0/ALMDj9v4YxLgojwPeREyVo=
 github.com/opencontainers/go-digest v0.0.0-20170106003457-a6d0ee40d420/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
@@ -2731,7 +2724,6 @@ gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/square/go-jose.v2 v2.2.2/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/square/go-jose.v2 v2.3.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/square/go-jose.v2 v2.5.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
-gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -69,19 +69,6 @@ func (ns Namespace) Permalink() string {
 	return fmt.Sprintf("%s/%s", ns.NsType, ns.NsUID.String())
 }
 
-func UserUIDToUserPermalink(userUID uuid.UUID) string {
-	return fmt.Sprintf("users/%s", userUID.String())
-}
-
-func ConvertConnectorToResourceName(connectorName string) string {
-
-	connectorTypeStr := "connectors"
-
-	resourceName := fmt.Sprintf("resources/%s/types/%s", connectorName, connectorTypeStr)
-
-	return resourceName
-}
-
 func GetOperationID(name string) (string, error) {
 	id := strings.TrimPrefix(name, "operations/")
 	if !strings.HasPrefix(name, "operations/") || id == "" {

--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -13,10 +13,11 @@ const MaxPayloadSize = 1024 * 1024 * 32
 
 // Constants for resource owner
 const DefaultUserID string = "admin"
+const StartConnectorID = "start"
+const EndConnectorID = "end"
+
 const HeaderUserUIDKey = "Instill-User-Uid"
 const HeaderVisitorUIDKey = "Instill-Visitor-Uid"
 const HeaderAuthTypeKey = "Instill-Auth-Type"
 const HeaderInstillCodeKey = "Instill-Share-Code"
-const StartConnectorID = "start"
-const EndConnectorID = "end"
-const ReturnTracesKey = "instill-return-traces"
+const HeaderReturnTracesKey = "Instill-Return-Traces"

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -98,6 +98,24 @@ func GetSharedConnection() *gorm.DB {
 			panic("Could not open database connection")
 		}
 
+		if databaseConfig.Replica.Host != "" {
+			replicaDSN := fmt.Sprintf("host=%s user=%s password=%s dbname=%s port=%d sslmode=disable TimeZone=%s",
+				databaseConfig.Replica.Host,
+				databaseConfig.Replica.Username,
+				databaseConfig.Replica.Password,
+				databaseConfig.Name,
+				databaseConfig.Replica.Port,
+				databaseConfig.TimeZone,
+			)
+			err = db.Use(dbresolver.Register(dbresolver.Config{
+				Replicas:          []gorm.Dialector{postgres.Open(replicaDSN)},
+				TraceResolverMode: true,
+			}))
+			if err != nil {
+				panic("Could not open replica database connection")
+			}
+		}
+
 		sqlDB, _ := db.DB()
 
 		// SetMaxIdleConns sets the maximum number of connections in the idle connection pool.

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -93,25 +93,24 @@ func (h *PrivateHandler) SetService(s service.Service) {
 func (h *PublicHandler) CheckName(ctx context.Context, req *pipelinePB.CheckNameRequest) (resp *pipelinePB.CheckNameResponse, err error) {
 	name := req.GetName()
 
-	ns, id, err := h.service.GetRscNamespaceAndNameID(name)
+	ns, id, err := h.service.GetRscNamespaceAndNameID(ctx, name)
 	if err != nil {
 		return nil, err
 	}
-	authUser, err := h.service.AuthenticateUser(ctx, false)
-	if err != nil {
+	if err := authenticateUser(ctx, false); err != nil {
 		return nil, err
 	}
 	rscType := strings.Split(name, "/")[2]
 
 	if rscType == "pipelines" {
-		_, err := h.service.GetNamespacePipelineByID(ctx, ns, authUser, id, service.ViewBasic)
+		_, err := h.service.GetNamespacePipelineByID(ctx, ns, id, service.ViewBasic)
 		if err != nil && errors.Is(err, service.ErrNotFound) {
 			return &pipelinePB.CheckNameResponse{
 				Availability: pipelinePB.CheckNameResponse_NAME_AVAILABLE,
 			}, nil
 		}
 	} else if rscType == "connectors" {
-		_, err := h.service.GetNamespaceConnectorByID(ctx, ns, authUser, id, service.ViewBasic, true)
+		_, err := h.service.GetNamespaceConnectorByID(ctx, ns, id, service.ViewBasic, true)
 		if err != nil && errors.Is(err, service.ErrNotFound) {
 			return &pipelinePB.CheckNameResponse{
 				Availability: pipelinePB.CheckNameResponse_NAME_AVAILABLE,

--- a/pkg/handler/pipeline.go
+++ b/pkg/handler/pipeline.go
@@ -26,7 +26,6 @@ import (
 	"github.com/instill-ai/pipeline-backend/internal/resource"
 	"github.com/instill-ai/pipeline-backend/pkg/constant"
 	"github.com/instill-ai/pipeline-backend/pkg/logger"
-
 	"github.com/instill-ai/pipeline-backend/pkg/service"
 	"github.com/instill-ai/x/checkfield"
 
@@ -150,8 +149,7 @@ func (h *PublicHandler) ListPipelines(ctx context.Context, req *pipelinePB.ListP
 
 	logger, _ := logger.GetZapLogger(ctx)
 
-	authUser, err := h.service.AuthenticateUser(ctx, true)
-	if err != nil {
+	if err := authenticateUser(ctx, true); err != nil {
 		span.SetStatus(1, err.Error())
 		return &pipelinePB.ListPipelinesResponse{}, err
 	}
@@ -181,16 +179,16 @@ func (h *PublicHandler) ListPipelines(ctx context.Context, req *pipelinePB.ListP
 	}
 
 	pbPipelines, totalSize, nextPageToken, err := h.service.ListPipelines(
-		ctx, authUser, req.GetPageSize(), req.GetPageToken(), parseView(int32(*req.GetView().Enum())), req.Visibility, filter, req.GetShowDeleted())
+		ctx, req.GetPageSize(), req.GetPageToken(), parseView(int32(*req.GetView().Enum())), req.Visibility, filter, req.GetShowDeleted())
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return &pipelinePB.ListPipelinesResponse{}, err
 	}
 
 	logger.Info(string(custom_otel.NewLogMessage(
+		ctx,
 		span,
 		logUUID.String(),
-		authUser.UID,
 		eventName,
 	)))
 
@@ -256,16 +254,14 @@ func (h *PublicHandler) createNamespacePipeline(ctx context.Context, req CreateN
 		return nil, ErrResourceID
 	}
 
-	ns, _, err := h.service.GetRscNamespaceAndNameID(req.GetParent())
+	ns, _, err := h.service.GetRscNamespaceAndNameID(ctx, req.GetParent())
 
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
 	}
 
-	authUser, err := h.service.AuthenticateUser(ctx, false)
-
-	if err != nil {
+	if err := authenticateUser(ctx, false); err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
 	}
@@ -283,7 +279,7 @@ func (h *PublicHandler) createNamespacePipeline(ctx context.Context, req CreateN
 		}
 	}
 
-	pipeline, err = h.service.CreateNamespacePipeline(ctx, ns, authUser, pipelineToCreate)
+	pipeline, err = h.service.CreateNamespacePipeline(ctx, ns, pipelineToCreate)
 
 	if err != nil {
 		span.SetStatus(1, err.Error())
@@ -297,9 +293,9 @@ func (h *PublicHandler) createNamespacePipeline(ctx context.Context, req CreateN
 	}
 
 	logger.Info(string(custom_otel.NewLogMessage(
+		ctx,
 		span,
 		logUUID.String(),
-		authUser.UID,
 		eventName,
 		custom_otel.SetEventResource(pipeline),
 	)))
@@ -341,13 +337,13 @@ func (h *PublicHandler) listNamespacePipelines(ctx context.Context, req ListName
 
 	logger, _ := logger.GetZapLogger(ctx)
 
-	ns, _, err := h.service.GetRscNamespaceAndNameID(req.GetParent())
+	ns, _, err := h.service.GetRscNamespaceAndNameID(ctx, req.GetParent())
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, "", 0, err
 	}
-	authUser, err := h.service.AuthenticateUser(ctx, true)
-	if err != nil {
+
+	if err := authenticateUser(ctx, true); err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, "", 0, err
 	}
@@ -377,16 +373,16 @@ func (h *PublicHandler) listNamespacePipelines(ctx context.Context, req ListName
 	}
 	visibility := req.GetVisibility()
 
-	pbPipelines, totalSize, nextPageToken, err := h.service.ListNamespacePipelines(ctx, ns, authUser, req.GetPageSize(), req.GetPageToken(), parseView(int32(*req.GetView().Enum())), &visibility, filter, req.GetShowDeleted())
+	pbPipelines, totalSize, nextPageToken, err := h.service.ListNamespacePipelines(ctx, ns, req.GetPageSize(), req.GetPageToken(), parseView(int32(*req.GetView().Enum())), &visibility, filter, req.GetShowDeleted())
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, "", 0, err
 	}
 
 	logger.Info(string(custom_otel.NewLogMessage(
+		ctx,
 		span,
 		logUUID.String(),
-		authUser.UID,
 		eventName,
 	)))
 
@@ -422,18 +418,17 @@ func (h *PublicHandler) getNamespacePipeline(ctx context.Context, req GetNamespa
 
 	logger, _ := logger.GetZapLogger(ctx)
 
-	ns, id, err := h.service.GetRscNamespaceAndNameID(req.GetName())
+	ns, id, err := h.service.GetRscNamespaceAndNameID(ctx, req.GetName())
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
 	}
-	authUser, err := h.service.AuthenticateUser(ctx, true)
-	if err != nil {
+	if err := authenticateUser(ctx, true); err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
 	}
 
-	pbPipeline, err := h.service.GetNamespacePipelineByID(ctx, ns, authUser, id, parseView(int32(*req.GetView().Enum())))
+	pbPipeline, err := h.service.GetNamespacePipelineByID(ctx, ns, id, parseView(int32(*req.GetView().Enum())))
 
 	if err != nil {
 		span.SetStatus(1, err.Error())
@@ -441,9 +436,9 @@ func (h *PublicHandler) getNamespacePipeline(ctx context.Context, req GetNamespa
 	}
 
 	logger.Info(string(custom_otel.NewLogMessage(
+		ctx,
 		span,
 		logUUID.String(),
-		authUser.UID,
 		eventName,
 		custom_otel.SetEventResource(pbPipeline),
 	)))
@@ -480,13 +475,12 @@ func (h *PublicHandler) updateNamespacePipeline(ctx context.Context, req UpdateN
 
 	// logger, _ := logger.GetZapLogger(ctx)
 
-	ns, id, err := h.service.GetRscNamespaceAndNameID(req.GetPipeline().Name)
+	ns, id, err := h.service.GetRscNamespaceAndNameID(ctx, req.GetPipeline().Name)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
 	}
-	authUser, err := h.service.AuthenticateUser(ctx, false)
-	if err != nil {
+	if err := authenticateUser(ctx, false); err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
 	}
@@ -554,7 +548,7 @@ func (h *PublicHandler) updateNamespacePipeline(ctx context.Context, req UpdateN
 		}
 	}
 
-	pbPipeline, err := h.service.UpdateNamespacePipelineByID(ctx, ns, authUser, id, pbPipelineToUpdate)
+	pbPipeline, err := h.service.UpdateNamespacePipelineByID(ctx, ns, id, pbPipelineToUpdate)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
@@ -598,13 +592,12 @@ func (h *PublicHandler) deleteNamespacePipeline(ctx context.Context, req DeleteN
 
 	logger, _ := logger.GetZapLogger(ctx)
 
-	ns, id, err := h.service.GetRscNamespaceAndNameID(req.GetName())
+	ns, id, err := h.service.GetRscNamespaceAndNameID(ctx, req.GetName())
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return err
 	}
-	authUser, err := h.service.AuthenticateUser(ctx, false)
-	if err != nil {
+	if err := authenticateUser(ctx, false); err != nil {
 		span.SetStatus(1, err.Error())
 		return err
 	}
@@ -614,7 +607,7 @@ func (h *PublicHandler) deleteNamespacePipeline(ctx context.Context, req DeleteN
 		return err
 	}
 
-	if err := h.service.DeleteNamespacePipelineByID(ctx, ns, authUser, id); err != nil {
+	if err := h.service.DeleteNamespacePipelineByID(ctx, ns, id); err != nil {
 		span.SetStatus(1, err.Error())
 		return err
 	}
@@ -626,9 +619,9 @@ func (h *PublicHandler) deleteNamespacePipeline(ctx context.Context, req DeleteN
 	}
 
 	logger.Info(string(custom_otel.NewLogMessage(
+		ctx,
 		span,
 		logUUID.String(),
-		authUser.UID,
 		eventName,
 		custom_otel.SetEventResource(existPipeline.GetPipeline()),
 	)))
@@ -659,13 +652,12 @@ func (h *PublicHandler) LookUpPipeline(ctx context.Context, req *pipelinePB.Look
 		span.SetStatus(1, err.Error())
 		return nil, err
 	}
-	authUser, err := h.service.AuthenticateUser(ctx, false)
-	if err != nil {
+	if err := authenticateUser(ctx, false); err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
 	}
 
-	pbPipeline, err := h.service.GetPipelineByUID(ctx, authUser, uid, parseView(int32(*req.GetView().Enum())))
+	pbPipeline, err := h.service.GetPipelineByUID(ctx, uid, parseView(int32(*req.GetView().Enum())))
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
@@ -676,9 +668,9 @@ func (h *PublicHandler) LookUpPipeline(ctx context.Context, req *pipelinePB.Look
 	}
 
 	logger.Info(string(custom_otel.NewLogMessage(
+		ctx,
 		span,
 		logUUID.String(),
-		authUser.UID,
 		eventName,
 		custom_otel.SetEventResource(pbPipeline),
 	)))
@@ -714,27 +706,26 @@ func (h *PublicHandler) validateNamespacePipeline(ctx context.Context, req Valid
 
 	logger, _ := logger.GetZapLogger(ctx)
 
-	ns, id, err := h.service.GetRscNamespaceAndNameID(req.GetName())
+	ns, id, err := h.service.GetRscNamespaceAndNameID(ctx, req.GetName())
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
 	}
-	authUser, err := h.service.AuthenticateUser(ctx, false)
-	if err != nil {
+	if err := authenticateUser(ctx, false); err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
 	}
 
-	pbPipeline, err := h.service.ValidateNamespacePipelineByID(ctx, ns, authUser, id)
+	pbPipeline, err := h.service.ValidateNamespacePipelineByID(ctx, ns, id)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, status.Error(codes.FailedPrecondition, fmt.Sprintf("[Pipeline Recipe Error] %+v", err.Error()))
 	}
 
 	logger.Info(string(custom_otel.NewLogMessage(
+		ctx,
 		span,
 		logUUID.String(),
-		authUser.UID,
 		eventName,
 		custom_otel.SetEventResource(pbPipeline),
 	)))
@@ -777,13 +768,12 @@ func (h *PublicHandler) renameNamespacePipeline(ctx context.Context, req RenameN
 		return nil, ErrCheckRequiredFields
 	}
 
-	ns, id, err := h.service.GetRscNamespaceAndNameID(req.GetName())
+	ns, id, err := h.service.GetRscNamespaceAndNameID(ctx, req.GetName())
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
 	}
-	authUser, err := h.service.AuthenticateUser(ctx, false)
-	if err != nil {
+	if err := authenticateUser(ctx, false); err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
 	}
@@ -794,16 +784,16 @@ func (h *PublicHandler) renameNamespacePipeline(ctx context.Context, req RenameN
 		return nil, ErrResourceID
 	}
 
-	pbPipeline, err := h.service.UpdateNamespacePipelineIDByID(ctx, ns, authUser, id, newID)
+	pbPipeline, err := h.service.UpdateNamespacePipelineIDByID(ctx, ns, id, newID)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
 	}
 
 	logger.Info(string(custom_otel.NewLogMessage(
+		ctx,
 		span,
 		logUUID.String(),
-		authUser.UID,
 		eventName,
 		custom_otel.SetEventResource(pbPipeline),
 	)))
@@ -840,60 +830,58 @@ func (h *PublicHandler) cloneNamespacePipeline(ctx context.Context, req CloneNam
 
 	logger, _ := logger.GetZapLogger(ctx)
 
-	ns, id, err := h.service.GetRscNamespaceAndNameID(req.GetName())
+	ns, id, err := h.service.GetRscNamespaceAndNameID(ctx, req.GetName())
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
 	}
-	authUser, err := h.service.AuthenticateUser(ctx, false)
+	if err := authenticateUser(ctx, false); err != nil {
+		span.SetStatus(1, err.Error())
+		return nil, err
+	}
+
+	targetNS, targetID, err := h.service.GetRscNamespaceAndNameID(ctx, req.GetTarget())
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
 	}
 
-	targetNS, targetID, err := h.service.GetRscNamespaceAndNameID(req.GetTarget())
-	if err != nil {
-		span.SetStatus(1, err.Error())
-		return nil, err
-	}
-
-	pbPipeline, err := h.service.CloneNamespacePipeline(ctx, ns, authUser, id, targetNS, targetID)
+	pbPipeline, err := h.service.CloneNamespacePipeline(ctx, ns, id, targetNS, targetID)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
 	}
 
 	logger.Info(string(custom_otel.NewLogMessage(
+		ctx,
 		span,
 		logUUID.String(),
-		authUser.UID,
 		eventName,
 		custom_otel.SetEventResource(pbPipeline),
 	)))
 	return pbPipeline, nil
 }
 
-func (h *PublicHandler) preTriggerUserPipeline(ctx context.Context, req TriggerPipelineRequestInterface) (resource.Namespace, *service.AuthUser, string, *pipelinePB.Pipeline, bool, error) {
+func (h *PublicHandler) preTriggerUserPipeline(ctx context.Context, req TriggerPipelineRequestInterface) (resource.Namespace, string, *pipelinePB.Pipeline, bool, error) {
 
 	// Return error if REQUIRED fields are not provided in the requested payload pipeline resource
 	if err := checkfield.CheckRequiredFields(req, triggerPipelineRequiredFields); err != nil {
-		return resource.Namespace{}, nil, "", nil, false, ErrCheckRequiredFields
+		return resource.Namespace{}, "", nil, false, ErrCheckRequiredFields
 	}
 
-	ns, id, err := h.service.GetRscNamespaceAndNameID(req.GetName())
+	ns, id, err := h.service.GetRscNamespaceAndNameID(ctx, req.GetName())
 	if err != nil {
-		return ns, nil, id, nil, false, err
+		return ns, id, nil, false, err
 	}
-	authUser, err := h.service.AuthenticateUser(ctx, false)
-	if err != nil {
-		return ns, nil, id, nil, false, err
+	if err := authenticateUser(ctx, false); err != nil {
+		return ns, id, nil, false, err
 	}
 
-	pbPipeline, err := h.service.GetNamespacePipelineByID(ctx, ns, authUser, id, service.ViewFull)
+	pbPipeline, err := h.service.GetNamespacePipelineByID(ctx, ns, id, service.ViewFull)
 	if err != nil {
-		return ns, nil, id, nil, false, err
+		return ns, id, nil, false, err
 	}
-	// _, err = h.service.ValidateNamespacePipelineByID(ctx, ns, authUser, id)
+	// _, err = h.service.ValidateNamespacePipelineByID(ctx, ns,  id)
 	// if err != nil {
 	// 	return ns, nil, id, nil, false, status.Error(codes.FailedPrecondition, fmt.Sprintf("[Pipeline Recipe Error] %+v", err.Error()))
 	// }
@@ -902,12 +890,12 @@ func (h *PublicHandler) preTriggerUserPipeline(ctx context.Context, req TriggerP
 		if len(md.Get(constant.ReturnTracesKey)) > 0 {
 			returnTraces, err = strconv.ParseBool(md.Get(constant.ReturnTracesKey)[0])
 			if err != nil {
-				return ns, nil, id, nil, false, err
+				return ns, id, nil, false, err
 			}
 		}
 	}
 
-	return ns, authUser, id, pbPipeline, returnTraces, nil
+	return ns, id, pbPipeline, returnTraces, nil
 
 }
 
@@ -940,13 +928,13 @@ func (h *PublicHandler) triggerNamespacePipeline(ctx context.Context, req Trigge
 
 	// logger, _ := logger.GetZapLogger(ctx)
 
-	ns, authUser, id, _, returnTraces, err := h.preTriggerUserPipeline(ctx, req)
+	ns, id, _, returnTraces, err := h.preTriggerUserPipeline(ctx, req)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, nil, err
 	}
 
-	outputs, metadata, err = h.service.TriggerNamespacePipelineByID(ctx, ns, authUser, id, req.GetInputs(), logUUID.String(), returnTraces)
+	outputs, metadata, err = h.service.TriggerNamespacePipelineByID(ctx, ns, id, req.GetInputs(), logUUID.String(), returnTraces)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, nil, err
@@ -992,22 +980,22 @@ func (h *PublicHandler) triggerAsyncNamespacePipeline(ctx context.Context, req T
 
 	logger, _ := logger.GetZapLogger(ctx)
 
-	ns, authUser, id, dbPipeline, returnTraces, err := h.preTriggerUserPipeline(ctx, req)
+	ns, id, dbPipeline, returnTraces, err := h.preTriggerUserPipeline(ctx, req)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
 	}
 
-	operation, err = h.service.TriggerAsyncNamespacePipelineByID(ctx, ns, authUser, id, req.GetInputs(), logUUID.String(), returnTraces)
+	operation, err = h.service.TriggerAsyncNamespacePipelineByID(ctx, ns, id, req.GetInputs(), logUUID.String(), returnTraces)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
 	}
 
 	logger.Info(string(custom_otel.NewLogMessage(
+		ctx,
 		span,
 		logUUID.String(),
-		authUser.UID,
 		eventName,
 		custom_otel.SetEventResource(dbPipeline),
 	)))
@@ -1061,25 +1049,24 @@ func (h *PublicHandler) createNamespacePipelineRelease(ctx context.Context, req 
 		return nil, ErrSematicVersion
 	}
 
-	ns, pipelineID, err := h.service.GetRscNamespaceAndNameID(req.GetParent())
+	ns, pipelineID, err := h.service.GetRscNamespaceAndNameID(ctx, req.GetParent())
 	if err != nil {
 		return nil, err
 	}
-	authUser, err := h.service.AuthenticateUser(ctx, false)
-	if err != nil {
+	if err := authenticateUser(ctx, false); err != nil {
 		return nil, err
 	}
 
-	pipeline, err := h.service.GetNamespacePipelineByID(ctx, ns, authUser, pipelineID, service.ViewBasic)
+	pipeline, err := h.service.GetNamespacePipelineByID(ctx, ns, pipelineID, service.ViewBasic)
 	if err != nil {
 		return nil, err
 	}
-	_, err = h.service.ValidateNamespacePipelineByID(ctx, ns, authUser, pipeline.Id)
+	_, err = h.service.ValidateNamespacePipelineByID(ctx, ns, pipeline.Id)
 	if err != nil {
 		return nil, status.Error(codes.FailedPrecondition, fmt.Sprintf("[Pipeline Recipe Error] %+v", err.Error()))
 	}
 
-	pbPipelineRelease, err := h.service.CreateNamespacePipelineRelease(ctx, ns, authUser, uuid.FromStringOrNil(pipeline.Uid), req.GetRelease())
+	pbPipelineRelease, err := h.service.CreateNamespacePipelineRelease(ctx, ns, uuid.FromStringOrNil(pipeline.Uid), req.GetRelease())
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		// Manually set the custom header to have a StatusBadRequest http response for REST endpoint
@@ -1096,9 +1083,9 @@ func (h *PublicHandler) createNamespacePipelineRelease(ctx context.Context, req 
 	}
 
 	logger.Info(string(custom_otel.NewLogMessage(
+		ctx,
 		span,
 		logUUID.String(),
-		authUser.UID,
 		eventName,
 		custom_otel.SetEventResource(pbPipelineRelease),
 	)))
@@ -1140,12 +1127,11 @@ func (h *PublicHandler) listNamespacePipelineReleases(ctx context.Context, req L
 
 	logger, _ := logger.GetZapLogger(ctx)
 
-	ns, pipelineID, err := h.service.GetRscNamespaceAndNameID(req.GetParent())
+	ns, pipelineID, err := h.service.GetRscNamespaceAndNameID(ctx, req.GetParent())
 	if err != nil {
 		return nil, "", 0, err
 	}
-	authUser, err := h.service.AuthenticateUser(ctx, true)
-	if err != nil {
+	if err := authenticateUser(ctx, true); err != nil {
 		return nil, "", 0, err
 	}
 
@@ -1173,21 +1159,21 @@ func (h *PublicHandler) listNamespacePipelineReleases(ctx context.Context, req L
 		return nil, "", 0, err
 	}
 
-	pipeline, err := h.service.GetNamespacePipelineByID(ctx, ns, authUser, pipelineID, service.ViewBasic)
+	pipeline, err := h.service.GetNamespacePipelineByID(ctx, ns, pipelineID, service.ViewBasic)
 	if err != nil {
 		return nil, "", 0, err
 	}
 
-	pbPipelineReleases, totalSize, nextPageToken, err := h.service.ListNamespacePipelineReleases(ctx, ns, authUser, uuid.FromStringOrNil(pipeline.Uid), req.GetPageSize(), req.GetPageToken(), parseView(int32(*req.GetView().Enum())), filter, req.GetShowDeleted())
+	pbPipelineReleases, totalSize, nextPageToken, err := h.service.ListNamespacePipelineReleases(ctx, ns, uuid.FromStringOrNil(pipeline.Uid), req.GetPageSize(), req.GetPageToken(), parseView(int32(*req.GetView().Enum())), filter, req.GetShowDeleted())
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, "", 0, err
 	}
 
 	logger.Info(string(custom_otel.NewLogMessage(
+		ctx,
 		span,
 		logUUID.String(),
-		authUser.UID,
 		eventName,
 	)))
 
@@ -1224,34 +1210,33 @@ func (h *PublicHandler) getNamespacePipelineRelease(ctx context.Context, req Get
 
 	logger, _ := logger.GetZapLogger(ctx)
 
-	ns, pipelineID, releaseID, err := h.service.GetRscNamespaceAndNameIDAndReleaseID(req.GetName())
+	ns, pipelineID, releaseID, err := h.service.GetRscNamespaceAndNameIDAndReleaseID(ctx, req.GetName())
 	if err != nil {
 		return nil, err
 	}
-	authUser, err := h.service.AuthenticateUser(ctx, true)
-	if err != nil {
+	if err := authenticateUser(ctx, true); err != nil {
 		return nil, err
 	}
-	releaseID, err = h.service.ConvertReleaseIDAlias(ctx, ns, authUser, pipelineID, releaseID)
-	if err != nil {
-		return nil, err
-	}
-
-	pipeline, err := h.service.GetNamespacePipelineByID(ctx, ns, authUser, pipelineID, service.ViewBasic)
+	releaseID, err = h.service.ConvertReleaseIDAlias(ctx, ns, pipelineID, releaseID)
 	if err != nil {
 		return nil, err
 	}
 
-	pbPipelineRelease, err := h.service.GetNamespacePipelineReleaseByID(ctx, ns, authUser, uuid.FromStringOrNil(pipeline.Uid), releaseID, parseView(int32(*req.GetView().Enum())))
+	pipeline, err := h.service.GetNamespacePipelineByID(ctx, ns, pipelineID, service.ViewBasic)
+	if err != nil {
+		return nil, err
+	}
+
+	pbPipelineRelease, err := h.service.GetNamespacePipelineReleaseByID(ctx, ns, uuid.FromStringOrNil(pipeline.Uid), releaseID, parseView(int32(*req.GetView().Enum())))
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
 	}
 
 	logger.Info(string(custom_otel.NewLogMessage(
+		ctx,
 		span,
 		logUUID.String(),
-		authUser.UID,
 		eventName,
 		custom_otel.SetEventResource(pbPipelineRelease),
 	)))
@@ -1289,15 +1274,14 @@ func (h *PublicHandler) updateNamespacePipelineRelease(ctx context.Context, req 
 
 	logger, _ := logger.GetZapLogger(ctx)
 
-	ns, pipelineID, releaseID, err := h.service.GetRscNamespaceAndNameIDAndReleaseID(req.GetRelease().GetName())
+	ns, pipelineID, releaseID, err := h.service.GetRscNamespaceAndNameIDAndReleaseID(ctx, req.GetRelease().GetName())
 	if err != nil {
 		return nil, err
 	}
-	authUser, err := h.service.AuthenticateUser(ctx, false)
-	if err != nil {
+	if err := authenticateUser(ctx, false); err != nil {
 		return nil, err
 	}
-	releaseID, err = h.service.ConvertReleaseIDAlias(ctx, ns, authUser, pipelineID, releaseID)
+	releaseID, err = h.service.ConvertReleaseIDAlias(ctx, ns, pipelineID, releaseID)
 	if err != nil {
 		return nil, err
 	}
@@ -1310,7 +1294,7 @@ func (h *PublicHandler) updateNamespacePipelineRelease(ctx context.Context, req 
 		return nil, ErrUpdateMask
 	}
 
-	pipeline, err := h.service.GetNamespacePipelineByID(ctx, ns, authUser, pipelineID, service.ViewBasic)
+	pipeline, err := h.service.GetNamespacePipelineByID(ctx, ns, pipelineID, service.ViewBasic)
 	if err != nil {
 		return nil, err
 	}
@@ -1352,16 +1336,16 @@ func (h *PublicHandler) updateNamespacePipelineRelease(ctx context.Context, req 
 		return nil, err
 	}
 
-	pbPipelineRelease, err := h.service.UpdateNamespacePipelineReleaseByID(ctx, ns, authUser, uuid.FromStringOrNil(pipeline.Uid), releaseID, pbPipelineReleaseToUpdate)
+	pbPipelineRelease, err := h.service.UpdateNamespacePipelineReleaseByID(ctx, ns, uuid.FromStringOrNil(pipeline.Uid), releaseID, pbPipelineReleaseToUpdate)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
 	}
 
 	logger.Info(string(custom_otel.NewLogMessage(
+		ctx,
 		span,
 		logUUID.String(),
-		authUser.UID,
 		eventName,
 		custom_otel.SetEventResource(pbPipelineRelease),
 	)))
@@ -1404,20 +1388,19 @@ func (h *PublicHandler) renameNamespacePipelineRelease(ctx context.Context, req 
 		return nil, ErrCheckRequiredFields
 	}
 
-	ns, pipelineID, releaseID, err := h.service.GetRscNamespaceAndNameIDAndReleaseID(req.GetName())
+	ns, pipelineID, releaseID, err := h.service.GetRscNamespaceAndNameIDAndReleaseID(ctx, req.GetName())
 	if err != nil {
 		return nil, err
 	}
-	authUser, err := h.service.AuthenticateUser(ctx, false)
-	if err != nil {
+	if err := authenticateUser(ctx, false); err != nil {
 		return nil, err
 	}
-	releaseID, err = h.service.ConvertReleaseIDAlias(ctx, ns, authUser, pipelineID, releaseID)
+	releaseID, err = h.service.ConvertReleaseIDAlias(ctx, ns, pipelineID, releaseID)
 	if err != nil {
 		return nil, err
 	}
 
-	pipeline, err := h.service.GetNamespacePipelineByID(ctx, ns, authUser, pipelineID, service.ViewBasic)
+	pipeline, err := h.service.GetNamespacePipelineByID(ctx, ns, pipelineID, service.ViewBasic)
 	if err != nil {
 		return nil, err
 	}
@@ -1430,16 +1413,16 @@ func (h *PublicHandler) renameNamespacePipelineRelease(ctx context.Context, req 
 		return nil, ErrSematicVersion
 	}
 
-	pbPipelineRelease, err := h.service.UpdateNamespacePipelineReleaseIDByID(ctx, ns, authUser, uuid.FromStringOrNil(pipeline.Uid), releaseID, newID)
+	pbPipelineRelease, err := h.service.UpdateNamespacePipelineReleaseIDByID(ctx, ns, uuid.FromStringOrNil(pipeline.Uid), releaseID, newID)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
 	}
 
 	logger.Info(string(custom_otel.NewLogMessage(
+		ctx,
 		span,
 		logUUID.String(),
-		authUser.UID,
 		eventName,
 		custom_otel.SetEventResource(pbPipelineRelease),
 	)))
@@ -1474,15 +1457,14 @@ func (h *PublicHandler) deleteNamespacePipelineRelease(ctx context.Context, req 
 
 	logger, _ := logger.GetZapLogger(ctx)
 
-	ns, pipelineID, releaseID, err := h.service.GetRscNamespaceAndNameIDAndReleaseID(req.GetName())
+	ns, pipelineID, releaseID, err := h.service.GetRscNamespaceAndNameIDAndReleaseID(ctx, req.GetName())
 	if err != nil {
 		return err
 	}
-	authUser, err := h.service.AuthenticateUser(ctx, false)
-	if err != nil {
+	if err := authenticateUser(ctx, false); err != nil {
 		return err
 	}
-	releaseID, err = h.service.ConvertReleaseIDAlias(ctx, ns, authUser, pipelineID, releaseID)
+	releaseID, err = h.service.ConvertReleaseIDAlias(ctx, ns, pipelineID, releaseID)
 	if err != nil {
 		return err
 	}
@@ -1493,12 +1475,12 @@ func (h *PublicHandler) deleteNamespacePipelineRelease(ctx context.Context, req 
 		return err
 	}
 
-	pipeline, err := h.service.GetNamespacePipelineByID(ctx, ns, authUser, pipelineID, service.ViewBasic)
+	pipeline, err := h.service.GetNamespacePipelineByID(ctx, ns, pipelineID, service.ViewBasic)
 	if err != nil {
 		return err
 	}
 
-	if err := h.service.DeleteNamespacePipelineReleaseByID(ctx, ns, authUser, uuid.FromStringOrNil(pipeline.Uid), releaseID); err != nil {
+	if err := h.service.DeleteNamespacePipelineReleaseByID(ctx, ns, uuid.FromStringOrNil(pipeline.Uid), releaseID); err != nil {
 		span.SetStatus(1, err.Error())
 		return err
 	}
@@ -1510,9 +1492,9 @@ func (h *PublicHandler) deleteNamespacePipelineRelease(ctx context.Context, req 
 	}
 
 	logger.Info(string(custom_otel.NewLogMessage(
+		ctx,
 		span,
 		logUUID.String(),
-		authUser.UID,
 		eventName,
 		custom_otel.SetEventResource(existPipelineRelease.GetRelease()),
 	)))
@@ -1548,15 +1530,14 @@ func (h *PublicHandler) restoreNamespacePipelineRelease(ctx context.Context, req
 
 	logger, _ := logger.GetZapLogger(ctx)
 
-	ns, pipelineID, releaseID, err := h.service.GetRscNamespaceAndNameIDAndReleaseID(req.GetName())
+	ns, pipelineID, releaseID, err := h.service.GetRscNamespaceAndNameIDAndReleaseID(ctx, req.GetName())
 	if err != nil {
 		return nil, err
 	}
-	authUser, err := h.service.AuthenticateUser(ctx, false)
-	if err != nil {
+	if err := authenticateUser(ctx, false); err != nil {
 		return nil, err
 	}
-	releaseID, err = h.service.ConvertReleaseIDAlias(ctx, ns, authUser, pipelineID, releaseID)
+	releaseID, err = h.service.ConvertReleaseIDAlias(ctx, ns, pipelineID, releaseID)
 	if err != nil {
 		return nil, err
 	}
@@ -1567,26 +1548,26 @@ func (h *PublicHandler) restoreNamespacePipelineRelease(ctx context.Context, req
 		return nil, err
 	}
 
-	pipeline, err := h.service.GetNamespacePipelineByID(ctx, ns, authUser, pipelineID, service.ViewBasic)
+	pipeline, err := h.service.GetNamespacePipelineByID(ctx, ns, pipelineID, service.ViewBasic)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := h.service.RestoreNamespacePipelineReleaseByID(ctx, ns, authUser, uuid.FromStringOrNil(pipeline.Uid), releaseID); err != nil {
+	if err := h.service.RestoreNamespacePipelineReleaseByID(ctx, ns, uuid.FromStringOrNil(pipeline.Uid), releaseID); err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
 	}
 
-	pbPipelineRelease, err := h.service.GetNamespacePipelineReleaseByID(ctx, ns, authUser, uuid.FromStringOrNil(pipeline.Uid), releaseID, service.ViewFull)
+	pbPipelineRelease, err := h.service.GetNamespacePipelineReleaseByID(ctx, ns, uuid.FromStringOrNil(pipeline.Uid), releaseID, service.ViewFull)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
 	}
 
 	logger.Info(string(custom_otel.NewLogMessage(
+		ctx,
 		span,
 		logUUID.String(),
-		authUser.UID,
 		eventName,
 		custom_otel.SetEventResource(existPipelineRelease.GetRelease()),
 	)))
@@ -1594,47 +1575,46 @@ func (h *PublicHandler) restoreNamespacePipelineRelease(ctx context.Context, req
 	return pbPipelineRelease, nil
 }
 
-func (h *PublicHandler) preTriggerUserPipelineRelease(ctx context.Context, req TriggerPipelineRequestInterface) (resource.Namespace, *service.AuthUser, string, *pipelinePB.Pipeline, *pipelinePB.PipelineRelease, bool, error) {
+func (h *PublicHandler) preTriggerUserPipelineRelease(ctx context.Context, req TriggerPipelineRequestInterface) (resource.Namespace, string, *pipelinePB.Pipeline, *pipelinePB.PipelineRelease, bool, error) {
 
 	// Return error if REQUIRED fields are not provided in the requested payload pipeline resource
 	if err := checkfield.CheckRequiredFields(req, triggerPipelineRequiredFields); err != nil {
-		return resource.Namespace{}, nil, "", nil, nil, false, ErrCheckRequiredFields
+		return resource.Namespace{}, "", nil, nil, false, ErrCheckRequiredFields
 	}
 
-	ns, pipelineID, releaseID, err := h.service.GetRscNamespaceAndNameIDAndReleaseID(req.GetName())
+	ns, pipelineID, releaseID, err := h.service.GetRscNamespaceAndNameIDAndReleaseID(ctx, req.GetName())
 	if err != nil {
-		return ns, nil, "", nil, nil, false, err
+		return ns, "", nil, nil, false, err
 	}
-	authUser, err := h.service.AuthenticateUser(ctx, false)
-	if err != nil {
-		return ns, nil, "", nil, nil, false, err
-	}
-
-	releaseID, err = h.service.ConvertReleaseIDAlias(ctx, ns, authUser, pipelineID, releaseID)
-	if err != nil {
-		return ns, nil, "", nil, nil, false, err
+	if err := authenticateUser(ctx, false); err != nil {
+		return ns, "", nil, nil, false, err
 	}
 
-	pbPipeline, err := h.service.GetNamespacePipelineByID(ctx, ns, authUser, pipelineID, service.ViewFull)
+	releaseID, err = h.service.ConvertReleaseIDAlias(ctx, ns, pipelineID, releaseID)
 	if err != nil {
-		return ns, nil, "", nil, nil, false, err
+		return ns, "", nil, nil, false, err
 	}
 
-	pbPipelineRelease, err := h.service.GetNamespacePipelineReleaseByID(ctx, ns, authUser, uuid.FromStringOrNil(pbPipeline.Uid), releaseID, service.ViewFull)
+	pbPipeline, err := h.service.GetNamespacePipelineByID(ctx, ns, pipelineID, service.ViewFull)
 	if err != nil {
-		return ns, nil, "", nil, nil, false, err
+		return ns, "", nil, nil, false, err
+	}
+
+	pbPipelineRelease, err := h.service.GetNamespacePipelineReleaseByID(ctx, ns, uuid.FromStringOrNil(pbPipeline.Uid), releaseID, service.ViewFull)
+	if err != nil {
+		return ns, "", nil, nil, false, err
 	}
 	returnTraces := false
 	if md, ok := metadata.FromIncomingContext(ctx); ok {
 		if len(md.Get(constant.ReturnTracesKey)) > 0 {
 			returnTraces, err = strconv.ParseBool(md.Get(constant.ReturnTracesKey)[0])
 			if err != nil {
-				return ns, nil, "", nil, nil, false, err
+				return ns, "", nil, nil, false, err
 			}
 		}
 	}
 
-	return ns, authUser, releaseID, pbPipeline, pbPipelineRelease, returnTraces, nil
+	return ns, releaseID, pbPipeline, pbPipelineRelease, returnTraces, nil
 
 }
 
@@ -1667,22 +1647,22 @@ func (h *PublicHandler) triggerNamespacePipelineRelease(ctx context.Context, req
 
 	logger, _ := logger.GetZapLogger(ctx)
 
-	ns, authUser, releaseID, pbPipeline, pbPipelineRelease, returnTraces, err := h.preTriggerUserPipelineRelease(ctx, req)
+	ns, releaseID, pbPipeline, pbPipelineRelease, returnTraces, err := h.preTriggerUserPipelineRelease(ctx, req)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, nil, err
 	}
 
-	outputs, metadata, err = h.service.TriggerNamespacePipelineReleaseByID(ctx, ns, authUser, uuid.FromStringOrNil(pbPipeline.Uid), releaseID, req.GetInputs(), logUUID.String(), returnTraces)
+	outputs, metadata, err = h.service.TriggerNamespacePipelineReleaseByID(ctx, ns, uuid.FromStringOrNil(pbPipeline.Uid), releaseID, req.GetInputs(), logUUID.String(), returnTraces)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, nil, err
 	}
 
 	logger.Info(string(custom_otel.NewLogMessage(
+		ctx,
 		span,
 		logUUID.String(),
-		authUser.UID,
 		eventName,
 		custom_otel.SetEventResource(pbPipelineRelease),
 	)))
@@ -1719,22 +1699,22 @@ func (h *PublicHandler) triggerAsyncNamespacePipelineRelease(ctx context.Context
 
 	logger, _ := logger.GetZapLogger(ctx)
 
-	ns, authUser, releaseID, pbPipeline, pbPipelineRelease, returnTraces, err := h.preTriggerUserPipelineRelease(ctx, req)
+	ns, releaseID, pbPipeline, pbPipelineRelease, returnTraces, err := h.preTriggerUserPipelineRelease(ctx, req)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
 	}
 
-	operation, err = h.service.TriggerAsyncNamespacePipelineReleaseByID(ctx, ns, authUser, uuid.FromStringOrNil(pbPipeline.Uid), releaseID, req.GetInputs(), logUUID.String(), returnTraces)
+	operation, err = h.service.TriggerAsyncNamespacePipelineReleaseByID(ctx, ns, uuid.FromStringOrNil(pbPipeline.Uid), releaseID, req.GetInputs(), logUUID.String(), returnTraces)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
 	}
 
 	logger.Info(string(custom_otel.NewLogMessage(
+		ctx,
 		span,
 		logUUID.String(),
-		authUser.UID,
 		eventName,
 		custom_otel.SetEventResource(pbPipelineRelease),
 	)))

--- a/pkg/handler/pipeline.go
+++ b/pkg/handler/pipeline.go
@@ -886,13 +886,8 @@ func (h *PublicHandler) preTriggerUserPipeline(ctx context.Context, req TriggerP
 	// 	return ns, nil, id, nil, false, status.Error(codes.FailedPrecondition, fmt.Sprintf("[Pipeline Recipe Error] %+v", err.Error()))
 	// }
 	returnTraces := false
-	if md, ok := metadata.FromIncomingContext(ctx); ok {
-		if len(md.Get(constant.ReturnTracesKey)) > 0 {
-			returnTraces, err = strconv.ParseBool(md.Get(constant.ReturnTracesKey)[0])
-			if err != nil {
-				return ns, id, nil, false, err
-			}
-		}
+	if resource.GetRequestSingleHeader(ctx, constant.HeaderReturnTracesKey) == "true" {
+		returnTraces = true
 	}
 
 	return ns, id, pbPipeline, returnTraces, nil
@@ -1605,13 +1600,8 @@ func (h *PublicHandler) preTriggerUserPipelineRelease(ctx context.Context, req T
 		return ns, "", nil, nil, false, err
 	}
 	returnTraces := false
-	if md, ok := metadata.FromIncomingContext(ctx); ok {
-		if len(md.Get(constant.ReturnTracesKey)) > 0 {
-			returnTraces, err = strconv.ParseBool(md.Get(constant.ReturnTracesKey)[0])
-			if err != nil {
-				return ns, "", nil, nil, false, err
-			}
-		}
+	if resource.GetRequestSingleHeader(ctx, constant.HeaderReturnTracesKey) == "true" {
+		returnTraces = true
 	}
 
 	return ns, releaseID, pbPipeline, pbPipelineRelease, returnTraces, nil

--- a/pkg/handler/utils.go
+++ b/pkg/handler/utils.go
@@ -1,19 +1,34 @@
 package handler
 
 import (
+	"context"
+
+	"github.com/instill-ai/pipeline-backend/internal/resource"
+	"github.com/instill-ai/pipeline-backend/pkg/constant"
 	"github.com/instill-ai/pipeline-backend/pkg/service"
 	// pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
 
 func parseView(view int32) service.View {
-	// switch view.(type) {
-	// case pipelinePB.ListPipelinesRequest_View:
-	// 	return service.View(view.(pipelinePB.ListPipelinesRequest_View))
-	// default:
 	if view == 0 {
 		return service.ViewBasic
 	}
 	return service.View(view)
-	// }
-	// return service.View(0)
+}
+
+func authenticateUser(ctx context.Context, allowVisitor bool) error {
+	if resource.GetRequestSingleHeader(ctx, constant.HeaderAuthTypeKey) == "user" {
+		if resource.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey) == "" {
+			return service.ErrUnauthenticated
+		}
+		return nil
+	} else {
+		if !allowVisitor {
+			return service.ErrUnauthenticated
+		}
+		if resource.GetRequestSingleHeader(ctx, constant.HeaderVisitorUIDKey) == "" {
+			return service.ErrUnauthenticated
+		}
+		return nil
+	}
 }

--- a/pkg/logger/otel/const.go
+++ b/pkg/logger/otel/const.go
@@ -1,11 +1,13 @@
 package otel
 
 import (
+	"context"
 	"encoding/json"
 
 	"go.opentelemetry.io/otel/trace"
 
-	"github.com/gofrs/uuid"
+	"github.com/instill-ai/pipeline-backend/internal/resource"
+	"github.com/instill-ai/pipeline-backend/pkg/constant"
 	"github.com/instill-ai/pipeline-backend/pkg/utils"
 )
 
@@ -71,9 +73,9 @@ func SetMetadata(m string) Option {
 }
 
 func NewLogMessage(
+	ctx context.Context,
 	span trace.Span,
 	logID string,
-	userUID uuid.UUID,
 	eventName string,
 	options ...Option,
 ) []byte {
@@ -91,7 +93,7 @@ func NewLogMessage(
 		UserUUID string "json:\"userUUID\""
 	}{
 
-		UserUUID: userUID.String(),
+		UserUUID: resource.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey),
 	}
 	logMessage.Event = struct {
 		IsAuditEvent bool "json:\"isAuditEvent\""

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -190,6 +190,7 @@ func (r *repository) listPipelines(ctx context.Context, where string, whereArgs 
 		lastUID := (pipelines)[len(pipelines)-1].UID
 		lastItem := &datamodel.Pipeline{}
 
+		db := r.checkPinnedUser(ctx, r.db)
 		if uidAllowList != nil {
 			if result := db.Model(&datamodel.Pipeline{}).
 				Where(where, whereArgs...).
@@ -404,6 +405,7 @@ func (r *repository) ListNamespacePipelineReleases(ctx context.Context, ownerPer
 	if len(pipelineReleases) > 0 {
 		lastUID := (pipelineReleases)[len(pipelineReleases)-1].UID
 		lastItem := &datamodel.PipelineRelease{}
+		db := r.checkPinnedUser(ctx, r.db)
 		if result := db.Model(&datamodel.PipelineRelease{}).
 			Where("pipeline_uid = ?", pipelineUID).
 			Order("create_time ASC, uid ASC").
@@ -478,6 +480,7 @@ func (r *repository) ListPipelineReleasesAdmin(ctx context.Context, pageSize int
 	if len(pipelineReleases) > 0 {
 		lastUID := (pipelineReleases)[len(pipelineReleases)-1].UID
 		lastItem := &datamodel.PipelineRelease{}
+		db := r.checkPinnedUser(ctx, r.db)
 		if result := db.Model(&datamodel.PipelineRelease{}).
 			Order("create_time ASC, uid ASC").
 			Limit(1).Find(lastItem); result.Error != nil {
@@ -660,7 +663,7 @@ func (r *repository) listConnectors(ctx context.Context, where string, whereArgs
 	if len(connectors) > 0 {
 		lastUID := (connectors)[len(connectors)-1].UID
 		lastItem := &datamodel.Connector{}
-
+		db := r.checkPinnedUser(ctx, r.db)
 		if uidAllowList != nil {
 			if result := db.Model(&datamodel.Connector{}).
 				Where(where, whereArgs...).

--- a/pkg/usage/usage.go
+++ b/pkg/usage/usage.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/go-redis/redis/v9"
+	"github.com/redis/go-redis/v9"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/instill-ai/pipeline-backend/config"

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -3,8 +3,8 @@ package worker
 import (
 	"context"
 
-	"github.com/go-redis/redis/v9"
 	"github.com/influxdata/influxdb-client-go/v2/api"
+	"github.com/redis/go-redis/v9"
 	"go.temporal.io/sdk/workflow"
 
 	"github.com/instill-ai/pipeline-backend/pkg/logger"


### PR DESCRIPTION
Because

- Since there will be replication lag in the database replica, we will encounter the "read-after-write inconsistency" problem when deploying Core in a multi-region cluster. In our use case, we can choose the "Pinning User to Primary Database" approach as our first step. This means that after the user mutates some data, there will be a small time frame during which this user will always read data from the primary database, regardless of their location. This way, we can ensure read-after-write consistency.

This commit

- Pins the user to read from the primary database for a certain time frame after mutating the data.
- Refactors code to retrieve `authUser` data from context directly.