### PR TITLE
feat: add connection to read replica OpenFGA

### DIFF
--- a/cmd/init/main.go
+++ b/cmd/init/main.go
@@ -135,7 +135,7 @@ func main() {
 	if stores, err := fgaClient.ListStores(context.Background()).Execute(); err == nil {
 		fgaClient.SetStoreId(*(*stores.Stores)[0].Id)
 		if models, err := fgaClient.ReadAuthorizationModels(context.Background()).Execute(); err == nil {
-			aclClient = acl.NewACLClient(fgaClient, (*models.AuthorizationModels)[0].Id)
+			aclClient = acl.NewACLClient(fgaClient, nil, redisClient, (*models.AuthorizationModels)[0].Id)
 		}
 		if err != nil {
 			panic(err)

--- a/config/config.go
+++ b/config/config.go
@@ -34,8 +34,13 @@ type AppConfig struct {
 
 // OpenFGA config
 type OpenFGAConfig struct {
-	Host string `koanf:"host"`
-	Port int    `koanf:"port"`
+	Host    string `koanf:"host"`
+	Port    int    `koanf:"port"`
+	Replica struct {
+		Host                 string `koanf:"host"`
+		Port                 int    `koanf:"port"`
+		ReplicationTimeFrame int    `koanf:"replicationtimeframe"` // in seconds
+	} `koanf:"replica"`
 }
 
 // ServerConfig defines HTTP server configurations


### PR DESCRIPTION
Because

- In the multi-region deployment, we will separate the read/write operations into different databases and OpenFGA engines.

This commit

- Adds connection settings for OpenFGA read replica.
- Separates read/write modes into different OpenFGA engines.