### PR TITLE
fix: update error message for creating duplicated resource

### DIFF
--- a/pkg/middleware/interceptor.go
+++ b/pkg/middleware/interceptor.go
@@ -4,15 +4,15 @@ import (
 	"context"
 	"errors"
 
-	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
-	grpc_recovery "github.com/grpc-ecosystem/go-grpc-middleware/recovery"
-	"github.com/jackc/pgconn"
 	"golang.org/x/crypto/bcrypt"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"gorm.io/gorm"
+
+	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
+	grpc_recovery "github.com/grpc-ecosystem/go-grpc-middleware/recovery"
 
 	"github.com/instill-ai/pipeline-backend/pkg/acl"
 	"github.com/instill-ai/pipeline-backend/pkg/handler"
@@ -79,12 +79,11 @@ func AsGRPCError(err error) error {
 		return st.Err()
 	}
 
-	var pgErr *pgconn.PgError
 	var code codes.Code
 	switch {
 	case
-		errors.As(err, &pgErr) && pgErr.Code == "23505",
-		errors.Is(err, gorm.ErrDuplicatedKey):
+		errors.Is(err, gorm.ErrDuplicatedKey),
+		errors.Is(err, repository.ErrNameExisted):
 
 		code = codes.AlreadyExists
 	case

--- a/pkg/middleware/interceptor.go
+++ b/pkg/middleware/interceptor.go
@@ -83,7 +83,7 @@ func AsGRPCError(err error) error {
 	switch {
 	case
 		errors.Is(err, gorm.ErrDuplicatedKey),
-		errors.Is(err, repository.ErrNameExisted):
+		errors.Is(err, repository.ErrNameExists):
 
 		code = codes.AlreadyExists
 	case

--- a/pkg/middleware/interceptor_test.go
+++ b/pkg/middleware/interceptor_test.go
@@ -45,7 +45,7 @@ func TestAsGRPCError(t *testing.T) {
 				Detail:         "unique_violation",
 				ConstraintName: "idx_mytable_mycolumn",
 			},
-			wantCode:    codes.AlreadyExists,
+			wantCode:    codes.Unknown,
 			wantMessage: ".*FATAL.*unique_violation.*",
 		},
 		{

--- a/pkg/repository/errors.go
+++ b/pkg/repository/errors.go
@@ -11,3 +11,4 @@ var ErrOwnerTypeNotMatch = errors.New("owner type not match")
 var ErrNoDataDeleted = errors.New("no data deleted")
 var ErrNoDataUpdated = errors.New("no data updated")
 var ErrNotFound = gorm.ErrRecordNotFound
+var ErrNameExisted = errors.New("name or ID already existed")

--- a/pkg/repository/errors.go
+++ b/pkg/repository/errors.go
@@ -11,4 +11,4 @@ var ErrOwnerTypeNotMatch = errors.New("owner type not match")
 var ErrNoDataDeleted = errors.New("no data deleted")
 var ErrNoDataUpdated = errors.New("no data updated")
 var ErrNotFound = gorm.ErrRecordNotFound
-var ErrNameExisted = errors.New("name or ID already existed")
+var ErrNameExists = errors.New("name or ID already exists")

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -19,6 +19,7 @@ import (
 	"github.com/instill-ai/pipeline-backend/pkg/constant"
 	"github.com/instill-ai/pipeline-backend/pkg/datamodel"
 	"github.com/instill-ai/pipeline-backend/pkg/logger"
+	"github.com/instill-ai/x/errmsg"
 	"github.com/instill-ai/x/paginate"
 
 	pb "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
@@ -105,7 +106,7 @@ func (r *repository) CreateNamespacePipeline(ctx context.Context, ownerPermalink
 	if result := db.Model(&datamodel.Pipeline{}).Create(pipeline); result.Error != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(result.Error, &pgErr) && pgErr.Code == "23505" || errors.Is(result.Error, gorm.ErrDuplicatedKey) {
-			return ErrNameExisted
+			return errmsg.AddMessage(ErrNameExists, "Pipeline ID already exists")
 		}
 		return result.Error
 	}
@@ -406,7 +407,7 @@ func (r *repository) CreateNamespacePipelineRelease(ctx context.Context, ownerPe
 	if result := db.Model(&datamodel.PipelineRelease{}).Create(pipelineRelease); result.Error != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(result.Error, &pgErr) && pgErr.Code == "23505" || errors.Is(result.Error, gorm.ErrDuplicatedKey) {
-			return ErrNameExisted
+			return errmsg.AddMessage(ErrNameExists, "Release version already exists")
 		}
 		return result.Error
 	}
@@ -679,7 +680,7 @@ func (r *repository) CreateNamespaceSecret(ctx context.Context, ownerPermalink s
 		logger.Error(result.Error.Error())
 		var pgErr *pgconn.PgError
 		if errors.As(result.Error, &pgErr) && pgErr.Code == "23505" || errors.Is(result.Error, gorm.ErrDuplicatedKey) {
-			return ErrNameExisted
+			return errmsg.AddMessage(ErrNameExists, "Secret ID already exists")
 		}
 		return result.Error
 	}


### PR DESCRIPTION
Because

- We should return a readable error message when creating a resource with a duplicated ID.

This commit

- Updates the error message for creating a duplicated resource.