### PR TITLE
feat: use camelCase for HTTP body

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -265,7 +265,6 @@ func main() {
 		runtime.WithIncomingHeaderMatcher(middleware.CustomMatcher),
 		runtime.WithMarshalerOption(runtime.MIMEWildcard, &runtime.JSONPb{
 			MarshalOptions: protojson.MarshalOptions{
-				UseProtoNames:   true,
 				EmitUnpopulated: true,
 				UseEnumNumbers:  false,
 			},
@@ -281,7 +280,6 @@ func main() {
 		runtime.WithIncomingHeaderMatcher(middleware.CustomMatcher),
 		runtime.WithMarshalerOption(runtime.MIMEWildcard, &runtime.JSONPb{
 			MarshalOptions: protojson.MarshalOptions{
-				UseProtoNames:   true,
 				EmitUnpopulated: true,
 				UseEnumNumbers:  false,
 			},

--- a/integration-test/pipeline/grpc-pipeline-public.js
+++ b/integration-test/pipeline/grpc-pipeline-public.js
@@ -48,11 +48,11 @@ export function CheckCreate(data) {
         (r) => helper.validateRecipeGRPC(r.message.pipeline.recipe, false),
       "vdp.pipeline.v1beta.PipelinePublicService/CreateUserPipeline response pipeline owner is valid":
         (r) => helper.isValidOwner(r.message.pipeline.owner, data.expectedOwner),
-      "vdp.pipeline.v1beta.PipelinePublicService/CreateUserPipeline response pipeline create_time":
+      "vdp.pipeline.v1beta.PipelinePublicService/CreateUserPipeline response pipeline createTime":
         (r) =>
           new Date(r.message.pipeline.createTime).getTime() >
           new Date().setTime(0),
-      "vdp.pipeline.v1beta.PipelinePublicService/CreateUserPipeline response pipeline update_time":
+      "vdp.pipeline.v1beta.PipelinePublicService/CreateUserPipeline response pipeline updateTime":
         (r) =>
           new Date(r.message.pipeline.updateTime).getTime() >
           new Date().setTime(0),
@@ -597,7 +597,7 @@ export function CheckUpdate(data) {
           (r) =>
             new Date(r.message.pipeline.updateTime).getTime() >
             new Date().setTime(0),
-        [`vdp.pipeline.v1beta.PipelinePublicService/UpdateUserPipeline response pipeline updateTime > create_time`]:
+        [`vdp.pipeline.v1beta.PipelinePublicService/UpdateUserPipeline response pipeline updateTime > createTime`]:
           (r) =>
             new Date(r.message.pipeline.updateTime).getTime() >
             new Date(r.message.pipeline.createTime).getTime(),

--- a/integration-test/pipeline/grpc.js
+++ b/integration-test/pipeline/grpc.js
@@ -48,7 +48,7 @@ export function setup() {
 
   var metadata = {
     "metadata": {
-      "Authorization": `Bearer ${loginResp.json().access_token}`
+      "Authorization": `Bearer ${loginResp.json().accessToken}`
     },
     "timeout": "600s",
   }

--- a/integration-test/pipeline/rest-component-definition.js
+++ b/integration-test/pipeline/rest-component-definition.js
@@ -9,12 +9,12 @@ export function CheckList() {
     var defaultPageSize = 10;
     check(http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions`, null, null), {
       "GET /v1beta/component-definitions response status is 200": (r) => r.status === 200,
-      "GET /v1beta/component-definitions response has component_definitions array": (r) => Array.isArray(r.json().component_definitions),
-      "GET /v1beta/component-definitions response total_size > 0": (r) => r.json().total_size > 0,
+      "GET /v1beta/component-definitions response has componentDefinitions array": (r) => Array.isArray(r.json().componentDefinitions),
+      "GET /v1beta/component-definitions response totalSize > 0": (r) => r.json().totalSize > 0,
       "GET /v1beta/component-definitions response page 0": (r) => r.json().page === 0,
-      [`GET /v1beta/component-definitions response default page size ${defaultPageSize}`]: (r) => r.json().component_definitions.length === defaultPageSize,
-      [`GET /v1beta/component-definitions response page size in response ${defaultPageSize}`]: (r) => r.json().page_size === defaultPageSize,
-      "GET /v1beta/component-definitions response features Instill Model on top": (r) => r.json().component_definitions[0].id === "instill-model",
+      [`GET /v1beta/component-definitions response default page size ${defaultPageSize}`]: (r) => r.json().componentDefinitions.length === defaultPageSize,
+      [`GET /v1beta/component-definitions response page size in response ${defaultPageSize}`]: (r) => r.json().pageSize === defaultPageSize,
+      "GET /v1beta/component-definitions response features Instill Model on top": (r) => r.json().componentDefinitions[0].id === "instill-model",
     });
 
     var limitedRecords = http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions`, null, null)
@@ -22,87 +22,87 @@ export function CheckList() {
     // Page size 0.
     check(http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?page_size=0`, null, null), {
       "GET /v1beta/component-definitions?page_size=0 response status is 200": (r) => r.status === 200,
-      "GET /v1beta/component-definitions?page_size=0 response default page size": (r) => r.json().component_definitions.length === limitedRecords.json().component_definitions.length,
+      "GET /v1beta/component-definitions?page_size=0 response default page size": (r) => r.json().componentDefinitions.length === limitedRecords.json().componentDefinitions.length,
     });
 
     // Negative page size.
     check(http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?page_size=-1`, null, null), {
       "GET /v1beta/component-definitions?page_size=-1 response status is 200": (r) => r.status === 200,
-      "GET /v1beta/component-definitions?page_size=-1 response default page size": (r) => r.json().component_definitions.length === limitedRecords.json().component_definitions.length,
+      "GET /v1beta/component-definitions?page_size=-1 response default page size": (r) => r.json().componentDefinitions.length === limitedRecords.json().componentDefinitions.length,
     });
 
     // Valid, non-default page size.
     check(http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?page_size=1`, null, null), {
       "GET /v1beta/component-definitions?page_size=1 response status is 200": (r) => r.status === 200,
-      "GET /v1beta/component-definitions?page_size=1 response component_definitions size 1": (r) => r.json().component_definitions.length === 1,
+      "GET /v1beta/component-definitions?page_size=1 response componentDefinitions size 1": (r) => r.json().componentDefinitions.length === 1,
     });
 
     // Page size over total records.
-    var bigPage = limitedRecords.json().total_size + 10
+    var bigPage = limitedRecords.json().totalSize + 10
     check(http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?page_size=${bigPage}`, null, null), {
       [`GET /v1beta/component-definitions?page_size=${bigPage} response status 200`]: (r) => r.status === 200,
-      [`GET /v1beta/component-definitions?page_size=${bigPage} response component_definitions size ${limitedRecords.json().total_size }`]: (r) => r.json().component_definitions.length === limitedRecords.json().total_size,
+      [`GET /v1beta/component-definitions?page_size=${bigPage} response componentDefinitions size ${limitedRecords.json().totalSize }`]: (r) => r.json().componentDefinitions.length === limitedRecords.json().totalSize,
     });
 
     // Access non-first page.
     check(http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?page_size=2&page=2`, null, null), {
       "GET /v1beta/component-definitions?page_size=2&page=2 response status is 200": (r) => r.status === 200,
-      "GET /v1beta/component-definitions?page_size=2&page=2 response component_definitions size 3": (r) => r.json().component_definitions.length === 2,
+      "GET /v1beta/component-definitions?page_size=2&page=2 response componentDefinitions size 3": (r) => r.json().componentDefinitions.length === 2,
       "GET /v1beta/component-definitions?page_size=2&page=2 response page 0": (r) => r.json().page === 2,
-      "GET /v1beta/component-definitions?page_size=2&page=2 receives a different page": (r) => r.json().component_definitions[0].id != limitedRecords.json().component_definitions[0].id,
+      "GET /v1beta/component-definitions?page_size=2&page=2 receives a different page": (r) => r.json().componentDefinitions[0].id != limitedRecords.json().componentDefinitions[0].id,
     });
 
     // Negative page index yields page 0.
     check(http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?page_size=2&page=-2`, null, null), {
       "GET /v1beta/component-definitions?page_size=2&page=-2 response status is 200": (r) => r.status === 200,
-      "GET /v1beta/component-definitions?page_size=2&page=-2 response component_definitions size 3": (r) => r.json().component_definitions.length === 2,
+      "GET /v1beta/component-definitions?page_size=2&page=-2 response componentDefinitions size 3": (r) => r.json().componentDefinitions.length === 2,
       "GET /v1beta/component-definitions?page_size=2&page=-2 response page 0": (r) => r.json().page === 0,
     });
 
     // Page index beyond last page.
-    var bigPage = limitedRecords.json().total_size + 10
+    var bigPage = limitedRecords.json().totalSize + 10
     check(http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?page_size=${bigPage}&page=2`, null, null), {
       [`GET /v1beta/component-definitions?page_size=${bigPage}&page=2 response status 200`]: (r) => r.status === 200,
-      [`GET /v1beta/component-definitions?page_size=${bigPage}&page=2 response component_definitions size 0`]: (r) => r.json().component_definitions.length === 0,
+      [`GET /v1beta/component-definitions?page_size=${bigPage}&page=2 response componentDefinitions size 0`]: (r) => r.json().componentDefinitions.length === 0,
     });
 
     // Default view is BASIC, i.e. no spec property.
     check(http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?page_size=1`, null, null), {
       "GET /v1beta/component-definitions?page_size=1 response status 200": (r) => r.status === 200,
-      "GET /v1beta/component-definitions?page_size=1 response component_definitions[0].spec is null": (r) => r.json().component_definitions[0].spec === null,
+      "GET /v1beta/component-definitions?page_size=1 response componentDefinitions[0].spec is null": (r) => r.json().componentDefinitions[0].spec === null,
     });
 
     check(http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?page_size=1&view=VIEW_BASIC`, null, null), {
       "GET /v1beta/component-definitions?page_size=1&view=VIEW_BASIC response status 200": (r) => r.status === 200,
-      "GET /v1beta/component-definitions?page_size=1&view=VIEW_BASIC response component_definitions[0].spec is null": (r) => r.json().component_definitions[0].spec === null,
+      "GET /v1beta/component-definitions?page_size=1&view=VIEW_BASIC response componentDefinitions[0].spec is null": (r) => r.json().componentDefinitions[0].spec === null,
     });
 
     // FULL view.
     check(http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?page_size=1&view=VIEW_FULL`, null, null), {
       "GET /v1beta/component-definitions?page_size=1&view=VIEW_FULL response status 200": (r) => r.status === 200,
-      "GET /v1beta/component-definitions?page_size=1&view=VIEW_FULL response component_definitions[0].spec is not null": (r) => r.json().component_definitions[0].spec !== null,
+      "GET /v1beta/component-definitions?page_size=1&view=VIEW_FULL response componentDefinitions[0].spec is not null": (r) => r.json().componentDefinitions[0].spec !== null,
     });
 
     // Filter (fuzzy) title
     check(http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?page_size=1&filter=q_title="JSO"`, null, null), {
       [`GET /v1beta/component-definitions?page_size=1&filter=q_title="JSO" response status 200`]: (r) => r.status === 200,
-      [`GET /v1beta/component-definitions?page_size=1&filter=q_title="JSO" single result`]: (r) => r.json().total_size === 1,
-      [`GET /v1beta/component-definitions?page_size=1&filter=q_title="JSO" title is JSON`]: (r) => r.json().component_definitions[0].title === "JSON",
+      [`GET /v1beta/component-definitions?page_size=1&filter=q_title="JSO" single result`]: (r) => r.json().totalSize === 1,
+      [`GET /v1beta/component-definitions?page_size=1&filter=q_title="JSO" title is JSON`]: (r) => r.json().componentDefinitions[0].title === "JSON",
     });
 
     // Filter component type
     check(http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?page_size=1&filter=component_type=COMPONENT_TYPE_OPERATOR`, null, null), {
       "GET /v1beta/component-definitions?page_size=1&filter=component_type=COMPONENT_TYPE_OPERATOR response status 200": (r) => r.status === 200,
-      "GET /v1beta/component-definitions?page_size=1&filter=component_type=COMPONENT_TYPE_OPERATOR total size is smaller": (r) => r.json().total_size < limitedRecords.json().total_size,
-      "GET /v1beta/component-definitions?page_size=1&filter=component_type=COMPONENT_TYPE_OPERATOR type is COMPONENT_TYPE_OPERATOR": (r) => r.json().component_definitions[0].type === "COMPONENT_TYPE_OPERATOR",
+      "GET /v1beta/component-definitions?page_size=1&filter=component_type=COMPONENT_TYPE_OPERATOR total size is smaller": (r) => r.json().totalSize < limitedRecords.json().totalSize,
+      "GET /v1beta/component-definitions?page_size=1&filter=component_type=COMPONENT_TYPE_OPERATOR type is COMPONENT_TYPE_OPERATOR": (r) => r.json().componentDefinitions[0].type === "COMPONENT_TYPE_OPERATOR",
     });
 
     // Filter release stage
     check(http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?page_size=1&filter=release_stage=RELEASE_STAGE_ALPHA`, null, null), {
       [`GET /v1beta/component-definitions?page_size=1&filter=release_stage=RELEASE_STAGE_ALPHA response status 200`]: (r) => r.status === 200,
       // TODO when there are non-alpha components, update expectations.
-      [`GET /v1beta/component-definitions?page_size=1&filter=release_stage=RELEASE_STAGE_ALPHA number of results`]: (r) => r.json().total_size === limitedRecords.json().total_size,
-      [`GET /v1beta/component-definitions?page_size=1&filter=release_stage=RELEASE_STAGE_ALPHA release_stage is alpha`]: (r) => r.json().component_definitions[0].release_stage === "RELEASE_STAGE_ALPHA",
+      [`GET /v1beta/component-definitions?page_size=1&filter=release_stage=RELEASE_STAGE_ALPHA number of results`]: (r) => r.json().totalSize === limitedRecords.json().totalSize,
+      [`GET /v1beta/component-definitions?page_size=1&filter=release_stage=RELEASE_STAGE_ALPHA release_stage is alpha`]: (r) => r.json().componentDefinitions[0].releaseStage === "RELEASE_STAGE_ALPHA",
     });
   });
 }

--- a/integration-test/pipeline/rest-connector-definition.js
+++ b/integration-test/pipeline/rest-connector-definition.js
@@ -8,45 +8,45 @@ export function CheckList() {
   group("Component API: List connector definitions", () => {
     check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions`, null, null), {
       "GET /v1beta/connector-definitions response status is 200": (r) => r.status === 200,
-      "GET /v1beta/connector-definitions response has connector_definitions array": (r) => Array.isArray(r.json().connector_definitions),
-      "GET /v1beta/connector-definitions response total_size > 0": (r) => r.json().total_size > 0
+      "GET /v1beta/connector-definitions response has connectorDefinitions array": (r) => Array.isArray(r.json().connectorDefinitions),
+      "GET /v1beta/connector-definitions response totalSize > 0": (r) => r.json().totalSize > 0
     });
 
     var limitedRecords = http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions`, null, null)
     check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions?page_size=0`, null, null), {
       "GET /v1beta/connector-definitions?page_size=0 response status is 200": (r) => r.status === 200,
-      "GET /v1beta/connector-definitions?page_size=0 response limited records for 10": (r) => r.json().connector_definitions.length === limitedRecords.json().connector_definitions.length,
+      "GET /v1beta/connector-definitions?page_size=0 response limited records for 10": (r) => r.json().connectorDefinitions.length === limitedRecords.json().connectorDefinitions.length,
     });
 
     check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions?page_size=1`, null, null), {
       "GET /v1beta/connector-definitions?page_size=1 response status is 200": (r) => r.status === 200,
-      "GET /v1beta/connector-definitions?page_size=1 response connector_definitions size 1": (r) => r.json().connector_definitions.length === 1,
+      "GET /v1beta/connector-definitions?page_size=1 response connectorDefinitions size 1": (r) => r.json().connectorDefinitions.length === 1,
     });
 
     var pageRes = http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions?page_size=1`, null, null)
-    check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions?page_size=1&page_token=${pageRes.json().next_page_token}`, null, null), {
-      [`GET /v1beta/connector-definitions?page_size=1&page_token=${pageRes.json().next_page_token} response status is 200`]: (r) => r.status === 200,
-      [`GET /v1beta/connector-definitions?page_size=1&page_token=${pageRes.json().next_page_token} response connector_definitions size 1`]: (r) => r.json().connector_definitions.length === 1,
+    check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions?page_size=1&page_token=${pageRes.json().nextPageToken}`, null, null), {
+      [`GET /v1beta/connector-definitions?page_size=1&page_token=${pageRes.json().nextPageToken} response status is 200`]: (r) => r.status === 200,
+      [`GET /v1beta/connector-definitions?page_size=1&page_token=${pageRes.json().nextPageToken} response connectorDefinitions size 1`]: (r) => r.json().connectorDefinitions.length === 1,
     });
 
     check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions?page_size=1&view=VIEW_BASIC`, null, null), {
       "GET /v1beta/connector-definitions?page_size=1&view=VIEW_BASIC response status 200": (r) => r.status === 200,
-      "GET /v1beta/connector-definitions?page_size=1&view=VIEW_BASIC response connector_definitions[0].spec is null": (r) => r.json().connector_definitions[0].spec === null,
+      "GET /v1beta/connector-definitions?page_size=1&view=VIEW_BASIC response connectorDefinitions[0].spec is null": (r) => r.json().connectorDefinitions[0].spec === null,
     });
 
     check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions?page_size=1&view=VIEW_FULL`, null, null), {
       "GET /v1beta/connector-definitions?page_size=1&view=VIEW_FULL response status 200": (r) => r.status === 200,
-      "GET /v1beta/connector-definitions?page_size=1&view=VIEW_FULL response connector_definitions[0].spec is not null": (r) => r.json().connector_definitions[0].spec !== null,
+      "GET /v1beta/connector-definitions?page_size=1&view=VIEW_FULL response connectorDefinitions[0].spec is not null": (r) => r.json().connectorDefinitions[0].spec !== null,
     });
 
     check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions?page_size=1`, null, null), {
       "GET /v1beta/connector-definitions?page_size=1 response status 200": (r) => r.status === 200,
-      "GET /v1beta/connector-definitions?page_size=1 response connector_definitions[0].spec is null": (r) => r.json().connector_definitions[0].spec === null,
+      "GET /v1beta/connector-definitions?page_size=1 response connectorDefinitions[0].spec is null": (r) => r.json().connectorDefinitions[0].spec === null,
     });
 
-    check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions?page_size=${limitedRecords.json().total_size}`, null, null), {
-      [`GET /v1beta/connector-definitions?page_size=${limitedRecords.json().total_size} response status 200`]: (r) => r.status === 200,
-      [`GET /v1beta/connector-definitions?page_size=${limitedRecords.json().total_size} response next_page_token is empty`]: (r) => r.json().next_page_token === "",
+    check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions?page_size=${limitedRecords.json().totalSize}`, null, null), {
+      [`GET /v1beta/connector-definitions?page_size=${limitedRecords.json().totalSize} response status 200`]: (r) => r.status === 200,
+      [`GET /v1beta/connector-definitions?page_size=${limitedRecords.json().totalSize} response nextPageToken is empty`]: (r) => r.json().nextPageToken === "",
     });
   });
 }
@@ -54,27 +54,27 @@ export function CheckList() {
 export function CheckGet() {
   group("Connector API: Get destination connector definition", () => {
     var allRes = http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions`, null, null)
