### PR TITLE
chore: fix migration script

### DIFF
--- a/pkg/db/migration/convert/convert000013/main.go
+++ b/pkg/db/migration/convert/convert000013/main.go
@@ -270,6 +270,8 @@ func migrateSecret() (map[uuid.UUID]Connector, error) {
 
 func migrateConnectorComponent(connectorMap map[uuid.UUID]Connector, c *Component, owner string) {
 	newComp := Component{
+		ID:       c.ID,
+		Metadata: c.Metadata,
 		ConnectorComponent: &ConnectorComponent{
 			DefinitionName: c.ConnectorComponent.DefinitionName,
 			Task:           c.ConnectorComponent.Task,


### PR DESCRIPTION
Because

- The migration script caused the component ID to disappear.

This commit

- Fixes migration script.
