### PR TITLE
chore: export component definition update logic

### DIFF
--- a/cmd/init/definitionupdater/updater.go
+++ b/cmd/init/definitionupdater/updater.go
@@ -1,0 +1,139 @@
+package definitionupdater
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/gofrs/uuid"
+	"github.com/launchdarkly/go-semver"
+
+	"github.com/instill-ai/pipeline-backend/pkg/datamodel"
+	"github.com/instill-ai/pipeline-backend/pkg/logger"
+	"github.com/instill-ai/pipeline-backend/pkg/repository"
+	"github.com/instill-ai/pipeline-backend/pkg/service"
+	pb "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
+
+	connector "github.com/instill-ai/component/pkg/connector"
+	operator "github.com/instill-ai/component/pkg/operator"
+)
+
+type definition interface {
+	GetUid() string
+	GetId() string
+	GetVersion() string
+	GetTombstone() bool
+	GetPublic() bool
+}
+
+// UpdateComponentDefinitionIndex updates the component definitions in the
+// database based on latest version of their definition.json file.
+func UpdateComponentDefinitionIndex(ctx context.Context, repo repository.Repository) error {
+	logger, _ := logger.GetZapLogger(ctx)
+
+	connDefs := connector.Init(logger, nil, nil).ListConnectorDefinitions(nil, true)
+	for _, connDef := range connDefs {
+		cd := &pb.ComponentDefinition{
+			Type: service.ConnectorTypeToComponentType[connDef.Type],
+			Definition: &pb.ComponentDefinition_ConnectorDefinition{
+				ConnectorDefinition: connDef,
+			},
+		}
+
+		if err := updateComponentDefinition(ctx, cd, repo); err != nil {
+			return err
+		}
+	}
+
+	opDefs := operator.Init(logger).ListOperatorDefinitions(nil, true)
+	for _, opDef := range opDefs {
+		cd := &pb.ComponentDefinition{
+			Type: pb.ComponentType_COMPONENT_TYPE_OPERATOR,
+			Definition: &pb.ComponentDefinition_OperatorDefinition{
+				OperatorDefinition: opDef,
+			},
+		}
+
+		if err := updateComponentDefinition(ctx, cd, repo); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func updateComponentDefinition(ctx context.Context, cd *pb.ComponentDefinition, repo repository.Repository) error {
+	var def definition
+	switch cd.Type {
+	case pb.ComponentType_COMPONENT_TYPE_OPERATOR:
+		def = cd.GetOperatorDefinition()
+
+	case pb.ComponentType_COMPONENT_TYPE_CONNECTOR_AI,
+		pb.ComponentType_COMPONENT_TYPE_CONNECTOR_DATA,
+		pb.ComponentType_COMPONENT_TYPE_CONNECTOR_APPLICATION:
+
+		def = cd.GetConnectorDefinition()
+	default:
+		return fmt.Errorf("unsupported component definition type")
+	}
+
+	uid, err := uuid.FromString(def.GetUid())
+	if err != nil {
+		return fmt.Errorf("invalid UID in component definition %s: %w", def.GetId(), err)
+	}
+
+	inDB, err := repo.GetComponentDefinitionByUID(ctx, uid)
+	if err != nil && !errors.Is(err, repository.ErrNotFound) {
+		return fmt.Errorf("error fetching component definition %s from DB: %w", def.GetId(), err)
+	}
+
+	shouldSkip, err := shouldSkipUpsert(def, inDB)
+	if err != nil {
+		return err
+	}
+	if shouldSkip {
+		return nil
+	}
+
+	if err := repo.UpsertComponentDefinition(ctx, cd); err != nil {
+		return fmt.Errorf("failed to upsert component definition %s: %w", def.GetId(), err)
+	}
+
+	return nil
+}
+
+// A component definition is only upserted when either of these conditions is
+// satisfied:
+//   - There's a version bump in the definition.
+//   - The tombstone tag has changed.
+//   - The feature score of the component (defined in the codebase as this isn't
+//     a public property of the definition) has changed.
+func shouldSkipUpsert(def definition, inDB *datamodel.ComponentDefinition) (bool, error) {
+	if inDB == nil {
+		return false, nil
+	}
+
+	if inDB.IsVisible != (def.GetPublic() && !def.GetTombstone()) {
+		return false, nil
+	}
+
+	if inDB.FeatureScore != datamodel.FeatureScores[def.GetId()] {
+		return false, nil
+	}
+
+	v, err := semver.Parse(def.GetVersion())
+	if err != nil {
+		return false, fmt.Errorf("failed to parse version from component definition %s: %w", def.GetId(), err)
+	}
+
+	vInDB, err := semver.Parse(inDB.Version)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse version from DB component definition %s: %w", def.GetId(), err)
+	}
+
+	isDBVersionOutdated := v.ComparePrecedence(vInDB) > 0
+	if isDBVersionOutdated {
+		return false, nil
+	}
+	return true, nil
+}

--- a/cmd/init/definitionupdater/updater_test.go
+++ b/cmd/init/definitionupdater/updater_test.go
@@ -1,4 +1,4 @@
-package main
+package definitionupdater
 
 import (
 	"testing"

--- a/cmd/init/main.go
+++ b/cmd/init/main.go
@@ -3,53 +3,15 @@ package main
 import (
 	"context"
 	"log"
-	"time"
 
-	_ "embed"
-
-	"github.com/gofrs/uuid"
 	"github.com/redis/go-redis/v9"
 	"go.opentelemetry.io/otel"
-	"gorm.io/datatypes"
-	"gorm.io/gorm"
 
 	"github.com/instill-ai/pipeline-backend/cmd/init/definitionupdater"
 	"github.com/instill-ai/pipeline-backend/config"
 	database "github.com/instill-ai/pipeline-backend/pkg/db"
 	"github.com/instill-ai/pipeline-backend/pkg/repository"
 )
-
-type PrebuiltConnector struct {
-	ID                     string      `json:"id"`
-	UID                    string      `json:"uid"`
-	Owner                  string      `json:"owner"`
-	ConnectorDefinitionUID string      `json:"connector_definition_uid"`
-	Configuration          interface{} `json:"configuration"`
-	Task                   string      `json:"task"`
-}
-
-// BaseDynamic contains common columns for all tables with dynamic UUID as primary key generated when creating
-type BaseDynamic struct {
-	UID        uuid.UUID      `gorm:"type:uuid;primary_key;<-:create"` // allow read and create
-	CreateTime time.Time      `gorm:"autoCreateTime:nano"`
-	UpdateTime time.Time      `gorm:"autoUpdateTime:nano"`
-	DeleteTime gorm.DeletedAt `sql:"index"`
-}
-
-// Connector is the data model of the connector table
-type Connector struct {
-	BaseDynamic
-	ID                     string
-	Owner                  string
-	ConnectorDefinitionUID uuid.UUID
-	Description            string
-	Tombstone              bool
-	Configuration          datatypes.JSON `gorm:"type:jsonb"`
-	ConnectorType          string         `sql:"type:string"`
-	State                  string         `sql:"type:string"`
-	Visibility             string         `sql:"type:string"`
-	Task                   string         `sql:"type:string"`
-}
 
 func main() {
 	if err := config.Init(config.ParseConfigFlag()); err != nil {

--- a/cmd/init/main.go
+++ b/cmd/init/main.go
@@ -2,30 +2,21 @@ package main
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"log"
 	"time"
 
 	_ "embed"
 
 	"github.com/gofrs/uuid"
-	"github.com/launchdarkly/go-semver"
 	"github.com/redis/go-redis/v9"
 	"go.opentelemetry.io/otel"
 	"gorm.io/datatypes"
 	"gorm.io/gorm"
 
+	"github.com/instill-ai/pipeline-backend/cmd/init/definitionupdater"
 	"github.com/instill-ai/pipeline-backend/config"
-	"github.com/instill-ai/pipeline-backend/pkg/datamodel"
-	"github.com/instill-ai/pipeline-backend/pkg/logger"
-	"github.com/instill-ai/pipeline-backend/pkg/repository"
-	"github.com/instill-ai/pipeline-backend/pkg/service"
-	pb "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
-
-	connector "github.com/instill-ai/component/pkg/connector"
-	operator "github.com/instill-ai/component/pkg/operator"
 	database "github.com/instill-ai/pipeline-backend/pkg/db"
+	"github.com/instill-ai/pipeline-backend/pkg/repository"
 )
 
 type PrebuiltConnector struct {
@@ -71,8 +62,6 @@ func main() {
 	defer span.End()
 	defer cancel()
 
-	logger, _ := logger.GetZapLogger(ctx)
-
 	db := database.GetConnection()
 	defer database.Close(db)
 
@@ -83,120 +72,7 @@ func main() {
 	_ = redisClient.Del(ctx, "instill_model_connector_def")
 
 	repo := repository.NewRepository(db, redisClient)
-
-	// Update component definitions and connectors based on latest version of
-	// definitions.json.
-	connDefs := connector.Init(logger, nil, nil).ListConnectorDefinitions(nil, true)
-	for _, connDef := range connDefs {
-
-		cd := &pb.ComponentDefinition{
-			Type: service.ConnectorTypeToComponentType[connDef.Type],
-			Definition: &pb.ComponentDefinition_ConnectorDefinition{
-				ConnectorDefinition: connDef,
-			},
-		}
-
-		if err := updateComponentDefinition(ctx, cd, repo); err != nil {
-			log.Fatal(err)
-		}
+	if err := definitionupdater.UpdateComponentDefinitionIndex(ctx, repo); err != nil {
+		log.Fatal(err)
 	}
-
-	opDefs := operator.Init(logger).ListOperatorDefinitions(nil, true)
-	for _, opDef := range opDefs {
-		cd := &pb.ComponentDefinition{
-			Type: pb.ComponentType_COMPONENT_TYPE_OPERATOR,
-			Definition: &pb.ComponentDefinition_OperatorDefinition{
-				OperatorDefinition: opDef,
-			},
-		}
-
-		if err := updateComponentDefinition(ctx, cd, repo); err != nil {
-			log.Fatal(err)
-		}
-	}
-
-}
-
-type definition interface {
-	GetUid() string
-	GetId() string
-	GetVersion() string
-	GetTombstone() bool
-	GetPublic() bool
-}
-
-func updateComponentDefinition(ctx context.Context, cd *pb.ComponentDefinition, repo repository.Repository) error {
-	var def definition
-	switch cd.Type {
-	case pb.ComponentType_COMPONENT_TYPE_OPERATOR:
-		def = cd.GetOperatorDefinition()
-
-	case pb.ComponentType_COMPONENT_TYPE_CONNECTOR_AI,
-		pb.ComponentType_COMPONENT_TYPE_CONNECTOR_DATA,
-		pb.ComponentType_COMPONENT_TYPE_CONNECTOR_APPLICATION:
-
-		def = cd.GetConnectorDefinition()
-	default:
-		return fmt.Errorf("unsupported component definition type")
-	}
-
-	uid, err := uuid.FromString(def.GetUid())
-	if err != nil {
-		return fmt.Errorf("invalid UID in component definition %s: %w", def.GetId(), err)
-	}
-
-	inDB, err := repo.GetComponentDefinitionByUID(ctx, uid)
-	if err != nil && !errors.Is(err, repository.ErrNotFound) {
-		return fmt.Errorf("error fetching component definition %s from DB: %w", def.GetId(), err)
-	}
-
-	shouldSkip, err := shouldSkipUpsert(def, inDB)
-	if err != nil {
-		return err
-	}
-	if shouldSkip {
-		return nil
-	}
-
-	if err := repo.UpsertComponentDefinition(ctx, cd); err != nil {
-		return fmt.Errorf("failed to upsert component definition %s: %w", def.GetId(), err)
-	}
-
-	return nil
-}
-
-// A component definition is only upserted when either of these conditions is
-// satisfied:
-//   - There's a version bump in the definition.
-//   - The tombstone tag has changed.
-//   - The feature score of the component (defined in the codebase as this isn't
-//     a public property of the definition) has changed.
-func shouldSkipUpsert(def definition, inDB *datamodel.ComponentDefinition) (bool, error) {
-	if inDB == nil {
-		return false, nil
-	}
-
-	if inDB.IsVisible != (def.GetPublic() && !def.GetTombstone()) {
-		return false, nil
-	}
-
-	if inDB.FeatureScore != datamodel.FeatureScores[def.GetId()] {
-		return false, nil
-	}
-
-	v, err := semver.Parse(def.GetVersion())
-	if err != nil {
-		return false, fmt.Errorf("failed to parse version from component definition %s: %w", def.GetId(), err)
-	}
-
-	vInDB, err := semver.Parse(inDB.Version)
-	if err != nil {
-		return false, fmt.Errorf("failed to parse version from DB component definition %s: %w", def.GetId(), err)
-	}
-
-	isDBVersionOutdated := v.ComparePrecedence(vInDB) > 0
-	if isDBVersionOutdated {
-		return false, nil
-	}
-	return true, nil
 }


### PR DESCRIPTION
Because

- Component definition update logic is duplicated in Cloud. This caused a bug when both versions became out of sync.

This commit

- Exports logic so changes are propagated to Cloud.
