### PR TITLE
feat: support sorting pipelines options by id and update_time

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/iancoleman/strcase v0.2.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
 	github.com/instill-ai/component v0.16.0-beta.0.20240515044655-536f5af2acc3
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240512102101-9bd49969ca1d
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240514163612-e3a71a5e8d06
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha
 	github.com/knadh/koanf v1.5.0

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/iancoleman/strcase v0.2.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
 	github.com/instill-ai/component v0.16.0-beta.0.20240515044655-536f5af2acc3
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240514163612-e3a71a5e8d06
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240515034849-65092bc5a7ad
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha
 	github.com/knadh/koanf v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -1195,8 +1195,8 @@ github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
 github.com/instill-ai/component v0.16.0-beta.0.20240515044655-536f5af2acc3 h1:fFiMd86RyUMyFuHxpeYW7IneID52jJJHNBGKghnu2M8=
 github.com/instill-ai/component v0.16.0-beta.0.20240515044655-536f5af2acc3/go.mod h1:kGV9Bm6hQ1SBH9nvqIV4UtJFJjF9gVsb01HNBsbgbU0=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240512102101-9bd49969ca1d h1:857/EVs2MxGSJoAmxqznkuLs561uQxkP0TEqB/rEJwc=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240512102101-9bd49969ca1d/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240514163612-e3a71a5e8d06 h1:BG4BIco4240Fc1K6XpYgcsStMAyak9ixbU7XEkfuoMs=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240514163612-e3a71a5e8d06/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a/go.mod h1:EpX3Yr661uWULtZf5UnJHfr5rw2PDyX8ku4Kx0UtYFw=
 github.com/instill-ai/x v0.4.0-alpha h1:zQV2VLbSHjMv6gyBN/2mwwrvWk0/mJM6ZKS12AzjfQg=

--- a/go.sum
+++ b/go.sum
@@ -1195,8 +1195,8 @@ github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
 github.com/instill-ai/component v0.16.0-beta.0.20240515044655-536f5af2acc3 h1:fFiMd86RyUMyFuHxpeYW7IneID52jJJHNBGKghnu2M8=
 github.com/instill-ai/component v0.16.0-beta.0.20240515044655-536f5af2acc3/go.mod h1:kGV9Bm6hQ1SBH9nvqIV4UtJFJjF9gVsb01HNBsbgbU0=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240514163612-e3a71a5e8d06 h1:BG4BIco4240Fc1K6XpYgcsStMAyak9ixbU7XEkfuoMs=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240514163612-e3a71a5e8d06/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240515034849-65092bc5a7ad h1:wcrCrQjb0E2zp8pzG+ryQ7ZkuzOVsz1RASmFbS6QT2A=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240515034849-65092bc5a7ad/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a/go.mod h1:EpX3Yr661uWULtZf5UnJHfr5rw2PDyX8ku4Kx0UtYFw=
 github.com/instill-ai/x v0.4.0-alpha h1:zQV2VLbSHjMv6gyBN/2mwwrvWk0/mJM6ZKS12AzjfQg=

--- a/integration-test/pipeline/rest-component-definition.js
+++ b/integration-test/pipeline/rest-component-definition.js
@@ -83,19 +83,6 @@ export function CheckList() {
       "GET /v1beta/component-definitions?page_size=1&view=VIEW_FULL response component_definitions[0].connector_definition.spec is not null": (r) => r.json().component_definitions[0].connector_definition.spec !== null,
     });
 
