### PR TITLE
wip: feat: implement streaming of intermediate result of pipeline component

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/instill-ai/pipeline-backend
 
 go 1.21.3
 
-toolchain go1.22.0
+toolchain go1.22.3
 
 require (
 	cloud.google.com/go/longrunning v0.5.4
@@ -146,7 +146,7 @@ require (
 	github.com/gogo/googleapis v1.4.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
-	github.com/google/uuid v1.4.0 // indirect
+	github.com/google/uuid v1.4.0
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 // indirect

--- a/pkg/handler/utils.go
+++ b/pkg/handler/utils.go
@@ -2,6 +2,10 @@ package handler
 
 import (
 	"context"
+	"fmt"
+	"github.com/instill-ai/pipeline-backend/pkg/middleware"
+	"net/http"
+	"time"
 
 	"github.com/instill-ai/pipeline-backend/pkg/constant"
 	"github.com/instill-ai/pipeline-backend/pkg/resource"
@@ -24,4 +28,68 @@ func authenticateUser(ctx context.Context, allowVisitor bool) error {
 		}
 		return nil
 	}
+}
+
+func sseHandler(w http.ResponseWriter, r *http.Request) {
+	// Get the session UUID from the request URL
+	sessionUUID := r.URL.Path[len("/sse/"):]
+
+	// Get the data channel for the session UUID
+	dataChanValue, ok := middleware.DataChanMap.Load(sessionUUID)
+	if !ok {
+		http.Error(w, "Invalid session UUID", http.StatusBadRequest)
+		return
+	}
+	dataChan, ok := dataChanValue.(chan []byte)
+	if !ok {
+		http.Error(w, "Invalid data channel", http.StatusInternalServerError)
+		return
+	}
+
+	// Set the response headers for SSE
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+
+	var lastTimestamp int64 = 0
+	var eventIDCounter int64 = 0
+
+	// Send the data chunks as SSE events
+	for data := range dataChan {
+		timestamp := time.Now().UnixNano()
+		if timestamp == lastTimestamp {
+			eventIDCounter++
+		} else {
+			eventIDCounter = 0
+		}
+		lastTimestamp = timestamp
+
+		fmt.Fprintf(w, "event: output\n")
+		fmt.Fprintf(w, "id: %d:%d\n", timestamp, eventIDCounter)
+		fmt.Fprintf(w, "data: %s\n\n", data)
+
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+	}
+
+	// Send the "done" event
+	currentTimestamp := time.Now().UnixNano()
+	if currentTimestamp == lastTimestamp {
+		eventIDCounter++
+	} else {
+		eventIDCounter = 0
+	}
+
+	fmt.Fprintf(w, "event: done\n")
+	fmt.Fprintf(w, "id: %d:%d\n", currentTimestamp, eventIDCounter)
+	fmt.Fprintf(w, "data: {}\n\n")
+	if flusher, ok := w.(http.Flusher); ok {
+		flusher.Flush()
+	}
+
+	// Remove the data channel from the map when the SSE connection is closed
+	middleware.DataChanMap.Delete(sessionUUID)
 }

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"net/http"
+	"net/http/httptest"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 
@@ -15,5 +16,64 @@ func AppendCustomHeaderMiddleware(mux *runtime.ServeMux, client pb.PipelinePubli
 
 	return runtime.HandlerFunc(func(w http.ResponseWriter, r *http.Request, pathParams map[string]string) {
 		next(mux, client, w, r, pathParams)
+	})
+}
+
+// sseResponseStreamingMiddleware intercepts requests with X-Use-SSE header present
+// and gives back immediately a session token. It continues calling the grpc-gateway
+// endpoint and streams data to the SSE handler using the session ID token.
+func sseResponseStreamingMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Use-SSE") == "true" {
+
+			sessionUUID := generateSecureSessionID()
+			dataChan := make(chan []byte, 10) //TODO tillknuesting: Make the buffer configurable
+			DataChanMap.Store(sessionUUID, dataChan)
+
+			sessionData := SessionMetadata{
+				SessionUUID:      sessionUUID,
+				SourceInstanceID: "test-server-1", // TODO tillknuesting: get with from env
+			}
+
+			// Marshal session metadata into JSON
+			responseData, err := json.Marshal(sessionData)
+			if err != nil {
+				http.Error(w, "Failed to generate session", http.StatusInternalServerError)
+				return
+			}
+
+			// Get the underlying connection using http.Hijacker
+			hijacker, ok := w.(http.Hijacker)
+			if !ok {
+				http.Error(w, "Hijacking not supported", http.StatusInternalServerError)
+				return
+			}
+
+			conn, bufw, err := hijacker.Hijack()
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+
+			// Set the response headers
+			bufw.WriteString("HTTP/1.1 200 OK\r\n")
+			bufw.WriteString("Content-Type: application/json\r\n")
+			bufw.WriteString("Connection: close\r\n\r\n")
+
+			// Write the initial response
+			bufw.WriteString(string(responseData) + "\n\n")
+			bufw.Flush()
+			conn.Close()
+
+			sw := &captureResponseWriter{
+				ResponseWriter: httptest.NewRecorder(),
+				DataChan:       dataChan,
+			}
+
+			next.ServeHTTP(sw, r)
+			return
+		}
+
+		next.ServeHTTP(w, r)
 	})
 }

--- a/pkg/service/main.go
+++ b/pkg/service/main.go
@@ -58,6 +58,8 @@ type Service interface {
 	TriggerNamespacePipelineByID(ctx context.Context, ns resource.Namespace, id string, inputs []*structpb.Struct, secrets map[string]string, pipelineTriggerID string, returnTraces bool) ([]*structpb.Struct, *pb.TriggerMetadata, error)
 	TriggerAsyncNamespacePipelineByID(ctx context.Context, ns resource.Namespace, id string, inputs []*structpb.Struct, secrets map[string]string, pipelineTriggerID string, returnTraces bool) (*longrunningpb.Operation, error)
 
+	TriggerNamespacePipelineByIDWithStream(ctx context.Context, ns resource.Namespace, id string, inputs []*structpb.Struct, secrets map[string]string, pipelineTriggerID string, returnTraces bool, streamChan chan<- StreamResult) error
+
 	TriggerNamespacePipelineReleaseByID(ctx context.Context, ns resource.Namespace, pipelineUID uuid.UUID, id string, inputs []*structpb.Struct, secrets map[string]string, pipelineTriggerID string, returnTraces bool) ([]*structpb.Struct, *pb.TriggerMetadata, error)
 	TriggerAsyncNamespacePipelineReleaseByID(ctx context.Context, ns resource.Namespace, pipelineUID uuid.UUID, id string, inputs []*structpb.Struct, secrets map[string]string, pipelineTriggerID string, returnTraces bool) (*longrunningpb.Operation, error)
 	GetOperation(ctx context.Context, workflowID string) (*longrunningpb.Operation, error)
@@ -77,6 +79,11 @@ type Service interface {
 
 	// Influx API
 	WriteNewConnectorDataPoint(ctx context.Context, data utils.ConnectorUsageMetricData, pipelineMetadata *structpb.Value) error
+}
+
+type StreamResult struct {
+	Result   []*structpb.Struct
+	Metadata *pb.TriggerMetadata
 }
 
 type service struct {


### PR DESCRIPTION
Because:
    

- We want to get results back when a intermediate step is available not wait until all workflows have concluded

    
This commit:
    

- Implements gRPC endpoints, service related methods and the query logic to get updates of returned workflows

gRPC endpoints are defined in https://github.com/instill-ai/protobufs/pull/318 INS-4319