### PR TITLE
feat: add repository tests against DB

### DIFF
--- a/.env
+++ b/.env
@@ -13,3 +13,7 @@ SOCAT_PORT=2375
 # container build
 DOCKER_BUILDKIT=1
 COMPOSE_DOCKER_CLI_BUILD=1
+
+# test
+TEST_DBHOST=localhost
+TEST_DBNAME=pipeline_test

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,6 +9,18 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_PASSWORD: password
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
     steps:
       - uses: actions/checkout@v3
         with:
@@ -28,11 +40,11 @@ jobs:
       - name: Generate coverage report
         run: |
           go mod tidy
-          go test -race ./... -coverprofile=coverage.txt -covermode=atomic
+          make coverage DBTEST=true
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v2
         with:
-          file: ./coverage.txt
+          file: ./coverage.out
           flags: unittests
           name: codecov-umbrella

--- a/Makefile
+++ b/Makefile
@@ -61,13 +61,15 @@ go-gen:       					## Generate codes
 dbtest-pre:
 	@${GOTEST_FLAGS} go run ./cmd/migration
 
-.PHONY: unit-test
-unit-test:       				## Run unit test
+.PHONY: coverage
+coverage:
 	@if [ "${DBTEST}" = "true" ]; then  make dbtest-pre; fi
-	@${GOTEST_FLAGS} go test -v -race ${GOTEST_TAGS} -coverpkg=./... -coverprofile=coverage.out ./...
-	@go tool cover -func=coverage.out
-	@go tool cover -html=coverage.out
-	@rm coverage.out
+	@${GOTEST_FLAGS} go test -v -race ${GOTEST_TAGS} -coverpkg=./... -coverprofile=coverage.out -covermode=atomic ./...
+	@if [ "${HTML}" = "true" ]; then  \
+		go tool cover -func=coverage.out && \
+		go tool cover -html=coverage.out && \
+		rm coverage.out; \
+	fi
 
 .PHONY: integration-test
 integration-test:				## Run integration test

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,11 @@
 include .env
 export
 
+GOTEST_FLAGS := CFG_DATABASE_HOST=${TEST_DBHOST} CFG_DATABASE_NAME=${TEST_DBNAME}
+ifeq (${DBTEST}, true)
+	GOTEST_TAGS := -tags=dbtest
+endif
+
 #============================================================================
 
 .PHONY: dev
@@ -52,9 +57,14 @@ build:							## Build dev docker image
 go-gen:       					## Generate codes
 	go generate ./...
 
+.PHONY: dbtest-pre
+dbtest-pre:
+	@${GOTEST_FLAGS} go run ./cmd/migration
+
 .PHONY: unit-test
 unit-test:       				## Run unit test
-	@go test -v -race -coverpkg=./... -coverprofile=coverage.out ./...
+	@if [ "${DBTEST}" = "true" ]; then  make dbtest-pre; fi
+	@${GOTEST_FLAGS} go test -v -race ${GOTEST_TAGS} -coverpkg=./... -coverprofile=coverage.out ./...
 	@go tool cover -func=coverage.out
 	@go tool cover -html=coverage.out
 	@rm coverage.out

