### PR TITLE
feat(endpoints): use camelCase for `filter` and `orderBy` query strings

### DIFF
--- a/integration-test/pipeline/grpc-pipeline-private.js
+++ b/integration-test/pipeline/grpc-pipeline-private.js
@@ -182,14 +182,14 @@ export function CheckList(data) {
         "vdp.pipeline.v1beta.PipelinePrivateService/ListPipelinesAdmin",
         {
           filter:
-            'create_time>timestamp("2000-06-19T23:31:08.657Z")',
+            'createTime>timestamp("2000-06-19T23:31:08.657Z")',
         },
         {}
       ),
       {
-        [`vdp.pipeline.v1beta.PipelinePrivateService/ListPipelinesAdmin filter: create_time>timestamp("2000-06-19T23:31:08.657Z") response StatusOK`]:
+        [`vdp.pipeline.v1beta.PipelinePrivateService/ListPipelinesAdmin filter: createTime>timestamp("2000-06-19T23:31:08.657Z") response StatusOK`]:
           (r) => r.status === grpc.StatusOK,
-        [`vdp.pipeline.v1beta.PipelinePrivateService/ListPipelinesAdmin filter: create_time>timestamp("2000-06-19T23:31:08.657Z") response pipelines.length`]:
+        [`vdp.pipeline.v1beta.PipelinePrivateService/ListPipelinesAdmin filter: createTime>timestamp("2000-06-19T23:31:08.657Z") response pipelines.length`]:
           (r) => r.message.pipelines.length > 0,
       }
     );

--- a/integration-test/pipeline/grpc-pipeline-public.js
+++ b/integration-test/pipeline/grpc-pipeline-public.js
@@ -389,14 +389,14 @@ export function CheckList(data) {
         {
           parent: `${constant.namespace}`,
           filter:
-            'create_time>timestamp("2000-06-19T23:31:08.657Z")',
+            'createTime>timestamp("2000-06-19T23:31:08.657Z")',
         },
         data.metadata
       ),
       {
-        [`vdp.pipeline.v1beta.PipelinePublicService/ListUserPipelines filter: state=create_time>timestamp("2000-06-19T23:31:08.657Z") response StatusOK`]:
+        [`vdp.pipeline.v1beta.PipelinePublicService/ListUserPipelines filter: state=createTime>timestamp("2000-06-19T23:31:08.657Z") response StatusOK`]:
           (r) => r.status === grpc.StatusOK,
-        [`vdp.pipeline.v1beta.PipelinePublicService/ListUserPipelines filter: state=create_time>timestamp("2000-06-19T23:31:08.657Z") response pipelines.length`]:
+        [`vdp.pipeline.v1beta.PipelinePublicService/ListUserPipelines filter: state=createTime>timestamp("2000-06-19T23:31:08.657Z") response pipelines.length`]:
           (r) => r.message.pipelines.length > 0,
       }
     );

