### PR TITLE
chore: fix dynamic definition bug

### DIFF
--- a/pkg/service/convert.go
+++ b/pkg/service/convert.go
@@ -183,7 +183,7 @@ func (c *converter) includeComponentDetail(ctx context.Context, ownerPermalink s
 	if err != nil {
 		return err
 	}
-	if useDynamicDef {
+	if useDynamicDef && comp.Input != nil {
 		def, err := c.component.GetDefinitionByUID(uuid.FromStringOrNil(comp.Type), vars, &componentbase.ComponentConfig{
 			Task:  comp.Task,
 			Input: comp.Input.(map[string]any),


### PR DESCRIPTION
Because

- The dynamic definition has a bug when the `component.Input` is nil.

This commit

- Fixes the dynamic definition bug.