--- a/cmd/init/main.go
+++ b/cmd/init/main.go
@@ -62,8 +62,7 @@ type Connector struct {
 }
 
 func main() {
-
-	if err := config.Init(); err != nil {
+	if err := config.Init(config.ParseConfigFlag()); err != nil {
 		log.Fatal(err.Error())
 	}
 	ctx, cancel := context.WithCancel(context.Background())

--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -97,8 +97,7 @@ func InitPipelinePublicServiceClient(ctx context.Context) (pipelinePB.PipelinePu
 }
 
 func main() {
-
-	if err := config.Init(); err != nil {
+	if err := config.Init(config.ParseConfigFlag()); err != nil {
 		log.Fatal(err.Error())
 	}
 

--- a/cmd/migration/main.go
+++ b/cmd/migration/main.go
@@ -75,7 +75,7 @@ func checkExist(databaseConfig config.DatabaseConfig) error {
 func main() {
 	migrateFolder, _ := os.Getwd()
 
-	if err := config.Init(); err != nil {
+	if err := config.Init(config.ParseConfigFlag()); err != nil {
 		panic(err)
 	}
 
@@ -119,33 +119,31 @@ func main() {
 		if ExpectedVersion <= step {
 			fmt.Printf("Migration to version %d complete\n", ExpectedVersion)
 			break
-		} else {
-			if step == 5 {
-				if err := migratePipelineRecipeUp000006(); err != nil {
-					panic(err)
-				}
-			}
-			if step == 6 {
-				if err := migratePipelineRecipeUp000007(); err != nil {
-					panic(err)
-				}
-			}
-			if step == 11 {
-				if err := migratePipelineRecipeUp000012(); err != nil {
-					panic(err)
-				}
-			}
+		}
 
-			fmt.Printf("Step up to version %d\n", step+1)
-			if err := m.Steps(1); err != nil {
+		switch step {
+		case 5:
+			if err := migratePipelineRecipeUp000006(); err != nil {
+				panic(err)
+			}
+		case 6:
+			if err := migratePipelineRecipeUp000007(); err != nil {
+				panic(err)
+			}
+		case 11:
+			if err := migratePipelineRecipeUp000012(); err != nil {
 				panic(err)
 			}
 		}
 
-		step, _, err = m.Version()
-
-		if err != nil {
+		fmt.Printf("Step up to version %d\n", step+1)
+		if err := m.Steps(1); err != nil {
 			panic(err)
 		}
+
+		if step, _, err = m.Version(); err != nil {
+			panic(err)
+		}
+
 	}
 }

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -69,8 +69,7 @@ func initTemporalNamespace(ctx context.Context, client client.Client) {
 }
 
 func main() {
-
-	if err := config.Init(); err != nil {
+	if err := config.Init(config.ParseConfigFlag()); err != nil {
 		log.Fatal(err.Error())
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -170,7 +170,7 @@ type ModelBackendConfig struct {
 }
 
 // Init - Assign global config to decoded config struct
-func Init() error {
+func Init(filePath string) error {
 	k := koanf.New(".")
 	parser := yaml.Parser()
 
@@ -181,11 +181,7 @@ func Init() error {
 		log.Fatal(err.Error())
 	}
 
-	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
-	fileRelativePath := fs.String("file", "config/config.yaml", "configuration file")
-	flag.Parse()
-
-	if err := k.Load(file.Provider(*fileRelativePath), parser); err != nil {
+	if err := k.Load(file.Provider(filePath), parser); err != nil {
 		log.Fatal(err.Error())
 	}
 
@@ -207,6 +203,18 @@ func Init() error {
 }
 
 // ValidateConfig is for custom validation rules for the configuration
-func ValidateConfig(cfg *AppConfig) error {
+func ValidateConfig(_ *AppConfig) error {
 	return nil
+}
+
+var defaultConfigPath = "config/config.yaml"
+
+// ParseConfigFlag allows clients to specify the relative path to the file from
+// which the configuration will be loaded.
+func ParseConfigFlag() string {
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	configPath := fs.String("file", defaultConfigPath, "configuration file")
+	flag.Parse()
+
+	return *configPath
 }

--- a/pkg/repository/repository_test.go
+++ b/pkg/repository/repository_test.go
@@ -1,0 +1,57 @@
+//go:build dbtest
+// +build dbtest
+
+package repository
+
+import (
+	"context"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/gofrs/uuid"
+	"github.com/instill-ai/pipeline-backend/config"
+	database "github.com/instill-ai/pipeline-backend/pkg/db"
+	pipelinepb "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
+)
+
+func TestRepository_ComponentDefinitionUIDs(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	err := config.Init("../../config/config.yaml")
+	c.Assert(err, qt.IsNil)
+
+	db := database.GetSharedConnection()
+	defer database.Close(db)
+
+	tx := db.Begin()
+	c.Cleanup(func() { tx.Rollback() })
+
+	repo := NewRepository(tx, nil)
+	uid := uuid.Must(uuid.NewV4())
+	id := "json"
+	cd := &pipelinepb.ComponentDefinition{
+		Type: pipelinepb.ComponentType_COMPONENT_TYPE_OPERATOR,
+		Definition: &pipelinepb.ComponentDefinition_OperatorDefinition{
+			OperatorDefinition: &pipelinepb.OperatorDefinition{
+				Uid:    uid.String(),
+				Id:     id,
+				Public: true,
+			},
+		},
+	}
+
+	err = repo.UpsertComponentDefinition(ctx, cd)
+	c.Check(err, qt.IsNil)
+
+	dbDef, err := repo.GetComponentDefinitionByUID(ctx, uid)
+	c.Check(err, qt.IsNil)
+	c.Check(dbDef.ID, qt.Equals, id)
+
+	p := ListComponentDefinitionsParams{Limit: 10}
+	dbDefs, size, err := repo.ListComponentDefinitionUIDs(ctx, p)
+	c.Check(err, qt.IsNil)
+	c.Check(size, qt.Equals, int64(1))
+	c.Check(dbDefs, qt.HasLen, 1)
+	c.Check(dbDefs[0].UID.String(), qt.Equals, uid.String())
+}


### PR DESCRIPTION
Because

- Repository layer has no coverage. We tend to rely on integration tests to verify this package communicates with the database correctly but these are expensive and should verify how each layer interconnects rather than covering all the behaviours of each layer.
- I set up these tests for [INS-4081](https://linear.app/instill-ai/issue/INS-4081/credit-data-model) as it has no high-level entrypoint (yet). The credit data model is being moved to `mgmt-backend` but having this functionality set up in `pipeline-backend` is still useful.

This commit

- Adds a simple test in `pkg/repository` that runs against a test DB. For that:
  - A new database `pipeline_test` is created with the current migration in the local PostgreSQL database.
  - Config initialisation takes a config path (so tests can also read the main configuration).
  - The `coverage` github action is modified to include the database coverage, too.

# Notes

`make unit-test` is modified to 
- be renamed as `make coverage`
- take a flag `DBTEST` to allow / disable DB tests
- take a flag `HTML` display the coverage as HTML

- Previous `make unit-test` -> `make coverage HTML=true`
- Run tests locally with the DB package -> `make coverage DBTEST=true`
- ... and display coverage (and clean up coverage report) -> `make coverage HTML=true DBTEST=true`