### PR TITLE
refactor: remove UseStaticModelList workaround

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -71,10 +71,6 @@ type ServerConfig struct {
 
 // ConnectorConfig defines the connector configurations
 type ConnectorConfig struct {
-	Instill struct {
-		UseStaticModelList bool `koanf:"usestaticmodellist"`
-	} `koanf:"instill"`
-
 	Secrets componentstore.ComponentSecrets
 }
 

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1
 	github.com/iancoleman/strcase v0.3.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/component v0.18.0-beta.0.20240531034601-ad35e10384ba
+	github.com/instill-ai/component v0.18.0-beta.0.20240531042836-7f2537baa825
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240530065422-d384f728a1e2
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha

--- a/go.sum
+++ b/go.sum
@@ -1183,8 +1183,8 @@ github.com/influxdata/influxdb-client-go/v2 v2.12.3 h1:28nRlNMRIV4QbtIUvxhWqaxn0
 github.com/influxdata/influxdb-client-go/v2 v2.12.3/go.mod h1:IrrLUbCjjfkmRuaCiGQg4m2GbkaeJDcuWoxiWdQEbA0=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/instill-ai/component v0.18.0-beta.0.20240531034601-ad35e10384ba h1:79UyhYUIys3cihbsAngwD3ZKO3OZAmgqu5Z+v2ooW3I=
-github.com/instill-ai/component v0.18.0-beta.0.20240531034601-ad35e10384ba/go.mod h1:e8h+R2Wyo7zQa991LFDznWBggVcOC+ISw6syMcNwy60=
+github.com/instill-ai/component v0.18.0-beta.0.20240531042836-7f2537baa825 h1:TGE7WRpeKYU7wIZ6zC0lK7QVry36vptC7kAFoWmVhDY=
+github.com/instill-ai/component v0.18.0-beta.0.20240531042836-7f2537baa825/go.mod h1:e8h+R2Wyo7zQa991LFDznWBggVcOC+ISw6syMcNwy60=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240530065422-d384f728a1e2 h1:YGvBMxWaHQK7xk+QAT68/9lc7x3LX5LYE+IDHipd6Fs=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240530065422-d384f728a1e2/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=

--- a/pkg/recipe/variable.go
+++ b/pkg/recipe/variable.go
@@ -24,7 +24,6 @@ type SystemVariables struct {
 	HeaderAuthorization string                 `json:"__PIPELINE_HEADER_AUTHORIZATION"`
 	ModelBackend        string                 `json:"__MODEL_BACKEND"`
 	MgmtBackend         string                 `json:"__MGMT_BACKEND"`
-	StaticModelList     bool                   `json:"__STATIC_MODEL_LIST"`
 }
 
 // System variables are available to all component
@@ -42,7 +41,6 @@ func GenerateSystemVariables(ctx context.Context, sysVar SystemVariables) (map[s
 	if sysVar.MgmtBackend == "" {
 		sysVar.MgmtBackend = fmt.Sprintf("%s:%d", config.Config.MgmtBackend.Host, config.Config.MgmtBackend.PublicPort)
 	}
-	sysVar.StaticModelList = config.Config.Connector.Instill.UseStaticModelList
 
 	b, err := json.Marshal(sysVar)
 	if err != nil {

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -114,7 +114,7 @@ func (s *service) GetPipelineByUID(ctx context.Context, uid uuid.UUID, view pb.P
 		return nil, err
 	}
 
-	return s.converter.ConvertPipelineToPB(ctx, dbPipeline, view, true)
+	return s.converter.ConvertPipelineToPB(ctx, dbPipeline, view, true, true)
 }
 
 func (s *service) CreateNamespacePipeline(ctx context.Context, ns resource.Namespace, pbPipeline *pb.Pipeline) (*pb.Pipeline, error) {
@@ -172,7 +172,7 @@ func (s *service) CreateNamespacePipeline(ctx context.Context, ns resource.Names
 		return nil, err
 	}
 
-	pipeline, err := s.converter.ConvertPipelineToPB(ctx, dbCreatedPipeline, pb.Pipeline_VIEW_FULL, false)
+	pipeline, err := s.converter.ConvertPipelineToPB(ctx, dbCreatedPipeline, pb.Pipeline_VIEW_FULL, false, true)
 	if err != nil {
 		return nil, err
 	}
@@ -253,7 +253,7 @@ func (s *service) GetNamespacePipelineByID(ctx context.Context, ns resource.Name
 		return nil, ErrNotFound
 	}
 
-	return s.converter.ConvertPipelineToPB(ctx, dbPipeline, view, true)
+	return s.converter.ConvertPipelineToPB(ctx, dbPipeline, view, true, true)
 }
 
 func (s *service) GetNamespacePipelineLatestReleaseUID(ctx context.Context, ns resource.Namespace, id string) (uuid.UUID, error) {
@@ -280,7 +280,7 @@ func (s *service) GetPipelineByUIDAdmin(ctx context.Context, uid uuid.UUID, view
 		return nil, err
 	}
 
-	return s.converter.ConvertPipelineToPB(ctx, dbPipeline, view, true)
+	return s.converter.ConvertPipelineToPB(ctx, dbPipeline, view, true, true)
 
 }
 
@@ -342,7 +342,7 @@ func (s *service) UpdateNamespacePipelineByID(ctx context.Context, ns resource.N
 	if err != nil {
 		return nil, err
 	}
-	pipeline, err := s.converter.ConvertPipelineToPB(ctx, dbPipelineUpdated, pb.Pipeline_VIEW_FULL, false)
+	pipeline, err := s.converter.ConvertPipelineToPB(ctx, dbPipelineUpdated, pb.Pipeline_VIEW_FULL, false, true)
 	if err != nil {
 		return nil, err
 	}
@@ -477,7 +477,7 @@ func (s *service) UpdateNamespacePipelineIDByID(ctx context.Context, ns resource
 		return nil, err
 	}
 
-	return s.converter.ConvertPipelineToPB(ctx, dbPipeline, pb.Pipeline_VIEW_FULL, true)
+	return s.converter.ConvertPipelineToPB(ctx, dbPipeline, pb.Pipeline_VIEW_FULL, true, true)
 }
 
 func (s *service) preTriggerPipeline(ctx context.Context, isAdmin bool, ns resource.Namespace, r *datamodel.Recipe, pipelineTriggerID string, pipelineData []*pb.TriggerData) (*recipe.BatchMemoryKey, error) {


### PR DESCRIPTION
Because:

- Originally, we had a config called `UseStaticModelList` to speed up the Instill Model connector. However, with the introduction of the Instill Model cloud allowing users to upload models, this config is no longer needed.
- In the Instill Model connector, the component definition is dynamically generated by sending a request to Instill Model to get the model list, which incurs extra communication time. To minimize the impact on our system, we introduce a new parameter called `useDynamicDef` to indicate whether we want to use the dynamic definition or not. We will turn it off in the ListPipelines endpoint since it does not require the dynamic definition.

This commit:

- Removes the `UseStaticModelList` config.
- Introduces the `useDynamicDef` function parameter.
