### PR TITLE
test: remove /core and /vdp HTTP endpoint prefixes in integration test

### DIFF
--- a/integration-test/pipeline/const.js
+++ b/integration-test/pipeline/const.js
@@ -25,8 +25,8 @@ if (__ENV.API_GATEWAY_PROTOCOL) {
 
 
 export const pipelinePrivateHost = `http://pipeline-backend:3081`;
-export const pipelinePublicHost = apiGatewayMode ? `${proto}://${__ENV.API_GATEWAY_URL}/vdp` : `http://api-gateway:8080/vdp`
-export const mgmtPublicHost = apiGatewayMode ? `${proto}://${__ENV.API_GATEWAY_URL}/core` : `http://api-gateway:8080/core`
+export const pipelinePublicHost = apiGatewayMode ? `${proto}://${__ENV.API_GATEWAY_URL}` : `http://api-gateway:8080`
+export const mgmtPublicHost = apiGatewayMode ? `${proto}://${__ENV.API_GATEWAY_URL}` : `http://api-gateway:8080`
 export const pipelineGRPCPrivateHost = apiGatewayMode ? `${__ENV.API_GATEWAY_URL}` : `pipeline-backend:3081`;
 export const pipelineGRPCPublicHost = apiGatewayMode ? `${__ENV.API_GATEWAY_URL}` : `api-gateway:8080`;
 export const mgmtGRPCPublicHost = apiGatewayMode ? `${__ENV.API_GATEWAY_URL}` : `api-gateway:8080`;


### PR DESCRIPTION
Because

- We've added new HTTP endpoints without the `/core` and `/vdp` prefixes.

This commit

- Removes the `/core` and `/vdp` HTTP endpoint prefixes in HTTP integration test.