### PR TITLE
feat: render secret value when using dynamic definition

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -253,7 +253,7 @@ func main() {
 		temporalClient,
 		influxDBWriteClient,
 		&aclClient,
-		service.NewConverter(mgmtPrivateServiceClient, redisClient, &aclClient),
+		service.NewConverter(mgmtPrivateServiceClient, redisClient, &aclClient, repository),
 	)
 
 	privateGrpcS := grpc.NewServer(grpcServerOpts...)

--- a/pkg/service/convert.go
+++ b/pkg/service/convert.go
@@ -161,6 +161,8 @@ func (c *converter) processSetup(ctx context.Context, ownerPermalink string, set
 				// reference target might not exist. We ignore the error here.
 				s, _ := c.repository.GetNamespaceSecretByID(ctx, ownerPermalink, secretKey)
 				rendered[k] = *s.Value
+			} else {
+				rendered[k] = v
 			}
 		default:
 			rendered[k] = v

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -631,7 +631,7 @@ func (s *service) preTriggerPipeline(ctx context.Context, isAdmin bool, ns resou
 	for {
 		var nsSecrets []*datamodel.Secret
 		// TODO: should use ctx user uid
-		nsSecrets, _, pt, err = s.repository.ListNamespaceSecrets(ctx, ns.Permalink(), 100, "", filtering.Filter{})
+		nsSecrets, _, pt, err = s.repository.ListNamespaceSecrets(ctx, ns.Permalink(), 100, pt, filtering.Filter{})
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/worker/workflow.go
+++ b/pkg/worker/workflow.go
@@ -276,7 +276,6 @@ func (w *worker) TriggerPipelineWorkflow(ctx workflow.Context, param *TriggerPip
 	dataPoint.ComputeTimeDuration = time.Since(startTime).Seconds()
 	dataPoint.Status = mgmtPB.Status_STATUS_COMPLETED
 
-	fmt.Println("param.IsIterator", param.IsIterator)
 	if !param.IsIterator {
 		// TODO: we should check whether to collect failed component or not
 		if err := workflow.ExecuteActivity(ctx, w.UsageCollectActivity, &UsageCollectActivityParam{


### PR DESCRIPTION
Because

- In the dynamic component definition, we might need to use the secret value to generate the dynamic definition. Therefore, we need to render the secret value for this.

This commit

- Renders the secret value when using dynamic definition.