### PR TITLE
refactor: rename instillCredentialField to instillSecret

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1
 	github.com/iancoleman/strcase v0.2.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/component v0.16.0-beta.0.20240510120358-80c47809f4a8
+	github.com/instill-ai/component v0.16.0-beta.0.20240513073622-a6751fa8737b
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240512102101-9bd49969ca1d
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha

--- a/go.sum
+++ b/go.sum
@@ -1189,8 +1189,8 @@ github.com/influxdata/influxdb-client-go/v2 v2.12.3 h1:28nRlNMRIV4QbtIUvxhWqaxn0
 github.com/influxdata/influxdb-client-go/v2 v2.12.3/go.mod h1:IrrLUbCjjfkmRuaCiGQg4m2GbkaeJDcuWoxiWdQEbA0=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/instill-ai/component v0.16.0-beta.0.20240510120358-80c47809f4a8 h1:9p4qbe5FIlBBLsmJKp0KXBA3JMZ0lp8AqhzrnGBmMWE=
-github.com/instill-ai/component v0.16.0-beta.0.20240510120358-80c47809f4a8/go.mod h1:KEZjjpYKAd266Inn82N4Ct42B4M7+Xhmhz8gLPsEgFg=
+github.com/instill-ai/component v0.16.0-beta.0.20240513073622-a6751fa8737b h1:R5m42+eoGrWc3F/jAr35lSPRTNNhj7bTJ8yKzHx+KM4=
+github.com/instill-ai/component v0.16.0-beta.0.20240513073622-a6751fa8737b/go.mod h1:KEZjjpYKAd266Inn82N4Ct42B4M7+Xhmhz8gLPsEgFg=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240512102101-9bd49969ca1d h1:857/EVs2MxGSJoAmxqznkuLs561uQxkP0TEqB/rEJwc=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240512102101-9bd49969ca1d/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=

--- a/pkg/db/migration/convert/convert000013/main.go
+++ b/pkg/db/migration/convert/convert000013/main.go
@@ -178,8 +178,8 @@ func (r *Recipe) Value() (driver.Value, error) {
 	return string(valueString), err
 }
 
-// Note: We list the `credentialFields` that need to be migrated manually.
-var credentialFields = map[string]string{
+// Note: We list the `secretFields` that need to be migrated manually.
+var secretFields = map[string]string{
 	"e414a1f8-5fdf-4292-b050-9f9176254a4b": "api_key",
 	"e2ffe076-ab2c-4e5e-9587-a613a6b1c146": "json_key",
 	"205cbeff-6f45-4abe-b0a8-cec1a310137f": "json_key",
@@ -237,7 +237,7 @@ func migrateSecret() (map[uuid.UUID]Connector, error) {
 	}
 	for _, con := range connectors {
 		defUID := con.ConnectorDefinitionUID.String()
-		if keys, ok := credentialFields[defUID]; ok {
+		if keys, ok := secretFields[defUID]; ok {
 			for _, key := range strings.Split(keys, ",") {
 				cfg := map[string]any{}
 				err := json.Unmarshal(con.Configuration, &cfg)
@@ -291,7 +291,7 @@ func migrateConnectorComponent(connectorMap map[uuid.UUID]Connector, c *Componen
 
 			b, _ := json.Marshal(connector.Configuration)
 			_ = protojson.Unmarshal(b, newComp.ConnectorComponent.Connection)
-			keys := credentialFields[defUID]
+			keys := secretFields[defUID]
 			for _, key := range strings.Split(keys, ",") {
 				if splits := strings.Split(key, "."); len(splits) == 1 {
 					conID := connectorMap[conUID].ID

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -124,6 +124,9 @@ func (s *service) CreateNamespacePipeline(ctx context.Context, ns resource.Names
 	if err != nil {
 		return nil, err
 	}
+	if err := s.checkSecret(ctx, dbPipeline.Recipe); err != nil {
+		return nil, err
+	}
 
 	if dbPipeline.ShareCode == "" {
 		dbPipeline.ShareCode = generateShareCode()
@@ -267,6 +270,9 @@ func (s *service) UpdateNamespacePipelineByID(ctx context.Context, ns resource.N
 
 	dbPipeline, err := s.converter.ConvertPipelineToDB(ctx, ns, toUpdPipeline)
 	if err != nil {
+		return nil, err
+	}
+	if err := s.checkSecret(ctx, dbPipeline.Recipe); err != nil {
 		return nil, err
 	}
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -15,17 +15,16 @@ import (
 )
 
 const (
-	CreateEvent          string = "Create"
-	UpdateEvent          string = "Update"
-	DeleteEvent          string = "Delete"
-	ActivateEvent        string = "Activate"
-	DeactivateEvent      string = "Deactivate"
-	TriggerEvent         string = "Trigger"
-	ConnectEvent         string = "Connect"
-	DisconnectEvent      string = "Disconnect"
-	RenameEvent          string = "Rename"
-	ExecuteEvent         string = "Execute"
-	credentialMaskString string = "*****MASK*****"
+	CreateEvent     string = "Create"
+	UpdateEvent     string = "Update"
+	DeleteEvent     string = "Delete"
+	ActivateEvent   string = "Activate"
+	DeactivateEvent string = "Deactivate"
+	TriggerEvent    string = "Trigger"
+	ConnectEvent    string = "Connect"
+	DisconnectEvent string = "Disconnect"
+	RenameEvent     string = "Rename"
+	ExecuteEvent    string = "Execute"
 )
 
 func IsAuditEvent(eventName string) bool {


### PR DESCRIPTION
Because

- We've introduced the secret management system. The naming is inconsistent with the `instillCredentialField` in the component JSON schema.

This commit

- Renames `instillCredentialField` to `instillSecret`.