--- a/integration-test/pipeline/rest-component-definition.js
+++ b/integration-test/pipeline/rest-component-definition.js
@@ -20,89 +20,89 @@ export function CheckList() {
     var limitedRecords = http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions`, null, null)
 
     // Page size 0.
-    check(http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?page_size=0`, null, null), {
-      "GET /v1beta/component-definitions?page_size=0 response status is 200": (r) => r.status === 200,
-      "GET /v1beta/component-definitions?page_size=0 response default page size": (r) => r.json().componentDefinitions.length === limitedRecords.json().componentDefinitions.length,
+    check(http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?pageSize=0`, null, null), {
+      "GET /v1beta/component-definitions?pageSize=0 response status is 200": (r) => r.status === 200,
+      "GET /v1beta/component-definitions?pageSize=0 response default page size": (r) => r.json().componentDefinitions.length === limitedRecords.json().componentDefinitions.length,
     });
 
     // Negative page size.
-    check(http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?page_size=-1`, null, null), {
-      "GET /v1beta/component-definitions?page_size=-1 response status is 200": (r) => r.status === 200,
-      "GET /v1beta/component-definitions?page_size=-1 response default page size": (r) => r.json().componentDefinitions.length === limitedRecords.json().componentDefinitions.length,
+    check(http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?pageSize=-1`, null, null), {
+      "GET /v1beta/component-definitions?pageSize=-1 response status is 200": (r) => r.status === 200,
+      "GET /v1beta/component-definitions?pageSize=-1 response default page size": (r) => r.json().componentDefinitions.length === limitedRecords.json().componentDefinitions.length,
     });
 
     // Valid, non-default page size.
-    check(http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?page_size=1`, null, null), {
-      "GET /v1beta/component-definitions?page_size=1 response status is 200": (r) => r.status === 200,
-      "GET /v1beta/component-definitions?page_size=1 response componentDefinitions size 1": (r) => r.json().componentDefinitions.length === 1,
+    check(http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?pageSize=1`, null, null), {
+      "GET /v1beta/component-definitions?pageSize=1 response status is 200": (r) => r.status === 200,
+      "GET /v1beta/component-definitions?pageSize=1 response componentDefinitions size 1": (r) => r.json().componentDefinitions.length === 1,
     });
 
     // Page size over total records.
     var bigPage = limitedRecords.json().totalSize + 10
-    check(http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?page_size=${bigPage}`, null, null), {
-      [`GET /v1beta/component-definitions?page_size=${bigPage} response status 200`]: (r) => r.status === 200,
-      [`GET /v1beta/component-definitions?page_size=${bigPage} response componentDefinitions size ${limitedRecords.json().totalSize }`]: (r) => r.json().componentDefinitions.length === limitedRecords.json().totalSize,
+    check(http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?pageSize=${bigPage}`, null, null), {
+      [`GET /v1beta/component-definitions?pageSize=${bigPage} response status 200`]: (r) => r.status === 200,
+      [`GET /v1beta/component-definitions?pageSize=${bigPage} response componentDefinitions size ${limitedRecords.json().totalSize }`]: (r) => r.json().componentDefinitions.length === limitedRecords.json().totalSize,
     });
 
     // Access non-first page.
-    check(http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?page_size=2&page=2`, null, null), {
-      "GET /v1beta/component-definitions?page_size=2&page=2 response status is 200": (r) => r.status === 200,
-      "GET /v1beta/component-definitions?page_size=2&page=2 response componentDefinitions size 3": (r) => r.json().componentDefinitions.length === 2,
-      "GET /v1beta/component-definitions?page_size=2&page=2 response page 0": (r) => r.json().page === 2,
-      "GET /v1beta/component-definitions?page_size=2&page=2 receives a different page": (r) => r.json().componentDefinitions[0].id != limitedRecords.json().componentDefinitions[0].id,
+    check(http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?pageSize=2&page=2`, null, null), {
+      "GET /v1beta/component-definitions?pageSize=2&page=2 response status is 200": (r) => r.status === 200,
+      "GET /v1beta/component-definitions?pageSize=2&page=2 response componentDefinitions size 3": (r) => r.json().componentDefinitions.length === 2,
+      "GET /v1beta/component-definitions?pageSize=2&page=2 response page 0": (r) => r.json().page === 2,
+      "GET /v1beta/component-definitions?pageSize=2&page=2 receives a different page": (r) => r.json().componentDefinitions[0].id != limitedRecords.json().componentDefinitions[0].id,
     });
 
     // Negative page index yields page 0.
-    check(http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?page_size=2&page=-2`, null, null), {
-      "GET /v1beta/component-definitions?page_size=2&page=-2 response status is 200": (r) => r.status === 200,
-      "GET /v1beta/component-definitions?page_size=2&page=-2 response componentDefinitions size 3": (r) => r.json().componentDefinitions.length === 2,
-      "GET /v1beta/component-definitions?page_size=2&page=-2 response page 0": (r) => r.json().page === 0,
+    check(http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?pageSize=2&page=-2`, null, null), {
+      "GET /v1beta/component-definitions?pageSize=2&page=-2 response status is 200": (r) => r.status === 200,
+      "GET /v1beta/component-definitions?pageSize=2&page=-2 response componentDefinitions size 3": (r) => r.json().componentDefinitions.length === 2,
+      "GET /v1beta/component-definitions?pageSize=2&page=-2 response page 0": (r) => r.json().page === 0,
     });
 
     // Page index beyond last page.
     var bigPage = limitedRecords.json().totalSize + 10
-    check(http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?page_size=${bigPage}&page=2`, null, null), {
-      [`GET /v1beta/component-definitions?page_size=${bigPage}&page=2 response status 200`]: (r) => r.status === 200,
-      [`GET /v1beta/component-definitions?page_size=${bigPage}&page=2 response componentDefinitions size 0`]: (r) => r.json().componentDefinitions.length === 0,
+    check(http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?pageSize=${bigPage}&page=2`, null, null), {
+      [`GET /v1beta/component-definitions?pageSize=${bigPage}&page=2 response status 200`]: (r) => r.status === 200,
+      [`GET /v1beta/component-definitions?pageSize=${bigPage}&page=2 response componentDefinitions size 0`]: (r) => r.json().componentDefinitions.length === 0,
     });
 
     // Default view is BASIC, i.e. no spec property.
-    check(http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?page_size=1`, null, null), {
-      "GET /v1beta/component-definitions?page_size=1 response status 200": (r) => r.status === 200,
-      "GET /v1beta/component-definitions?page_size=1 response componentDefinitions[0].spec is null": (r) => r.json().componentDefinitions[0].spec === null,
+    check(http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?pageSize=1`, null, null), {
+      "GET /v1beta/component-definitions?pageSize=1 response status 200": (r) => r.status === 200,
+      "GET /v1beta/component-definitions?pageSize=1 response componentDefinitions[0].spec is null": (r) => r.json().componentDefinitions[0].spec === null,
     });
 
-    check(http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?page_size=1&view=VIEW_BASIC`, null, null), {
-      "GET /v1beta/component-definitions?page_size=1&view=VIEW_BASIC response status 200": (r) => r.status === 200,
-      "GET /v1beta/component-definitions?page_size=1&view=VIEW_BASIC response componentDefinitions[0].spec is null": (r) => r.json().componentDefinitions[0].spec === null,
+    check(http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?pageSize=1&view=VIEW_BASIC`, null, null), {
+      "GET /v1beta/component-definitions?pageSize=1&view=VIEW_BASIC response status 200": (r) => r.status === 200,
+      "GET /v1beta/component-definitions?pageSize=1&view=VIEW_BASIC response componentDefinitions[0].spec is null": (r) => r.json().componentDefinitions[0].spec === null,
     });
 
     // FULL view.
-    check(http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?page_size=1&view=VIEW_FULL`, null, null), {
-      "GET /v1beta/component-definitions?page_size=1&view=VIEW_FULL response status 200": (r) => r.status === 200,
-      "GET /v1beta/component-definitions?page_size=1&view=VIEW_FULL response componentDefinitions[0].spec is not null": (r) => r.json().componentDefinitions[0].spec !== null,
+    check(http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?pageSize=1&view=VIEW_FULL`, null, null), {
+      "GET /v1beta/component-definitions?pageSize=1&view=VIEW_FULL response status 200": (r) => r.status === 200,
+      "GET /v1beta/component-definitions?pageSize=1&view=VIEW_FULL response componentDefinitions[0].spec is not null": (r) => r.json().componentDefinitions[0].spec !== null,
     });
 
     // Filter (fuzzy) title
-    check(http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?page_size=1&filter=q_title="JSO"`, null, null), {
-      [`GET /v1beta/component-definitions?page_size=1&filter=q_title="JSO" response status 200`]: (r) => r.status === 200,
-      [`GET /v1beta/component-definitions?page_size=1&filter=q_title="JSO" single result`]: (r) => r.json().totalSize === 1,
-      [`GET /v1beta/component-definitions?page_size=1&filter=q_title="JSO" title is JSON`]: (r) => r.json().componentDefinitions[0].title === "JSON",
+    check(http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?pageSize=1&filter=qTitle="JSO"`, null, null), {
+      [`GET /v1beta/component-definitions?pageSize=1&filter=qTitle="JSO" response status 200`]: (r) => r.status === 200,
+      [`GET /v1beta/component-definitions?pageSize=1&filter=qTitle="JSO" single result`]: (r) => r.json().totalSize === 1,
+      [`GET /v1beta/component-definitions?pageSize=1&filter=qTitle="JSO" title is JSON`]: (r) => r.json().componentDefinitions[0].title === "JSON",
     });
 
     // Filter component type
-    check(http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?page_size=1&filter=component_type=COMPONENT_TYPE_OPERATOR`, null, null), {
-      "GET /v1beta/component-definitions?page_size=1&filter=component_type=COMPONENT_TYPE_OPERATOR response status 200": (r) => r.status === 200,
-      "GET /v1beta/component-definitions?page_size=1&filter=component_type=COMPONENT_TYPE_OPERATOR total size is smaller": (r) => r.json().totalSize < limitedRecords.json().totalSize,
-      "GET /v1beta/component-definitions?page_size=1&filter=component_type=COMPONENT_TYPE_OPERATOR type is COMPONENT_TYPE_OPERATOR": (r) => r.json().componentDefinitions[0].type === "COMPONENT_TYPE_OPERATOR",
+    check(http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?pageSize=1&filter=componentType=COMPONENT_TYPE_OPERATOR`, null, null), {
+      "GET /v1beta/component-definitions?pageSize=1&filter=componentType=COMPONENT_TYPE_OPERATOR response status 200": (r) => r.status === 200,
+      "GET /v1beta/component-definitions?pageSize=1&filter=componentType=COMPONENT_TYPE_OPERATOR total size is smaller": (r) => r.json().totalSize < limitedRecords.json().totalSize,
+      "GET /v1beta/component-definitions?pageSize=1&filter=componentType=COMPONENT_TYPE_OPERATOR type is COMPONENT_TYPE_OPERATOR": (r) => r.json().componentDefinitions[0].type === "COMPONENT_TYPE_OPERATOR",
     });
 
     // Filter release stage
-    check(http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?page_size=1&filter=release_stage=RELEASE_STAGE_ALPHA`, null, null), {
-      [`GET /v1beta/component-definitions?page_size=1&filter=release_stage=RELEASE_STAGE_ALPHA response status 200`]: (r) => r.status === 200,
+    check(http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?pageSize=1&filter=releaseStage=RELEASE_STAGE_ALPHA`, null, null), {
+      [`GET /v1beta/component-definitions?pageSize=1&filter=releaseStage=RELEASE_STAGE_ALPHA response status 200`]: (r) => r.status === 200,
       // TODO when there are non-alpha components, update expectations.
-      [`GET /v1beta/component-definitions?page_size=1&filter=release_stage=RELEASE_STAGE_ALPHA number of results`]: (r) => r.json().totalSize === limitedRecords.json().totalSize,
-      [`GET /v1beta/component-definitions?page_size=1&filter=release_stage=RELEASE_STAGE_ALPHA release_stage is alpha`]: (r) => r.json().componentDefinitions[0].releaseStage === "RELEASE_STAGE_ALPHA",
+      [`GET /v1beta/component-definitions?pageSize=1&filter=releaseStage=RELEASE_STAGE_ALPHA number of results`]: (r) => r.json().totalSize === limitedRecords.json().totalSize,
+      [`GET /v1beta/component-definitions?pageSize=1&filter=releaseStage=RELEASE_STAGE_ALPHA release_stage is alpha`]: (r) => r.json().componentDefinitions[0].releaseStage === "RELEASE_STAGE_ALPHA",
     });
   });
 }

--- a/integration-test/pipeline/rest-connector-definition.js
+++ b/integration-test/pipeline/rest-connector-definition.js
@@ -13,40 +13,40 @@ export function CheckList() {
     });
 
     var limitedRecords = http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions`, null, null)
-    check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions?page_size=0`, null, null), {
-      "GET /v1beta/connector-definitions?page_size=0 response status is 200": (r) => r.status === 200,
-      "GET /v1beta/connector-definitions?page_size=0 response limited records for 10": (r) => r.json().connectorDefinitions.length === limitedRecords.json().connectorDefinitions.length,
+    check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions?pageSize=0`, null, null), {
+      "GET /v1beta/connector-definitions?pageSize=0 response status is 200": (r) => r.status === 200,
+      "GET /v1beta/connector-definitions?pageSize=0 response limited records for 10": (r) => r.json().connectorDefinitions.length === limitedRecords.json().connectorDefinitions.length,
     });
 
-    check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions?page_size=1`, null, null), {
-      "GET /v1beta/connector-definitions?page_size=1 response status is 200": (r) => r.status === 200,
-      "GET /v1beta/connector-definitions?page_size=1 response connectorDefinitions size 1": (r) => r.json().connectorDefinitions.length === 1,
+    check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions?pageSize=1`, null, null), {
+      "GET /v1beta/connector-definitions?pageSize=1 response status is 200": (r) => r.status === 200,
+      "GET /v1beta/connector-definitions?pageSize=1 response connectorDefinitions size 1": (r) => r.json().connectorDefinitions.length === 1,
     });
 
-    var pageRes = http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions?page_size=1`, null, null)
-    check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions?page_size=1&page_token=${pageRes.json().nextPageToken}`, null, null), {
-      [`GET /v1beta/connector-definitions?page_size=1&page_token=${pageRes.json().nextPageToken} response status is 200`]: (r) => r.status === 200,
-      [`GET /v1beta/connector-definitions?page_size=1&page_token=${pageRes.json().nextPageToken} response connectorDefinitions size 1`]: (r) => r.json().connectorDefinitions.length === 1,
+    var pageRes = http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions?pageSize=1`, null, null)
+    check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions?pageSize=1&pageToken=${pageRes.json().nextPageToken}`, null, null), {
+      [`GET /v1beta/connector-definitions?pageSize=1&pageToken=${pageRes.json().nextPageToken} response status is 200`]: (r) => r.status === 200,
+      [`GET /v1beta/connector-definitions?pageSize=1&pageToken=${pageRes.json().nextPageToken} response connectorDefinitions size 1`]: (r) => r.json().connectorDefinitions.length === 1,
     });
 
-    check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions?page_size=1&view=VIEW_BASIC`, null, null), {
-      "GET /v1beta/connector-definitions?page_size=1&view=VIEW_BASIC response status 200": (r) => r.status === 200,
-      "GET /v1beta/connector-definitions?page_size=1&view=VIEW_BASIC response connectorDefinitions[0].spec is null": (r) => r.json().connectorDefinitions[0].spec === null,
+    check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions?pageSize=1&view=VIEW_BASIC`, null, null), {
+      "GET /v1beta/connector-definitions?pageSize=1&view=VIEW_BASIC response status 200": (r) => r.status === 200,
+      "GET /v1beta/connector-definitions?pageSize=1&view=VIEW_BASIC response connectorDefinitions[0].spec is null": (r) => r.json().connectorDefinitions[0].spec === null,
     });
 
-    check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions?page_size=1&view=VIEW_FULL`, null, null), {
-      "GET /v1beta/connector-definitions?page_size=1&view=VIEW_FULL response status 200": (r) => r.status === 200,
-      "GET /v1beta/connector-definitions?page_size=1&view=VIEW_FULL response connectorDefinitions[0].spec is not null": (r) => r.json().connectorDefinitions[0].spec !== null,
+    check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions?pageSize=1&view=VIEW_FULL`, null, null), {
+      "GET /v1beta/connector-definitions?pageSize=1&view=VIEW_FULL response status 200": (r) => r.status === 200,
+      "GET /v1beta/connector-definitions?pageSize=1&view=VIEW_FULL response connectorDefinitions[0].spec is not null": (r) => r.json().connectorDefinitions[0].spec !== null,
     });
 
-    check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions?page_size=1`, null, null), {
-      "GET /v1beta/connector-definitions?page_size=1 response status 200": (r) => r.status === 200,
-      "GET /v1beta/connector-definitions?page_size=1 response connectorDefinitions[0].spec is null": (r) => r.json().connectorDefinitions[0].spec === null,
+    check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions?pageSize=1`, null, null), {
+      "GET /v1beta/connector-definitions?pageSize=1 response status 200": (r) => r.status === 200,
+      "GET /v1beta/connector-definitions?pageSize=1 response connectorDefinitions[0].spec is null": (r) => r.json().connectorDefinitions[0].spec === null,
     });
 
-    check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions?page_size=${limitedRecords.json().totalSize}`, null, null), {
-      [`GET /v1beta/connector-definitions?page_size=${limitedRecords.json().totalSize} response status 200`]: (r) => r.status === 200,
-      [`GET /v1beta/connector-definitions?page_size=${limitedRecords.json().totalSize} response nextPageToken is empty`]: (r) => r.json().nextPageToken === "",
+    check(http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions?pageSize=${limitedRecords.json().totalSize}`, null, null), {
+      [`GET /v1beta/connector-definitions?pageSize=${limitedRecords.json().totalSize} response status 200`]: (r) => r.status === 200,
+      [`GET /v1beta/connector-definitions?pageSize=${limitedRecords.json().totalSize} response nextPageToken is empty`]: (r) => r.json().nextPageToken === "",
     });
   });
 }

