### PR TITLE
chore: use `trigger` for the pipeline input reference

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -83,6 +83,7 @@ jobs:
           COMPOSE_PROFILES=all \
           EDITION=local-ce:test \
           RAY_LATEST_TAG=latest \
+          RAY_RELEASE_TAG=${RAY_SERVER_VERSION} \
           docker compose -f docker-compose.yml -f docker-compose-latest.yml up -d --quiet-pull
           COMPOSE_PROFILES=all \
           EDITION=local-ce:test \

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1
 	github.com/iancoleman/strcase v0.2.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/component v0.14.1-beta.0.20240422161142-3964615bbd27
+	github.com/instill-ai/component v0.14.1-beta.0.20240423030406-1749f6ee275e
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240421101300-a9c1026e03d4
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha

--- a/go.sum
+++ b/go.sum
@@ -1187,8 +1187,8 @@ github.com/influxdata/influxdb-client-go/v2 v2.12.3 h1:28nRlNMRIV4QbtIUvxhWqaxn0
 github.com/influxdata/influxdb-client-go/v2 v2.12.3/go.mod h1:IrrLUbCjjfkmRuaCiGQg4m2GbkaeJDcuWoxiWdQEbA0=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/instill-ai/component v0.14.1-beta.0.20240422161142-3964615bbd27 h1:9/U658tOJwb3TM5bjaWsxa+/9GlLH/U9jKCI/JpThR8=
-github.com/instill-ai/component v0.14.1-beta.0.20240422161142-3964615bbd27/go.mod h1:BBXItM3rbzXJsg0yPiqkNCWKsCefyrJXBkbj/M3Wetw=
+github.com/instill-ai/component v0.14.1-beta.0.20240423030406-1749f6ee275e h1:SL0dzuJpwwuvZrdG0Y7eb7X1zcO8iKn9W6Rvd3twD2A=
+github.com/instill-ai/component v0.14.1-beta.0.20240423030406-1749f6ee275e/go.mod h1:BBXItM3rbzXJsg0yPiqkNCWKsCefyrJXBkbj/M3Wetw=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240421101300-a9c1026e03d4 h1:pHGDBd9v3lG1eMczcfW4YB7lMqf47qS5D1mBvdlOTzc=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240421101300-a9c1026e03d4/go.mod h1:YP9zT4BMygrNkbHH0QX5AGWToj5Qnk+mt5yYYDQF5xY=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=

--- a/integration-test/pipeline/const.js
+++ b/integration-test/pipeline/const.js
@@ -104,7 +104,7 @@ export const simpleRecipe = {
           definition_name: "operator-definitions/base64",
           task: "TASK_ENCODE",
           input: {
-            data: "${request.input}"
+            data: "${trigger.input}"
           }
         }
       },
@@ -126,7 +126,7 @@ export const simpleRecipeDupId = {
         response_fields: {
           answer: {
             title: "Answer",
-            value: "${request.input}"
+            value: "${trigger.input}"
           }
         }
       },
@@ -138,7 +138,7 @@ export const simpleRecipeDupId = {
           definition_name: "operator-definitions/base64",
           task: "TASK_ENCODE",
           input: {
-            data: "${request.input}"
+            data: "${trigger.input}"
           }
         }
       },
@@ -148,7 +148,7 @@ export const simpleRecipeDupId = {
           definition_name: "operator-definitions/base64",
           task: "TASK_ENCODE",
           input: {
-            data: "${request.input}"
+            data: "${trigger.input}"
           }
         }
       },

--- a/pkg/db/migration/convert/convert000013/main.go
+++ b/pkg/db/migration/convert/convert000013/main.go
@@ -381,7 +381,7 @@ func migratePipeline(connectorMap map[uuid.UUID]Connector) error {
 
 		recipeJSON, _ := json.Marshal(p.Recipe)
 		recipeJSONStr := string(recipeJSON)
-		recipeJSONStr = strings.ReplaceAll(recipeJSONStr, "${start.", "${request.")
+		recipeJSONStr = strings.ReplaceAll(recipeJSONStr, "${start.", "${trigger.")
 		newRecipe := &Recipe{}
 
 		err = json.Unmarshal([]byte(recipeJSONStr), newRecipe)
@@ -471,7 +471,7 @@ func migratePipelineRelease(connectorMap map[uuid.UUID]Connector) error {
 
 		recipeJSON, _ := json.Marshal(r.Recipe)
 		recipeJSONStr := string(recipeJSON)
-		recipeJSONStr = strings.ReplaceAll(recipeJSONStr, "${start.", "${request.")
+		recipeJSONStr = strings.ReplaceAll(recipeJSONStr, "${start.", "${trigger.")
 		newRecipe := &Recipe{}
 
 		err = json.Unmarshal([]byte(recipeJSONStr), newRecipe)

--- a/pkg/service/convert.go
+++ b/pkg/service/convert.go
@@ -947,9 +947,9 @@ func (s *service) generatePipelineDataSpec(triggerByRequestOrigin *pb.TriggerByR
 				}
 			}
 
-			if upstreamCompIdx != -1 || compID == "request" {
+			if upstreamCompIdx != -1 || compID == "trigger" {
 				var walk *structpb.Value
-				if compID == "request" {
+				if compID == "trigger" {
 					walk = structpb.NewStructValue(dataInput)
 				} else {
 					comp := proto.Clone(compsOrigin[upstreamCompIdx]).(*pb.Component)

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -672,7 +672,7 @@ func (s *service) preTriggerPipeline(ctx context.Context, isAdmin bool, ns resou
 	mem := &recipe.TriggerMemory{
 		Inputs:   inputs,
 		Secrets:  secrets,
-		InputKey: "request",
+		InputKey: "trigger",
 	}
 	redisKey := fmt.Sprintf("pipeline_trigger:%s", pipelineTriggerID)
 	err = recipe.WriteMemoryAndRecipe(ctx, s.redisClient, redisKey, r, mem, ns.Permalink())
@@ -961,7 +961,7 @@ func (s *service) triggerPipeline(
 				HeaderAuthorization: resource.GetRequestSingleHeader(ctx, "authorization"),
 			},
 			Mode:     mgmtPB.Mode_MODE_SYNC,
-			InputKey: "request",
+			InputKey: "trigger",
 		})
 	if err != nil {
 		logger.Error(fmt.Sprintf("unable to execute workflow: %s", err.Error()))
@@ -1033,7 +1033,7 @@ func (s *service) triggerAsyncPipeline(
 				HeaderAuthorization: resource.GetRequestSingleHeader(ctx, "authorization"),
 			},
 			Mode:     mgmtPB.Mode_MODE_ASYNC,
-			InputKey: "request",
+			InputKey: "trigger",
 		})
 	if err != nil {
 		logger.Error(fmt.Sprintf("unable to execute workflow: %s", err.Error()))

--- a/pkg/worker/workflow.go
+++ b/pkg/worker/workflow.go
@@ -191,7 +191,7 @@ func (w *worker) TriggerPipelineWorkflow(ctx workflow.Context, param *TriggerPip
 						Inputs:     []recipe.InputsMemory{},
 						Secrets:    m.Secrets,
 						Vars:       m.Vars,
-						InputKey:   "request",
+						InputKey:   "trigger",
 					}
 
 					elems := make([]*recipe.ComponentItemMemory, len(input.([]any)))


### PR DESCRIPTION
Because

- Originally, we used `${request.xxx}` to reference the pipeline input. We have decided to change it to `${trigger.xxx}` so that future event-based triggers can utilize the same reference.

This commit

- Uses `trigger` for the pipeline input reference.
