### PR TITLE
refactor: remove UseStaticModelList workaround

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -70,10 +70,6 @@ type ServerConfig struct {
 
 // ConnectorConfig defines the connector configurations
 type ConnectorConfig struct {
-	Instill struct {
-		UseStaticModelList bool `koanf:"usestaticmodellist"`
-	} `koanf:"instill"`
-
 	Secrets connector.ConnectionSecrets
 }
 

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1
 	github.com/iancoleman/strcase v0.2.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/component v0.17.0-beta
+	github.com/instill-ai/component v0.17.0-beta.0.20240517032215-a53661c565b4
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240515152126-90f472ac6006
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha

--- a/go.sum
+++ b/go.sum
@@ -1193,8 +1193,8 @@ github.com/influxdata/influxdb-client-go/v2 v2.12.3 h1:28nRlNMRIV4QbtIUvxhWqaxn0
 github.com/influxdata/influxdb-client-go/v2 v2.12.3/go.mod h1:IrrLUbCjjfkmRuaCiGQg4m2GbkaeJDcuWoxiWdQEbA0=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/instill-ai/component v0.17.0-beta h1:kRWaFjX5HccTmbeopaPweSu1iQgos5ND3s/zXuvfNkY=
-github.com/instill-ai/component v0.17.0-beta/go.mod h1:kGV9Bm6hQ1SBH9nvqIV4UtJFJjF9gVsb01HNBsbgbU0=
+github.com/instill-ai/component v0.17.0-beta.0.20240517032215-a53661c565b4 h1:x4n9tRAqBsZ2OagHvHhrPj/VvvMS818st57ds8PPTFQ=
+github.com/instill-ai/component v0.17.0-beta.0.20240517032215-a53661c565b4/go.mod h1:A9zwKVDng8pkeNopdpkI3ne1lk0dV2mss5uASl/QzHU=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240515152126-90f472ac6006 h1:83zmuhpOUWGzM157YNIYcFSDw+rrrXGmy71B61fYTZ4=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240515152126-90f472ac6006/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=

--- a/pkg/recipe/variable.go
+++ b/pkg/recipe/variable.go
@@ -24,7 +24,6 @@ type SystemVariables struct {
 	HeaderAuthorization string                 `json:"__PIPELINE_HEADER_AUTHORIZATION"`
 	ModelBackend        string                 `json:"__MODEL_BACKEND"`
 	MgmtBackend         string                 `json:"__MGMT_BACKEND"`
-	StaticModelList     bool                   `json:"__STATIC_MODEL_LIST"`
 }
 
 // System variables are available to all component
@@ -42,7 +41,6 @@ func GenerateSystemVariables(ctx context.Context, sysVar SystemVariables) (map[s
 	if sysVar.MgmtBackend == "" {
 		sysVar.MgmtBackend = fmt.Sprintf("%s:%d", config.Config.MgmtBackend.Host, config.Config.MgmtBackend.PublicPort)
 	}
-	sysVar.StaticModelList = config.Config.Connector.Instill.UseStaticModelList
 
 	b, err := json.Marshal(sysVar)
 	if err != nil {

--- a/pkg/service/convert.go
+++ b/pkg/service/convert.go
@@ -31,7 +31,7 @@ import (
 
 type Converter interface {
 	ConvertPipelineToDB(ctx context.Context, ns resource.Namespace, pbPipeline *pb.Pipeline) (*datamodel.Pipeline, error)
-	ConvertPipelineToPB(ctx context.Context, dbPipeline *datamodel.Pipeline, view pb.Pipeline_View, checkPermission bool) (*pb.Pipeline, error)
+	ConvertPipelineToPB(ctx context.Context, dbPipeline *datamodel.Pipeline, view pb.Pipeline_View, checkPermission bool, useDynamicDef bool) (*pb.Pipeline, error)
 	ConvertPipelinesToPB(ctx context.Context, dbPipelines []*datamodel.Pipeline, view pb.Pipeline_View, checkPermission bool) ([]*pb.Pipeline, error)
 
 	ConvertPipelineReleaseToDB(ctx context.Context, pipelineUID uuid.UUID, pbPipelineRelease *pb.PipelineRelease) (*datamodel.PipelineRelease, error)
@@ -214,7 +214,7 @@ func (c *converter) convertResourcePermalinkToName(ctx context.Context, rsc any)
 	return nil
 }
 
-func (c *converter) includeOperatorComponentDetail(ctx context.Context, comp *pb.OperatorComponent) error {
+func (c *converter) includeOperatorComponentDetail(ctx context.Context, comp *pb.OperatorComponent, useDynamicDef bool) error {
 	uid, err := resource.GetRscPermalinkUID(comp.DefinitionName)
 	if err != nil {
 		return err
@@ -223,16 +223,24 @@ func (c *converter) includeOperatorComponentDetail(ctx context.Context, comp *pb
 	if err != nil {
 		return err
 	}
-	def, err := c.operator.GetOperatorDefinitionByUID(uid, vars, comp)
-	if err != nil {
-		return err
+	if useDynamicDef {
+		def, err := c.operator.GetOperatorDefinitionByUID(uid, vars, comp)
+		if err != nil {
+			return err
+		}
+		comp.Definition = def
+	} else {
+		def, err := c.operator.GetOperatorDefinitionByUID(uid, nil, nil)
+		if err != nil {
+			return err
+		}
+		comp.Definition = def
 	}
 
-	comp.Definition = def
 	return nil
 }
 
-func (c *converter) includeConnectorComponentDetail(ctx context.Context, comp *pb.ConnectorComponent) error {
+func (c *converter) includeConnectorComponentDetail(ctx context.Context, comp *pb.ConnectorComponent, useDynamicDef bool) error {
 	uid, err := resource.GetRscPermalinkUID(comp.DefinitionName)
 	if err != nil {
 		return err
@@ -241,24 +249,32 @@ func (c *converter) includeConnectorComponentDetail(ctx context.Context, comp *p
 	if err != nil {
 		return err
 	}
-	def, err := c.connector.GetConnectorDefinitionByUID(uid, vars, comp)
-	if err != nil {
-		return err
+	if useDynamicDef {
+		def, err := c.connector.GetConnectorDefinitionByUID(uid, vars, comp)
+		if err != nil {
+			return err
+		}
+		comp.Definition = def
+	} else {
+		def, err := c.connector.GetConnectorDefinitionByUID(uid, nil, nil)
+		if err != nil {
+			return err
+		}
+		comp.Definition = def
 	}
 
-	comp.Definition = def
 	return nil
 }
 
-func (c *converter) includeIteratorComponentDetail(ctx context.Context, comp *pb.IteratorComponent) error {
+func (c *converter) includeIteratorComponentDetail(ctx context.Context, comp *pb.IteratorComponent, useDynamicDef bool) error {
 
 	for nestIdx := range comp.Components {
 		var err error
 		switch comp.Components[nestIdx].Component.(type) {
 		case *pb.NestedComponent_ConnectorComponent:
-			err = c.includeConnectorComponentDetail(ctx, comp.Components[nestIdx].GetConnectorComponent())
+			err = c.includeConnectorComponentDetail(ctx, comp.Components[nestIdx].GetConnectorComponent(), useDynamicDef)
 		case *pb.NestedComponent_OperatorComponent:
-			err = c.includeOperatorComponentDetail(ctx, comp.Components[nestIdx].GetOperatorComponent())
+			err = c.includeOperatorComponentDetail(ctx, comp.Components[nestIdx].GetOperatorComponent(), useDynamicDef)
 		}
 		if err != nil {
 			return err
@@ -391,17 +407,17 @@ func (c *converter) includeIteratorComponentDetail(ctx context.Context, comp *pb
 	return nil
 }
 
-func (c *converter) includeDetailInRecipe(ctx context.Context, recipe *pb.Recipe) error {
+func (c *converter) includeDetailInRecipe(ctx context.Context, recipe *pb.Recipe, useDynamicDef bool) error {
 
 	for idx := range recipe.Components {
 		var err error
 		switch recipe.Components[idx].Component.(type) {
 		case *pb.Component_ConnectorComponent:
-			err = c.includeConnectorComponentDetail(ctx, recipe.Components[idx].GetConnectorComponent())
+			err = c.includeConnectorComponentDetail(ctx, recipe.Components[idx].GetConnectorComponent(), useDynamicDef)
 		case *pb.Component_OperatorComponent:
-			err = c.includeOperatorComponentDetail(ctx, recipe.Components[idx].GetOperatorComponent())
+			err = c.includeOperatorComponentDetail(ctx, recipe.Components[idx].GetOperatorComponent(), useDynamicDef)
 		case *pb.Component_IteratorComponent:
-			err = c.includeIteratorComponentDetail(ctx, recipe.Components[idx].GetIteratorComponent())
+			err = c.includeIteratorComponentDetail(ctx, recipe.Components[idx].GetIteratorComponent(), useDynamicDef)
 		}
 		if err != nil {
 			return err
@@ -502,7 +518,7 @@ var ConnectorTypeToComponentType = map[pb.ConnectorType]pb.ComponentType{
 }
 
 // ConvertPipelineToPB converts db data model to protobuf data model
-func (c *converter) ConvertPipelineToPB(ctx context.Context, dbPipeline *datamodel.Pipeline, view pb.Pipeline_View, checkPermission bool) (*pb.Pipeline, error) {
+func (c *converter) ConvertPipelineToPB(ctx context.Context, dbPipeline *datamodel.Pipeline, view pb.Pipeline_View, checkPermission bool, useDynamicDef bool) (*pb.Pipeline, error) {
 
 	logger, _ := logger.GetZapLogger(ctx)
 
@@ -530,7 +546,7 @@ func (c *converter) ConvertPipelineToPB(ctx context.Context, dbPipeline *datamod
 	}
 
 	if view == pb.Pipeline_VIEW_FULL {
-		if err := c.includeDetailInRecipe(ctx, pbRecipe); err != nil {
+		if err := c.includeDetailInRecipe(ctx, pbRecipe, useDynamicDef); err != nil {
 			return nil, err
 		}
 	}
@@ -694,6 +710,7 @@ func (c *converter) ConvertPipelinesToPB(ctx context.Context, dbPipelines []*dat
 				dbPipelines[i],
 				view,
 				checkPermission,
+				false, // to reduce loading, we don't use dynamic definition when convert the list
 			)
 			ch <- result{
 				idx:      i,
@@ -812,7 +829,7 @@ func (c *converter) ConvertPipelineReleaseToPB(ctx context.Context, dbPipeline *
 	var triggerByRequest *pb.TriggerByRequest
 
 	if view == pb.Pipeline_VIEW_FULL {
-		if err := c.includeDetailInRecipe(ctx, pbRecipe); err != nil {
+		if err := c.includeDetailInRecipe(ctx, pbRecipe, false); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -114,7 +114,7 @@ func (s *service) GetPipelineByUID(ctx context.Context, uid uuid.UUID, view pb.P
 		return nil, err
 	}
 
-	return s.converter.ConvertPipelineToPB(ctx, dbPipeline, view, true)
+	return s.converter.ConvertPipelineToPB(ctx, dbPipeline, view, true, true)
 }
 
 func (s *service) CreateNamespacePipeline(ctx context.Context, ns resource.Namespace, pbPipeline *pb.Pipeline) (*pb.Pipeline, error) {
@@ -172,7 +172,7 @@ func (s *service) CreateNamespacePipeline(ctx context.Context, ns resource.Names
 		return nil, err
 	}
 
-	pipeline, err := s.converter.ConvertPipelineToPB(ctx, dbCreatedPipeline, pb.Pipeline_VIEW_FULL, false)
+	pipeline, err := s.converter.ConvertPipelineToPB(ctx, dbCreatedPipeline, pb.Pipeline_VIEW_FULL, false, true)
 	if err != nil {
 		return nil, err
 	}
@@ -253,7 +253,7 @@ func (s *service) GetNamespacePipelineByID(ctx context.Context, ns resource.Name
 		return nil, ErrNotFound
 	}
 
-	return s.converter.ConvertPipelineToPB(ctx, dbPipeline, view, true)
+	return s.converter.ConvertPipelineToPB(ctx, dbPipeline, view, true, true)
 }
 
 func (s *service) GetNamespacePipelineLatestReleaseUID(ctx context.Context, ns resource.Namespace, id string) (uuid.UUID, error) {
@@ -280,7 +280,7 @@ func (s *service) GetPipelineByUIDAdmin(ctx context.Context, uid uuid.UUID, view
 		return nil, err
 	}
 
-	return s.converter.ConvertPipelineToPB(ctx, dbPipeline, view, true)
+	return s.converter.ConvertPipelineToPB(ctx, dbPipeline, view, true, true)
 
 }
 
@@ -342,7 +342,7 @@ func (s *service) UpdateNamespacePipelineByID(ctx context.Context, ns resource.N
 	if err != nil {
 		return nil, err
 	}
-	pipeline, err := s.converter.ConvertPipelineToPB(ctx, dbPipelineUpdated, pb.Pipeline_VIEW_FULL, false)
+	pipeline, err := s.converter.ConvertPipelineToPB(ctx, dbPipelineUpdated, pb.Pipeline_VIEW_FULL, false, true)
 	if err != nil {
 		return nil, err
 	}
@@ -449,7 +449,7 @@ func (s *service) ValidateNamespacePipelineByID(ctx context.Context, ns resource
 		return nil, err
 	}
 
-	return s.converter.ConvertPipelineToPB(ctx, dbPipeline, pb.Pipeline_VIEW_FULL, true)
+	return s.converter.ConvertPipelineToPB(ctx, dbPipeline, pb.Pipeline_VIEW_FULL, true, true)
 
 }
 
@@ -483,7 +483,7 @@ func (s *service) UpdateNamespacePipelineIDByID(ctx context.Context, ns resource
 		return nil, err
 	}
 
-	return s.converter.ConvertPipelineToPB(ctx, dbPipeline, pb.Pipeline_VIEW_FULL, true)
+	return s.converter.ConvertPipelineToPB(ctx, dbPipeline, pb.Pipeline_VIEW_FULL, true, true)
 }
 
 func (s *service) preTriggerPipeline(ctx context.Context, isAdmin bool, ns resource.Namespace, r *datamodel.Recipe, pipelineTriggerID string, pipelineInputs []*structpb.Struct, pipelineSecrets map[string]string) (*recipe.TriggerMemoryKey, error) {


### PR DESCRIPTION
Because:

- Originally, we had a config called `UseStaticModelList` to speed up the Instill Model connector. However, with the introduction of the Instill Model cloud allowing users to upload models, this config is no longer needed.
- In the Instill Model connector, the component definition is dynamically generated by sending a request to Instill Model to get the model list, which incurs extra communication time. To minimize the impact on our system, we introduce a new parameter called `useDynamicDef` to indicate whether we want to use the dynamic definition or not. We will turn it off in the ListPipelines endpoint since it does not require the dynamic definition.

This commit:

- Removes the `UseStaticModelList` config.
- Introduces the `useDynamicDef` function parameter.