--- a/integration-test/pipeline/rest-operator-definition.js
+++ b/integration-test/pipeline/rest-operator-definition.js
@@ -13,40 +13,40 @@ export function CheckList() {
     });
 
     var limitedRecords = http.request("GET", `${pipelinePublicHost}/v1beta/operator-definitions`, null, null)
-    check(http.request("GET", `${pipelinePublicHost}/v1beta/operator-definitions?page_size=0`, null, null), {
-      "GET /v1beta/operator-definitions?page_size=0 response status is 200": (r) => r.status === 200,
-      "GET /v1beta/operator-definitions?page_size=0 response limited records for 10": (r) => r.json().operatorDefinitions.length === limitedRecords.json().operatorDefinitions.length,
+    check(http.request("GET", `${pipelinePublicHost}/v1beta/operator-definitions?pageSize=0`, null, null), {
+      "GET /v1beta/operator-definitions?pageSize=0 response status is 200": (r) => r.status === 200,
+      "GET /v1beta/operator-definitions?pageSize=0 response limited records for 10": (r) => r.json().operatorDefinitions.length === limitedRecords.json().operatorDefinitions.length,
     });
 
-    check(http.request("GET", `${pipelinePublicHost}/v1beta/operator-definitions?page_size=1`, null, null), {
-      "GET /v1beta/operator-definitions?page_size=1 response status is 200": (r) => r.status === 200,
-      "GET /v1beta/operator-definitions?page_size=1 response operatorDefinitions size 1": (r) => r.json().operatorDefinitions.length === 1,
+    check(http.request("GET", `${pipelinePublicHost}/v1beta/operator-definitions?pageSize=1`, null, null), {
+      "GET /v1beta/operator-definitions?pageSize=1 response status is 200": (r) => r.status === 200,
+      "GET /v1beta/operator-definitions?pageSize=1 response operatorDefinitions size 1": (r) => r.json().operatorDefinitions.length === 1,
     });
 
-    var pageRes = http.request("GET", `${pipelinePublicHost}/v1beta/operator-definitions?page_size=1`, null, null)
-    check(http.request("GET", `${pipelinePublicHost}/v1beta/operator-definitions?page_size=1&page_token=${pageRes.json().nextPageToken}`, null, null), {
-      [`GET /v1beta/operator-definitions?page_size=1&page_token=${pageRes.json().nextPageToken} response status is 200`]: (r) => r.status === 200,
-      [`GET /v1beta/operator-definitions?page_size=1&page_token=${pageRes.json().nextPageToken} response operatorDefinitions size 1`]: (r) => r.json().operatorDefinitions.length === 1,
+    var pageRes = http.request("GET", `${pipelinePublicHost}/v1beta/operator-definitions?pageSize=1`, null, null)
+    check(http.request("GET", `${pipelinePublicHost}/v1beta/operator-definitions?pageSize=1&pageToken=${pageRes.json().nextPageToken}`, null, null), {
+      [`GET /v1beta/operator-definitions?pageSize=1&pageToken=${pageRes.json().nextPageToken} response status is 200`]: (r) => r.status === 200,
+      [`GET /v1beta/operator-definitions?pageSize=1&pageToken=${pageRes.json().nextPageToken} response operatorDefinitions size 1`]: (r) => r.json().operatorDefinitions.length === 1,
     });
 
-    check(http.request("GET", `${pipelinePublicHost}/v1beta/operator-definitions?page_size=1&view=VIEW_BASIC`, null, null), {
-      "GET /v1beta/operator-definitions?page_size=1&view=VIEW_BASIC response status 200": (r) => r.status === 200,
-      "GET /v1beta/operator-definitions?page_size=1&view=VIEW_BASIC response operatorDefinitions[0].spec is null": (r) => r.json().operatorDefinitions[0].spec === null,
+    check(http.request("GET", `${pipelinePublicHost}/v1beta/operator-definitions?pageSize=1&view=VIEW_BASIC`, null, null), {
+      "GET /v1beta/operator-definitions?pageSize=1&view=VIEW_BASIC response status 200": (r) => r.status === 200,
+      "GET /v1beta/operator-definitions?pageSize=1&view=VIEW_BASIC response operatorDefinitions[0].spec is null": (r) => r.json().operatorDefinitions[0].spec === null,
     });
 
-    check(http.request("GET", `${pipelinePublicHost}/v1beta/operator-definitions?page_size=1&view=VIEW_FULL`, null, null), {
-      "GET /v1beta/operator-definitions?page_size=1&view=VIEW_FULL response status 200": (r) => r.status === 200,
-      "GET /v1beta/operator-definitions?page_size=1&view=VIEW_FULL response operatorDefinitions[0].spec is not null": (r) => r.json().operatorDefinitions[0].spec !== null,
+    check(http.request("GET", `${pipelinePublicHost}/v1beta/operator-definitions?pageSize=1&view=VIEW_FULL`, null, null), {
+      "GET /v1beta/operator-definitions?pageSize=1&view=VIEW_FULL response status 200": (r) => r.status === 200,
+      "GET /v1beta/operator-definitions?pageSize=1&view=VIEW_FULL response operatorDefinitions[0].spec is not null": (r) => r.json().operatorDefinitions[0].spec !== null,
     });
 
-    check(http.request("GET", `${pipelinePublicHost}/v1beta/operator-definitions?page_size=1`, null, null), {
-      "GET /v1beta/operator-definitions?page_size=1 response status 200": (r) => r.status === 200,
-      "GET /v1beta/operator-definitions?page_size=1 response operatorDefinitions[0].spec is null": (r) => r.json().operatorDefinitions[0].spec === null,
+    check(http.request("GET", `${pipelinePublicHost}/v1beta/operator-definitions?pageSize=1`, null, null), {
+      "GET /v1beta/operator-definitions?pageSize=1 response status 200": (r) => r.status === 200,
+      "GET /v1beta/operator-definitions?pageSize=1 response operatorDefinitions[0].spec is null": (r) => r.json().operatorDefinitions[0].spec === null,
     });
 
-    check(http.request("GET", `${pipelinePublicHost}/v1beta/operator-definitions?page_size=${limitedRecords.json().totalSize}`, null, null), {
-      [`GET /v1beta/operator-definitions?page_size=${limitedRecords.json().totalSize} response status 200`]: (r) => r.status === 200,
-      [`GET /v1beta/operator-definitions?page_size=${limitedRecords.json().totalSize} response nextPageToken is empty`]: (r) => r.json().nextPageToken === "",
+    check(http.request("GET", `${pipelinePublicHost}/v1beta/operator-definitions?pageSize=${limitedRecords.json().totalSize}`, null, null), {
+      [`GET /v1beta/operator-definitions?pageSize=${limitedRecords.json().totalSize} response status 200`]: (r) => r.status === 200,
+      [`GET /v1beta/operator-definitions?pageSize=${limitedRecords.json().totalSize} response nextPageToken is empty`]: (r) => r.json().nextPageToken === "",
     });
   });
 }

--- a/integration-test/pipeline/rest-pipeline-private.js
+++ b/integration-test/pipeline/rest-pipeline-private.js
@@ -104,12 +104,12 @@ export function CheckList(data) {
     check(
       http.request(
         "GET",
-        `${pipelinePrivateHost}/v1beta/admin/pipelines?page_size=3`,
+        `${pipelinePrivateHost}/v1beta/admin/pipelines?pageSize=3`,
         null,
         constant.params
       ),
       {
-        [`GET /v1beta/admin/pipelines?page_size=3 response pipelines.length == 3`]:
+        [`GET /v1beta/admin/pipelines?pageSize=3 response pipelines.length == 3`]:
           (r) => r.json().pipelines.length == 3,
       }
     );
@@ -117,31 +117,31 @@ export function CheckList(data) {
     check(
       http.request(
         "GET",
-        `${pipelinePrivateHost}/v1beta/admin/pipelines?page_size=101`,
+        `${pipelinePrivateHost}/v1beta/admin/pipelines?pageSize=101`,
         null,
         constant.params
       ),
       {
-        [`GET /v1beta/admin/pipelines?page_size=101 response pipelines.length == 100`]:
+        [`GET /v1beta/admin/pipelines?pageSize=101 response pipelines.length == 100`]:
           (r) => r.json().pipelines.length == 100,
       }
     );
 
     var resFirst100 = http.request(
       "GET",
-      `${pipelinePrivateHost}/v1beta/admin/pipelines?page_size=100`
+      `${pipelinePrivateHost}/v1beta/admin/pipelines?pageSize=100`
     );
     var resSecond100 = http.request(
       "GET",
-      `${pipelinePrivateHost}/v1beta/admin/pipelines?page_size=100&page_token=${resFirst100.json().nextPageToken
+      `${pipelinePrivateHost}/v1beta/admin/pipelines?pageSize=100&pageToken=${resFirst100.json().nextPageToken
       }`
     );
     check(resSecond100, {
-      [`GET /v1beta/admin/pipelines?page_size=100&page_token=${resFirst100.json().nextPageToken
+      [`GET /v1beta/admin/pipelines?pageSize=100&pageToken=${resFirst100.json().nextPageToken
         } response status 200`]: (r) => r.status == 200,
-      [`GET /v1beta/admin/pipelines?page_size=100&page_token=${resFirst100.json().nextPageToken
+      [`GET /v1beta/admin/pipelines?pageSize=100&pageToken=${resFirst100.json().nextPageToken
         } response return 100 results`]: (r) => r.json().pipelines.length == 100,
-      [`GET /v1beta/admin/pipelines?page_size=100&page_token=${resFirst100.json().nextPageToken
+      [`GET /v1beta/admin/pipelines?pageSize=100&pageToken=${resFirst100.json().nextPageToken
         } response nextPageToken is empty`]: (r) =>
           r.json().nextPageToken === "",
     });
@@ -164,14 +164,14 @@ export function CheckList(data) {
     check(
       http.request(
         "GET",
-        `${pipelinePrivateHost}/v1beta/admin/pipelines?filter=create_time>timestamp%28%222000-06-19T23:31:08.657Z%22%29`,
+        `${pipelinePrivateHost}/v1beta/admin/pipelines?filter=createTime>timestamp%28%222000-06-19T23:31:08.657Z%22%29`,
         null,
         constant.params
       ),
       {
-        [`GET /v1beta/admin/pipelines?filter=create_time%20>%20timestamp%28%222000-06-19T23:31:08.657Z%22%29 response 200`]:
+        [`GET /v1beta/admin/pipelines?filter=createTime%20>%20timestamp%28%222000-06-19T23:31:08.657Z%22%29 response 200`]:
           (r) => r.status == 200,
-        [`GET /v1beta/admin/pipelines?filter=create_time%20>%20timestamp%28%222000-06-19T23:31:08.657Z%22%29 response pipelines.length > 0`]:
+        [`GET /v1beta/admin/pipelines?filter=createTime%20>%20timestamp%28%222000-06-19T23:31:08.657Z%22%29 response pipelines.length > 0`]:
           (r) => r.json().pipelines.length > 0,
       }
     );

--- a/integration-test/pipeline/rest-pipeline-public.js
+++ b/integration-test/pipeline/rest-pipeline-public.js
@@ -292,12 +292,12 @@ export function CheckList(data) {
     check(
       http.request(
         "GET",
-        `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines?page_size=3`,
+        `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines?pageSize=3`,
         null,
         data.header
       ),
       {
-        [`GET /v1beta/${constant.namespace}/pipelines?page_size=3 response pipelines.length == 3`]: (
+        [`GET /v1beta/${constant.namespace}/pipelines?pageSize=3 response pipelines.length == 3`]: (
           r
         ) => r.json().pipelines.length == 3,
       }
@@ -306,34 +306,34 @@ export function CheckList(data) {
     check(
       http.request(
         "GET",
-        `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines?page_size=101`,
+        `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines?pageSize=101`,
         null,
         data.header
       ),
       {
-        [`GET /v1beta/${constant.namespace}/pipelines?page_size=101 response pipelines.length == 100`]:
+        [`GET /v1beta/${constant.namespace}/pipelines?pageSize=101 response pipelines.length == 100`]:
           (r) => r.json().pipelines.length == 100,
       }
     );
 
     var resFirst100 = http.request(
       "GET",
-      `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines?page_size=100`,
+      `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines?pageSize=100`,
       null,
       data.header
     );
     var resSecond100 = http.request(
       "GET",
-      `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines?page_size=100&page_token=${resFirst100.json().nextPageToken
+      `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines?pageSize=100&pageToken=${resFirst100.json().nextPageToken
       }`,
       null, data.header
     );
     check(resSecond100, {
-      [`GET /v1beta/${constant.namespace}/pipelines?page_size=100&page_token=${resFirst100.json().nextPageToken
+      [`GET /v1beta/${constant.namespace}/pipelines?pageSize=100&pageToken=${resFirst100.json().nextPageToken
         } response status 200`]: (r) => r.status == 200,
-      [`GET /v1beta/${constant.namespace}/pipelines?page_size=100&page_token=${resFirst100.json().nextPageToken
+      [`GET /v1beta/${constant.namespace}/pipelines?pageSize=100&pageToken=${resFirst100.json().nextPageToken
         } response return 100 results`]: (r) => r.json().pipelines.length == 100,
-      [`GET /v1beta/${constant.namespace}/pipelines?page_size=100&page_token=${resFirst100.json().nextPageToken
+      [`GET /v1beta/${constant.namespace}/pipelines?pageSize=100&pageToken=${resFirst100.json().nextPageToken
         } response nextPageToken is empty`]: (r) =>
           r.json().nextPageToken === "",
     });
@@ -356,14 +356,14 @@ export function CheckList(data) {
     check(
       http.request(
         "GET",
-        `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines?filter=create_time>timestamp%28%222000-06-19T23:31:08.657Z%22%29`,
+        `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines?filter=createTime>timestamp%28%222000-06-19T23:31:08.657Z%22%29`,
         null,
         data.header
       ),
       {
-        [`GET /v1beta/${constant.namespace}/pipelines?filter=create_time%20>%20timestamp%28%222000-06-19T23:31:08.657Z%22%29 response 200`]:
+        [`GET /v1beta/${constant.namespace}/pipelines?filter=createTime%20>%20timestamp%28%222000-06-19T23:31:08.657Z%22%29 response 200`]:
           (r) => r.status == 200,
-        [`GET /v1beta/${constant.namespace}/pipelines?filter=create_time%20>%20timestamp%28%222000-06-19T23:31:08.657Z%22%29 response pipelines.length > 0`]:
+        [`GET /v1beta/${constant.namespace}/pipelines?filter=createTime%20>%20timestamp%28%222000-06-19T23:31:08.657Z%22%29 response pipelines.length > 0`]:
           (r) => r.json().pipelines.length > 0,
       }
     );

--- a/integration-test/pipeline/rest.js
+++ b/integration-test/pipeline/rest.js
@@ -99,7 +99,7 @@ export default function (data) {
 export function teardown(data) {
 
   group("Pipeline API: Delete all pipelines created by this test", () => {
-    for (const pipeline of http.request("GET", `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines?page_size=100`, null, data.header).json("pipelines")) {
+    for (const pipeline of http.request("GET", `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines?pageSize=100`, null, data.header).json("pipelines")) {
       check(http.request("DELETE", `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines/${pipeline.id}`, null, data.header), {
         [`DELETE /v1beta/${constant.namespace}/pipelines response status is 204`]: (r) => r.status === 204,
       });

--- a/pkg/handler/pipeline.go
+++ b/pkg/handler/pipeline.go
@@ -46,8 +46,8 @@ func (h *PrivateHandler) ListPipelinesAdmin(ctx context.Context, req *pb.ListPip
 		// only support "recipe.components.resource_name" for now
 		filtering.DeclareIdent("recipe", filtering.TypeMap(filtering.TypeString, filtering.TypeMap(filtering.TypeString, filtering.TypeString))),
 		filtering.DeclareIdent("owner", filtering.TypeString),
-		filtering.DeclareIdent("create_time", filtering.TypeTimestamp),
-		filtering.DeclareIdent("update_time", filtering.TypeTimestamp),
+		filtering.DeclareIdent("createTime", filtering.TypeTimestamp),
+		filtering.DeclareIdent("updateTime", filtering.TypeTimestamp),
 	}...)
 	if err != nil {
 		return &pb.ListPipelinesAdminResponse{}, err
@@ -163,8 +163,8 @@ func (h *PublicHandler) ListPipelines(ctx context.Context, req *pb.ListPipelines
 		// only support "recipe.components.resource_name" for now
 		filtering.DeclareIdent("recipe", filtering.TypeMap(filtering.TypeString, filtering.TypeMap(filtering.TypeString, filtering.TypeString))),
 		filtering.DeclareIdent("owner", filtering.TypeString),
-		filtering.DeclareIdent("create_time", filtering.TypeTimestamp),
-		filtering.DeclareIdent("update_time", filtering.TypeTimestamp),
+		filtering.DeclareIdent("createTime", filtering.TypeTimestamp),
+		filtering.DeclareIdent("updateTime", filtering.TypeTimestamp),
 	}...)
 	if err != nil {
 		span.SetStatus(1, err.Error())
@@ -355,8 +355,8 @@ func (h *PublicHandler) listNamespacePipelines(ctx context.Context, req ListName
 		// only support "recipe.components.resource_name" for now
 		filtering.DeclareIdent("recipe", filtering.TypeMap(filtering.TypeString, filtering.TypeMap(filtering.TypeString, filtering.TypeString))),
 		filtering.DeclareIdent("owner", filtering.TypeString),
-		filtering.DeclareIdent("create_time", filtering.TypeTimestamp),
-		filtering.DeclareIdent("update_time", filtering.TypeTimestamp),
+		filtering.DeclareIdent("createTime", filtering.TypeTimestamp),
+		filtering.DeclareIdent("updateTime", filtering.TypeTimestamp),
 	}...)
 	if err != nil {
 		span.SetStatus(1, err.Error())
@@ -1130,8 +1130,8 @@ func (h *PublicHandler) listNamespacePipelineReleases(ctx context.Context, req L
 		// only support "recipe.components.resource_name" for now
 		filtering.DeclareIdent("recipe", filtering.TypeMap(filtering.TypeString, filtering.TypeMap(filtering.TypeString, filtering.TypeString))),
 		filtering.DeclareIdent("owner", filtering.TypeString),
-		filtering.DeclareIdent("create_time", filtering.TypeTimestamp),
-		filtering.DeclareIdent("update_time", filtering.TypeTimestamp),
+		filtering.DeclareIdent("createTime", filtering.TypeTimestamp),
+		filtering.DeclareIdent("updateTime", filtering.TypeTimestamp),
 	}...)
 	if err != nil {
 		span.SetStatus(1, err.Error())

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/gofrs/uuid"
+	"github.com/iancoleman/strcase"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/redis/go-redis/v9"
 	"go.einride.tech/aip/filtering"
@@ -183,7 +184,8 @@ func (r *repository) listPipelines(ctx context.Context, where string, whereArgs 
 	}
 
 	for _, field := range order.Fields {
-		orderString := field.Path + transformBoolToDescString(field.Desc)
+		// TODO: We should implement a shared `orderBy` parser.
+		orderString := strcase.ToSnake(field.Path) + transformBoolToDescString(field.Desc)
 		queryBuilder.Order(orderString)
 	}
 	queryBuilder.Order("uid DESC")
@@ -286,9 +288,9 @@ func (r *repository) listPipelines(ctx context.Context, where string, whereArgs 
 		}
 
 		for _, field := range order.Fields {
-			orderString := field.Path + transformBoolToDescString(!field.Desc)
+			orderString := strcase.ToSnake(field.Path) + transformBoolToDescString(!field.Desc)
 			lastItemQueryBuilder.Order(orderString)
-			switch field.Path {
+			switch strcase.ToSnake(field.Path) {
 			case "id":
 				tokens[field.Path] = lastID
 			case "create_time":

--- a/pkg/repository/transpiler.go
+++ b/pkg/repository/transpiler.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/iancoleman/strcase"
 	"go.einride.tech/aip/filtering"
 	"gorm.io/gorm/clause"
 
@@ -110,7 +111,7 @@ func (t *transpiler) transpileIdentExpr(e *expr.Expr) (*clause.Expr, error) {
 		}
 	}
 	return &clause.Expr{
-		SQL:                identExpr.Name,
+		SQL:                strcase.ToSnake(identExpr.Name),
 		Vars:               nil,
 		WithoutParentheses: true,
 	}, nil

--- a/pkg/service/component_definition.go
+++ b/pkg/service/component_definition.go
@@ -191,9 +191,9 @@ func (s *service) ListComponentDefinitions(ctx context.Context, req *pb.ListComp
 	var releaseStage pb.ComponentDefinition_ReleaseStage
 	declarations, err := filtering.NewDeclarations(
 		filtering.DeclareStandardFunctions(),
-		filtering.DeclareIdent("q_title", filtering.TypeString),
-		filtering.DeclareEnumIdent("release_stage", releaseStage.Type()),
-		filtering.DeclareEnumIdent("component_type", compType.Type()),
+		filtering.DeclareIdent("qTitle", filtering.TypeString),
+		filtering.DeclareEnumIdent("releaseStage", releaseStage.Type()),
+		filtering.DeclareEnumIdent("componentType", compType.Type()),
 	)
 	if err != nil {
 		return nil, err
@@ -282,7 +282,7 @@ func (s *service) ListConnectorDefinitions(ctx context.Context, req *pb.ListConn
 	var connType pb.ConnectorType
 	declarations, err := filtering.NewDeclarations([]filtering.DeclarationOption{
 		filtering.DeclareStandardFunctions(),
-		filtering.DeclareEnumIdent("connector_type", connType.Type()),
+		filtering.DeclareEnumIdent("connectorType", connType.Type()),
 	}...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Because

- We should use camelCase for query strings to align with the HTTP body.

This commit

- Updates query strings `filter` and `orderBy` to use camelCase.

Note:

- We should further extract the common code in the `filter` and `orderBy` parsers into a shared function in the future.