### PR TITLE
feat: implement hub-stats endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/iancoleman/strcase v0.2.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
 	github.com/instill-ai/component v0.16.0-beta.0.20240515044655-536f5af2acc3
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240515122505-aeea938049a2
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240515152126-90f472ac6006
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha
 	github.com/knadh/koanf v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -1195,8 +1195,8 @@ github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
 github.com/instill-ai/component v0.16.0-beta.0.20240515044655-536f5af2acc3 h1:fFiMd86RyUMyFuHxpeYW7IneID52jJJHNBGKghnu2M8=
 github.com/instill-ai/component v0.16.0-beta.0.20240515044655-536f5af2acc3/go.mod h1:kGV9Bm6hQ1SBH9nvqIV4UtJFJjF9gVsb01HNBsbgbU0=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240515122505-aeea938049a2 h1:W6CG1I9ryeUEwijAMHFT1t8S0hQEg8TuI11N5G67qOk=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240515122505-aeea938049a2/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240515152126-90f472ac6006 h1:83zmuhpOUWGzM157YNIYcFSDw+rrrXGmy71B61fYTZ4=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240515152126-90f472ac6006/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a/go.mod h1:EpX3Yr661uWULtZf5UnJHfr5rw2PDyX8ku4Kx0UtYFw=
 github.com/instill-ai/x v0.4.0-alpha h1:zQV2VLbSHjMv6gyBN/2mwwrvWk0/mJM6ZKS12AzjfQg=

--- a/pkg/datamodel/datamodel.go
+++ b/pkg/datamodel/datamodel.go
@@ -52,6 +52,11 @@ func (base *BaseDynamicHardDelete) BeforeCreate(db *gorm.DB) error {
 	return nil
 }
 