-    var def = allRes.json().connector_definitions[0]
+    var def = allRes.json().connectorDefinitions[0]
     check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions/${def.id}`, null, null), {
       [`GET /v1beta/connector-definitions/${def.id} response status is 200`]: (r) => r.status === 200,
-      [`GET /v1beta/connector-definitions/${def.id} response has the exact record`]: (r) => deepEqual(r.json().connector_definition, def),
-      [`GET /v1beta/connector-definitions/${def.id} response has the non-empty resource name ${def.name}`]: (r) => r.json().connector_definition.name != "",
-      [`GET /v1beta/connector-definitions/${def.id} response has the resource name ${def.name}`]: (r) => r.json().connector_definition.name === def.name,
+      [`GET /v1beta/connector-definitions/${def.id} response has the exact record`]: (r) => deepEqual(r.json().connectorDefinition, def),
+      [`GET /v1beta/connector-definitions/${def.id} response has the non-empty resource name ${def.name}`]: (r) => r.json().connectorDefinition.name != "",
+      [`GET /v1beta/connector-definitions/${def.id} response has the resource name ${def.name}`]: (r) => r.json().connectorDefinition.name === def.name,
     });
 
     check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions/${def.id}?view=VIEW_BASIC`, null, null), {
       [`GET /v1beta/connector-definitions/${def.id}?view=VIEW_BASIC response status 200`]: (r) => r.status === 200,
-      [`GET /v1beta/connector-definitions/${def.id}?view=VIEW_BASIC response connector_definition.spec is null`]: (r) => r.json().connector_definition.spec === null,
+      [`GET /v1beta/connector-definitions/${def.id}?view=VIEW_BASIC response connectorDefinition.spec is null`]: (r) => r.json().connectorDefinition.spec === null,
     });
 
     check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions/${def.id}?view=VIEW_FULL`, null, null), {
       [`GET /v1beta/connector-definitions/${def.id}?view=VIEW_FULL response status 200`]: (r) => r.status === 200,
-      [`GET /v1beta/connector-definitions/${def.id}?view=VIEW_FULL response connector_definition.spec is not null`]: (r) => r.json().connector_definition.spec !== null,
+      [`GET /v1beta/connector-definitions/${def.id}?view=VIEW_FULL response connectorDefinition.spec is not null`]: (r) => r.json().connectorDefinition.spec !== null,
     });
 
     check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions/${def.id}`, null, null), {
       [`GET /v1beta/connector-definitions/${def.id} response status 200`]: (r) => r.status === 200,
-      [`GET /v1beta/connector-definitions/${def.id} response connector_definition.spec is null`]: (r) => r.json().connector_definition.spec === null,
+      [`GET /v1beta/connector-definitions/${def.id} response connectorDefinition.spec is null`]: (r) => r.json().connectorDefinition.spec === null,
     });
   });
 }

