### PR TITLE
fix: fix trigger pipeline bug when the secret value is nil

### DIFF
--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -647,6 +647,7 @@ func (s *service) preTriggerPipeline(ctx context.Context, isAdmin bool, ns resou
 
 	secrets := map[string]string{}
 	pt := ""
+	// TODO: We should only query the needed key.
 	for {
 		var nsSecrets []*datamodel.Secret
 		// TODO: should use ctx user uid

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -656,7 +656,9 @@ func (s *service) preTriggerPipeline(ctx context.Context, isAdmin bool, ns resou
 		}
 
 		for _, nsSecret := range nsSecrets {
-			secrets[nsSecret.ID] = *nsSecret.Value
+			if nsSecret.Value != nil {
+				secrets[nsSecret.ID] = *nsSecret.Value
+			}
 		}
 
 		if pt == "" {


### PR DESCRIPTION
Because

- We didn't handle the nil value in the secrets query.

This commit

- Fixes trigger pipeline bug when the secret value is nil.
