### PR TITLE
refactor: use sysVars when getting connector/operator definitions

### DIFF
--- a/cmd/init/main.go
+++ b/cmd/init/main.go
@@ -86,7 +86,7 @@ func main() {
 
 	// Update component definitions and connectors based on latest version of
 	// definitions.json.
-	connDefs := connector.Init(logger, nil).ListConnectorDefinitions(true)
+	connDefs := connector.Init(logger, nil).ListConnectorDefinitions(nil, true)
 	for _, connDef := range connDefs {
 
 		cd := &pb.ComponentDefinition{
@@ -101,7 +101,7 @@ func main() {
 		}
 	}
 
-	opDefs := operator.Init(logger, nil).ListOperatorDefinitions(true)
+	opDefs := operator.Init(logger, nil).ListOperatorDefinitions(nil, true)
 	for _, opDef := range opDefs {
 		cd := &pb.ComponentDefinition{
 			Type: pb.ComponentType_COMPONENT_TYPE_OPERATOR,

--- a/go.mod
+++ b/go.mod
@@ -16,8 +16,8 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1
 	github.com/iancoleman/strcase v0.2.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/component v0.14.1-beta.0.20240423101831-5d9387ab602a
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240421101300-a9c1026e03d4
+	github.com/instill-ai/component v0.14.1-beta.0.20240424152036-b0c091b5e510
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240423142304-54b986803884
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha
 	github.com/knadh/koanf v1.5.0

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1
 	github.com/iancoleman/strcase v0.2.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/component v0.14.1-beta.0.20240424152036-b0c091b5e510
+	github.com/instill-ai/component v0.14.1-beta.0.20240424154917-0f47c05f64fd
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240423142304-54b986803884
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha

--- a/go.sum
+++ b/go.sum
@@ -1187,8 +1187,8 @@ github.com/influxdata/influxdb-client-go/v2 v2.12.3 h1:28nRlNMRIV4QbtIUvxhWqaxn0
 github.com/influxdata/influxdb-client-go/v2 v2.12.3/go.mod h1:IrrLUbCjjfkmRuaCiGQg4m2GbkaeJDcuWoxiWdQEbA0=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/instill-ai/component v0.14.1-beta.0.20240424152036-b0c091b5e510 h1:Qf6+lO8BzM0WSDZhB6buDfHIL80Fd9Nut40i7+wqdlk=
-github.com/instill-ai/component v0.14.1-beta.0.20240424152036-b0c091b5e510/go.mod h1:ytgA8yOgMJO1wqgfWgmSk7ilkiXgwp/WzoRuEGA/Oz8=
+github.com/instill-ai/component v0.14.1-beta.0.20240424154917-0f47c05f64fd h1:G7n+PEAuBTYOF6SufW9IJD/SFYrhGGaUlEqX7gyzNNw=
+github.com/instill-ai/component v0.14.1-beta.0.20240424154917-0f47c05f64fd/go.mod h1:ytgA8yOgMJO1wqgfWgmSk7ilkiXgwp/WzoRuEGA/Oz8=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240423142304-54b986803884 h1:FfNGEn+USpO8z+/fOA6+WGcOSaOw2SQcR+ovyAUC03A=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240423142304-54b986803884/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=

--- a/go.sum
+++ b/go.sum
@@ -1187,10 +1187,10 @@ github.com/influxdata/influxdb-client-go/v2 v2.12.3 h1:28nRlNMRIV4QbtIUvxhWqaxn0
 github.com/influxdata/influxdb-client-go/v2 v2.12.3/go.mod h1:IrrLUbCjjfkmRuaCiGQg4m2GbkaeJDcuWoxiWdQEbA0=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/instill-ai/component v0.14.1-beta.0.20240423101831-5d9387ab602a h1:0kcuQoKpNPani9WVfTcpvkRr29w1ty6xAFdauGBd85Q=
-github.com/instill-ai/component v0.14.1-beta.0.20240423101831-5d9387ab602a/go.mod h1:BBXItM3rbzXJsg0yPiqkNCWKsCefyrJXBkbj/M3Wetw=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240421101300-a9c1026e03d4 h1:pHGDBd9v3lG1eMczcfW4YB7lMqf47qS5D1mBvdlOTzc=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240421101300-a9c1026e03d4/go.mod h1:YP9zT4BMygrNkbHH0QX5AGWToj5Qnk+mt5yYYDQF5xY=
+github.com/instill-ai/component v0.14.1-beta.0.20240424152036-b0c091b5e510 h1:Qf6+lO8BzM0WSDZhB6buDfHIL80Fd9Nut40i7+wqdlk=
+github.com/instill-ai/component v0.14.1-beta.0.20240424152036-b0c091b5e510/go.mod h1:ytgA8yOgMJO1wqgfWgmSk7ilkiXgwp/WzoRuEGA/Oz8=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240423142304-54b986803884 h1:FfNGEn+USpO8z+/fOA6+WGcOSaOw2SQcR+ovyAUC03A=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240423142304-54b986803884/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a/go.mod h1:EpX3Yr661uWULtZf5UnJHfr5rw2PDyX8ku4Kx0UtYFw=
 github.com/instill-ai/x v0.4.0-alpha h1:zQV2VLbSHjMv6gyBN/2mwwrvWk0/mJM6ZKS12AzjfQg=

--- a/pkg/recipe/variable.go
+++ b/pkg/recipe/variable.go
@@ -24,6 +24,7 @@ type SystemVariables struct {
 	HeaderAuthorization string                 `json:"__PIPELINE_HEADER_AUTHORIZATION"`
 	ModelBackend        string                 `json:"__MODEL_BACKEND"`
 	MgmtBackend         string                 `json:"__MGMT_BACKEND"`
+	StaticModelList     bool                   `json:"__STATIC_MODEL_LIST"`
 }
 
 // System variables are available to all component
@@ -41,6 +42,7 @@ func GenerateSystemVariables(ctx context.Context, sysVar SystemVariables) (map[s
 	if sysVar.MgmtBackend == "" {
 		sysVar.MgmtBackend = fmt.Sprintf("%s:%d", config.Config.MgmtBackend.Host, config.Config.MgmtBackend.PublicPort)
 	}
+	sysVar.StaticModelList = config.Config.Connector.Instill.UseStaticModelList
 
 	b, err := json.Marshal(sysVar)
 	if err != nil {

--- a/pkg/recipe/variable.go
+++ b/pkg/recipe/variable.go
@@ -1,12 +1,14 @@
 package recipe
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
 	"github.com/gofrs/uuid"
 	"github.com/instill-ai/pipeline-backend/config"
 	"github.com/instill-ai/pipeline-backend/internal/resource"
+	"github.com/instill-ai/pipeline-backend/pkg/constant"
 	"github.com/instill-ai/pipeline-backend/pkg/datamodel"
 )
 
@@ -25,10 +27,20 @@ type SystemVariables struct {
 }
 
 // System variables are available to all component
-func GenerateSystemVariables(sysVar SystemVariables) (map[string]any, error) {
+func GenerateSystemVariables(ctx context.Context, sysVar SystemVariables) (map[string]any, error) {
 
-	sysVar.ModelBackend = fmt.Sprintf("%s:%d", config.Config.ModelBackend.Host, config.Config.ModelBackend.PublicPort)
-	sysVar.MgmtBackend = fmt.Sprintf("%s:%d", config.Config.MgmtBackend.Host, config.Config.MgmtBackend.PublicPort)
+	if sysVar.PipelineUserUID == uuid.Nil {
+		sysVar.PipelineUserUID = uuid.FromStringOrNil(resource.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey))
+	}
+	if sysVar.HeaderAuthorization == "" {
+		sysVar.HeaderAuthorization = resource.GetRequestSingleHeader(ctx, "Authorization")
+	}
+	if sysVar.ModelBackend == "" {
+		sysVar.ModelBackend = fmt.Sprintf("%s:%d", config.Config.ModelBackend.Host, config.Config.ModelBackend.PublicPort)
+	}
+	if sysVar.MgmtBackend == "" {
+		sysVar.MgmtBackend = fmt.Sprintf("%s:%d", config.Config.MgmtBackend.Host, config.Config.MgmtBackend.PublicPort)
+	}
 
 	b, err := json.Marshal(sysVar)
 	if err != nil {

--- a/pkg/service/convert.go
+++ b/pkg/service/convert.go
@@ -173,10 +173,7 @@ func (s *service) includeOperatorComponentDetail(ctx context.Context, comp *pb.O
 	if err != nil {
 		return err
 	}
-	vars, err := recipe.GenerateSystemVariables(recipe.SystemVariables{
-		PipelineUserUID:     uuid.FromStringOrNil(resource.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey)),
-		HeaderAuthorization: resource.GetRequestSingleHeader(ctx, "authorization"),
-	})
+	vars, err := recipe.GenerateSystemVariables(ctx, recipe.SystemVariables{})
 	if err != nil {
 		return err
 	}
@@ -194,10 +191,7 @@ func (s *service) includeConnectorComponentDetail(ctx context.Context, comp *pb.
 	if err != nil {
 		return err
 	}
-	vars, err := recipe.GenerateSystemVariables(recipe.SystemVariables{
-		PipelineUserUID:     uuid.FromStringOrNil(resource.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey)),
-		HeaderAuthorization: resource.GetRequestSingleHeader(ctx, "authorization"),
-	})
+	vars, err := recipe.GenerateSystemVariables(ctx, recipe.SystemVariables{})
 	if err != nil {
 		return err
 	}

--- a/pkg/worker/workflow.go
+++ b/pkg/worker/workflow.go
@@ -322,7 +322,7 @@ func (w *worker) ConnectorActivity(ctx context.Context, param *ConnectorActivity
 		return w.toApplicationError(err, param.ID, ConnectorActivityError)
 	}
 
-	vars, err := recipe.GenerateSystemVariables(param.SystemVariables)
+	vars, err := recipe.GenerateSystemVariables(ctx, param.SystemVariables)
 	if err != nil {
 		return w.toApplicationError(err, param.ID, ConnectorActivityError)
 	}
@@ -366,7 +366,7 @@ func (w *worker) OperatorActivity(ctx context.Context, param *OperatorActivityPa
 		return w.toApplicationError(err, param.ID, OperatorActivityError)
 	}
 
-	vars, err := recipe.GenerateSystemVariables(param.SystemVariables)
+	vars, err := recipe.GenerateSystemVariables(ctx, param.SystemVariables)
 	if err != nil {
 		return w.toApplicationError(err, param.ID, OperatorActivityError)
 	}


### PR DESCRIPTION
Because

- We need to pass some system-wide variables into connector/operator definitions so that the definitions can be generated based on some dynamic values.

This commit

- Refactors: Use sysVars when getting connector/operator definitions.
- Chore: Pass the UseStaticModelList config into the connector.