### PR TITLE
chore: fix pageToken bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,11 @@ dev:							## Run dev container
 	@docker run -d --rm \
 		-v $(PWD):/${SERVICE_NAME} \
 		-p ${SERVICE_PORT}:${SERVICE_PORT} \
+		-v $(PWD)/../go.work:/go.work \
+		-v $(PWD)/../go.work.sum:/go.work.sum \
+		-v $(PWD)/../component:/component \
+		-v $(PWD)/../pipeline-backend-cloud:/pipeline-backend-cloud \
+		-v $(PWD)/../protogengo:/protogengo \
 		--network instill-network \
 		--name ${SERVICE_NAME} \
 		instill/${SERVICE_NAME}:dev >/dev/null 2>&1
@@ -46,6 +51,7 @@ top:							## Display all running service processes
 build:							## Build dev docker image
 	@docker build \
 		--build-arg SERVICE_NAME=${SERVICE_NAME} \
+		--build-arg GOLANG_VERSION=${GOLANG_VERSION} \
 		--build-arg K6_VERSION=${K6_VERSION} \
 		-f Dockerfile.dev  -t instill/${SERVICE_NAME}:dev .
 

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1
 	github.com/iancoleman/strcase v0.3.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/component v0.19.1-beta.0.20240618054722-d3de43ea6b74
+	github.com/instill-ai/component v0.19.1-beta.0.20240618161039-c7059d77ab27
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240531114421-d7be5dd350e5
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha

--- a/go.sum
+++ b/go.sum
@@ -1183,8 +1183,8 @@ github.com/influxdata/influxdb-client-go/v2 v2.12.3 h1:28nRlNMRIV4QbtIUvxhWqaxn0
 github.com/influxdata/influxdb-client-go/v2 v2.12.3/go.mod h1:IrrLUbCjjfkmRuaCiGQg4m2GbkaeJDcuWoxiWdQEbA0=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/instill-ai/component v0.19.1-beta.0.20240618054722-d3de43ea6b74 h1:dVcdDrInqkZFZtAB57GnIY+2xe3p4SVWAje24gdU+HE=
-github.com/instill-ai/component v0.19.1-beta.0.20240618054722-d3de43ea6b74/go.mod h1:4w/nWenyxLrGVUmAZ1Y+yWFa+IjXEiFTyay63HkAXZ4=
+github.com/instill-ai/component v0.19.1-beta.0.20240618161039-c7059d77ab27 h1:w1Y2Zm2AxZ4e87LSv2xDYqMYqEW/hBJyKfHsF42joQA=
+github.com/instill-ai/component v0.19.1-beta.0.20240618161039-c7059d77ab27/go.mod h1:4w/nWenyxLrGVUmAZ1Y+yWFa+IjXEiFTyay63HkAXZ4=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240531114421-d7be5dd350e5 h1:lAOZK6B63kIC7dRFEeILzQp4dEb14ngYRnD03k8LkOw=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240531114421-d7be5dd350e5/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -210,19 +210,20 @@ func (r *repository) listPipelines(ctx context.Context, where string, whereArgs 
 		for _, o := range order.Fields {
 
 			if v, ok := tokens[o.Path]; ok {
+				p := strcase.ToSnake(o.Path)
 				switch o.Path {
 				case "create_time", "update_time":
 					// Add "pipeline." prefix to prevent ambiguous since tag table also has the two columns.
 					if o.Desc {
-						queryBuilder = queryBuilder.Where("pipeline."+o.Path+" < ?::timestamp", v)
+						queryBuilder = queryBuilder.Where("pipeline."+p+" < ?::timestamp", v)
 					} else {
-						queryBuilder = queryBuilder.Where("pipeline."+o.Path+" > ?::timestamp", v)
+						queryBuilder = queryBuilder.Where("pipeline."+p+" > ?::timestamp", v)
 					}
 				default:
 					if o.Desc {
-						queryBuilder = queryBuilder.Where(o.Path+" < ?", v)
+						queryBuilder = queryBuilder.Where(p+" < ?", v)
 					} else {
-						queryBuilder = queryBuilder.Where(o.Path+" > ?", v)
+						queryBuilder = queryBuilder.Where(p+" > ?", v)
 					}
 				}
 
@@ -290,13 +291,13 @@ func (r *repository) listPipelines(ctx context.Context, where string, whereArgs 
 		for _, field := range order.Fields {
 			orderString := strcase.ToSnake(field.Path) + transformBoolToDescString(!field.Desc)
 			lastItemQueryBuilder.Order(orderString)
-			switch strcase.ToSnake(field.Path) {
+			switch p := strcase.ToSnake(field.Path); p {
 			case "id":
-				tokens[field.Path] = lastID
+				tokens[p] = lastID
 			case "create_time":
-				tokens[field.Path] = lastCreateTime.Format(time.RFC3339Nano)
+				tokens[p] = lastCreateTime.Format(time.RFC3339Nano)
 			case "update_time":
-				tokens[field.Path] = lastUpdateTime.Format(time.RFC3339Nano)
+				tokens[p] = lastUpdateTime.Format(time.RFC3339Nano)
 			}
 
 		}


### PR DESCRIPTION
Because

- The `pageToken` is not correctly encoded due to the refactor to camelCase.

This commit

- Fixes the `pageToken` bug.