-
-    // Fetch a page with operator definitions.
-    // TODO when there are more connector definitions than the max page size
-    // (100), accessing the 2nd page won't work. We'll need to use a smaller
-    // page size and compute the page where operator definitions start.
-    var connectorRecords = http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions?page_size=1`, null, null)
-    var connectorSize = connectorRecords.json().total_size
-    check(http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?page_size=${connectorSize}&page=1`, null, null), {
-      [`GET /v1beta/component-definitions?page_size=${connectorSize}&page=1 response status 200`]: (r) => r.status === 200,
-      [`GET /v1beta/component-definitions?page_size=${connectorSize}&page=1 response contains operator definition type`]: (r) => r.json().component_definitions[0].type === "COMPONENT_TYPE_OPERATOR",
-      [`GET /v1beta/component-definitions?page_size=${connectorSize}&page=1 response contains operator definitions`]: (r) => r.json().component_definitions[0].operator_definition.id != "",
-    });
-
     // Filter (fuzzy) title
     check(http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?page_size=1&filter=q_title="JSO"`, null, null), {
       [`GET /v1beta/component-definitions?page_size=1&filter=q_title="JSO" response status 200`]: (r) => r.status === 200,

--- a/pkg/handler/pipeline.go
+++ b/pkg/handler/pipeline.go
@@ -267,6 +267,7 @@ type ListNamespacePipelinesRequestInterface interface {
 	GetView() pb.Pipeline_View
 	GetVisibility() pb.Pipeline_Visibility
 	GetFilter() string
+	GetOrderBy() string
 	GetParent() string
 	GetShowDeleted() bool
 }
@@ -331,7 +332,13 @@ func (h *PublicHandler) listNamespacePipelines(ctx context.Context, req ListName
 	}
 	visibility := req.GetVisibility()
 
-	pbPipelines, totalSize, nextPageToken, err := h.service.ListNamespacePipelines(ctx, ns, req.GetPageSize(), req.GetPageToken(), req.GetView(), &visibility, filter, req.GetShowDeleted())
+	orderBy, err := ordering.ParseOrderBy(req)
+	if err != nil {
+		span.SetStatus(1, err.Error())
+		return nil, "", 0, err
+	}
+
+	pbPipelines, totalSize, nextPageToken, err := h.service.ListNamespacePipelines(ctx, ns, req.GetPageSize(), req.GetPageToken(), req.GetView(), &visibility, filter, req.GetShowDeleted(), orderBy)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, "", 0, err

--- a/pkg/handler/pipeline.go
+++ b/pkg/handler/pipeline.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/iancoleman/strcase"
 	"go.einride.tech/aip/filtering"
+	"go.einride.tech/aip/ordering"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/mod/semver"
 	"google.golang.org/grpc"
@@ -140,8 +141,14 @@ func (h *PublicHandler) ListPipelines(ctx context.Context, req *pb.ListPipelines
 		return &pb.ListPipelinesResponse{}, err
 	}
 
+	orderBy, err := ordering.ParseOrderBy(req)
+	if err != nil {
+		span.SetStatus(1, err.Error())
+		return &pb.ListPipelinesResponse{}, err
+	}
+
 	pbPipelines, totalSize, nextPageToken, err := h.service.ListPipelines(
-		ctx, req.GetPageSize(), req.GetPageToken(), req.GetView(), req.Visibility, filter, req.GetShowDeleted())
+		ctx, req.GetPageSize(), req.GetPageToken(), req.GetView(), req.Visibility, filter, req.GetShowDeleted(), orderBy)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return &pb.ListPipelinesResponse{}, err

--- a/pkg/repository/base.go
+++ b/pkg/repository/base.go
@@ -1,8 +1,0 @@
-package repository
-
-func transformBoolToDescString(b bool) string {
-	if b {
-		return " DESC"
-	}
-	return ""
-}

--- a/pkg/repository/base.go
+++ b/pkg/repository/base.go
@@ -1,0 +1,8 @@
+package repository
+
+func transformBoolToDescString(b bool) string {
+	if b {
+		return " DESC"
+	}
+	return ""
+}

--- a/pkg/repository/utils.go
+++ b/pkg/repository/utils.go
@@ -1,0 +1,38 @@
+package repository
+
+import (
+	"encoding/base64"
+	"encoding/json"
+)
+
+func transformBoolToDescString(b bool) string {
+	if b {
+		return " DESC"
+	}
+	return ""
+}
+
+// TODO: we should refactor this to have a flexible format and merge it into x package.
+
+// DecodeToken decodes the token string into create_time and UUID
+func DecodeToken(encodedToken string) (map[string]string, error) {
+	byt, err := base64.StdEncoding.DecodeString(encodedToken)
+	if err != nil {
+		return nil, err
+	}
+	tokens := map[string]string{}
+	err = json.Unmarshal(byt, &tokens)
+	if err != nil {
+		return nil, err
+	}
+	return tokens, nil
+}
+
+// EncodeToken encodes create_time and UUID into a single string
+func EncodeToken(tokens map[string]string) (string, error) {
+	b, err := json.Marshal(tokens)
+	if err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(b), nil
+}

--- a/pkg/service/main.go
+++ b/pkg/service/main.go
@@ -28,7 +28,7 @@ type Service interface {
 	ListPipelines(ctx context.Context, pageSize int32, pageToken string, view pb.Pipeline_View, visibility *pb.Pipeline_Visibility, filter filtering.Filter, showDeleted bool, order ordering.OrderBy) ([]*pb.Pipeline, int32, string, error)
 	GetPipelineByUID(ctx context.Context, uid uuid.UUID, view pb.Pipeline_View) (*pb.Pipeline, error)
 	CreateNamespacePipeline(ctx context.Context, ns resource.Namespace, pipeline *pb.Pipeline) (*pb.Pipeline, error)
-	ListNamespacePipelines(ctx context.Context, ns resource.Namespace, pageSize int32, pageToken string, view pb.Pipeline_View, visibility *pb.Pipeline_Visibility, filter filtering.Filter, showDeleted bool) ([]*pb.Pipeline, int32, string, error)
+	ListNamespacePipelines(ctx context.Context, ns resource.Namespace, pageSize int32, pageToken string, view pb.Pipeline_View, visibility *pb.Pipeline_Visibility, filter filtering.Filter, showDeleted bool, order ordering.OrderBy) ([]*pb.Pipeline, int32, string, error)
 	GetNamespacePipelineByID(ctx context.Context, ns resource.Namespace, id string, view pb.Pipeline_View) (*pb.Pipeline, error)
 	UpdateNamespacePipelineByID(ctx context.Context, ns resource.Namespace, id string, updatedPipeline *pb.Pipeline) (*pb.Pipeline, error)
 	UpdateNamespacePipelineIDByID(ctx context.Context, ns resource.Namespace, id string, newID string) (*pb.Pipeline, error)

--- a/pkg/service/main.go
+++ b/pkg/service/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/influxdata/influxdb-client-go/v2/api"
 	"github.com/redis/go-redis/v9"
 	"go.einride.tech/aip/filtering"
+	"go.einride.tech/aip/ordering"
 	"go.temporal.io/sdk/client"
 	"google.golang.org/protobuf/types/known/structpb"
 
@@ -24,7 +25,7 @@ import (
 
 // Service interface
 type Service interface {
-	ListPipelines(ctx context.Context, pageSize int32, pageToken string, view pb.Pipeline_View, visibility *pb.Pipeline_Visibility, filter filtering.Filter, showDeleted bool) ([]*pb.Pipeline, int32, string, error)
+	ListPipelines(ctx context.Context, pageSize int32, pageToken string, view pb.Pipeline_View, visibility *pb.Pipeline_Visibility, filter filtering.Filter, showDeleted bool, order ordering.OrderBy) ([]*pb.Pipeline, int32, string, error)
 	GetPipelineByUID(ctx context.Context, uid uuid.UUID, view pb.Pipeline_View) (*pb.Pipeline, error)
 	CreateNamespacePipeline(ctx context.Context, ns resource.Namespace, pipeline *pb.Pipeline) (*pb.Pipeline, error)
 	ListNamespacePipelines(ctx context.Context, ns resource.Namespace, pageSize int32, pageToken string, view pb.Pipeline_View, visibility *pb.Pipeline_Visibility, filter filtering.Filter, showDeleted bool) ([]*pb.Pipeline, int32, string, error)

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/santhosh-tekuri/jsonschema/v5"
 	"go.einride.tech/aip/filtering"
+	"go.einride.tech/aip/ordering"
 	"go.temporal.io/api/enums/v1"
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/temporal"
@@ -40,7 +41,7 @@ import (
 	pb "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
 
-func (s *service) ListPipelines(ctx context.Context, pageSize int32, pageToken string, view pb.Pipeline_View, visibility *pb.Pipeline_Visibility, filter filtering.Filter, showDeleted bool) ([]*pb.Pipeline, int32, string, error) {
+func (s *service) ListPipelines(ctx context.Context, pageSize int32, pageToken string, view pb.Pipeline_View, visibility *pb.Pipeline_Visibility, filter filtering.Filter, showDeleted bool, order ordering.OrderBy) ([]*pb.Pipeline, int32, string, error) {
 
 	uidAllowList := []uuid.UUID{}
 	var err error

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -164,7 +164,7 @@ func (s *service) CreateNamespacePipeline(ctx context.Context, ns resource.Names
 	return pipeline, nil
 }
 
-func (s *service) ListNamespacePipelines(ctx context.Context, ns resource.Namespace, pageSize int32, pageToken string, view pb.Pipeline_View, visibility *pb.Pipeline_Visibility, filter filtering.Filter, showDeleted bool) ([]*pb.Pipeline, int32, string, error) {
+func (s *service) ListNamespacePipelines(ctx context.Context, ns resource.Namespace, pageSize int32, pageToken string, view pb.Pipeline_View, visibility *pb.Pipeline_Visibility, filter filtering.Filter, showDeleted bool, order ordering.OrderBy) ([]*pb.Pipeline, int32, string, error) {
 
 	ownerPermalink := ns.Permalink()
 
@@ -198,7 +198,7 @@ func (s *service) ListNamespacePipelines(ctx context.Context, ns resource.Namesp
 		}
 	}
 
-	dbPipelines, ps, pt, err := s.repository.ListNamespacePipelines(ctx, ownerPermalink, int64(pageSize), pageToken, view <= pb.Pipeline_VIEW_BASIC, filter, uidAllowList, showDeleted, true)
+	dbPipelines, ps, pt, err := s.repository.ListNamespacePipelines(ctx, ownerPermalink, int64(pageSize), pageToken, view <= pb.Pipeline_VIEW_BASIC, filter, uidAllowList, showDeleted, true, order)
 	if err != nil {
 		return nil, 0, "", err
 	}

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -73,7 +73,7 @@ func (s *service) ListPipelines(ctx context.Context, pageSize int32, pageToken s
 		}
 	}
 
-	dbPipelines, totalSize, nextPageToken, err := s.repository.ListPipelines(ctx, int64(pageSize), pageToken, view <= pb.Pipeline_VIEW_BASIC, filter, uidAllowList, showDeleted, true)
+	dbPipelines, totalSize, nextPageToken, err := s.repository.ListPipelines(ctx, int64(pageSize), pageToken, view <= pb.Pipeline_VIEW_BASIC, filter, uidAllowList, showDeleted, true, order)
 	if err != nil {
 		return nil, 0, "", err
 	}


### PR DESCRIPTION
Because

- We want users to have a better UX in pipeline main page.

This commit

- frontend can pass order_by to make the pipeline sorted according to the params.