+type HubStats struct {
+	NumberOfPublicPipelines int32
+	NumberOfFeaturedPipelines int32
+}
+
 // Pipeline is the data model of the pipeline table
 type Pipeline struct {
 	BaseDynamic

--- a/pkg/handler/pipeline.go
+++ b/pkg/handler/pipeline.go
@@ -100,6 +100,40 @@ func (h *PrivateHandler) LookUpPipelineAdmin(ctx context.Context, req *pb.LookUp
 	return &resp, nil
 }
 
+func (h *PublicHandler) GetHubStats(ctx context.Context, req *pb.GetHubStatsRequest) (*pb.GetHubStatsResponse, error) {
+
+	eventName := "GetHubStats"
+
+	ctx, span := tracer.Start(ctx, eventName,
+		trace.WithSpanKind(trace.SpanKindServer))
+	defer span.End()
+
+	logUUID, _ := uuid.NewV4()
+
+	logger, _ := logger.GetZapLogger(ctx)
+
+	if err := authenticateUser(ctx, true); err != nil {
+		span.SetStatus(1, err.Error())
+		return &pb.GetHubStatsResponse{}, err
+	}
+
+	resp, err := h.service.GetHubStats(ctx)
+
+	if err != nil {
+		span.SetStatus(1, err.Error())
+		return &pb.GetHubStatsResponse{}, err
+	}
+
+	logger.Info(string(customotel.NewLogMessage(
+		ctx,
+		span,
+		logUUID.String(),
+		eventName,
+	)))
+
+	return resp, nil
+}
+
 func (h *PublicHandler) ListPipelines(ctx context.Context, req *pb.ListPipelinesRequest) (*pb.ListPipelinesResponse, error) {
 
 	eventName := "ListPipelines"

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -36,6 +36,7 @@ const MaxPageSize = 100
 
 // Repository interface
 type Repository interface {
+	GetHubStats(uidAllowList []uuid.UUID) (*datamodel.HubStats, error)
 	ListPipelines(ctx context.Context, pageSize int64, pageToken string, isBasicView bool, filter filtering.Filter, uidAllowList []uuid.UUID, showDeleted bool, embedReleases bool, order ordering.OrderBy) ([]*datamodel.Pipeline, int64, string, error)
 	GetPipelineByUID(ctx context.Context, uid uuid.UUID, isBasicView bool, embedReleases bool) (*datamodel.Pipeline, error)
 
@@ -84,6 +85,20 @@ func NewRepository(db *gorm.DB, redisClient *redis.Client) Repository {
 		db:          db,
 		redisClient: redisClient,
 	}
+}
+
+func (r *repository) GetHubStats(uidAllowList []uuid.UUID) (*datamodel.HubStats, error) {
+
+	db := r.db
+
+	var totalSize int64
+
+	db.Model(&datamodel.Pipeline{}).Where("uid in ?", uidAllowList).Count(&totalSize)
+
+	return &datamodel.HubStats{
+		NumberOfPublicPipelines: int32(totalSize),
+		NumberOfFeaturedPipelines: int32(totalSize), // TODO: after tag system is ok, we can extract the count of featured pipelines.
+	}, nil
 }
 
 func (r *repository) checkPinnedUser(ctx context.Context, db *gorm.DB, table string) *gorm.DB {

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -92,12 +92,17 @@ func (r *repository) GetHubStats(uidAllowList []uuid.UUID) (*datamodel.HubStats,
 	db := r.db
 
 	var totalSize int64
+	var totalFeaturedSize int64
 
 	db.Model(&datamodel.Pipeline{}).Where("uid in ?", uidAllowList).Count(&totalSize)
+	db.Model(&datamodel.Pipeline{}).Joins("left join tag on tag.pipeline_uid = pipeline.uid").
+		Where("uid in ?", uidAllowList).
+		Where("tag.tag_name = ?", "featured").
+		Count(&totalFeaturedSize)
 
 	return &datamodel.HubStats{
-		NumberOfPublicPipelines: int32(totalSize),
-		NumberOfFeaturedPipelines: int32(totalSize), // TODO: after tag system is ok, we can extract the count of featured pipelines.
+		NumberOfPublicPipelines:   int32(totalSize),
+		NumberOfFeaturedPipelines: int32(totalFeaturedSize),
 	}, nil
 }
 

--- a/pkg/service/main.go
+++ b/pkg/service/main.go
@@ -25,6 +25,7 @@ import (
 
 // Service interface
 type Service interface {
+	GetHubStats(ctx context.Context) (*pb.GetHubStatsResponse, error)
 	ListPipelines(ctx context.Context, pageSize int32, pageToken string, view pb.Pipeline_View, visibility *pb.Pipeline_Visibility, filter filtering.Filter, showDeleted bool, order ordering.OrderBy) ([]*pb.Pipeline, int32, string, error)
 	GetPipelineByUID(ctx context.Context, uid uuid.UUID, view pb.Pipeline_View) (*pb.Pipeline, error)
 	CreateNamespacePipeline(ctx context.Context, ns resource.Namespace, pipeline *pb.Pipeline) (*pb.Pipeline, error)

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -41,9 +41,8 @@ import (
 	pb "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
 
-
 func (s *service) GetHubStats(ctx context.Context) (*pb.GetHubStatsResponse, error) {
-	
+
 	uidAllowList, err := s.aclClient.ListPermissions(ctx, "pipeline", "reader", true)
 	if err != nil {
 		return &pb.GetHubStatsResponse{}, err
@@ -56,11 +55,10 @@ func (s *service) GetHubStats(ctx context.Context) (*pb.GetHubStatsResponse, err
 	}
 
 	return &pb.GetHubStatsResponse{
-		NumberOfPublicPipelines: int32(hubStats.NumberOfPublicPipelines),
-		NumberOfFeaturedPipelines: int32(hubStats.NumberOfFeaturedPipelines), // TODO: change to the featured count.
+		NumberOfPublicPipelines:   int32(hubStats.NumberOfPublicPipelines),
+		NumberOfFeaturedPipelines: int32(hubStats.NumberOfFeaturedPipelines),
 	}, nil
 }
-
 
 func (s *service) ListPipelines(ctx context.Context, pageSize int32, pageToken string, view pb.Pipeline_View, visibility *pb.Pipeline_Visibility, filter filtering.Filter, showDeleted bool, order ordering.OrderBy) ([]*pb.Pipeline, int32, string, error) {
 

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -41,6 +41,27 @@ import (
 	pb "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
 
+
+func (s *service) GetHubStats(ctx context.Context) (*pb.GetHubStatsResponse, error) {
+	
+	uidAllowList, err := s.aclClient.ListPermissions(ctx, "pipeline", "reader", true)
+	if err != nil {
+		return &pb.GetHubStatsResponse{}, err
+	}
+
+	hubStats, err := s.repository.GetHubStats(uidAllowList)
+
+	if err != nil {
+		return &pb.GetHubStatsResponse{}, err
+	}
+
+	return &pb.GetHubStatsResponse{
+		NumberOfPublicPipelines: int32(hubStats.NumberOfPublicPipelines),
+		NumberOfFeaturedPipelines: int32(hubStats.NumberOfFeaturedPipelines), // TODO: change to the featured count.
+	}, nil
+}
+
+
 func (s *service) ListPipelines(ctx context.Context, pageSize int32, pageToken string, view pb.Pipeline_View, visibility *pb.Pipeline_Visibility, filter filtering.Filter, showDeleted bool, order ordering.OrderBy) ([]*pb.Pipeline, int32, string, error) {
 
 	uidAllowList := []uuid.UUID{}


### PR DESCRIPTION
Because

- We'll provide a helper endpoint that returns metadata that Instill Hub needs.

This commit:

- Adds hub-stats endpoints.