### PR TITLE
refactor: use combination keys to read/write the trigger memory

### DIFF
--- a/pkg/recipe/dag.go
+++ b/pkg/recipe/dag.go
@@ -94,7 +94,7 @@ func (d *dag) AddEdge(from *datamodel.Component, to *datamodel.Component) {
 	d.ancestorsMap[to.ID] = append(d.ancestorsMap[to.ID], d.ancestorsMap[from.ID]...)
 }
 
-func (d *dag) GetAncestorIDs(id string) []string {
+func (d *dag) GetUpstreamCompIDs(id string) []string {
 	return d.ancestorsMap[id]
 }
 
@@ -179,23 +179,23 @@ func traverseBinding(compsMemory map[string]ComponentsMemory, inputsMemory []Inp
 	}
 
 	m := map[string]any{
-		MemoryKey: map[string]any{},
+		SegMemory: map[string]any{},
 	}
 	for k := range compsMemory {
-		m[MemoryKey].(map[string]any)[k] = compsMemory[k][dataIndex]
+		m[SegMemory].(map[string]any)[k] = compsMemory[k][dataIndex]
 	}
 
 	if inputsMemory != nil {
-		m[MemoryKey].(map[string]any)[TriggerKey] = inputsMemory[dataIndex]
+		m[SegMemory].(map[string]any)[SegTrigger] = inputsMemory[dataIndex]
 	}
 	if secretsMemory != nil {
-		m[MemoryKey].(map[string]any)[SecretsKey] = secretsMemory
+		m[SegMemory].(map[string]any)[SegSecrets] = secretsMemory
 	}
 
 	b, _ := json.Marshal(m)
 	var mParsed any
 	_ = json.Unmarshal(b, &mParsed)
-	res, err := jsonpath.Get(fmt.Sprintf("$.memory%s", newPath), mParsed)
+	res, err := jsonpath.Get(fmt.Sprintf("$.%s%s", SegMemory, newPath), mParsed)
 	if err != nil {
 		// check primitive value
 		var ret any

--- a/pkg/recipe/memory.go
+++ b/pkg/recipe/memory.go
@@ -258,10 +258,10 @@ func LoadOwnerPermalink(ctx context.Context, rc *redis.Client, key string) strin
 }
 
 func Purge(ctx context.Context, rc *redis.Client, pipelineTriggerID string) {
-	iter := rc.Scan(ctx, 0, fmt.Sprintf("%s:%s:*", redisKeyPrefix, pipelineTriggerID), 0).Iterator()
-	for iter.Next(ctx) {
-		rc.Del(ctx, iter.Val())
-	}
+	// iter := rc.Scan(ctx, 0, fmt.Sprintf("%s:%s:*", redisKeyPrefix, pipelineTriggerID), 0).Iterator()
+	// for iter.Next(ctx) {
+	// 	rc.Del(ctx, iter.Val())
+	// }
 }
 
 func WriteComponentMemory(ctx context.Context, rc *redis.Client, key string, compsMem []*ComponentItemMemory) error {

--- a/pkg/recipe/memory.go
+++ b/pkg/recipe/memory.go
@@ -3,6 +3,7 @@ package recipe
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"time"
 
@@ -13,10 +14,31 @@ import (
 )
 
 const (
-	MemoryKey  = "memory"
-	TriggerKey = "trigger"
-	SecretsKey = "secrets"
+	SegMemory    = "memory"
+	SegTrigger   = "trigger"
+	SegSecrets   = "secrets"
+	SegRecipe    = "recipe"
+	SegOwner     = "owner_permalink"
+	SegVars      = "vars"
+	SegComponent = "components"
+	SegIteration = "iterations"
+	SegInputs    = "inputs"
+
+	redisKeyPrefix = "pipeline_trigger"
 )
+
+// Key formats
+
+// For regular components:
+// pipeline_trigger:<workflowID>:recipe
+// pipeline_trigger:<workflowID>:vars
+// pipeline_trigger:<workflowID>:secrets
+// pipeline_trigger:<workflowID>:inputs:<batchIdx>
+// pipeline_trigger:<workflowID>:components:<compID>:<batchIdx>
+
+// For the child pipeline in the iterator:
+// pipeline_trigger:<workflowID>:components:<compID>:recipe
+// pipeline_trigger:<workflowID>:components:<compID>:iterations:<iter>:components:<iterCompID>
 
 type TriggerMemory struct {
 	Components      map[string]ComponentsMemory `json:"components"`
@@ -24,6 +46,15 @@ type TriggerMemory struct {
 	Secrets         map[string]string           `json:"secrets"`
 	Vars            map[string]any              `json:"vars"`
 	SystemVariables SystemVariables             `json:"sys_vars"`
+}
+
+type TriggerMemoryKey struct {
+	Components     map[string][]string
+	Inputs         []string
+	Secrets        string
+	Vars           string
+	Recipe         string
+	OwnerPermalink string
 }
 
 type ComponentsMemory []*ComponentItemMemory
@@ -44,172 +75,255 @@ type ComponentStatus struct {
 	Skipped   bool `json:"skipped"`
 }
 
-func WriteMemoryAndRecipe(ctx context.Context, rc *redis.Client, redisKey string, recipe *datamodel.Recipe, memory *TriggerMemory, ownerPermalink string) error {
+func Write(ctx context.Context, rc *redis.Client, triggerID string, recipe *datamodel.Recipe, memory *TriggerMemory, ownerPermalink string) (*TriggerMemoryKey, error) {
+
+	batchSize := len(memory.Inputs)
+	inputStorageKeys := make([]string, batchSize)
+	for i := 0; i < batchSize; i++ {
+		inputStorageKeys[i] = fmt.Sprintf("%s:%s:%d", triggerID, SegInputs, i)
+	}
+	triggerStorageKey := &TriggerMemoryKey{
+		Recipe:         fmt.Sprintf("%s:%s", triggerID, SegRecipe),
+		OwnerPermalink: fmt.Sprintf("%s:%s", triggerID, SegOwner),
+		Secrets:        fmt.Sprintf("%s:%s", triggerID, SegSecrets),
+		Vars:           fmt.Sprintf("%s:%s", triggerID, SegVars),
+		Inputs:         inputStorageKeys,
+	}
+
 	var b []byte
 	var err error
 
-	rc.Set(
-		ctx,
-		redisKey+":owner_permalink",
-		ownerPermalink,
-		time.Duration(config.Config.Server.Workflow.MaxWorkflowTimeout)*time.Second,
-	)
+	if err := writeData(ctx, rc, triggerStorageKey.OwnerPermalink, ownerPermalink); err != nil {
+		return nil, err
+	}
+
+	if recipe != nil {
+		b, err = json.Marshal(recipe)
+		if err != nil {
+			return nil, err
+		}
+		if err := writeData(ctx, rc, triggerStorageKey.Recipe, b); err != nil {
+			return nil, err
+		}
+	}
+
+	if memory.Secrets == nil {
+		memory.Secrets = map[string]string{}
+	}
+
+	b, err = json.Marshal(memory.Secrets)
+	if err != nil {
+		return nil, err
+	}
+	if err := writeData(ctx, rc, triggerStorageKey.Secrets, b); err != nil {
+		return nil, err
+	}
+
+	if memory.Vars == nil {
+		memory.Vars = map[string]any{}
+	}
+
+	b, err = json.Marshal(memory.Vars)
+	if err != nil {
+		return nil, err
+	}
+	if err := writeData(ctx, rc, triggerStorageKey.Vars, b); err != nil {
+		return nil, err
+	}
+
+	for idx, input := range memory.Inputs {
+		b, err = json.Marshal(input)
+		if err != nil {
+			return nil, err
+		}
+		if err := writeData(ctx, rc, triggerStorageKey.Inputs[idx], b); err != nil {
+			return nil, err
+		}
+	}
+
+	return triggerStorageKey, nil
+}
+
+func WriteRecipe(ctx context.Context, rc *redis.Client, key string, recipe *datamodel.Recipe) error {
+	var b []byte
+	var err error
 
 	if recipe != nil {
 		b, err = json.Marshal(recipe)
 		if err != nil {
 			return err
 		}
-		rc.Set(
-			ctx,
-			redisKey+":recipe",
-			b,
-			time.Duration(config.Config.Server.Workflow.MaxWorkflowTimeout)*time.Second,
-		)
-	}
-
-	if memory.Secrets != nil {
-		b, err = json.Marshal(memory.Secrets)
-		if err != nil {
+		if err := writeData(ctx, rc, key, b); err != nil {
 			return err
 		}
-		rc.Set(
-			ctx,
-			redisKey+":secrets",
-			b,
-			time.Duration(config.Config.Server.Workflow.MaxWorkflowTimeout)*time.Second,
-		)
-	}
 
-	if memory.Vars != nil {
-		b, err = json.Marshal(memory.Vars)
-		if err != nil {
-			return err
-		}
-		rc.Set(
-			ctx,
-			redisKey+":vars",
-			b,
-			time.Duration(config.Config.Server.Workflow.MaxWorkflowTimeout)*time.Second,
-		)
-	}
-
-	if memory.Inputs != nil {
-		b, err = json.Marshal(memory.Inputs)
-		if err != nil {
-			return err
-		}
-		rc.Set(
-			ctx,
-			redisKey+":inputs",
-			b,
-			time.Duration(config.Config.Server.Workflow.MaxWorkflowTimeout)*time.Second,
-		)
-	}
-
-	for compID, compMem := range memory.Components {
-		b, err = json.Marshal(compMem)
-		if err != nil {
-			return err
-		}
-		rc.Set(
-			ctx,
-			redisKey+":components:"+compID,
-			b,
-			time.Duration(config.Config.Server.Workflow.MaxWorkflowTimeout)*time.Second,
-		)
 	}
 
 	return nil
 }
 
-func LoadMemory(ctx context.Context, rc *redis.Client, redisKey string) (*TriggerMemory, error) {
-	memory := TriggerMemory{
+func LoadMemory(
+	ctx context.Context,
+	rc *redis.Client,
+	key *TriggerMemoryKey,
+) (*TriggerMemory, error) {
+	memory := &TriggerMemory{
 		Secrets:    map[string]string{},
 		Vars:       map[string]any{},
 		Inputs:     []InputsMemory{},
 		Components: map[string]ComponentsMemory{},
 	}
 
-	if b, err := rc.Get(ctx, redisKey+":secrets").Bytes(); err == nil {
-		err = json.Unmarshal(b, &memory.Secrets)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if b, err := rc.Get(ctx, redisKey+":vars").Bytes(); err == nil {
-		err = json.Unmarshal(b, &memory.Vars)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if b, err := rc.Get(ctx, redisKey+":inputs").Bytes(); err == nil {
-		err = json.Unmarshal(b, &memory.Inputs)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	iter := rc.Scan(ctx, 0, redisKey+":components:*", 0).Iterator()
-	for iter.Next(ctx) {
-		key := iter.Val()
-		var result []*ComponentItemMemory
-		b, err := rc.Get(ctx, key).Bytes()
-		if err != nil {
-			return nil, err
-		}
-		err = json.Unmarshal(b, &result)
-		if err != nil {
-			return nil, err
-		}
-		memory.Components[strings.Split(key, ":")[len(strings.Split(key, ":"))-1]] = result
-
-	}
-
-	return &memory, nil
-}
-
-func LoadRecipe(ctx context.Context, rc *redis.Client, redisKey string) (*datamodel.Recipe, error) {
-	recipe := &datamodel.Recipe{}
-
-	var b []byte
-
-	b, err := rc.Get(ctx, redisKey+":recipe").Bytes()
-	if err != nil {
+	if err := loadData(ctx, rc, key.Secrets, &memory.Secrets); err != nil {
 		return nil, err
 	}
-	err = json.Unmarshal(b, recipe)
-	if err != nil {
+
+	if err := loadData(ctx, rc, key.Vars, &memory.Vars); err != nil {
+		return nil, err
+	}
+
+	memory.Inputs = make([]InputsMemory, len(key.Inputs))
+	cacheInputs := map[string]*InputsMemory{}
+	for idx, k := range key.Inputs {
+		// Note: In an iterator, the same key might exist. We can use a local map to reduce Redis requests.
+		if v, ok := cacheInputs[k]; ok {
+			memory.Inputs[idx] = *v
+			continue
+		}
+		if err := loadData(ctx, rc, k, &memory.Inputs[idx]); err != nil {
+			return nil, err
+		}
+		cacheInputs[k] = &memory.Inputs[idx]
+	}
+
+	for compID, ks := range key.Components {
+		memory.Components[compID] = make(ComponentsMemory, len(ks))
+		cacheComps := map[string]*ComponentItemMemory{}
+		for idx, k := range ks {
+			// Note: In an iterator, the same key might exist. We can use a local map to reduce Redis requests.
+			if v, ok := cacheComps[k]; ok {
+				memory.Components[compID][idx] = v
+				continue
+			}
+			var result ComponentItemMemory
+			if err := loadData(ctx, rc, k, &result); err != nil {
+				return nil, err
+			}
+			memory.Components[compID][idx] = &result
+			cacheComps[k] = &result
+		}
+	}
+	return memory, nil
+}
+
+func LoadMemoryByTriggerID(ctx context.Context, rc *redis.Client, triggerID string) (*TriggerMemory, error) {
+	batchSize := getBatchSize(ctx, rc, triggerID)
+	compIDs := getCompIDs(ctx, rc, triggerID)
+	keyInputs := make([]string, batchSize)
+	for i := 0; i < batchSize; i++ {
+		keyInputs[i] = fmt.Sprintf("%s:%s:%d", triggerID, SegInputs, i)
+	}
+	keyComps := map[string][]string{}
+	for _, compID := range compIDs {
+		keyComps[compID] = make([]string, batchSize)
+		for i := 0; i < batchSize; i++ {
+			keyComps[compID][i] = fmt.Sprintf("%s:%s:%s:%d", triggerID, SegComponent, compID, i)
+		}
+	}
+
+	return LoadMemory(
+		ctx,
+		rc,
+		&TriggerMemoryKey{
+			Components: keyComps,
+			Inputs:     keyInputs,
+			Secrets:    fmt.Sprintf("%s:%s", triggerID, SegSecrets),
+			Vars:       fmt.Sprintf("%s:%s", triggerID, SegVars),
+		},
+	)
+}
+
+func LoadRecipe(ctx context.Context, rc *redis.Client, key string) (*datamodel.Recipe, error) {
+	recipe := &datamodel.Recipe{}
+
+	if err := loadData(ctx, rc, key, recipe); err != nil {
 		return nil, err
 	}
 
 	return recipe, nil
 }
 
-func LoadOwnerPermalink(ctx context.Context, rc *redis.Client, redisKey string) string {
-	return rc.Get(ctx, redisKey+":owner_permalink").Val()
+func LoadOwnerPermalink(ctx context.Context, rc *redis.Client, key string) string {
+	return rc.Get(ctx, fmt.Sprintf("%s:%s:%s", redisKeyPrefix, key, SegOwner)).Val()
 }
 
-func PurgeMemory(ctx context.Context, rc *redis.Client, redisKey string) {
-	iter := rc.Scan(ctx, 0, redisKey+":*", 0).Iterator()
+func Purge(ctx context.Context, rc *redis.Client, pipelineTriggerID string) {
+	iter := rc.Scan(ctx, 0, fmt.Sprintf("%s:%s:*", redisKeyPrefix, pipelineTriggerID), 0).Iterator()
 	for iter.Next(ctx) {
 		rc.Del(ctx, iter.Val())
 	}
 }
 
-func WriteComponentMemory(ctx context.Context, rc *redis.Client, redisKey string, compID string, compsMem []*ComponentItemMemory) error {
+func WriteComponentMemory(ctx context.Context, rc *redis.Client, key string, compsMem []*ComponentItemMemory) error {
 
-	b, err := json.Marshal(compsMem)
+	for idx, itemMem := range compsMem {
+		b, err := json.Marshal(itemMem)
+		if err != nil {
+			return err
+		}
+		if err := writeData(ctx, rc, fmt.Sprintf("%s:%d", key, idx), b); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func writeData(ctx context.Context, rc *redis.Client, key string, data any) error {
+	if cmd := rc.Set(
+		ctx,
+		fmt.Sprintf("%s:%s", redisKeyPrefix, key),
+		data,
+		time.Duration(config.Config.Server.Workflow.MaxWorkflowTimeout)*time.Second,
+	); cmd.Err() != nil {
+		return cmd.Err()
+	}
+	return nil
+}
+
+func loadData(ctx context.Context, rc *redis.Client, key string, target any) error {
+	b, err := rc.Get(ctx, fmt.Sprintf("%s:%s", redisKeyPrefix, key)).Bytes()
 	if err != nil {
 		return err
 	}
-	rc.Set(
-		ctx,
-		redisKey+":components:"+compID,
-		b,
-		time.Duration(config.Config.Server.Workflow.MaxWorkflowTimeout)*time.Second,
-	)
+	err = json.Unmarshal(b, target)
+	if err != nil {
+		return err
+	}
 	return nil
+}
+
+func getBatchSize(ctx context.Context, rc *redis.Client, key string) int {
+	iter := rc.Scan(ctx, 0, fmt.Sprintf("%s:%s:%s:*", redisKeyPrefix, key, SegInputs), 0).Iterator()
+	batchSize := 0
+	for iter.Next(ctx) {
+		batchSize += 1
+	}
+	return batchSize
+}
+
+func getCompIDs(ctx context.Context, rc *redis.Client, key string) []string {
+	iter := rc.Scan(ctx, 0, fmt.Sprintf("%s:%s:%s:*", redisKeyPrefix, key, SegComponent), 0).Iterator()
+	compIDMap := map[string]bool{}
+	for iter.Next(ctx) {
+		key := iter.Val()
+		keySplits := strings.Split(key, ":")
+		compID := keySplits[3]
+		compIDMap[compID] = true
+	}
+	compIDs := []string{}
+	for k := range compIDMap {
+		compIDs = append(compIDs, k)
+	}
+	return compIDs
 }

--- a/pkg/service/convert.go
+++ b/pkg/service/convert.go
@@ -946,9 +946,9 @@ func (s *service) generatePipelineDataSpec(triggerByRequestOrigin *pb.TriggerByR
 				}
 			}
 
-			if upstreamCompIdx != -1 || compID == recipe.TriggerKey {
+			if upstreamCompIdx != -1 || compID == recipe.SegTrigger {
 				var walk *structpb.Value
-				if compID == recipe.TriggerKey {
+				if compID == recipe.SegTrigger {
 					walk = structpb.NewStructValue(dataInput)
 				} else {
 					comp := proto.Clone(compsOrigin[upstreamCompIdx]).(*pb.Component)

--- a/pkg/worker/main.go
+++ b/pkg/worker/main.go
@@ -23,7 +23,7 @@ type Worker interface {
 	TriggerPipelineWorkflow(ctx workflow.Context, param *TriggerPipelineWorkflowParam) error
 	ConnectorActivity(ctx context.Context, param *ConnectorActivityParam) error
 	OperatorActivity(ctx context.Context, param *OperatorActivityParam) error
-	PreIteratorActivity(ctx context.Context, param *PreIteratorActivityParam) (childWorkflowIDs []string, err error)
+	PreIteratorActivity(ctx context.Context, param *PreIteratorActivityParam) (*PreIteratorActivityResult, error)
 	PostIteratorActivity(ctx context.Context, param *PostIteratorActivityParam) error
 }
 

--- a/pkg/worker/workflow.go
+++ b/pkg/worker/workflow.go
@@ -29,50 +29,58 @@ import (
 )
 
 type TriggerPipelineWorkflowParam struct {
-	MemoryRedisKey  string
-	SystemVariables recipe.SystemVariables
-	Mode            mgmtPB.Mode
+	BatchSize        int
+	MemoryStorageKey *recipe.TriggerMemoryKey
+	SystemVariables  recipe.SystemVariables // TODO: we should store vars directly in trigger memory.
+	Mode             mgmtPB.Mode
 }
 
 // ConnectorActivityParam represents the parameters for TriggerActivity
 type ConnectorActivityParam struct {
-	MemoryRedisKey  string
-	ID              string
-	AncestorIDs     []string
-	Condition       *string
-	Input           *structpb.Struct
-	Connection      *structpb.Struct
-	DefinitionUID   uuid.UUID
-	Task            string
-	SystemVariables recipe.SystemVariables
+	MemoryStorageKey *recipe.TriggerMemoryKey
+	TargetStorageKey string
+	ID               string
+	UpstreamIDs      []string
+	Condition        *string
+	Input            *structpb.Struct
+	Connection       *structpb.Struct
+	DefinitionUID    uuid.UUID
+	Task             string
+	SystemVariables  recipe.SystemVariables // TODO: we should store vars directly in trigger memory.
 }
 
 // OperatorActivityParam represents the parameters for TriggerActivity
 type OperatorActivityParam struct {
-	MemoryRedisKey  string
-	ID              string
-	AncestorIDs     []string
-	Condition       *string
-	Input           *structpb.Struct
-	DefinitionUID   uuid.UUID
-	Task            string
-	SystemVariables recipe.SystemVariables
+	MemoryStorageKey *recipe.TriggerMemoryKey
+	TargetStorageKey string
+	ID               string
+	UpstreamIDs      []string
+	Condition        *string
+	Input            *structpb.Struct
+	DefinitionUID    uuid.UUID
+	Task             string
+	SystemVariables  recipe.SystemVariables // TODO: we should store vars directly in trigger memory.
 }
 
 type PreIteratorActivityParam struct {
-	MemoryRedisKey  string
-	ID              string
-	Input           string
-	WorkflowID      string
-	SystemVariables recipe.SystemVariables
+	MemoryStorageKey *recipe.TriggerMemoryKey
+	TargetStorageKey string
+	ID               string
+	UpstreamIDs      []string
+	Input            string
+	SystemVariables  recipe.SystemVariables // TODO: we should store vars directly in trigger memory.
+}
+
+type PreIteratorActivityResult struct {
+	MemoryStorageKeys []*recipe.TriggerMemoryKey
 }
 
 type PostIteratorActivityParam struct {
-	MemoryRedisKey   string
-	ID               string
-	OutputElements   map[string]string
-	ChildWorkflowIDs []string
-	SystemVariables  recipe.SystemVariables
+	MemoryStorageKeys []*recipe.TriggerMemoryKey
+	TargetStorageKey  string
+	ID                string
+	OutputElements    map[string]string
+	SystemVariables   recipe.SystemVariables // TODO: we should store vars directly in trigger memory.
 }
 
 var tracer = otel.Tracer("pipeline-backend.temporal.tracer")
@@ -124,7 +132,7 @@ func (w *worker) TriggerPipelineWorkflow(ctx workflow.Context, param *TriggerPip
 	}
 	ctx = workflow.WithActivityOptions(ctx, ao)
 
-	r, err := recipe.LoadRecipe(sCtx, w.redisClient, param.MemoryRedisKey)
+	r, err := recipe.LoadRecipe(sCtx, w.redisClient, param.MemoryStorageKey.Recipe)
 	if err != nil {
 		return err
 	}
@@ -139,77 +147,87 @@ func (w *worker) TriggerPipelineWorkflow(ctx workflow.Context, param *TriggerPip
 		return err
 	}
 
+	workflowID := workflow.GetInfo(ctx).WorkflowExecution.ID
+
+	if param.MemoryStorageKey.Components == nil {
+		param.MemoryStorageKey.Components = map[string][]string{}
+	}
+
 	// The components in the same group can be executed in parallel
 	for group := range orderedComp {
 
 		futures := []workflow.Future{}
 		for _, comp := range orderedComp[group] {
 
+			upstreamIDs := dag.GetUpstreamCompIDs(comp.ID)
+			targetStorageKey := fmt.Sprintf("%s:%s:%s", workflowID, recipe.SegComponent, comp.ID)
+
 			switch {
 			case comp.IsConnectorComponent():
 				futures = append(futures, workflow.ExecuteActivity(ctx, w.ConnectorActivity, &ConnectorActivityParam{
-					ID:              comp.ID,
-					AncestorIDs:     dag.GetAncestorIDs(comp.ID),
-					MemoryRedisKey:  param.MemoryRedisKey,
-					DefinitionUID:   uuid.FromStringOrNil(strings.Split(comp.ConnectorComponent.DefinitionName, "/")[1]),
-					Task:            comp.ConnectorComponent.Task,
-					Input:           comp.ConnectorComponent.Input,
-					Connection:      comp.ConnectorComponent.Connection,
-					Condition:       comp.ConnectorComponent.Condition,
-					SystemVariables: param.SystemVariables,
+					ID:               comp.ID,
+					UpstreamIDs:      upstreamIDs,
+					DefinitionUID:    uuid.FromStringOrNil(strings.Split(comp.ConnectorComponent.DefinitionName, "/")[1]),
+					Task:             comp.ConnectorComponent.Task,
+					Input:            comp.ConnectorComponent.Input,
+					Connection:       comp.ConnectorComponent.Connection,
+					Condition:        comp.ConnectorComponent.Condition,
+					MemoryStorageKey: param.MemoryStorageKey,
+					TargetStorageKey: targetStorageKey,
+					SystemVariables:  param.SystemVariables,
 				}))
 
 			case comp.IsOperatorComponent():
 				futures = append(futures, workflow.ExecuteActivity(ctx, w.OperatorActivity, &OperatorActivityParam{
-					ID:              comp.ID,
-					AncestorIDs:     dag.GetAncestorIDs(comp.ID),
-					MemoryRedisKey:  param.MemoryRedisKey,
-					DefinitionUID:   uuid.FromStringOrNil(strings.Split(comp.OperatorComponent.DefinitionName, "/")[1]),
-					Task:            comp.OperatorComponent.Task,
-					Input:           comp.OperatorComponent.Input,
-					Condition:       comp.OperatorComponent.Condition,
-					SystemVariables: param.SystemVariables,
+					ID:               comp.ID,
+					UpstreamIDs:      upstreamIDs,
+					DefinitionUID:    uuid.FromStringOrNil(strings.Split(comp.OperatorComponent.DefinitionName, "/")[1]),
+					Task:             comp.OperatorComponent.Task,
+					Input:            comp.OperatorComponent.Input,
+					Condition:        comp.OperatorComponent.Condition,
+					MemoryStorageKey: param.MemoryStorageKey,
+					TargetStorageKey: targetStorageKey,
+					SystemVariables:  param.SystemVariables,
 				}))
 
 			case comp.IsIteratorComponent():
 
-				var childWorkflowIDs []string
+				preIteratorResult := &PreIteratorActivityResult{}
 				if err = workflow.ExecuteActivity(ctx, w.PreIteratorActivity, &PreIteratorActivityParam{
-					ID:              comp.ID,
-					MemoryRedisKey:  param.MemoryRedisKey,
-					Input:           comp.IteratorComponent.Input,
-					WorkflowID:      workflow.GetInfo(ctx).WorkflowExecution.ID,
-					SystemVariables: param.SystemVariables,
-				}).Get(ctx, &childWorkflowIDs); err != nil {
+					ID:               comp.ID,
+					UpstreamIDs:      upstreamIDs,
+					Input:            comp.IteratorComponent.Input,
+					SystemVariables:  param.SystemVariables,
+					MemoryStorageKey: param.MemoryStorageKey,
+					TargetStorageKey: targetStorageKey,
+				}).Get(ctx, &preIteratorResult); err != nil {
 					return err
 				}
 
 				itFutures := []workflow.Future{}
-				for _, childWorkflowID := range childWorkflowIDs {
-
+				for iter := 0; iter < param.BatchSize; iter++ {
+					childWorkflowID := fmt.Sprintf("%s:%s:%s:%s:%d", workflowID, recipe.SegComponent, comp.ID, recipe.SegIteration, iter)
 					childWorkflowOptions := workflow.ChildWorkflowOptions{
 						TaskQueue:                TaskQueue,
-						WorkflowID:               fmt.Sprintf("%s:iterators:%s", workflow.GetInfo(ctx).WorkflowExecution.ID, comp.ID),
+						WorkflowID:               childWorkflowID,
 						WorkflowExecutionTimeout: time.Duration(config.Config.Server.Workflow.MaxWorkflowTimeout) * time.Second,
 						RetryPolicy: &temporal.RetryPolicy{
 							MaximumAttempts: config.Config.Server.Workflow.MaxWorkflowRetry,
 						},
 					}
-					itCtx := workflow.WithChildOptions(ctx, childWorkflowOptions)
 
-					iteratorRedisKey := fmt.Sprintf("pipeline_trigger:%s", childWorkflowID)
 					itFutures = append(itFutures, workflow.ExecuteChildWorkflow(
-						itCtx,
+						workflow.WithChildOptions(ctx, childWorkflowOptions),
 						"TriggerPipelineWorkflow",
 						&TriggerPipelineWorkflowParam{
-							MemoryRedisKey:  iteratorRedisKey,
-							SystemVariables: param.SystemVariables,
-							Mode:            mgmtPB.Mode_MODE_SYNC,
+							MemoryStorageKey: preIteratorResult.MemoryStorageKeys[iter],
+							SystemVariables:  param.SystemVariables,
+							Mode:             mgmtPB.Mode_MODE_SYNC,
 						}))
 
 				}
-				for idx := range childWorkflowIDs {
-					err = itFutures[idx].Get(ctx, nil)
+				for iter := 0; iter < param.BatchSize; iter++ {
+					err = itFutures[iter].Get(ctx, nil)
 					if err != nil {
 						logger.Error(fmt.Sprintf("unable to execute iterator workflow: %s", err.Error()))
 						return err
@@ -217,12 +235,12 @@ func (w *worker) TriggerPipelineWorkflow(ctx workflow.Context, param *TriggerPip
 				}
 
 				if err = workflow.ExecuteActivity(ctx, w.PostIteratorActivity, &PostIteratorActivityParam{
-					ID:               comp.ID,
-					MemoryRedisKey:   param.MemoryRedisKey,
-					OutputElements:   comp.IteratorComponent.OutputElements,
-					ChildWorkflowIDs: childWorkflowIDs,
-					SystemVariables:  param.SystemVariables,
-				}).Get(ctx, &childWorkflowIDs); err != nil {
+					ID:                comp.ID,
+					MemoryStorageKeys: preIteratorResult.MemoryStorageKeys,
+					TargetStorageKey:  targetStorageKey,
+					OutputElements:    comp.IteratorComponent.OutputElements,
+					SystemVariables:   param.SystemVariables,
+				}).Get(ctx, nil); err != nil {
 					return err
 				}
 
@@ -236,7 +254,12 @@ func (w *worker) TriggerPipelineWorkflow(ctx workflow.Context, param *TriggerPip
 				w.writeErrorDataPoint(sCtx, err, span, startTime, &dataPoint)
 				return err
 			}
-
+		}
+		for _, comp := range orderedComp[group] {
+			param.MemoryStorageKey.Components[comp.ID] = make([]string, param.BatchSize)
+			for batchIdx := 0; batchIdx < param.BatchSize; batchIdx++ {
+				param.MemoryStorageKey.Components[comp.ID][batchIdx] = fmt.Sprintf("%s:%s:%s:%d", workflowID, recipe.SegComponent, comp.ID, batchIdx)
+			}
 		}
 
 	}
@@ -255,12 +278,12 @@ func (w *worker) ConnectorActivity(ctx context.Context, param *ConnectorActivity
 	logger, _ := logger.GetZapLogger(ctx)
 	logger.Info("ConnectorActivity started")
 
-	memory, err := recipe.LoadMemory(ctx, w.redisClient, param.MemoryRedisKey)
+	memory, err := recipe.LoadMemory(ctx, w.redisClient, param.MemoryStorageKey)
 	if err != nil {
 		return w.toApplicationError(err, param.ID, ConnectorActivityError)
 	}
 
-	compInputs, idxMap, err := w.processInput(memory, param.ID, param.AncestorIDs, param.Condition, param.Input, param.DefinitionUID)
+	compInputs, idxMap, err := w.processInput(memory, param.ID, param.UpstreamIDs, param.Condition, param.Input)
 	if err != nil {
 		return w.toApplicationError(err, param.ID, ConnectorActivityError)
 	}
@@ -290,7 +313,7 @@ func (w *worker) ConnectorActivity(ctx context.Context, param *ConnectorActivity
 		return w.toApplicationError(err, param.ID, ConnectorActivityError)
 	}
 
-	err = recipe.WriteComponentMemory(ctx, w.redisClient, param.MemoryRedisKey, param.ID, compMem)
+	err = recipe.WriteComponentMemory(ctx, w.redisClient, param.TargetStorageKey, compMem)
 	if err != nil {
 		return w.toApplicationError(err, param.ID, ConnectorActivityError)
 	}
@@ -304,12 +327,12 @@ func (w *worker) OperatorActivity(ctx context.Context, param *OperatorActivityPa
 	logger, _ := logger.GetZapLogger(ctx)
 	logger.Info("OperatorActivity started")
 
-	memory, err := recipe.LoadMemory(ctx, w.redisClient, param.MemoryRedisKey)
+	memory, err := recipe.LoadMemory(ctx, w.redisClient, param.MemoryStorageKey)
 	if err != nil {
 		return w.toApplicationError(err, param.ID, OperatorActivityError)
 	}
 
-	compInputs, idxMap, err := w.processInput(memory, param.ID, param.AncestorIDs, param.Condition, param.Input, param.DefinitionUID)
+	compInputs, idxMap, err := w.processInput(memory, param.ID, param.UpstreamIDs, param.Condition, param.Input)
 	if err != nil {
 		return w.toApplicationError(err, param.ID, OperatorActivityError)
 	}
@@ -334,7 +357,7 @@ func (w *worker) OperatorActivity(ctx context.Context, param *OperatorActivityPa
 		return w.toApplicationError(err, param.ID, OperatorActivityError)
 	}
 
-	err = recipe.WriteComponentMemory(ctx, w.redisClient, param.MemoryRedisKey, param.ID, compMem)
+	err = recipe.WriteComponentMemory(ctx, w.redisClient, param.TargetStorageKey, compMem)
 	if err != nil {
 		return w.toApplicationError(err, param.ID, OperatorActivityError)
 	}
@@ -343,17 +366,17 @@ func (w *worker) OperatorActivity(ctx context.Context, param *OperatorActivityPa
 	return nil
 }
 
-func (w *worker) PreIteratorActivity(ctx context.Context, param *PreIteratorActivityParam) (childWorkflowIDs []string, err error) {
+// PreIteratorActivity generate the trigger memory for each iteration.
+func (w *worker) PreIteratorActivity(ctx context.Context, param *PreIteratorActivityParam) (*PreIteratorActivityResult, error) {
 
 	logger, _ := logger.GetZapLogger(ctx)
 	logger.Info("PreIteratorActivity started")
 
-	m, err := recipe.LoadMemory(ctx, w.redisClient, param.MemoryRedisKey)
+	m, err := recipe.LoadMemory(ctx, w.redisClient, param.MemoryStorageKey)
 	if err != nil {
-		logger.Error(fmt.Sprintf("unable to execute workflow: %s", err.Error()))
 		return nil, w.toApplicationError(err, param.ID, PreIteratorActivityError)
 	}
-	r, err := recipe.LoadRecipe(ctx, w.redisClient, param.MemoryRedisKey)
+	r, err := recipe.LoadRecipe(ctx, w.redisClient, param.MemoryStorageKey.Recipe)
 	if err != nil {
 		return nil, w.toApplicationError(err, param.ID, PreIteratorActivityError)
 	}
@@ -364,25 +387,23 @@ func (w *worker) PreIteratorActivity(ctx context.Context, param *PreIteratorActi
 			iteratorRecipe = &datamodel.Recipe{
 				Components: comp.IteratorComponent.Components,
 			}
+			break
 		}
 	}
 
-	childWorkflowIDs = make([]string, len(m.Inputs))
-	for batchIdx := range m.Inputs {
+	result := &PreIteratorActivityResult{
+		MemoryStorageKeys: make([]*recipe.TriggerMemoryKey, len(m.Inputs)),
+	}
+	recipeKey := fmt.Sprintf("%s:%s", param.TargetStorageKey, recipe.SegRecipe)
+	err = recipe.WriteRecipe(ctx, w.redisClient, recipeKey, iteratorRecipe)
+	if err != nil {
+		return nil, w.toApplicationError(err, param.ID, PreIteratorActivityError)
+	}
+	for iter := range m.Inputs {
 
-		childWorkflowID := fmt.Sprintf("%s:iterators:%s", param.WorkflowID, param.ID)
-		childWorkflowIDs[batchIdx] = childWorkflowID
-
-		input, err := recipe.RenderInput(param.Input, batchIdx, m.Components, m.Inputs, m.Secrets)
+		input, err := recipe.RenderInput(param.Input, iter, m.Components, m.Inputs, m.Secrets)
 		if err != nil {
 			return nil, w.toApplicationError(err, param.ID, PreIteratorActivityError)
-		}
-
-		subM := &recipe.TriggerMemory{
-			Components: map[string]recipe.ComponentsMemory{},
-			Inputs:     []recipe.InputsMemory{},
-			Secrets:    m.Secrets,
-			Vars:       m.Vars,
 		}
 
 		elems := make([]*recipe.ComponentItemMemory, len(input.([]any)))
@@ -392,59 +413,70 @@ func (w *worker) PreIteratorActivity(ctx context.Context, param *PreIteratorActi
 			}
 
 		}
+		elementSize := len(elems)
 
-		subM.Components[param.ID] = elems
-
-		for k := range m.Components {
-			subM.Components[k] = recipe.ComponentsMemory{}
-			for range elems {
-				subM.Components[k] = append(subM.Components[k], m.Components[k][batchIdx])
-			}
-		}
-
-		for range elems {
-			subM.Inputs = append(subM.Inputs, m.Inputs[batchIdx])
-		}
-
-		iteratorRedisKey := fmt.Sprintf("pipeline_trigger:%s", childWorkflowID)
-		err = recipe.WriteMemoryAndRecipe(
-			ctx,
-			w.redisClient,
-			iteratorRedisKey,
-			iteratorRecipe,
-			subM,
-			fmt.Sprintf("%s/%s", param.SystemVariables.PipelineOwnerType, param.SystemVariables.PipelineOwnerUID),
-		)
+		err = recipe.WriteComponentMemory(ctx, w.redisClient, fmt.Sprintf("%s:%s:%d:%s:%s", param.TargetStorageKey, recipe.SegIteration, iter, recipe.SegComponent, param.ID), elems)
 		if err != nil {
-			logger.Error(fmt.Sprintf("unable to execute workflow: %s", err.Error()))
 			return nil, w.toApplicationError(err, param.ID, PreIteratorActivityError)
 		}
+
+		inputStorageKeys := make([]string, elementSize)
+		for e := 0; e < elementSize; e++ {
+			inputStorageKeys[e] = param.MemoryStorageKey.Inputs[iter]
+		}
+		compStorageKeys := map[string][]string{}
+		for _, ID := range param.UpstreamIDs {
+			compStorageKeys[ID] = make([]string, elementSize)
+			for e := 0; e < elementSize; e++ {
+				compStorageKeys[ID][e] = param.MemoryStorageKey.Components[ID][iter]
+			}
+		}
+		compStorageKeys[param.ID] = make([]string, elementSize)
+		for e := 0; e < elementSize; e++ {
+			compStorageKeys[param.ID][e] = fmt.Sprintf("%s:%s:%d:%s:%s:%d",
+				param.TargetStorageKey, recipe.SegIteration, iter, recipe.SegComponent, param.ID, e)
+		}
+
+		k := &recipe.TriggerMemoryKey{
+			Components: compStorageKeys,
+			Inputs:     inputStorageKeys,
+			Secrets:    param.MemoryStorageKey.Secrets,
+			Vars:       param.MemoryStorageKey.Vars,
+			Recipe:     recipeKey,
+		}
+		result.MemoryStorageKeys[iter] = k
 
 	}
 
 	logger.Info("PreIteratorActivity completed")
-	return childWorkflowIDs, nil
+	return result, nil
 }
 
+// PostIteratorActivity merges the trigger memory from each iteration.
 func (w *worker) PostIteratorActivity(ctx context.Context, param *PostIteratorActivityParam) error {
 
 	logger, _ := logger.GetZapLogger(ctx)
 	logger.Info("PostIteratorActivity started")
 
-	m, err := recipe.LoadMemory(ctx, w.redisClient, param.MemoryRedisKey)
+	// recipes for all iteration are the same
+	r, err := recipe.LoadRecipe(ctx, w.redisClient, param.MemoryStorageKeys[0].Recipe)
 	if err != nil {
-		logger.Error(fmt.Sprintf("unable to execute workflow: %s", err.Error()))
-		return w.toApplicationError(err, param.ID, PostIteratorActivityError)
+		return w.toApplicationError(err, param.ID, PreIteratorActivityError)
 	}
 
 	iterComp := recipe.ComponentsMemory{}
-	for batchIdx := range m.Inputs {
+	for iter := range param.MemoryStorageKeys {
 
-		iteratorRedisKey := fmt.Sprintf("pipeline_trigger:%s", param.ChildWorkflowIDs[batchIdx])
+		k := param.MemoryStorageKeys[iter]
+		for _, comp := range r.Components {
+			k.Components[comp.ID] = make([]string, len(k.Inputs))
+			for e := 0; e < len(k.Inputs); e++ {
+				k.Components[comp.ID][e] = fmt.Sprintf("%s:%s:%d:%s:%s:%d", param.TargetStorageKey, recipe.SegIteration, iter, recipe.SegComponent, comp.ID, e)
+			}
+		}
 
-		iteratorResult, err := recipe.LoadMemory(ctx, w.redisClient, iteratorRedisKey)
+		m, err := recipe.LoadMemory(ctx, w.redisClient, k)
 		if err != nil {
-			logger.Error(fmt.Sprintf("unable to execute workflow: %s", err.Error()))
 			return w.toApplicationError(err, param.ID, PostIteratorActivityError)
 		}
 
@@ -452,8 +484,8 @@ func (w *worker) PostIteratorActivity(ctx context.Context, param *PostIteratorAc
 		for k, v := range param.OutputElements {
 			elemVals := []any{}
 
-			for elemIdx := range iteratorResult.Inputs {
-				elemVal, err := recipe.RenderInput(v, elemIdx, iteratorResult.Components, iteratorResult.Inputs, iteratorResult.Secrets)
+			for elemIdx := range m.Inputs {
+				elemVal, err := recipe.RenderInput(v, elemIdx, m.Components, m.Inputs, m.Secrets)
 				if err != nil {
 					return w.toApplicationError(err, param.ID, PostIteratorActivityError)
 				}
@@ -471,7 +503,7 @@ func (w *worker) PostIteratorActivity(ctx context.Context, param *PostIteratorAc
 			},
 		})
 	}
-	err = recipe.WriteComponentMemory(ctx, w.redisClient, param.MemoryRedisKey, param.ID, iterComp)
+	err = recipe.WriteComponentMemory(ctx, w.redisClient, param.TargetStorageKey, iterComp)
 	if err != nil {
 		logger.Error(fmt.Sprintf("unable to execute workflow: %s", err.Error()))
 		return w.toApplicationError(err, param.ID, PostIteratorActivityError)
@@ -481,7 +513,7 @@ func (w *worker) PostIteratorActivity(ctx context.Context, param *PostIteratorAc
 	return nil
 }
 
-func (w *worker) processInput(memory *recipe.TriggerMemory, id string, ancestorIDs []string, condition *string, input *structpb.Struct, definitionUID uuid.UUID) ([]*structpb.Struct, map[int]int, error) {
+func (w *worker) processInput(memory *recipe.TriggerMemory, id string, UpstreamIDs []string, condition *string, input *structpb.Struct) ([]*structpb.Struct, map[int]int, error) {
 	batchSize := len(memory.Inputs)
 	var compInputs []*structpb.Struct
 	idxMap := map[int]int{}
@@ -496,8 +528,8 @@ func (w *worker) processInput(memory *recipe.TriggerMemory, id string, ancestorI
 			Status: &recipe.ComponentStatus{},
 		}
 
-		for _, ancestorID := range ancestorIDs {
-			if memory.Components[ancestorID][idx].Status.Skipped {
+		for _, upstreamID := range UpstreamIDs {
+			if memory.Components[upstreamID][idx].Status.Skipped {
 				memory.Components[id][idx].Status.Skipped = true
 				break
 			}


### PR DESCRIPTION
Because

- Originally, we used a single key to read/write the trigger memory to/from Redis. When using the iterator, we needed to duplicate the component memory N times (N = size of the iteration batch). In the original implementation, this caused a lot of duplicated storage. For the duplicated data in the iterator memory, we should be able to use the same Redis key across the batch to get the data instead of duplicating the data.

This commit

- Uses combination keyset to read/write the trigger memory. This way, we can reuse the same data in the iteration instead of duplicating it.