### PR TITLE
chore: add context to usage handler methods

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1
 	github.com/iancoleman/strcase v0.2.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/component v0.16.0-beta.0.20240509102403-ed2068ffb10f
+	github.com/instill-ai/component v0.16.0-beta.0.20240510120358-80c47809f4a8
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240423142304-54b986803884
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha

--- a/go.sum
+++ b/go.sum
@@ -1189,8 +1189,8 @@ github.com/influxdata/influxdb-client-go/v2 v2.12.3 h1:28nRlNMRIV4QbtIUvxhWqaxn0
 github.com/influxdata/influxdb-client-go/v2 v2.12.3/go.mod h1:IrrLUbCjjfkmRuaCiGQg4m2GbkaeJDcuWoxiWdQEbA0=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/instill-ai/component v0.16.0-beta.0.20240509102403-ed2068ffb10f h1:0oKmicPWoQNUBp0xowG65OcK5T5HJk+oNAnOoxVJrKk=
-github.com/instill-ai/component v0.16.0-beta.0.20240509102403-ed2068ffb10f/go.mod h1:KEZjjpYKAd266Inn82N4Ct42B4M7+Xhmhz8gLPsEgFg=
+github.com/instill-ai/component v0.16.0-beta.0.20240510120358-80c47809f4a8 h1:9p4qbe5FIlBBLsmJKp0KXBA3JMZ0lp8AqhzrnGBmMWE=
+github.com/instill-ai/component v0.16.0-beta.0.20240510120358-80c47809f4a8/go.mod h1:KEZjjpYKAd266Inn82N4Ct42B4M7+Xhmhz8gLPsEgFg=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240423142304-54b986803884 h1:FfNGEn+USpO8z+/fOA6+WGcOSaOw2SQcR+ovyAUC03A=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240423142304-54b986803884/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=

--- a/pkg/worker/workflow.go
+++ b/pkg/worker/workflow.go
@@ -305,7 +305,7 @@ func (w *worker) ConnectorActivity(ctx context.Context, param *ConnectorActivity
 		return w.toApplicationError(err, param.ID, ConnectorActivityError)
 	}
 
-	compOutputs, err := execution.Execute(compInputs)
+	compOutputs, err := execution.Execute(ctx, compInputs)
 	if err != nil {
 		return w.toApplicationError(err, param.ID, ConnectorActivityError)
 	}
@@ -349,7 +349,7 @@ func (w *worker) OperatorActivity(ctx context.Context, param *OperatorActivityPa
 		return w.toApplicationError(err, param.ID, OperatorActivityError)
 	}
 
-	compOutputs, err := execution.Execute(compInputs)
+	compOutputs, err := execution.Execute(ctx, compInputs)
 	if err != nil {
 		return w.toApplicationError(err, param.ID, OperatorActivityError)
 	}


### PR DESCRIPTION
Because

- We want the pipeline trigger context to be propagated to the component execution and usage handler.

This commit

- Adds a context param to Execute, Check and Collect.
- Makes system variables accessible at the UsageHandler methods.

