### PR TITLE
feat: add pipelineUsageHandler

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -156,6 +156,7 @@ func main() {
 		influxDBWriteClient,
 		config.Config.Connector.Secrets,
 		map[string]component.UsageHandlerCreator{},
+		nil,
 	)
 
 	w := worker.New(temporalClient, pipelineWorker.TaskQueue, worker.Options{

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1
 	github.com/iancoleman/strcase v0.2.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/component v0.16.0-beta.0.20240513073622-a6751fa8737b
+	github.com/instill-ai/component v0.16.0-beta.0.20240514000213-0b0cf81a2cc0
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240512102101-9bd49969ca1d
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha

--- a/go.sum
+++ b/go.sum
@@ -1189,8 +1189,8 @@ github.com/influxdata/influxdb-client-go/v2 v2.12.3 h1:28nRlNMRIV4QbtIUvxhWqaxn0
 github.com/influxdata/influxdb-client-go/v2 v2.12.3/go.mod h1:IrrLUbCjjfkmRuaCiGQg4m2GbkaeJDcuWoxiWdQEbA0=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/instill-ai/component v0.16.0-beta.0.20240513073622-a6751fa8737b h1:R5m42+eoGrWc3F/jAr35lSPRTNNhj7bTJ8yKzHx+KM4=
-github.com/instill-ai/component v0.16.0-beta.0.20240513073622-a6751fa8737b/go.mod h1:KEZjjpYKAd266Inn82N4Ct42B4M7+Xhmhz8gLPsEgFg=
+github.com/instill-ai/component v0.16.0-beta.0.20240514000213-0b0cf81a2cc0 h1:se9gfXRecDJ7KGWJPl3+qGpck0cV7dNxOYU7GUAlyjI=
+github.com/instill-ai/component v0.16.0-beta.0.20240514000213-0b0cf81a2cc0/go.mod h1:KEZjjpYKAd266Inn82N4Ct42B4M7+Xhmhz8gLPsEgFg=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240512102101-9bd49969ca1d h1:857/EVs2MxGSJoAmxqznkuLs561uQxkP0TEqB/rEJwc=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240512102101-9bd49969ca1d/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=

--- a/pkg/usage/usage.go
+++ b/pkg/usage/usage.go
@@ -12,6 +12,7 @@ import (
 	"github.com/instill-ai/pipeline-backend/config"
 	"github.com/instill-ai/pipeline-backend/pkg/constant"
 	"github.com/instill-ai/pipeline-backend/pkg/logger"
+	"github.com/instill-ai/pipeline-backend/pkg/recipe"
 	"github.com/instill-ai/pipeline-backend/pkg/repository"
 	"github.com/instill-ai/pipeline-backend/pkg/utils"
 	"github.com/instill-ai/x/repo"
@@ -419,4 +420,23 @@ func (u *usage) TriggerSingleReporter(ctx context.Context) {
 	if err != nil {
 		logger.Error(fmt.Sprintf("unable to trigger single reporter: %v\n", err))
 	}
+}
+
+type PipelineUsageHandler interface {
+	Check(ctx context.Context, vars recipe.SystemVariables, numComponents int) error
+	Collect(ctx context.Context, vars recipe.SystemVariables, numComponents int) error
+}
+
+type noopPipelineUsageHandler struct{}
+
+func (h *noopPipelineUsageHandler) Check(_ context.Context, _ recipe.SystemVariables, _ int) error {
+	return nil
+}
+func (h *noopPipelineUsageHandler) Collect(_ context.Context, _ recipe.SystemVariables, _ int) error {
+	return nil
+}
+
+// NewNoopPipelineUsageHandler is a no-op usage handler initializer.
+func NewNoopPipelineUsageHandler() PipelineUsageHandler {
+	return new(noopPipelineUsageHandler)
 }


### PR DESCRIPTION
Because

- We need a `PipelineUsageHandler` to collect the Instill Credit usage in the Cloud version.

This commit

- Adds a `PipelineUsageHandler` interface and a dummy `pipelineUsageHandler`.