### PR TITLE
chore: return the owner in pipeline response when using VIEW_BASIC

### DIFF
--- a/pkg/handler/pipeline.go
+++ b/pkg/handler/pipeline.go
@@ -1042,10 +1042,14 @@ func (h *PublicHandler) createNamespacePipelineRelease(ctx context.Context, req 
 	if err != nil {
 		return nil, err
 	}
-	_, err = h.service.ValidateNamespacePipelineByID(ctx, ns, pipeline.Id)
-	if err != nil {
-		return nil, status.Error(codes.FailedPrecondition, fmt.Sprintf("[Pipeline Recipe Error] %+v", err.Error()))
-	}
+
+	// TODO: We temporarily removed the release validation due to a malfunction
+	// in the validation function. We'll add it back after we fix the validation
+	// function.
+	// _, err = h.service.ValidateNamespacePipelineByID(ctx, ns, pipeline.Id)
+	// if err != nil {
+	// 	return nil, status.Error(codes.FailedPrecondition, fmt.Sprintf("[Pipeline Recipe Error] %+v", err.Error()))
+	// }
 
 	pbPipelineRelease, err := h.service.CreateNamespacePipelineRelease(ctx, ns, uuid.FromStringOrNil(pipeline.Uid), req.GetRelease())
 	if err != nil {

--- a/pkg/service/convert.go
+++ b/pkg/service/convert.go
@@ -498,13 +498,12 @@ func (c *converter) ConvertPipelineToPB(ctx context.Context, dbPipelineOrigin *d
 	}
 
 	var owner *mgmtpb.Owner
-	if view > pb.Pipeline_VIEW_BASIC {
-		owner, err = c.fetchOwnerByPermalink(ctx, dbPipeline.Owner)
-		if err != nil {
-			return nil, err
-		}
-		pbPipeline.Owner = owner
+	owner, err = c.fetchOwnerByPermalink(ctx, dbPipeline.Owner)
+	if err != nil {
+		return nil, err
 	}
+	pbPipeline.Owner = owner
+
 	pbPipeline.Permission = &pb.Permission{}
 	if checkPermission {
 		if strings.Split(dbPipeline.Owner, "/")[1] == ctxUserUID {


### PR DESCRIPTION
Because

- The Console needs to show the owner profile. Currently, only using `VIEW_FULL` can return the profile, but it makes the payload size too big. So, we'd like to return the owner profile when using `VIEW_BASIC`.
- The recipe validation function doesn't work properly and prevents users from releasing a pipeline.

This commit

- Returns the owner in the pipeline response when using `VIEW_BASIC`.
- Removes recipe validation in pipeline release as a temporary solution.