--- a/integration-test/pipeline/rest-operator-definition.js
+++ b/integration-test/pipeline/rest-operator-definition.js
@@ -8,45 +8,45 @@ export function CheckList() {
   group("Component API: List operator definitions", () => {
     check(http.request("GET", `${pipelinePublicHost}/v1beta/operator-definitions`, null, null), {
       "GET /v1beta/operator-definitions response status is 200": (r) => r.status === 200,
-      "GET /v1beta/operator-definitions response has operator_definitions array": (r) => Array.isArray(r.json().operator_definitions),
-      "GET /v1beta/operator-definitions response total_size > 0": (r) => r.json().total_size > 0
+      "GET /v1beta/operator-definitions response has operatorDefinitions array": (r) => Array.isArray(r.json().operatorDefinitions),
+      "GET /v1beta/operator-definitions response totalSize > 0": (r) => r.json().totalSize > 0
     });
 
     var limitedRecords = http.request("GET", `${pipelinePublicHost}/v1beta/operator-definitions`, null, null)
     check(http.request("GET", `${pipelinePublicHost}/v1beta/operator-definitions?page_size=0`, null, null), {
       "GET /v1beta/operator-definitions?page_size=0 response status is 200": (r) => r.status === 200,
-      "GET /v1beta/operator-definitions?page_size=0 response limited records for 10": (r) => r.json().operator_definitions.length === limitedRecords.json().operator_definitions.length,
+      "GET /v1beta/operator-definitions?page_size=0 response limited records for 10": (r) => r.json().operatorDefinitions.length === limitedRecords.json().operatorDefinitions.length,
     });
 
     check(http.request("GET", `${pipelinePublicHost}/v1beta/operator-definitions?page_size=1`, null, null), {
       "GET /v1beta/operator-definitions?page_size=1 response status is 200": (r) => r.status === 200,
-      "GET /v1beta/operator-definitions?page_size=1 response operator_definitions size 1": (r) => r.json().operator_definitions.length === 1,
+      "GET /v1beta/operator-definitions?page_size=1 response operatorDefinitions size 1": (r) => r.json().operatorDefinitions.length === 1,
     });
 
     var pageRes = http.request("GET", `${pipelinePublicHost}/v1beta/operator-definitions?page_size=1`, null, null)
-    check(http.request("GET", `${pipelinePublicHost}/v1beta/operator-definitions?page_size=1&page_token=${pageRes.json().next_page_token}`, null, null), {
-      [`GET /v1beta/operator-definitions?page_size=1&page_token=${pageRes.json().next_page_token} response status is 200`]: (r) => r.status === 200,
-      [`GET /v1beta/operator-definitions?page_size=1&page_token=${pageRes.json().next_page_token} response operator_definitions size 1`]: (r) => r.json().operator_definitions.length === 1,
+    check(http.request("GET", `${pipelinePublicHost}/v1beta/operator-definitions?page_size=1&page_token=${pageRes.json().nextPageToken}`, null, null), {
+      [`GET /v1beta/operator-definitions?page_size=1&page_token=${pageRes.json().nextPageToken} response status is 200`]: (r) => r.status === 200,
+      [`GET /v1beta/operator-definitions?page_size=1&page_token=${pageRes.json().nextPageToken} response operatorDefinitions size 1`]: (r) => r.json().operatorDefinitions.length === 1,
     });
 
     check(http.request("GET", `${pipelinePublicHost}/v1beta/operator-definitions?page_size=1&view=VIEW_BASIC`, null, null), {
       "GET /v1beta/operator-definitions?page_size=1&view=VIEW_BASIC response status 200": (r) => r.status === 200,
-      "GET /v1beta/operator-definitions?page_size=1&view=VIEW_BASIC response operator_definitions[0].spec is null": (r) => r.json().operator_definitions[0].spec === null,
+      "GET /v1beta/operator-definitions?page_size=1&view=VIEW_BASIC response operatorDefinitions[0].spec is null": (r) => r.json().operatorDefinitions[0].spec === null,
     });
 
     check(http.request("GET", `${pipelinePublicHost}/v1beta/operator-definitions?page_size=1&view=VIEW_FULL`, null, null), {
       "GET /v1beta/operator-definitions?page_size=1&view=VIEW_FULL response status 200": (r) => r.status === 200,
-      "GET /v1beta/operator-definitions?page_size=1&view=VIEW_FULL response operator_definitions[0].spec is not null": (r) => r.json().operator_definitions[0].spec !== null,
+      "GET /v1beta/operator-definitions?page_size=1&view=VIEW_FULL response operatorDefinitions[0].spec is not null": (r) => r.json().operatorDefinitions[0].spec !== null,
     });
 
     check(http.request("GET", `${pipelinePublicHost}/v1beta/operator-definitions?page_size=1`, null, null), {
       "GET /v1beta/operator-definitions?page_size=1 response status 200": (r) => r.status === 200,
-      "GET /v1beta/operator-definitions?page_size=1 response operator_definitions[0].spec is null": (r) => r.json().operator_definitions[0].spec === null,
+      "GET /v1beta/operator-definitions?page_size=1 response operatorDefinitions[0].spec is null": (r) => r.json().operatorDefinitions[0].spec === null,
     });
 
-    check(http.request("GET", `${pipelinePublicHost}/v1beta/operator-definitions?page_size=${limitedRecords.json().total_size}`, null, null), {
-      [`GET /v1beta/operator-definitions?page_size=${limitedRecords.json().total_size} response status 200`]: (r) => r.status === 200,
-      [`GET /v1beta/operator-definitions?page_size=${limitedRecords.json().total_size} response next_page_token is empty`]: (r) => r.json().next_page_token === "",
+    check(http.request("GET", `${pipelinePublicHost}/v1beta/operator-definitions?page_size=${limitedRecords.json().totalSize}`, null, null), {
+      [`GET /v1beta/operator-definitions?page_size=${limitedRecords.json().totalSize} response status 200`]: (r) => r.status === 200,
+      [`GET /v1beta/operator-definitions?page_size=${limitedRecords.json().totalSize} response nextPageToken is empty`]: (r) => r.json().nextPageToken === "",
     });
   });
 }
@@ -54,27 +54,27 @@ export function CheckList() {
 export function CheckGet() {
   group("Operator API: Get destination operator definition", () => {
     var allRes = http.request("GET", `${pipelinePublicHost}/v1beta/operator-definitions`, null, null)
-    var def = allRes.json().operator_definitions[0]
+    var def = allRes.json().operatorDefinitions[0]
     check(http.request("GET", `${pipelinePublicHost}/v1beta/operator-definitions/${def.id}`, null, null), {
       [`GET /v1beta/operator-definitions/${def.id} response status is 200`]: (r) => r.status === 200,
-      [`GET /v1beta/operator-definitions/${def.id} response has the exact record`]: (r) => deepEqual(r.json().operator_definition, def),
-      [`GET /v1beta/operator-definitions/${def.id} response has the non-empty resource name ${def.name}`]: (r) => r.json().operator_definition.name != "",
-      [`GET /v1beta/operator-definitions/${def.id} response has the resource name ${def.name}`]: (r) => r.json().operator_definition.name === def.name,
+      [`GET /v1beta/operator-definitions/${def.id} response has the exact record`]: (r) => deepEqual(r.json().operatorDefinition, def),
+      [`GET /v1beta/operator-definitions/${def.id} response has the non-empty resource name ${def.name}`]: (r) => r.json().operatorDefinition.name != "",
+      [`GET /v1beta/operator-definitions/${def.id} response has the resource name ${def.name}`]: (r) => r.json().operatorDefinition.name === def.name,
     });
 
     check(http.request("GET", `${pipelinePublicHost}/v1beta/operator-definitions/${def.id}?view=VIEW_BASIC`, null, null), {
       [`GET /v1beta/operator-definitions/${def.id}?view=VIEW_BASIC response status 200`]: (r) => r.status === 200,
-      [`GET /v1beta/operator-definitions/${def.id}?view=VIEW_BASIC response operator_definition.spec is null`]: (r) => r.json().operator_definition.spec === null,
+      [`GET /v1beta/operator-definitions/${def.id}?view=VIEW_BASIC response operatorDefinition.spec is null`]: (r) => r.json().operatorDefinition.spec === null,
     });
 
     check(http.request("GET", `${pipelinePublicHost}/v1beta/operator-definitions/${def.id}?view=VIEW_FULL`, null, null), {
       [`GET /v1beta/operator-definitions/${def.id}?view=VIEW_FULL response status 200`]: (r) => r.status === 200,
-      [`GET /v1beta/operator-definitions/${def.id}?view=VIEW_FULL response operator_definition.spec is not null`]: (r) => r.json().operator_definition.spec !== null,
+      [`GET /v1beta/operator-definitions/${def.id}?view=VIEW_FULL response operatorDefinition.spec is not null`]: (r) => r.json().operatorDefinition.spec !== null,
     });
 
     check(http.request("GET", `${pipelinePublicHost}/v1beta/operator-definitions/${def.id}`, null, null), {
       [`GET /v1beta/operator-definitions/${def.id} response status 200`]: (r) => r.status === 200,
-      [`GET /v1beta/operator-definitions/${def.id} response operator_definition.spec is null`]: (r) => r.json().operator_definition.spec === null,
+      [`GET /v1beta/operator-definitions/${def.id} response operatorDefinition.spec is null`]: (r) => r.json().operatorDefinition.spec === null,
     });
   });
 }

--- a/integration-test/pipeline/rest-pipeline-private.js
+++ b/integration-test/pipeline/rest-pipeline-private.js
@@ -17,11 +17,11 @@ export function CheckList(data) {
       {
         [`GET /v1beta/admin/pipelines response status is 200`]: (r) =>
           r.status === 200,
-        [`GET /v1beta/admin/pipelines response next_page_token is empty`]: (
+        [`GET /v1beta/admin/pipelines response nextPageToken is empty`]: (
           r
-        ) => r.json().next_page_token === "",
-        [`GET /v1beta/admin/pipelines response total_size is 0`]: (r) =>
-          r.json().total_size == 0,
+        ) => r.json().nextPageToken === "",
+        [`GET /v1beta/admin/pipelines response totalSize is 0`]: (r) =>
+          r.json().totalSize == 0,
       }
     );
 
@@ -68,8 +68,8 @@ export function CheckList(data) {
         [`GET /v1beta/admin/pipelines response pipelines[0].recipe is null`]: (
           r
         ) => r.json().pipelines[0].recipe === null,
-        [`GET /v1beta/admin/pipelines response total_size == 200`]: (r) =>
-          r.json().total_size == 200,
+        [`GET /v1beta/admin/pipelines response totalSize == 200`]: (r) =>
+          r.json().totalSize == 200,
       }
     );
 
@@ -133,17 +133,17 @@ export function CheckList(data) {
     );
     var resSecond100 = http.request(
       "GET",
-      `${pipelinePrivateHost}/v1beta/admin/pipelines?page_size=100&page_token=${resFirst100.json().next_page_token
+      `${pipelinePrivateHost}/v1beta/admin/pipelines?page_size=100&page_token=${resFirst100.json().nextPageToken
       }`
     );
     check(resSecond100, {
-      [`GET /v1beta/admin/pipelines?page_size=100&page_token=${resFirst100.json().next_page_token
+      [`GET /v1beta/admin/pipelines?page_size=100&page_token=${resFirst100.json().nextPageToken
         } response status 200`]: (r) => r.status == 200,
-      [`GET /v1beta/admin/pipelines?page_size=100&page_token=${resFirst100.json().next_page_token
+      [`GET /v1beta/admin/pipelines?page_size=100&page_token=${resFirst100.json().nextPageToken
         } response return 100 results`]: (r) => r.json().pipelines.length == 100,
-      [`GET /v1beta/admin/pipelines?page_size=100&page_token=${resFirst100.json().next_page_token
-        } response next_page_token is empty`]: (r) =>
-          r.json().next_page_token === "",
+      [`GET /v1beta/admin/pipelines?page_size=100&page_token=${resFirst100.json().nextPageToken
+        } response nextPageToken is empty`]: (r) =>
+          r.json().nextPageToken === "",
     });
 
     // Filtering

--- a/integration-test/pipeline/rest-pipeline-public.js
+++ b/integration-test/pipeline/rest-pipeline-public.js
@@ -39,11 +39,11 @@ export function CheckCreate(data) {
         helper.validateRecipe(r.json().pipeline.recipe, false),
       "POST /v1beta/${constant.namespace}/pipelines response pipeline owner isinvalid": (r) =>
         helper.isValidOwner(r.json().pipeline.owner, data.expectedOwner),
-      "POST /v1beta/${constant.namespace}/pipelines response pipeline create_time": (r) =>
-        new Date(r.json().pipeline.create_time).getTime() >
+      "POST /v1beta/${constant.namespace}/pipelines response pipeline createTime": (r) =>
+        new Date(r.json().pipeline.createTime).getTime() >
         new Date().setTime(0),
-      "POST /v1beta/${constant.namespace}/pipelines response pipeline update_time": (r) =>
-        new Date(r.json().pipeline.update_time).getTime() >
+      "POST /v1beta/${constant.namespace}/pipelines response pipeline updateTime": (r) =>
+        new Date(r.json().pipeline.updateTime).getTime() >
         new Date().setTime(0),
     });
 
@@ -208,10 +208,10 @@ export function CheckList(data) {
     check(http.request("GET", `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines`, null, data.header), {
       [`GET /v1beta/${constant.namespace}/pipelines response status is 200`]: (r) =>
         r.status === 200,
-      [`GET /v1beta/${constant.namespace}/pipelines response next_page_token is empty`]: (r) =>
-        r.json().next_page_token === "",
-      [`GET /v1beta/${constant.namespace}/pipelines response total_size is 0`]: (r) =>
-        r.json().total_size == 0,
+      [`GET /v1beta/${constant.namespace}/pipelines response nextPageToken is empty`]: (r) =>
+        r.json().nextPageToken === "",
+      [`GET /v1beta/${constant.namespace}/pipelines response totalSize is 0`]: (r) =>
+        r.json().totalSize == 0,
     });
 
     const numPipelines = 200;
@@ -256,8 +256,8 @@ export function CheckList(data) {
           r.json().pipelines.length == 10,
         [`GET /v1beta/${constant.namespace}/pipelines response pipelines[0].recipe is null`]: (r) =>
           r.json().pipelines[0].recipe === null,
-        [`GET /v1beta/${constant.namespace}/pipelines response total_size == 200`]: (r) =>
-          r.json().total_size == 200,
+        [`GET /v1beta/${constant.namespace}/pipelines response totalSize == 200`]: (r) =>
+          r.json().totalSize == 200,
       }
     );
 
@@ -324,18 +324,18 @@ export function CheckList(data) {
     );
     var resSecond100 = http.request(
       "GET",
-      `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines?page_size=100&page_token=${resFirst100.json().next_page_token
+      `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines?page_size=100&page_token=${resFirst100.json().nextPageToken
       }`,
       null, data.header
     );
     check(resSecond100, {
-      [`GET /v1beta/${constant.namespace}/pipelines?page_size=100&page_token=${resFirst100.json().next_page_token
+      [`GET /v1beta/${constant.namespace}/pipelines?page_size=100&page_token=${resFirst100.json().nextPageToken
         } response status 200`]: (r) => r.status == 200,
-      [`GET /v1beta/${constant.namespace}/pipelines?page_size=100&page_token=${resFirst100.json().next_page_token
+      [`GET /v1beta/${constant.namespace}/pipelines?page_size=100&page_token=${resFirst100.json().nextPageToken
         } response return 100 results`]: (r) => r.json().pipelines.length == 100,
-      [`GET /v1beta/${constant.namespace}/pipelines?page_size=100&page_token=${resFirst100.json().next_page_token
-        } response next_page_token is empty`]: (r) =>
-          r.json().next_page_token === "",
+      [`GET /v1beta/${constant.namespace}/pipelines?page_size=100&page_token=${resFirst100.json().nextPageToken
+        } response nextPageToken is empty`]: (r) =>
+          r.json().nextPageToken === "",
     });
 
     // Filtering
@@ -531,18 +531,18 @@ export function CheckUpdate(data) {
           (r) => r.json().pipeline.description === reqBodyUpdate.description,
         [`PATCH /v1beta/${constant.namespace}/pipelines/${reqBody.id} response pipeline owner isvalid`]:
           (r) => helper.isValidOwner(r.json().pipeline.owner, data.expectedOwner),
-        [`PATCH /v1beta/${constant.namespace}/pipelines/${reqBody.id} response pipeline create_time (OUTPUT_ONLY)`]:
+        [`PATCH /v1beta/${constant.namespace}/pipelines/${reqBody.id} response pipeline createTime (OUTPUT_ONLY)`]:
           (r) =>
-            new Date(r.json().pipeline.create_time).getTime() >
+            new Date(r.json().pipeline.createTime).getTime() >
             new Date().setTime(0),
-        [`PATCH /v1beta/${constant.namespace}/pipelines/${reqBody.id} response pipeline update_time (OUTPUT_ONLY)`]:
+        [`PATCH /v1beta/${constant.namespace}/pipelines/${reqBody.id} response pipeline updateTime (OUTPUT_ONLY)`]:
           (r) =>
-            new Date(r.json().pipeline.update_time).getTime() >
+            new Date(r.json().pipeline.updateTime).getTime() >
             new Date().setTime(0),
-        [`PATCH /v1beta/${constant.namespace}/pipelines/${reqBody.id} response pipeline update_time > create_time`]:
+        [`PATCH /v1beta/${constant.namespace}/pipelines/${reqBody.id} response pipeline updateTime > createTime`]:
           (r) =>
-            new Date(r.json().pipeline.update_time).getTime() >
-            new Date(r.json().pipeline.create_time).getTime(),
+            new Date(r.json().pipeline.updateTime).getTime() >
+            new Date(r.json().pipeline.createTime).getTime(),
       }
     );
 

--- a/integration-test/pipeline/rest.js
+++ b/integration-test/pipeline/rest.js
@@ -43,12 +43,12 @@ export function setup() {
 
   var header = {
     "headers": {
-      "Authorization": `Bearer ${loginResp.json().access_token}`
+      "Authorization": `Bearer ${loginResp.json().accessToken}`
     },
     "timeout": "600s",
   }
 
-  var resp = http.request("GET", `${constant.mgmtPublicHost}/v1beta/user`, {}, {headers: {"Authorization": `Bearer ${loginResp.json().access_token}`}})
+  var resp = http.request("GET", `${constant.mgmtPublicHost}/v1beta/user`, {}, {headers: {"Authorization": `Bearer ${loginResp.json().accessToken}`}})
   return {header: header, expectedOwner: resp.json().user}
 }
 

--- a/pkg/datamodel/datamodel.go
+++ b/pkg/datamodel/datamodel.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/gofrs/uuid"
+	"google.golang.org/protobuf/encoding/protojson"
 	"gopkg.in/yaml.v3"
 	"gorm.io/datatypes"
 	"gorm.io/gorm"
@@ -210,13 +211,36 @@ type Component struct {
 	Metadata  map[string]any `json:"metadata,omitempty"  yaml:"metadata,omitempty"`
 
 	// Fields for regular components
-	Setup      map[string]any          `json:"setup,omitempty" yaml:"setup,omitempty"`
-	Definition *pb.ComponentDefinition `json:"definition,omitempty" yaml:"-"`
+	Setup      map[string]any `json:"setup,omitempty" yaml:"setup,omitempty"`
+	Definition *Definition    `json:"definition,omitempty" yaml:"-"`
 
 	// Fields for iterators
 	Component         map[string]*Component `json:"component,omitempty" yaml:"component,omitempty"`
 	OutputElements    map[string]string     `json:"outputElements,omitempty" yaml:"output-elements,omitempty"`
 	DataSpecification *pb.DataSpecification `json:"dataSpecification,omitempty" yaml:"-"`
+}
+
+type Definition struct {
+	*pb.ComponentDefinition
+}
+type DataSpecification struct {
+	*pb.DataSpecification
+}
+
+func (c *Definition) MarshalJSON() ([]byte, error) {
+	defBytes, err := protojson.Marshal(c.ComponentDefinition)
+	if err != nil {
+		return nil, err
+	}
+	return defBytes, nil
+}
+
+func (c *DataSpecification) MarshalJSON() ([]byte, error) {
+	defBytes, err := protojson.Marshal(c.DataSpecification)
+	if err != nil {
+		return nil, err
+	}
+	return defBytes, nil
 }
 
 type Sharing struct {

--- a/pkg/service/convert.go
+++ b/pkg/service/convert.go
@@ -192,13 +192,13 @@ func (c *converter) includeComponentDetail(ctx context.Context, ownerPermalink s
 		if err != nil {
 			return err
 		}
-		comp.Definition = def
+		comp.Definition = &datamodel.Definition{ComponentDefinition: def}
 	} else {
 		def, err := c.component.GetDefinitionByUID(uuid.FromStringOrNil(comp.Type), nil, nil)
 		if err != nil {
 			return err
 		}
-		comp.Definition = def
+		comp.Definition = &datamodel.Definition{ComponentDefinition: def}
 	}
 
 	return nil


### PR DESCRIPTION
Because

- Currently, our API HTTP request and response bodies are a mix of camelCase and snake_case, which is not consistent.

This commit

- Uses camelCase for HTTP bodies.