### PR TITLE
chore: adjust secret endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/iancoleman/strcase v0.2.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
 	github.com/instill-ai/component v0.14.1-beta.0.20240420203347-e8ae4e145fc0
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240417093304-8eed38d0734f
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240421101300-a9c1026e03d4
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha
 	github.com/knadh/koanf v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -1189,8 +1189,8 @@ github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
 github.com/instill-ai/component v0.14.1-beta.0.20240420203347-e8ae4e145fc0 h1:hLFb40rdFaB9f1RPK5C7m79AE5UzUdclA92TDw1m82w=
 github.com/instill-ai/component v0.14.1-beta.0.20240420203347-e8ae4e145fc0/go.mod h1:BBXItM3rbzXJsg0yPiqkNCWKsCefyrJXBkbj/M3Wetw=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240417093304-8eed38d0734f h1:UbP4ZvNUkONHZUh6acIT6ks3a6HiDyv0TOcHOS8eXhw=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240417093304-8eed38d0734f/go.mod h1:jhEL0SauySMoPLVvx105DWyThju9sYTbsXIySVCArmM=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240421101300-a9c1026e03d4 h1:pHGDBd9v3lG1eMczcfW4YB7lMqf47qS5D1mBvdlOTzc=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240421101300-a9c1026e03d4/go.mod h1:YP9zT4BMygrNkbHH0QX5AGWToj5Qnk+mt5yYYDQF5xY=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a/go.mod h1:EpX3Yr661uWULtZf5UnJHfr5rw2PDyX8ku4Kx0UtYFw=
 github.com/instill-ai/x v0.4.0-alpha h1:zQV2VLbSHjMv6gyBN/2mwwrvWk0/mJM6ZKS12AzjfQg=


### PR DESCRIPTION
Because

- Originally, we used the `user/secrets` path for managing user secrets. However, this path style is not consistent with the pipeline endpoints. We should change it to `users/<userid>/secrets` for consistency.

This commit
- Adjusts the user secrets endpoint.