### PR TITLE
chore: fix typo in errmsg plain text secret

### DIFF
--- a/pkg/service/errors.go
+++ b/pkg/service/errors.go
@@ -17,5 +17,5 @@ var ErrTriggerFail = fmt.Errorf("failed to trigger the pipeline")
 
 var errCanNotUsePlaintextSecret = errmsg.AddMessage(
 	fmt.Errorf("%w: plaintext value in credential field", errdomain.ErrInvalidArgument),
-	"Plaintext values are forbidden in credential fields. You can create a secret and reference it with the syntax ${secrets.my-secret}.",
+	"Plaintext values are forbidden in credential fields. You can create a secret and reference it with the syntax ${secret.my-secret}.",
 )


### PR DESCRIPTION
**Because**

- The typo fix ensures the documentation and error messages are accurate and clear.

**This commit**

- Corrects the syntax from `${secrets.my-secret}` to `${secret.my-secret}` to ensure proper referencing.