### PR TITLE
chore: implement a workaround to improve Instill Cloud performance

### DIFF
--- a/cmd/init/main.go
+++ b/cmd/init/main.go
@@ -81,6 +81,9 @@ func main() {
 	redisClient := redis.NewClient(&config.Config.Cache.Redis.RedisOptions)
 	defer redisClient.Close()
 
+	// This is a workaround solution for the Instill Model connector in Instill Cloud to improve response speed.
+	_ = redisClient.Del(ctx, "instill_model_connector_def")
+
 	repo := repository.NewRepository(db, redisClient)
 
 	// Update component definitions and connectors based on latest version of

--- a/config/config.go
+++ b/config/config.go
@@ -80,6 +80,9 @@ type ConnectorConfig struct {
 		}
 		ExcludeLocalConnector bool `koanf:"excludelocalconnector"`
 	}
+	Instill struct {
+		UseStaticModelList bool `koanf:"usestaticmodellist"`
+	} `koanf:"instill"`
 }
 
 // DatabaseConfig related to database


### PR DESCRIPTION
Because

- In Instill Cloud, the Instill Model connector will frequently send GET requests to /models endpoint, as it connects to Instill Model through an external network, resulting in poor performance. Since we have a static model list in Instill Cloud for now, we can implement a temporary workaround by caching the model list to improve performance.

This commit

- Implements a workaround to improve Instill Cloud performance.