### PR TITLE
feat: return total pipeline count to frontend

### DIFF
--- a/pkg/datamodel/datamodel.go
+++ b/pkg/datamodel/datamodel.go
@@ -52,6 +52,11 @@ func (base *BaseDynamicHardDelete) BeforeCreate(db *gorm.DB) error {
 	return nil
 }
 
+type HubStats struct {
+	NumberOfPublicPipelines int32
+	NumberOfFeaturedPipelines int32
+}
+
 // Pipeline is the data model of the pipeline table
 type Pipeline struct {
 	BaseDynamic

--- a/pkg/handler/pipeline.go
+++ b/pkg/handler/pipeline.go
@@ -99,6 +99,42 @@ func (h *PrivateHandler) LookUpPipelineAdmin(ctx context.Context, req *pb.LookUp
 	return &resp, nil
 }
 
+func (h *PublicHandler) CountPipelines(ctx context.Context, req *pb.CountPipelinesRequest) (*pb.CountPipelinesResponse, error) {
+
+	eventName := "CountPipelines"
+
+	ctx, span := tracer.Start(ctx, eventName,
+		trace.WithSpanKind(trace.SpanKindServer))
+	defer span.End()
+
+	logUUID, _ := uuid.NewV4()
+
+	logger, _ := logger.GetZapLogger(ctx)
+
+	if err := authenticateUser(ctx, true); err != nil {
+		span.SetStatus(1, err.Error())
+		return &pb.CountPipelinesResponse{}, err
+	}
+
+	count, err := h.service.CountPublicPipelines()
+
+	if err != nil {
+		span.SetStatus(1, err.Error())
+		return &pb.CountPipelinesResponse{}, err
+	}
+
+	logger.Info(string(customotel.NewLogMessage(
+		ctx,
+		span,
+		logUUID.String(),
+		eventName,
+	)))
+	
+	return &pb.CountPipelinesResponse{
+		TotalSize: int32(count),
+	}, nil
+}
+
 func (h *PublicHandler) ListPipelines(ctx context.Context, req *pb.ListPipelinesRequest) (*pb.ListPipelinesResponse, error) {
 
 	eventName := "ListPipelines"

--- a/pkg/handler/pipeline.go
+++ b/pkg/handler/pipeline.go
@@ -99,9 +99,9 @@ func (h *PrivateHandler) LookUpPipelineAdmin(ctx context.Context, req *pb.LookUp
 	return &resp, nil
 }
 
-func (h *PublicHandler) CountPipelines(ctx context.Context, req *pb.CountPipelinesRequest) (*pb.CountPipelinesResponse, error) {
+func (h *PublicHandler) GetHubStats(ctx context.Context, req *pb.GetHubStatsRequest) (*pb.GetHubStatsResponse, error) {
 
-	eventName := "CountPipelines"
+	eventName := "GetHubStats"
 
 	ctx, span := tracer.Start(ctx, eventName,
 		trace.WithSpanKind(trace.SpanKindServer))
@@ -113,14 +113,14 @@ func (h *PublicHandler) CountPipelines(ctx context.Context, req *pb.CountPipelin
 
 	if err := authenticateUser(ctx, true); err != nil {
 		span.SetStatus(1, err.Error())
-		return &pb.CountPipelinesResponse{}, err
+		return &pb.GetHubStatsResponse{}, err
 	}
 
-	count, err := h.service.CountPublicPipelines(ctx)
+	resp, err := h.service.GetHubStats(ctx)
 
 	if err != nil {
 		span.SetStatus(1, err.Error())
-		return &pb.CountPipelinesResponse{}, err
+		return &pb.GetHubStatsResponse{}, err
 	}
 
 	logger.Info(string(customotel.NewLogMessage(
@@ -130,9 +130,7 @@ func (h *PublicHandler) CountPipelines(ctx context.Context, req *pb.CountPipelin
 		eventName,
 	)))
 	
-	return &pb.CountPipelinesResponse{
-		TotalSize: int32(count),
-	}, nil
+	return resp, nil
 }
 
 func (h *PublicHandler) ListPipelines(ctx context.Context, req *pb.ListPipelinesRequest) (*pb.ListPipelinesResponse, error) {

--- a/pkg/handler/pipeline.go
+++ b/pkg/handler/pipeline.go
@@ -116,7 +116,7 @@ func (h *PublicHandler) CountPipelines(ctx context.Context, req *pb.CountPipelin
 		return &pb.CountPipelinesResponse{}, err
 	}
 
-	count, err := h.service.CountPublicPipelines()
+	count, err := h.service.CountPublicPipelines(ctx)
 
 	if err != nil {
 		span.SetStatus(1, err.Error())

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -35,7 +35,7 @@ const MaxPageSize = 100
 
 // Repository interface
 type Repository interface {
-	CountPublicPipelines() (int64, error)
+	CountPublicPipelines(uidAllowList []uuid.UUID) (int64, error)
 	ListPipelines(ctx context.Context, pageSize int64, pageToken string, isBasicView bool, filter filtering.Filter, uidAllowList []uuid.UUID, showDeleted bool, embedReleases bool) ([]*datamodel.Pipeline, int64, string, error)
 	GetPipelineByUID(ctx context.Context, uid uuid.UUID, isBasicView bool, embedReleases bool) (*datamodel.Pipeline, error)
 
@@ -114,13 +114,13 @@ func (r *repository) CreateNamespacePipeline(ctx context.Context, ownerPermalink
 	return nil
 }
 
-func (r *repository) CountPublicPipelines() (int64, error) {
+func (r *repository) CountPublicPipelines(uidAllowList []uuid.UUID) (int64, error) {
 
 	db := r.db
 
 	var totalSize int64
-	// TODO: which column is for public pipeline?
-	db.Model(&datamodel.Pipeline{}).Count(&totalSize)
+	
+	db.Model(&datamodel.Pipeline{}).Where("uid in ?", uidAllowList).Count(&totalSize)
 
 	return totalSize, nil
 }

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -35,7 +35,7 @@ const MaxPageSize = 100
 
 // Repository interface
 type Repository interface {
-	CountPublicPipelines(uidAllowList []uuid.UUID) (int64, error)
+	GetHubStats(uidAllowList []uuid.UUID) (*datamodel.HubStats, error)
 	ListPipelines(ctx context.Context, pageSize int64, pageToken string, isBasicView bool, filter filtering.Filter, uidAllowList []uuid.UUID, showDeleted bool, embedReleases bool) ([]*datamodel.Pipeline, int64, string, error)
 	GetPipelineByUID(ctx context.Context, uid uuid.UUID, isBasicView bool, embedReleases bool) (*datamodel.Pipeline, error)
 
@@ -114,7 +114,7 @@ func (r *repository) CreateNamespacePipeline(ctx context.Context, ownerPermalink
 	return nil
 }
 
-func (r *repository) CountPublicPipelines(uidAllowList []uuid.UUID) (int64, error) {
+func (r *repository) GetHubStats(uidAllowList []uuid.UUID) (*datamodel.HubStats, error) {
 
 	db := r.db
 
@@ -122,7 +122,10 @@ func (r *repository) CountPublicPipelines(uidAllowList []uuid.UUID) (int64, erro
 	
 	db.Model(&datamodel.Pipeline{}).Where("uid in ?", uidAllowList).Count(&totalSize)
 
-	return totalSize, nil
+	return &datamodel.HubStats{
+		NumberOfPublicPipelines: int32(totalSize),
+		NumberOfFeaturedPipelines: int32(totalSize), // TODO: after tag system is ok, we can extract the count of featured pipelines.
+	}, nil
 }
 
 func (r *repository) listPipelines(ctx context.Context, where string, whereArgs []interface{}, pageSize int64, pageToken string, isBasicView bool, filter filtering.Filter, uidAllowList []uuid.UUID, showDeleted bool, embedReleases bool) (pipelines []*datamodel.Pipeline, totalSize int64, nextPageToken string, err error) {

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -35,6 +35,7 @@ const MaxPageSize = 100
 
 // Repository interface
 type Repository interface {
+	CountPublicPipelines() (int64, error)
 	ListPipelines(ctx context.Context, pageSize int64, pageToken string, isBasicView bool, filter filtering.Filter, uidAllowList []uuid.UUID, showDeleted bool, embedReleases bool) ([]*datamodel.Pipeline, int64, string, error)
 	GetPipelineByUID(ctx context.Context, uid uuid.UUID, isBasicView bool, embedReleases bool) (*datamodel.Pipeline, error)
 
@@ -111,6 +112,17 @@ func (r *repository) CreateNamespacePipeline(ctx context.Context, ownerPermalink
 		return result.Error
 	}
 	return nil
+}
+
+func (r *repository) CountPublicPipelines() (int64, error) {
+
+	db := r.db
+
+	var totalSize int64
+	// TODO: which column is for public pipeline?
+	db.Model(&datamodel.Pipeline{}).Count(&totalSize)
+
+	return totalSize, nil
 }
 
 func (r *repository) listPipelines(ctx context.Context, where string, whereArgs []interface{}, pageSize int64, pageToken string, isBasicView bool, filter filtering.Filter, uidAllowList []uuid.UUID, showDeleted bool, embedReleases bool) (pipelines []*datamodel.Pipeline, totalSize int64, nextPageToken string, err error) {

--- a/pkg/service/main.go
+++ b/pkg/service/main.go
@@ -24,7 +24,7 @@ import (
 
 // Service interface
 type Service interface {
-	CountPublicPipelines() (int64, error)
+	CountPublicPipelines(ctx context.Context) (int64, error)
 	ListPipelines(ctx context.Context, pageSize int32, pageToken string, view pb.Pipeline_View, visibility *pb.Pipeline_Visibility, filter filtering.Filter, showDeleted bool) ([]*pb.Pipeline, int32, string, error)
 	GetPipelineByUID(ctx context.Context, uid uuid.UUID, view pb.Pipeline_View) (*pb.Pipeline, error)
 	CreateNamespacePipeline(ctx context.Context, ns resource.Namespace, pipeline *pb.Pipeline) (*pb.Pipeline, error)

--- a/pkg/service/main.go
+++ b/pkg/service/main.go
@@ -24,6 +24,7 @@ import (
 
 // Service interface
 type Service interface {
+	CountPublicPipelines() (int64, error)
 	ListPipelines(ctx context.Context, pageSize int32, pageToken string, view pb.Pipeline_View, visibility *pb.Pipeline_Visibility, filter filtering.Filter, showDeleted bool) ([]*pb.Pipeline, int32, string, error)
 	GetPipelineByUID(ctx context.Context, uid uuid.UUID, view pb.Pipeline_View) (*pb.Pipeline, error)
 	CreateNamespacePipeline(ctx context.Context, ns resource.Namespace, pipeline *pb.Pipeline) (*pb.Pipeline, error)

--- a/pkg/service/main.go
+++ b/pkg/service/main.go
@@ -24,7 +24,7 @@ import (
 
 // Service interface
 type Service interface {
-	CountPublicPipelines(ctx context.Context) (int64, error)
+	GetHubStats(ctx context.Context) (*pb.GetHubStatsResponse, error)
 	ListPipelines(ctx context.Context, pageSize int32, pageToken string, view pb.Pipeline_View, visibility *pb.Pipeline_Visibility, filter filtering.Filter, showDeleted bool) ([]*pb.Pipeline, int32, string, error)
 	GetPipelineByUID(ctx context.Context, uid uuid.UUID, view pb.Pipeline_View) (*pb.Pipeline, error)
 	CreateNamespacePipeline(ctx context.Context, ns resource.Namespace, pipeline *pb.Pipeline) (*pb.Pipeline, error)

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -40,9 +40,14 @@ import (
 	pb "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
 
-func (s *service) CountPublicPipelines() (int64, error) {
+func (s *service) CountPublicPipelines(ctx context.Context) (int64, error) {
+	
+	uidAllowList, err := s.aclClient.ListPermissions(ctx, "pipeline", "reader", true)
+	if err != nil {
+		return 0, err
+	}
 
-	count, err := s.repository.CountPublicPipelines()
+	count, err := s.repository.CountPublicPipelines(uidAllowList)
 
 	if err != nil {
 		return 0, err

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -40,20 +40,23 @@ import (
 	pb "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
 
-func (s *service) CountPublicPipelines(ctx context.Context) (int64, error) {
+func (s *service) GetHubStats(ctx context.Context) (*pb.GetHubStatsResponse, error) {
 	
 	uidAllowList, err := s.aclClient.ListPermissions(ctx, "pipeline", "reader", true)
 	if err != nil {
-		return 0, err
+		return &pb.GetHubStatsResponse{}, err
 	}
 
-	count, err := s.repository.CountPublicPipelines(uidAllowList)
+	hubStats, err := s.repository.GetHubStats(uidAllowList)
 
 	if err != nil {
-		return 0, err
+		return &pb.GetHubStatsResponse{}, err
 	}
 
-	return count, nil
+	return &pb.GetHubStatsResponse{
+		NumberOfPublicPipelines: int32(hubStats.NumberOfPublicPipelines),
+		NumberOfFeaturedPipelines: int32(hubStats.NumberOfFeaturedPipelines), // TODO: change to the featured count.
+	}, nil
 }
 
 func (s *service) ListPipelines(ctx context.Context, pageSize int32, pageToken string, view pb.Pipeline_View, visibility *pb.Pipeline_Visibility, filter filtering.Filter, showDeleted bool) ([]*pb.Pipeline, int32, string, error) {

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -40,6 +40,17 @@ import (
 	pb "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
 
+func (s *service) CountPublicPipelines() (int64, error) {
+
+	count, err := s.repository.CountPublicPipelines()
+
+	if err != nil {
+		return 0, err
+	}
+
+	return count, nil
+}
+
 func (s *service) ListPipelines(ctx context.Context, pageSize int32, pageToken string, view pb.Pipeline_View, visibility *pb.Pipeline_Visibility, filter filtering.Filter, showDeleted bool) ([]*pb.Pipeline, int32, string, error) {
 
 	uidAllowList := []uuid.UUID{}


### PR DESCRIPTION
Because

- We want to let the users know the count of public pipeline

This commit

- get the pipeline count
