### PR TITLE
feat: store recipe as YAML

### DIFF
--- a/cmd/migration/main.go
+++ b/cmd/migration/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/instill-ai/pipeline-backend/config"
 	"github.com/instill-ai/pipeline-backend/pkg/db/migration/convert/convert000013"
 	"github.com/instill-ai/pipeline-backend/pkg/db/migration/convert/convert000015"
+	"github.com/instill-ai/pipeline-backend/pkg/db/migration/convert/convert000016"
 	"github.com/instill-ai/pipeline-backend/pkg/db/migration/convert/legacy"
 )
 
@@ -154,6 +155,10 @@ func main() {
 			}
 		case 15:
 			if err := convert000015.Migrate(); err != nil {
+				panic(err)
+			}
+		case 16:
+			if err := convert000016.Migrate(); err != nil {
 				panic(err)
 			}
 		}

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -23,7 +23,7 @@ database:
   host: pg-sql
   port: 5432
   name: pipeline
-  version: 15
+  version: 16
   timezone: Etc/UTC
   pool:
     idleconnections: 5

--- a/go.mod
+++ b/go.mod
@@ -9,12 +9,11 @@ require (
 	github.com/gabriel-vasile/mimetype v1.4.3
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/golang-migrate/migrate/v4 v4.15.2
-	github.com/golang/mock v1.6.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1
 	github.com/iancoleman/strcase v0.3.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/component v0.19.0-beta
+	github.com/instill-ai/component v0.19.1-beta.0.20240614182950-f4afabd23ee9
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240531114421-d7be5dd350e5
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha
@@ -72,6 +71,7 @@ require (
 	github.com/gogo/status v1.1.1 // indirect
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+	github.com/golang/mock v1.6.0 // indirect
 	github.com/google/flatbuffers v23.5.26+incompatible // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/s2a-go v0.1.7 // indirect
@@ -82,6 +82,7 @@ require (
 	github.com/itchyny/gojq v0.12.14 // indirect
 	github.com/itchyny/timefmt-go v0.1.5 // indirect
 	github.com/jackc/puddle/v2 v2.2.1 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kennygrant/sanitize v1.2.4 // indirect
 	github.com/klauspost/compress v1.17.2 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.5 // indirect
@@ -92,6 +93,8 @@ require (
 	github.com/lestrrat-go/option v1.0.0 // indirect
 	github.com/lestrrat-go/pdebug v0.0.0-20210111095411-35b07dbf089b // indirect
 	github.com/lestrrat-go/structinfo v0.0.0-20210312050401-7f8bd69d6acb // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pierrec/lz4/v4 v4.1.18 // indirect
 	github.com/pkoukk/tiktoken-go v0.1.6 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
@@ -183,6 +186,6 @@ require (
 	golang.org/x/text v0.15.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
 	google.golang.org/genproto v0.0.0-20240221002015-b0ce06bbee7c // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/driver/mysql v1.4.7 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1183,8 +1183,8 @@ github.com/influxdata/influxdb-client-go/v2 v2.12.3 h1:28nRlNMRIV4QbtIUvxhWqaxn0
 github.com/influxdata/influxdb-client-go/v2 v2.12.3/go.mod h1:IrrLUbCjjfkmRuaCiGQg4m2GbkaeJDcuWoxiWdQEbA0=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/instill-ai/component v0.19.0-beta h1:EB2czj1SMX/Dr49FouNkRD8ykrgNIZPAwhHmGiCFxWw=
-github.com/instill-ai/component v0.19.0-beta/go.mod h1:e8h+R2Wyo7zQa991LFDznWBggVcOC+ISw6syMcNwy60=
+github.com/instill-ai/component v0.19.1-beta.0.20240614182950-f4afabd23ee9 h1:/MNygTwaPS4mUk+sXJ3q/NlIlPsVJSoO1S+bVzPsBQY=
+github.com/instill-ai/component v0.19.1-beta.0.20240614182950-f4afabd23ee9/go.mod h1:4w/nWenyxLrGVUmAZ1Y+yWFa+IjXEiFTyay63HkAXZ4=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240531114421-d7be5dd350e5 h1:lAOZK6B63kIC7dRFEeILzQp4dEb14ngYRnD03k8LkOw=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240531114421-d7be5dd350e5/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=
@@ -1284,6 +1284,7 @@ github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCV
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
+github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
@@ -1448,9 +1449,11 @@ github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6/go.mod h1:E2VnQOmVuvZB6U
 github.com/moby/term v0.5.0 h1:xt8Q1nalod/v7BqbG21f8mQPqH+xAaC9C3N3wfWbVP0=
 github.com/moby/term v0.5.0/go.mod h1:8FzsFHVUBGZdbDsJw/ot+X+d5HLUbvklYLJ9uGfcI3Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
+github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=

--- a/pkg/db/migration/000016_init.down.sql
+++ b/pkg/db/migration/000016_init.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE public.pipeline DROP COLUMN recipe_yaml;
+ALTER TABLE public.pipeline_release DROP COLUMN recipe_yaml;
+COMMIT;

--- a/pkg/db/migration/000016_init.up.sql
+++ b/pkg/db/migration/000016_init.up.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+ALTER TABLE public.pipeline ADD COLUMN recipe_yaml TEXT DEFAULT '';
+ALTER TABLE public.pipeline_release ADD COLUMN recipe_yaml TEXT DEFAULT '';
+ALTER TABLE public.pipeline ALTER COLUMN recipe DROP NOT NULL;
+ALTER TABLE public.pipeline_release ALTER COLUMN recipe DROP NOT NULL;
+
+COMMIT;

--- a/pkg/db/migration/convert/convert000016/main.go
+++ b/pkg/db/migration/convert/convert000016/main.go
@@ -1,0 +1,341 @@
+package convert000016
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/gofrs/uuid"
+	"gopkg.in/yaml.v3"
+
+	database "github.com/instill-ai/pipeline-backend/pkg/db"
+)
+
+const Iterator = "iterator"
+
+// Pipeline is the data model of the pipeline table
+type Pipeline struct {
+	UID    uuid.UUID `gorm:"type:uuid;primary_key;<-:create"` // allow read and create
+	ID     string
+	Owner  string
+	Recipe *Recipe `gorm:"type:jsonb"`
+	// RecipeYAML string  `gorm:"recipe_yaml"`
+}
+
+func (Pipeline) TableName() string {
+	return "pipeline"
+}
+
+// PipelineRelease is the data model of the pipeline release table
+type PipelineRelease struct {
+	UID         uuid.UUID `gorm:"type:uuid;primary_key;<-:create"` // allow read and create
+	ID          string
+	PipelineUID uuid.UUID
+	Recipe      *Recipe `gorm:"type:jsonb"`
+	// RecipeYAML  string  `gorm:"recipe_yaml"`
+}
+
+func (PipelineRelease) TableName() string {
+	return "pipeline_release"
+}
+
+// Recipe is the data model of the pipeline recipe
+type Recipe struct {
+	Version   string                `json:"version,omitempty" yaml:"version,omitempty"`
+	RunOn     *RunOn                `json:"runOn,omitempty" yaml:"run-on,omitempty"`
+	Component map[string]*Component `json:"component,omitempty" yaml:"component,omitempty"`
+	Variable  map[string]*Variable  `json:"variable,omitempty" yaml:"variable,omitempty"`
+	Secret    map[string]string     `json:"secret,omitempty" yaml:"secret,omitempty"`
+	Output    map[string]*Output    `json:"output,omitempty" yaml:"output,omitempty"`
+}
+
+// Scan function for custom GORM type Recipe
+func (r *Recipe) Scan(value interface{}) error {
+	bytes, ok := value.([]byte)
+	if !ok {
+		return errors.New(fmt.Sprint("Failed to unmarshal Recipe value:", value))
+	}
+
+	if err := json.Unmarshal(bytes, &r); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Value function for custom GORM type Recipe
+func (r *Recipe) Value() (driver.Value, error) {
+	valueString, err := json.Marshal(r)
+	return string(valueString), err
+}
+
+type Variable struct {
+	Title              string `json:"title,omitempty" yaml:"title,omitempty"`
+	Description        string `json:"description,omitempty" yaml:"description,omitempty"`
+	InstillFormat      string `json:"instillFormat,omitempty" yaml:"instill-format,omitempty"`
+	InstillUIOrder     int32  `json:"instillUiOrder,omitempty" yaml:"instill-ui-order,omitempty"`
+	InstillUIMultiline bool   `json:"instillUiMultiline,omitempty" yaml:"instill-ui-multiline,omitempty"`
+}
+
+type Output struct {
+	Title          string `json:"title,omitempty" yaml:"title,omitempty"`
+	Description    string `json:"description,omitempty" yaml:"description,omitempty"`
+	Value          string `json:"value,omitempty" yaml:"value,omitempty"`
+	InstillUIOrder int32  `json:"instillUiOrder,omitempty" yaml:"instill-ui-order,omitempty"`
+}
+
+type RunOn struct {
+}
+
+type Component struct {
+	// Shared fields
+	Type      string         `json:"type,omitempty" yaml:"type,omitempty"`
+	Task      string         `json:"task,omitempty" yaml:"task,omitempty"`
+	Input     any            `json:"input,omitempty" yaml:"input,omitempty"`
+	Condition string         `json:"condition,omitempty" yaml:"condition,omitempty"`
+	Metadata  map[string]any `json:"metadata,omitempty"  yaml:"metadata,omitempty"`
+
+	// Fields for regular components
+	Setup map[string]any `json:"setup,omitempty" yaml:"setup,omitempty"`
+
+	// Fields for iterators
+	Component      map[string]*Component `json:"component,omitempty" yaml:"component,omitempty"`
+	OutputElements map[string]string     `json:"outputElements,omitempty" yaml:"output-elements,omitempty"`
+}
+
+func updateReferenceToKebabCase(in string, compIDmap map[string]string) string {
+	// Note: Update the string inside the ${} block
+	// 1. Update the component ID based on the component ID mapping
+	// 2. Update all the reference fields to kebab-case
+
+	val := ""
+	for {
+		startIdx := strings.Index(in, "${")
+		if startIdx == -1 {
+			val += in
+			break
+		}
+		val += in[:startIdx+2]
+		in = in[startIdx:]
+		endIdx := strings.Index(in, "}")
+		if endIdx == -1 {
+			val += in
+			break
+		}
+
+		ref := strings.TrimSpace(in[2:endIdx])
+
+		// We don't update the naming in variables and secrets to maintain
+		// compatibility with the API request.
+		if strings.HasPrefix(ref, "variable") || strings.HasPrefix(ref, "secret") {
+			val += ref
+		} else {
+			compID := strings.Split(ref, ".")[0]
+			if newCompID, ok := compIDmap[compID]; ok {
+				compID = newCompID
+			}
+			val += compID + "." + updateStringToKebabCase(strings.Join(strings.Split(ref, ".")[1:], "."))
+		}
+
+		in = in[endIdx:]
+	}
+	return val
+}
+
+func updateStringToKebabCase(in string) string {
+	return strings.ReplaceAll(in, "_", "-")
+}
+
+func updateToKebabCase(in any, compIDmap map[string]string) any {
+	switch in := in.(type) {
+	case string:
+		return updateReferenceToKebabCase(in, compIDmap)
+
+	case map[string]any:
+		out := map[string]any{}
+		for k, v := range in {
+			newK := updateStringToKebabCase(k)
+			switch v := v.(type) {
+			case map[string]any:
+				out[newK] = updateToKebabCase(v, compIDmap)
+			case string:
+				out[newK] = updateToKebabCase(v, compIDmap)
+			default:
+				out[newK] = v
+			}
+		}
+		return out
+	}
+	return in
+}
+func convertToYAML(recipe *Recipe) (string, error) {
+	compIDmap := map[string]string{}
+	newComponentMap := map[string]*Component{}
+	for id := range recipe.Component {
+		newID := strings.ReplaceAll(id, "_", "-")
+		if _, exist := compIDmap[newID]; exist {
+			// If ID duplicated after migrate, we add a postfix
+			newID = newID + "0"
+		}
+		compIDmap[id] = newID
+		newComponentMap[newID] = recipe.Component[id]
+
+		if recipe.Component[id].Type == Iterator {
+
+			newIterComponentMap := map[string]*Component{}
+			for nestedID := range recipe.Component[id].Component {
+				newID := strings.ReplaceAll(nestedID, "_", "-")
+				if _, exist := compIDmap[newID]; exist {
+					// If ID duplicated after migrate, we'll add a postfix
+					newID = newID + "0"
+				}
+				compIDmap[id] = newID
+				newIterComponentMap[newID] = recipe.Component[id].Component[nestedID]
+			}
+			recipe.Component[id].Component = newIterComponentMap
+			newComponentMap[newID] = recipe.Component[id]
+		}
+
+	}
+	recipe.Component = newComponentMap
+
+	for id := range recipe.Component {
+
+		switch recipe.Component[id].Type {
+		default:
+			recipe.Component[id].Input = updateToKebabCase(recipe.Component[id].Input, compIDmap)
+			recipe.Component[id].Condition = updateReferenceToKebabCase(recipe.Component[id].Condition, compIDmap)
+			if recipe.Component[id].Setup != nil {
+				recipe.Component[id].Setup = updateToKebabCase(recipe.Component[id].Setup, compIDmap).(map[string]any)
+			}
+
+		case Iterator:
+			if recipe.Component[id].Input != nil {
+				recipe.Component[id].Input = updateReferenceToKebabCase(recipe.Component[id].Input.(string), compIDmap)
+			}
+
+			for k := range recipe.Component[id].OutputElements {
+				recipe.Component[id].OutputElements[updateStringToKebabCase(k)] = updateReferenceToKebabCase(recipe.Component[id].OutputElements[k], compIDmap)
+			}
+			for nestedID := range recipe.Component[id].Component {
+				if recipe.Component[id].Component[nestedID].Type != Iterator {
+					recipe.Component[id].Component[nestedID].Input = updateToKebabCase(recipe.Component[id].Component[nestedID].Input, compIDmap)
+					recipe.Component[id].Component[nestedID].Condition = updateReferenceToKebabCase(recipe.Component[id].Component[nestedID].Condition, compIDmap)
+				}
+			}
+			recipe.Component[id].Condition = updateReferenceToKebabCase(recipe.Component[id].Condition, compIDmap)
+		}
+	}
+	for k := range recipe.Output {
+		recipe.Output[k].Value = updateReferenceToKebabCase(recipe.Output[k].Value, compIDmap)
+	}
+
+	yamlStr, err := yaml.Marshal(recipe)
+	if err != nil {
+		return "", err
+	}
+	return string(yamlStr), nil
+}
+func migratePipeline() error {
+	db := database.GetConnection()
+	defer database.Close(db)
+
+	var pipelines []Pipeline
+	result := db.Model(&Pipeline{})
+	if result.Error != nil {
+		return result.Error
+	}
+
+	rows, err := result.Rows()
+	if err != nil {
+		return err
+	}
+
+	defer rows.Close()
+
+	for rows.Next() {
+		var pipeline Pipeline
+		if err = db.ScanRows(rows, &pipeline); err != nil {
+			return err
+		}
+		pipelines = append(pipelines, pipeline)
+	}
+	for _, p := range pipelines {
+
+		recipe := p.Recipe
+		if recipe == nil {
+			continue
+		}
+		fmt.Println(p.ID, p.Owner)
+		yamlStr, err := convertToYAML(p.Recipe)
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(string(yamlStr))
+		// result := db.Model(&Pipeline{}).Where("uid = ?", p.UID).Update("recipe_yaml", string(yamlStr))
+		// if result.Error != nil {
+		// 	return result.Error
+		// }
+	}
+	return nil
+}
+
+func migratePipelineRelease() error {
+	db := database.GetConnection()
+	defer database.Close(db)
+
+	var releases []PipelineRelease
+	result := db.Model(&PipelineRelease{})
+	if result.Error != nil {
+		return result.Error
+	}
+
+	rows, err := result.Rows()
+	if err != nil {
+		return err
+	}
+
+	defer rows.Close()
+
+	for rows.Next() {
+		var release PipelineRelease
+		if err = db.ScanRows(rows, &release); err != nil {
+			return err
+		}
+		releases = append(releases, release)
+	}
+	for _, r := range releases {
+
+		recipe := r.Recipe
+		if recipe == nil {
+			continue
+		}
+		yamlStr, err := convertToYAML(r.Recipe)
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(yamlStr))
+		// result := db.Model(&PipelineRelease{}).Where("uid = ?", r.UID).Update("recipe_yaml", string(yamlStr))
+		// if result.Error != nil {
+		// 	return result.Error
+		// }
+	}
+	return nil
+
+}
+
+func Migrate() error {
+
+	var err error
+
+	if err = migratePipeline(); err != nil {
+		return err
+	}
+	if err = migratePipelineRelease(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/db/migration/convert/convert000016/main.go
+++ b/pkg/db/migration/convert/convert000016/main.go
@@ -21,7 +21,6 @@ type Pipeline struct {
 	ID     string
 	Owner  string
 	Recipe *Recipe `gorm:"type:jsonb"`
-	// RecipeYAML string  `gorm:"recipe_yaml"`
 }
 
 func (Pipeline) TableName() string {
@@ -34,7 +33,6 @@ type PipelineRelease struct {
 	ID          string
 	PipelineUID uuid.UUID
 	Recipe      *Recipe `gorm:"type:jsonb"`
-	// RecipeYAML  string  `gorm:"recipe_yaml"`
 }
 
 func (PipelineRelease) TableName() string {
@@ -268,17 +266,15 @@ func migratePipeline() error {
 		if recipe == nil {
 			continue
 		}
-		fmt.Println(p.ID, p.Owner)
+
 		yamlStr, err := convertToYAML(p.Recipe)
 		if err != nil {
 			return err
 		}
-
-		fmt.Println(string(yamlStr))
-		// result := db.Model(&Pipeline{}).Where("uid = ?", p.UID).Update("recipe_yaml", string(yamlStr))
-		// if result.Error != nil {
-		// 	return result.Error
-		// }
+		result := db.Model(&Pipeline{}).Where("uid = ?", p.UID).Update("recipe_yaml", string(yamlStr))
+		if result.Error != nil {
+			return result.Error
+		}
 	}
 	return nil
 }
@@ -317,11 +313,10 @@ func migratePipelineRelease() error {
 		if err != nil {
 			return err
 		}
-		fmt.Println(string(yamlStr))
-		// result := db.Model(&PipelineRelease{}).Where("uid = ?", r.UID).Update("recipe_yaml", string(yamlStr))
-		// if result.Error != nil {
-		// 	return result.Error
-		// }
+		result := db.Model(&PipelineRelease{}).Where("uid = ?", r.UID).Update("recipe_yaml", string(yamlStr))
+		if result.Error != nil {
+			return result.Error
+		}
 	}
 	return nil
 

--- a/pkg/recipe/dag.go
+++ b/pkg/recipe/dag.go
@@ -61,14 +61,14 @@ func (uf *unionFind) Count() int {
 }
 
 type dag struct {
-	compMap          map[string]datamodel.IComponent
+	compMap          map[string]*datamodel.Component
 	compsIdx         map[string]int
 	prerequisitesMap map[string][]string
 	uf               *unionFind
 	ancestorsMap     map[string][]string
 }
 
-func NewDAG(compMap map[string]datamodel.IComponent) *dag {
+func NewDAG(compMap map[string]*datamodel.Component) *dag {
 
 	uf := NewUnionFind(len(compMap))
 
@@ -102,10 +102,10 @@ type topologicalSortNode struct {
 // TopologicalSort returns the topological sorted components
 // the result is a list of list of components
 // each list is a group of components that can be executed in parallel
-func (d *dag) TopologicalSort() ([]map[string]datamodel.IComponent, error) {
+func (d *dag) TopologicalSort() ([]map[string]*datamodel.Component, error) {
 
 	if len(d.compMap) == 0 {
-		return []map[string]datamodel.IComponent{}, nil
+		return []map[string]*datamodel.Component{}, nil
 	}
 
 	indegreesMap := map[string]int{}
@@ -125,7 +125,7 @@ func (d *dag) TopologicalSort() ([]map[string]datamodel.IComponent, error) {
 		}
 	}
 
-	ans := []map[string]datamodel.IComponent{}
+	ans := []map[string]*datamodel.Component{}
 
 	count := 0
 	taken := make(map[string]bool)
@@ -133,7 +133,7 @@ func (d *dag) TopologicalSort() ([]map[string]datamodel.IComponent, error) {
 		from := q[0]
 		q = q[1:]
 		if len(ans) <= from.group {
-			ans = append(ans, map[string]datamodel.IComponent{})
+			ans = append(ans, map[string]*datamodel.Component{})
 		}
 		ans[from.group][from.compID] = d.compMap[from.compID]
 		count += 1
@@ -570,15 +570,15 @@ func SanitizeCondition(cond string) (string, map[string]string, map[string]strin
 	return cond, varMapping, revVarMapping
 }
 
-func GenerateDAG(componentMap map[string]datamodel.IComponent) (*dag, error) {
+func GenerateDAG(componentMap map[string]*datamodel.Component) (*dag, error) {
 
 	componentIDMap := make(map[string]bool)
 
 	for id := range componentMap {
 		componentIDMap[id] = true
-		switch comp := componentMap[id].(type) {
-		case *datamodel.IteratorComponent:
-			for nestedID := range comp.Component {
+		switch componentMap[id].Type {
+		case datamodel.Iterator:
+			for nestedID := range componentMap[id].Component {
 				componentIDMap[nestedID] = true
 			}
 		}
@@ -590,24 +590,24 @@ func GenerateDAG(componentMap map[string]datamodel.IComponent) (*dag, error) {
 
 		parents := []string{}
 
-		if component.GetCondition() != nil && *component.GetCondition() != "" {
-			parents = append(parents, FindReferenceParent(*component.GetCondition())...)
+		if component.Condition != "" {
+			parents = append(parents, FindReferenceParent(component.Condition)...)
 		}
 
-		switch comp := component.(type) {
-		case *componentbase.ComponentConfig:
-			template, _ := json.Marshal(comp.Input)
+		switch component.Type {
+		default:
+			template, _ := json.Marshal(component.Input)
 			parents = append(parents, FindReferenceParent(string(template))...)
-		case *datamodel.IteratorComponent:
-			parents = append(parents, FindReferenceParent(comp.Input)...)
+		case datamodel.Iterator:
+			parents = append(parents, FindReferenceParent(component.Input.(string))...)
 			nestedComponentIDs := []string{id}
-			for nestedID := range comp.Component {
+			for nestedID := range component.Component {
 				nestedComponentIDs = append(nestedComponentIDs, nestedID)
 			}
-			for _, nestedComponent := range comp.Component {
+			for _, nestedComponent := range component.Component {
 
-				if nestedComponent.GetCondition() != nil && *nestedComponent.GetCondition() != "" {
-					nestedParent := FindReferenceParent(*nestedComponent.GetCondition())
+				if nestedComponent.Condition != "" {
+					nestedParent := FindReferenceParent(nestedComponent.Condition)
 					for idx := range nestedParent {
 						if !slices.Contains(nestedComponentIDs, nestedParent[idx]) {
 							parents = append(parents, nestedParent[idx])
@@ -615,9 +615,10 @@ func GenerateDAG(componentMap map[string]datamodel.IComponent) (*dag, error) {
 					}
 				}
 
-				switch nestedComp := nestedComponent.(type) {
-				case *componentbase.ComponentConfig:
-					template, _ := json.Marshal(nestedComp.Input)
+				switch nestedComponent.Type {
+				case "default":
+				default:
+					template, _ := json.Marshal(nestedComponent.Input)
 					nestedParent := FindReferenceParent(string(template))
 					for idx := range nestedParent {
 						if !slices.Contains(nestedComponentIDs, nestedParent[idx]) {
@@ -658,7 +659,7 @@ func FindReferenceParent(input string) []string {
 	return upstreams
 }
 
-func GenerateTraces(comps map[string]datamodel.IComponent, memory []*Memory) (map[string]*pb.Trace, error) {
+func GenerateTraces(comps map[string]*datamodel.Component, memory []*Memory) (map[string]*pb.Trace, error) {
 	trace := map[string]*pb.Trace{}
 
 	batchSize := len(memory)

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -145,7 +145,7 @@ func (s *service) CreateNamespacePipeline(ctx context.Context, ns resource.Names
 	if err != nil {
 		return nil, err
 	}
-	if err := s.checkSecret(ctx, dbPipeline.Recipe); err != nil {
+	if err := s.checkSecret(ctx, dbPipeline.Recipe.Component); err != nil {
 		return nil, err
 	}
 
@@ -293,7 +293,7 @@ func (s *service) UpdateNamespacePipelineByID(ctx context.Context, ns resource.N
 	if err != nil {
 		return nil, err
 	}
-	if err := s.checkSecret(ctx, dbPipeline.Recipe); err != nil {
+	if err := s.checkSecret(ctx, dbPipeline.Recipe.Component); err != nil {
 		return nil, err
 	}
 

--- a/pkg/service/validator.go
+++ b/pkg/service/validator.go
@@ -12,7 +12,6 @@ import (
 	"github.com/instill-ai/pipeline-backend/pkg/datamodel"
 	"github.com/instill-ai/pipeline-backend/pkg/recipe"
 
-	componentbase "github.com/instill-ai/component/base"
 	pb "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
 
@@ -45,8 +44,8 @@ func (s *service) checkRecipe(recipePermalink *datamodel.Recipe) ([]*pb.Pipeline
 	compProperties := map[string]any{}
 
 	for id, comp := range recipePermalink.Component {
-		switch comp := comp.(type) {
-		case *componentbase.ComponentConfig:
+		switch comp.Type {
+		default:
 
 			def, err := s.component.GetDefinitionByUID(uuid.FromStringOrNil(comp.Type), nil, nil)
 			if err != nil {
@@ -54,13 +53,11 @@ func (s *service) checkRecipe(recipePermalink *datamodel.Recipe) ([]*pb.Pipeline
 			}
 			checkTask(id, comp.Task, def.Spec.ComponentSpecification, compProperties, &validationErrors)
 
-		case *datamodel.IteratorComponent:
+		case datamodel.Iterator:
 			nestedCompProperties := map[string]any{}
 			nestedValidationErrors := []*pb.PipelineValidationError{}
 			for nestedID, nestedComp := range comp.Component {
-				switch nestedComp := nestedComp.(type) {
-
-				case *componentbase.ComponentConfig:
+				if nestedComp.Type != datamodel.Iterator {
 					def, err := s.component.GetDefinitionByUID(uuid.FromStringOrNil(nestedComp.Type), nil, nil)
 					if err != nil {
 						return nil, err
@@ -88,7 +85,6 @@ func (s *service) checkRecipe(recipePermalink *datamodel.Recipe) ([]*pb.Pipeline
 
 		}
 
-		// compProperties[id] = p
 	}
 
 	schema["properties"].(map[string]any)["component"].(map[string]any)["properties"] = compProperties


### PR DESCRIPTION
Because
- To introduce "recipe as code", we will adopt YAML as the recipe format. YAML offers advanced features that JSON does not, such as the ability to include comments. We will gradually transition VDP to use YAML recipes.

This commit

- Recipes are now stored as YAML in the database. However, since the frontend has not yet adopted this format, we will continue to convert the recipes to JSON for the HTTP/gRPC API for now. We utilize GORM hooks to perform the JSON to YAML conversion.
- The datamodel has been simplified to facilitate easier marshaling/unmarshaling between struct, JSON and YAML.