### PR TITLE
feat: allow user to store recipe in YAML format

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/iancoleman/strcase v0.3.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
 	github.com/instill-ai/component v0.20.2-beta
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240531114421-d7be5dd350e5
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240624123720-e67c66096d2d
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha
 	github.com/jackc/pgx/v5 v5.5.5

--- a/go.sum
+++ b/go.sum
@@ -1185,8 +1185,8 @@ github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
 github.com/instill-ai/component v0.20.2-beta h1:1Ox671L6eeknILd8KNcIQ+VUKMlw42yniaqnNSvtcoY=
 github.com/instill-ai/component v0.20.2-beta/go.mod h1:4w/nWenyxLrGVUmAZ1Y+yWFa+IjXEiFTyay63HkAXZ4=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240531114421-d7be5dd350e5 h1:lAOZK6B63kIC7dRFEeILzQp4dEb14ngYRnD03k8LkOw=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240531114421-d7be5dd350e5/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240624123720-e67c66096d2d h1:JLRgUBDFGlgFso9X8pD/UnpF7blEwfzqJXU98DC327k=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240624123720-e67c66096d2d/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a/go.mod h1:EpX3Yr661uWULtZf5UnJHfr5rw2PDyX8ku4Kx0UtYFw=
 github.com/instill-ai/x v0.4.0-alpha h1:zQV2VLbSHjMv6gyBN/2mwwrvWk0/mJM6ZKS12AzjfQg=

--- a/integration-test/pipeline/const.js
+++ b/integration-test/pipeline/const.js
@@ -78,7 +78,7 @@ export const paramsHTTPWithJwt = {
 };
 
 
-export const simpleRecipe = {
+export const simplePipelineWithJSONRecipe = {
   recipe: {
     version:  "v1beta",
     variable: {
@@ -104,6 +104,32 @@ export const simpleRecipe = {
     },
   },
 };
+
+const yamlRecipe = `
+version: v1beta
+variable:
+  input:
+    title: Input
+    instill-format: string
+
+output:
+  answer:
+    title: Answer
+    value: \${b01.output.data}
+
+component:
+  b01:
+    type: base64
+    task: TASK_ENCODE
+    input:
+      data: \${variable.input}
+`;
+
+export const simplePipelineWithYAMLRecipe = {
+  rawRecipe: yamlRecipe,
+};
+
+
 
 
 export const simplePayload = {

--- a/integration-test/pipeline/grpc-pipeline-private.js
+++ b/integration-test/pipeline/grpc-pipeline-private.js
@@ -51,7 +51,7 @@ export function CheckList(data) {
           id: randomString(10),
           description: randomString(50),
         },
-        constant.simpleRecipe
+        constant.simplePipelineWithJSONRecipe
       );
     }
 
@@ -231,7 +231,7 @@ export function CheckLookUp(data) {
       {
         id: randomString(10),
       },
-      constant.simpleRecipe
+      constant.simplePipelineWithJSONRecipe
     );
 
     // Create a pipeline

--- a/integration-test/pipeline/grpc-pipeline-public-with-jwt.js
+++ b/integration-test/pipeline/grpc-pipeline-public-with-jwt.js
@@ -20,7 +20,7 @@ export function CheckCreate(data) {
           id: randomString(32),
           description: randomString(50),
         },
-        constant.simpleRecipe
+        constant.simplePipelineWithJSONRecipe
       );
 
       // Cannot create a pipeline of a non-exist user
@@ -80,7 +80,7 @@ export function CheckGet(data) {
         id: randomString(10),
         description: randomString(50),
       },
-      constant.simpleRecipe
+      constant.simplePipelineWithJSONRecipe
     );
 
     check(
@@ -145,7 +145,7 @@ export function CheckUpdate(data) {
         {
           id: randomString(10),
         },
-        constant.simpleRecipe
+        constant.simplePipelineWithJSONRecipe
       );
 
       // Create a pipeline
@@ -219,7 +219,7 @@ export function CheckRename(data) {
         {
           id: randomString(10),
         },
-        constant.simpleRecipe
+        constant.simplePipelineWithJSONRecipe
       );
 
       // Create a pipeline
@@ -290,7 +290,7 @@ export function CheckLookUp(data) {
         {
           id: randomString(10),
         },
-        constant.simpleRecipe
+        constant.simplePipelineWithJSONRecipe
       );
 
       // Create a pipeline

--- a/integration-test/pipeline/grpc-pipeline-public.js
+++ b/integration-test/pipeline/grpc-pipeline-public.js
@@ -20,7 +20,7 @@ export function CheckCreate(data) {
         id: randomString(32),
         description: randomString(50),
       },
-      constant.simpleRecipe
+      constant.simplePipelineWithJSONRecipe
     );
 
     // Create a pipeline
@@ -246,7 +246,7 @@ export function CheckList(data) {
           id: randomString(10),
           description: randomString(50),
         },
-        constant.simpleRecipe
+        constant.simplePipelineWithJSONRecipe
       );
     }
 
@@ -433,7 +433,7 @@ export function CheckGet(data) {
         id: randomString(10),
         description: randomString(50),
       },
-      constant.simpleRecipe
+      constant.simplePipelineWithJSONRecipe
     );
 
     check(
@@ -538,7 +538,7 @@ export function CheckUpdate(data) {
       {
         id: randomString(10),
       },
-      constant.simpleRecipe
+      constant.simplePipelineWithJSONRecipe
     );
 
     // Create a pipeline
@@ -698,7 +698,7 @@ export function CheckRename(data) {
       {
         id: randomString(10),
       },
-      constant.simpleRecipe
+      constant.simplePipelineWithJSONRecipe
     );
 
     // Create a pipeline
@@ -769,7 +769,7 @@ export function CheckLookUp(data) {
       {
         id: randomString(10),
       },
-      constant.simpleRecipe
+      constant.simplePipelineWithJSONRecipe
     );
 
     // Create a pipeline

--- a/integration-test/pipeline/grpc-trigger.js
+++ b/integration-test/pipeline/grpc-trigger.js
@@ -21,7 +21,73 @@ export function CheckTrigger(data) {
           id: randomString(10),
           description: randomString(50),
         },
-        constant.simpleRecipe
+        constant.simplePipelineWithJSONRecipe
+      );
+
+      check(
+        client.invoke(
+          "vdp.pipeline.v1beta.PipelinePublicService/CreateUserPipeline",
+          {
+            parent: `${constant.namespace}`,
+            pipeline: reqGRPC,
+          },
+          data.metadata
+        ),
+        {
+          "vdp.pipeline.v1beta.PipelinePublicService/CreateUserPipeline GRPC pipeline response StatusOK":
+            (r) => r.status === grpc.StatusOK,
+        }
+      );
+
+      check(
+        client.invoke(
+          "vdp.pipeline.v1beta.PipelinePublicService/TriggerUserPipeline",
+          {
+            name: `${constant.namespace}/pipelines/${reqGRPC.id}`,
+            data: constant.simplePayload.data,
+          },
+          data.metadata
+        ),
+        {
+          [`vdp.pipeline.v1beta.PipelinePublicService/TriggerUserPipeline response StatusOK`]:
+            (r) => r.status === grpc.StatusOK,
+        }
+      );
+
+
+      check(
+        client.invoke(
+          `vdp.pipeline.v1beta.PipelinePublicService/DeleteUserPipeline`,
+          {
+            name: `${constant.namespace}/pipelines/${reqGRPC.id}`,
+          },
+          data.metadata
+        ),
+        {
+          [`vdp.pipeline.v1beta.PipelinePublicService/DeleteUserPipeline ${reqGRPC.id} response StatusOK`]:
+            (r) => r.status === grpc.StatusOK,
+        }
+      );
+
+
+
+      client.close();
+    }
+  );
+
+  group(
+    "Pipelines API: Trigger a pipeline with YAML recipe",
+    () => {
+      client.connect(constant.pipelineGRPCPublicHost, {
+        plaintext: true,
+      });
+
+      var reqGRPC = Object.assign(
+        {
+          id: randomString(10),
+          description: randomString(50),
+        },
+        constant.simplePipelineWithYAMLRecipe
       );
 
       check(

--- a/integration-test/pipeline/rest-pipeline-private.js
+++ b/integration-test/pipeline/rest-pipeline-private.js
@@ -33,7 +33,7 @@ export function CheckList(data) {
           id: randomString(10),
           description: randomString(50),
         },
-        constant.simpleRecipe
+        constant.simplePipelineWithJSONRecipe
       );
     }
 
@@ -200,7 +200,7 @@ export function CheckLookUp(data) {
       {
         id: randomString(10),
       },
-      constant.simpleRecipe
+      constant.simplePipelineWithJSONRecipe
     );
 
     // Create a pipeline

--- a/integration-test/pipeline/rest-pipeline-public-with-jwt.js
+++ b/integration-test/pipeline/rest-pipeline-public-with-jwt.js
@@ -15,7 +15,7 @@ export function CheckCreate(data) {
           id: randomString(32),
           description: randomString(50),
         },
-        constant.simpleRecipe
+        constant.simplePipelineWithJSONRecipe
       );
 
       // Cannot create a pipeline of a non-exist user
@@ -60,7 +60,7 @@ export function CheckGet(data) {
         id: randomString(10),
         description: randomString(50),
       },
-      constant.simpleRecipe
+      constant.simplePipelineWithJSONRecipe
     );
 
     // Create a pipeline
@@ -115,7 +115,7 @@ export function CheckUpdate(data) {
         {
           id: randomString(10),
         },
-        constant.simpleRecipe
+        constant.simplePipelineWithJSONRecipe
       );
 
       // Create a pipeline
@@ -178,7 +178,7 @@ export function CheckRename(data) {
         {
           id: id,
         },
-        constant.simpleRecipe
+        constant.simplePipelineWithJSONRecipe
       );
 
       // Create a pipeline
@@ -238,7 +238,7 @@ export function CheckLookUp(data) {
         {
           id: randomString(10),
         },
-        constant.simpleRecipe
+        constant.simplePipelineWithJSONRecipe
       );
 
       // Create a pipeline

--- a/integration-test/pipeline/rest-pipeline-public.js
+++ b/integration-test/pipeline/rest-pipeline-public.js
@@ -15,7 +15,7 @@ export function CheckCreate(data) {
         id: randomString(32),
         description: randomString(50),
       },
-      constant.simpleRecipe
+      constant.simplePipelineWithJSONRecipe
     );
 
     // Create a pipeline
@@ -222,7 +222,7 @@ export function CheckList(data) {
           id: randomString(10),
           description: randomString(50),
         },
-        constant.simpleRecipe
+        constant.simplePipelineWithJSONRecipe
       );
     }
 
@@ -393,7 +393,7 @@ export function CheckGet(data) {
         id: randomString(10),
         description: randomString(50),
       },
-      constant.simpleRecipe
+      constant.simplePipelineWithJSONRecipe
     );
 
     // Create a pipeline
@@ -485,7 +485,7 @@ export function CheckUpdate(data) {
       {
         id: randomString(10),
       },
-      constant.simpleRecipe
+      constant.simplePipelineWithJSONRecipe
     );
 
     // Create a pipeline
@@ -638,7 +638,7 @@ export function CheckRename(data) {
       {
         id: randomString(10),
       },
-      constant.simpleRecipe
+      constant.simplePipelineWithJSONRecipe
     );
 
     // Create a pipeline
@@ -699,7 +699,7 @@ export function CheckLookUp(data) {
       {
         id: randomString(10),
       },
-      constant.simpleRecipe
+      constant.simplePipelineWithJSONRecipe
     );
 
     // Create a pipeline

--- a/integration-test/pipeline/rest-trigger-async.js
+++ b/integration-test/pipeline/rest-trigger-async.js
@@ -9,15 +9,15 @@ import * as constant from "./const.js"
 
 export function CheckTrigger(data) {
 
-  var reqBody = Object.assign(
-    {
-      id: randomString(10),
-      description: randomString(50),
-    },
-    constant.simpleRecipe
-  );
-
   group("Pipelines API: Trigger an async pipeline", () => {
+
+    var reqBody = Object.assign(
+      {
+        id: randomString(10),
+        description: randomString(50),
+      },
+      constant.simplePipelineWithJSONRecipe
+    );
 
     check(http.request("POST", `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines`, JSON.stringify(reqBody), data.header), {
       "POST /v1beta/${constant.namespace}/pipelines response status is 201": (r) => r.status === 201,
@@ -29,10 +29,38 @@ export function CheckTrigger(data) {
       [`POST /v1beta/${constant.namespace}/pipelines/${reqBody.id}/triggerAsync response status is 200`]: (r) => r.json().operation.name.startsWith("operations/"),
     });
 
+    // Delete the pipeline
+    check(http.request("DELETE", `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines/${reqBody.id}`, null, data.header), {
+      [`DELETE /v1beta/${constant.namespace}/pipelines/${reqBody.id} response status 204`]: (r) => r.status === 204,
+    });
+
   });
 
-  // Delete the pipeline
-  check(http.request("DELETE", `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines/${reqBody.id}`, null, data.header), {
-    [`DELETE /v1beta/${constant.namespace}/pipelines/${reqBody.id} response status 204`]: (r) => r.status === 204,
+  group("Pipelines API: Trigger an async pipeline with YAML recipe", () => {
+
+    var reqBody = Object.assign(
+      {
+        id: randomString(10),
+        description: randomString(50),
+      },
+      constant.simplePipelineWithYAMLRecipe
+    );
+
+    check(http.request("POST", `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines`, JSON.stringify(reqBody), data.header), {
+      "POST /v1beta/${constant.namespace}/pipelines response status is 201": (r) => r.status === 201,
+    });
+
+
+    check(http.request("POST", `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines/${reqBody.id}/triggerAsync`, JSON.stringify(constant.simplePayload), data.header), {
+      [`POST /v1beta/${constant.namespace}/pipelines/${reqBody.id}/triggerAsync response status is 200`]: (r) => r.status === 200,
+      [`POST /v1beta/${constant.namespace}/pipelines/${reqBody.id}/triggerAsync response status is 200`]: (r) => r.json().operation.name.startsWith("operations/"),
+    });
+
+    // Delete the pipeline
+    check(http.request("DELETE", `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines/${reqBody.id}`, null, data.header), {
+      [`DELETE /v1beta/${constant.namespace}/pipelines/${reqBody.id} response status 204`]: (r) => r.status === 204,
+    });
+
   });
+
 }

--- a/integration-test/pipeline/rest-trigger.js
+++ b/integration-test/pipeline/rest-trigger.js
@@ -16,7 +16,32 @@ export function CheckTrigger(data) {
         id: randomString(10),
         description: randomString(50),
       },
-      constant.simpleRecipe
+      constant.simplePipelineWithJSONRecipe
+    );
+
+    check(http.request("POST", `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines`, JSON.stringify(reqHTTP), data.header), {
+      "POST /v1beta/${constant.namespace}/pipelines response status is 201 (HTTP pipeline)": (r) => r.status === 201,
+    });
+
+    check(http.request("POST", `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines/${reqHTTP.id}/trigger`, JSON.stringify(constant.simplePayload), data.header), {
+      [`POST /v1beta/${constant.namespace}/pipelines/${reqHTTP.id}/trigger response status is 200`]: (r) => r.status === 200,
+    });
+
+
+    check(http.request("DELETE", `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines/${reqHTTP.id}`, null, data.header), {
+      [`DELETE /v1beta/${constant.namespace}/pipelines/${reqHTTP.id} response status 204`]: (r) => r.status === 204,
+    });
+
+  });
+
+  group("Pipelines API: Trigger a pipeline with YAML recipe", () => {
+
+    var reqHTTP = Object.assign(
+      {
+        id: randomString(10),
+        description: randomString(50),
+      },
+      constant.simplePipelineWithYAMLRecipe
     );
 
     check(http.request("POST", `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines`, JSON.stringify(reqHTTP), data.header), {

--- a/integration-test/proto/vdp/pipeline/v1beta/pipeline.proto
+++ b/integration-test/proto/vdp/pipeline/v1beta/pipeline.proto
@@ -90,6 +90,14 @@ message Pipeline {
     VISIBILITY_PUBLIC = 2;
   }
 
+  // Statistic data
+  message Stats {
+    // Number of pipeline runs.
+    int32 number_of_runs = 1;
+    // Last run time.
+    google.protobuf.Timestamp last_run_time = 2;
+  }
+
   // The name of the pipeline, defined by its parent and ID.
   // - Format: `{parent_type}/{parent.id}/pipelines/{pipeline.id}`.
   string name = 1 [
@@ -143,6 +151,11 @@ message Pipeline {
   DataSpecification data_specification = 24 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Tags.
   repeated string tags = 25 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Statistic data.
+  Stats stats = 26;
+  // Recipe in YAML format describes the components of a pipeline and how they
+  // are connected.
+  string raw_recipe = 27 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // TriggerMetadata contains the traces of the pipeline inference.
@@ -230,6 +243,9 @@ message PipelineRelease {
   string readme = 13 [(google.api.field_behavior) = OPTIONAL];
   // Data specifications.
   DataSpecification data_specification = 14 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Recipe in YAML format describes the components of a pipeline and how they
+  // are connected.
+  string raw_recipe = 15 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // ListPipelinesRequest represents a request to list pipelines.
@@ -530,10 +546,10 @@ message TriggerUserPipelineWithStreamRequest {
       field_configuration: {path_param_name: "user_pipeline_name"}
     }
   ];
-  // Pipeline input parameters.
-  repeated google.protobuf.Struct inputs = 2 [(google.api.field_behavior) = REQUIRED];
-  // Pipeline secrets parameters that will override the pipeline's or owner's secrets.
-  map<string, string> secrets = 3 [(google.api.field_behavior) = OPTIONAL];
+  // Pipeline input parameters, it will be deprecated soon.
+  repeated google.protobuf.Struct inputs = 2;
+  // Data
+  repeated TriggerData data = 3;
 }
 
 // TriggerUserPipelineWithStreamResponse contains the pipeline execution results, i.e.,
@@ -1021,6 +1037,34 @@ message TriggerOrganizationPipelineRequest {
 // TriggerOrganizationPipelineResponse contains the pipeline execution results,
 // i.e., the multiple model inference outputs.
 message TriggerOrganizationPipelineResponse {
+  // Model inference outputs.
+  repeated google.protobuf.Struct outputs = 1;
+  // Traces of the pipeline inference.
+  TriggerMetadata metadata = 2;
+}
+
+// TriggerOrganizationPipelineRequest represents a request to trigger an
+// organization-owned pipeline synchronously.
+message TriggerOrganizationPipelineStreamRequest {
+  // The resource name of the pipeline, which allows its access by parent
+  // organization and ID.
+  // - Format: `organizations/{organization.id}/pipelines/{pipeline.id}`.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"},
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration: {path_param_name: "organization_pipeline_name"}
+    }
+  ];
+  // Pipeline input parameters, it will be deprecated soon.
+  repeated google.protobuf.Struct inputs = 2;
+  // Data
+  repeated TriggerData data = 3;
+}
+
+// TriggerOrganizationPipelineResponse contains the pipeline execution results,
+// i.e., the multiple model inference outputs.
+message TriggerOrganizationPipelineStreamResponse {
   // Model inference outputs.
   repeated google.protobuf.Struct outputs = 1;
   // Traces of the pipeline inference.

--- a/integration-test/proto/vdp/pipeline/v1beta/pipeline_public_service.proto
+++ b/integration-test/proto/vdp/pipeline/v1beta/pipeline_public_service.proto
@@ -209,7 +209,7 @@ service PipelinePublicService {
   // and ID of the pipeline.
   rpc TriggerUserPipelineWithStream(TriggerUserPipelineWithStreamRequest) returns (stream TriggerUserPipelineWithStreamResponse) {
     option (google.api.http) = {
-      post: "/v1beta/{name=users/*/pipelines/*}/trigger:stream"
+      post: "/v1beta/{name=users/*/pipelines/*}/trigger-stream"
       body: "*"
     };
     option (google.api.method_signature) = "name,inputs";
@@ -475,6 +475,26 @@ service PipelinePublicService {
     };
     option (google.api.method_signature) = "name,target";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+  }
+
+  // Trigger a pipeline owned by an organization
+  //
+  // Triggers the execution of a pipeline synchronously, i.e., the result is sent
+  // back to the organization right after the data is processed. This method is
+  // intended for real-time inference when low latency is of concern.
+  //
+  // The pipeline is identified by its resource name, formed by the parent
+  // organization and ID of the pipeline.
+  //
+  // For more information, see [Trigger
+  // Pipeline](https://www.instill.tech/docs/latest/core/concepts/pipeline#trigger-pipeline).
+  rpc TriggerOrganizationPipelineStream(TriggerOrganizationPipelineStreamRequest) returns (stream TriggerOrganizationPipelineStreamResponse) {
+    option (google.api.http) = {
+      post: "/v1beta/{name=organizations/*/pipelines/*}/trigger-stream"
+      body: "*"
+    };
+    option (google.api.method_signature) = "name,data";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
   }
 
   // Trigger a pipeline owned by an organization

--- a/pkg/datamodel/datamodel.go
+++ b/pkg/datamodel/datamodel.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -115,14 +116,18 @@ type PipelineRelease struct {
 	Readme   string
 }
 
+type ComponentMap map[string]*Component
+
 // Recipe is the data model of the pipeline recipe
 type Recipe struct {
-	Version   string                `json:"version,omitempty" yaml:"version,omitempty"`
-	RunOn     *RunOn                `json:"runOn,omitempty" yaml:"run-on,omitempty"`
-	Component map[string]*Component `json:"component,omitempty" yaml:"component"`
-	Variable  map[string]*Variable  `json:"variable,omitempty" yaml:"variable,omitempty"`
-	Secret    map[string]string     `json:"secret,omitempty" yaml:"secret,omitempty"`
-	Output    map[string]*Output    `json:"output,omitempty" yaml:"output,omitempty"`
+	Version   string               `json:"version,omitempty" yaml:"version,omitempty"`
+	RunOn     *RunOn               `json:"runOn,omitempty" yaml:"run-on,omitempty"`
+	Component ComponentMap         `json:"component,omitempty" yaml:"component,omitempty"`
+	Variable  map[string]*Variable `json:"variable,omitempty" yaml:"variable,omitempty"`
+	Secret    map[string]string    `json:"secret,omitempty" yaml:"secret,omitempty"`
+	Output    map[string]*Output   `json:"output,omitempty" yaml:"output,omitempty"`
+
+	UseJSON bool `json:"-,omitempty" yaml:"-,omitempty"`
 }
 
 func convertRecipeYAMLToRecipe(recipeYAML string) (*Recipe, error) {
@@ -135,6 +140,35 @@ func convertRecipeYAMLToRecipe(recipeYAML string) (*Recipe, error) {
 	return recipe, nil
 }
 
+func (c *ComponentMap) UnmarshalYAML(node *yaml.Node) error {
+
+	// In this function, we decode the YAML of ComponentMap and parse the YAML
+	// comments into `description` and `note`. To achieve this, we need to
+	// decode the original `ComponentMap` once and then add the `description`
+	// and `note` into the decoded struct. To prevent infinite recursion, we
+	// define an alias of `ComponentMap` called `LocalComponentMap`. We decode
+	// into `LocalComponentMap`, add the corresponding comments, and then
+	// convert it back to `ComponentMap`.
+	type LocalComponentMap ComponentMap
+	var result LocalComponentMap
+	if err := node.Decode(&result); err != nil {
+		return err
+	}
+
+	for _, content := range node.Content {
+		if _, ok := result[content.Value]; ok {
+			headCommentLines := strings.Split(content.HeadComment, "\n")
+			for i := range headCommentLines {
+				headCommentLines[i] = strings.TrimLeft(headCommentLines[i], "# ")
+			}
+			result[content.Value].Description = strings.Join(headCommentLines, "\n")
+		}
+
+	}
+	*c = ComponentMap(result)
+	return nil
+}
+
 func convertRecipeToRecipeYAML(recipe *Recipe) (string, error) {
 	recipeYAML, err := yaml.Marshal(recipe)
 	if err != nil {
@@ -144,19 +178,19 @@ func convertRecipeToRecipeYAML(recipe *Recipe) (string, error) {
 }
 
 func (p *Pipeline) BeforeSave(db *gorm.DB) (err error) {
-	p.RecipeYAML, err = convertRecipeToRecipeYAML(p.Recipe)
-	if err != nil {
-		return err
+
+	// In the future, we'll make YAML the only input data type for pipeline
+	// recipes. Until then, if the YAML recipe is empty, we'll use the JSON
+	// recipe as the input data. Once the JSON recipe becomes output-only, this
+	// condition will no longer be necessary.
+	if p.RecipeYAML == "" {
+		p.RecipeYAML, err = convertRecipeToRecipeYAML(p.Recipe)
+		if err != nil {
+			return err
+		}
+
 	}
 
-	return nil
-}
-
-func (p *PipelineRelease) BeforeSave(db *gorm.DB) (err error) {
-	p.RecipeYAML, err = convertRecipeToRecipeYAML(p.Recipe)
-	if err != nil {
-		return err
-	}
 	return nil
 }
 
@@ -203,19 +237,22 @@ type RunOn struct {
 }
 
 type Component struct {
-	// Share fields
+	// Common fields
 	Type      string         `json:"type,omitempty" yaml:"type,omitempty"`
 	Task      string         `json:"task,omitempty" yaml:"task,omitempty"`
 	Input     any            `json:"input,omitempty" yaml:"input,omitempty"`
 	Condition string         `json:"condition,omitempty" yaml:"condition,omitempty"`
 	Metadata  map[string]any `json:"metadata,omitempty"  yaml:"metadata,omitempty"`
 
+	// The YAML header comment will be parsed into the `Description` field.
+	Description string `json:"description,omitempty"  yaml:"-"`
+
 	// Fields for regular components
 	Setup      map[string]any `json:"setup,omitempty" yaml:"setup,omitempty"`
 	Definition *Definition    `json:"definition,omitempty" yaml:"-"`
 
 	// Fields for iterators
-	Component         map[string]*Component `json:"component,omitempty" yaml:"component,omitempty"`
+	Component         ComponentMap          `json:"component,omitempty" yaml:"component,omitempty"`
 	OutputElements    map[string]string     `json:"outputElements,omitempty" yaml:"output-elements,omitempty"`
 	DataSpecification *pb.DataSpecification `json:"dataSpecification,omitempty" yaml:"-"`
 }

--- a/pkg/datamodel/datamodel.go
+++ b/pkg/datamodel/datamodel.go
@@ -126,8 +126,6 @@ type Recipe struct {
 	Variable  map[string]*Variable `json:"variable,omitempty" yaml:"variable,omitempty"`
 	Secret    map[string]string    `json:"secret,omitempty" yaml:"secret,omitempty"`
 	Output    map[string]*Output   `json:"output,omitempty" yaml:"output,omitempty"`
-
-	UseJSON bool `json:"-,omitempty" yaml:"-,omitempty"`
 }
 
 func convertRecipeYAMLToRecipe(recipeYAML string) (*Recipe, error) {

--- a/pkg/handler/pipeline.go
+++ b/pkg/handler/pipeline.go
@@ -493,10 +493,10 @@ func (h *PublicHandler) updateNamespacePipeline(ctx context.Context, req UpdateN
 
 	// metadata field is type google.protobuf.Struct, which needs to be updated as a whole
 	for idx, path := range pbUpdateMask.Paths {
-		if strings.Contains(path, "metadata") {
+		if strings.Split(path, ".")[0] == "metadata" {
 			pbUpdateMask.Paths[idx] = "metadata"
 		}
-		if strings.Contains(path, "recipe") {
+		if strings.Split(path, ".")[0] == "recipe" {
 			pbUpdateMask.Paths[idx] = "recipe"
 		}
 	}
@@ -540,6 +540,14 @@ func (h *PublicHandler) updateNamespacePipeline(ctx context.Context, req UpdateN
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
+	}
+
+	// In the future, we'll make YAML the only input data type for pipeline
+	// recipes. Until then, if the YAML recipe is empty, we'll use the JSON
+	// recipe as the input data. Therefore, we set `RawRecipe` to an empty
+	// string here.
+	if req.GetPipeline().Recipe != nil {
+		pbPipelineToUpdate.RawRecipe = ""
 	}
 
 	pbPipeline, err := h.service.UpdateNamespacePipelineByID(ctx, ns, id, pbPipelineToUpdate)

--- a/pkg/recipe/dag.go
+++ b/pkg/recipe/dag.go
@@ -61,14 +61,14 @@ func (uf *unionFind) Count() int {
 }
 
 type dag struct {
-	compMap          map[string]*datamodel.Component
+	compMap          datamodel.ComponentMap
 	compsIdx         map[string]int
 	prerequisitesMap map[string][]string
 	uf               *unionFind
 	ancestorsMap     map[string][]string
 }
 
-func NewDAG(compMap map[string]*datamodel.Component) *dag {
+func NewDAG(compMap datamodel.ComponentMap) *dag {
 
 	uf := NewUnionFind(len(compMap))
 
@@ -102,10 +102,10 @@ type topologicalSortNode struct {
 // TopologicalSort returns the topological sorted components
 // the result is a list of list of components
 // each list is a group of components that can be executed in parallel
-func (d *dag) TopologicalSort() ([]map[string]*datamodel.Component, error) {
+func (d *dag) TopologicalSort() ([]datamodel.ComponentMap, error) {
 
 	if len(d.compMap) == 0 {
-		return []map[string]*datamodel.Component{}, nil
+		return []datamodel.ComponentMap{}, nil
 	}
 
 	indegreesMap := map[string]int{}
@@ -125,7 +125,7 @@ func (d *dag) TopologicalSort() ([]map[string]*datamodel.Component, error) {
 		}
 	}
 
-	ans := []map[string]*datamodel.Component{}
+	ans := []datamodel.ComponentMap{}
 
 	count := 0
 	taken := make(map[string]bool)
@@ -133,7 +133,7 @@ func (d *dag) TopologicalSort() ([]map[string]*datamodel.Component, error) {
 		from := q[0]
 		q = q[1:]
 		if len(ans) <= from.group {
-			ans = append(ans, map[string]*datamodel.Component{})
+			ans = append(ans, datamodel.ComponentMap{})
 		}
 		ans[from.group][from.compID] = d.compMap[from.compID]
 		count += 1
@@ -570,7 +570,7 @@ func SanitizeCondition(cond string) (string, map[string]string, map[string]strin
 	return cond, varMapping, revVarMapping
 }
 
-func GenerateDAG(componentMap map[string]*datamodel.Component) (*dag, error) {
+func GenerateDAG(componentMap datamodel.ComponentMap) (*dag, error) {
 
 	componentIDMap := make(map[string]bool)
 
@@ -659,7 +659,7 @@ func FindReferenceParent(input string) []string {
 	return upstreams
 }
 
-func GenerateTraces(comps map[string]*datamodel.Component, memory []*Memory) (map[string]*pb.Trace, error) {
+func GenerateTraces(comps datamodel.ComponentMap, memory []*Memory) (map[string]*pb.Trace, error) {
 	trace := map[string]*pb.Trace{}
 
 	batchSize := len(memory)

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -343,7 +343,7 @@ func (s *service) UpdateNamespacePipelineByID(ctx context.Context, ns resource.N
 	if err != nil {
 		return nil, err
 	}
-	pipeline, err := s.converter.ConvertPipelineToPB(ctx, dbPipelineUpdated, pipelinepb.Pipeline_VIEW_FULL, false, true)
+	pipeline, err := s.converter.ConvertPipelineToPB(ctx, dbPipelineUpdated, pipelinepb.Pipeline_VIEW_RECIPE, false, true)
 	if err != nil {
 		return nil, err
 	}
@@ -686,7 +686,7 @@ func (s *service) CreateNamespacePipelineRelease(ctx context.Context, ns resourc
 		return nil, err
 	}
 
-	dbPipelineReleaseToCreate.Recipe = dbPipeline.Recipe
+	dbPipelineReleaseToCreate.RecipeYAML = dbPipeline.RecipeYAML
 	dbPipelineReleaseToCreate.Metadata = dbPipeline.Metadata
 
 	if err := s.repository.CreateNamespacePipelineRelease(ctx, ownerPermalink, pipelineUID, dbPipelineReleaseToCreate); err != nil {

--- a/pkg/service/secret.go
+++ b/pkg/service/secret.go
@@ -131,7 +131,7 @@ func (s *service) checkSecretFields(ctx context.Context, uid uuid.UUID, setup ma
 	}
 	return nil
 }
-func (s *service) checkSecret(ctx context.Context, components map[string]*datamodel.Component) error {
+func (s *service) checkSecret(ctx context.Context, components datamodel.ComponentMap) error {
 
 	for _, comp := range components {
 		switch comp.Type {

--- a/pkg/service/validator.go
+++ b/pkg/service/validator.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"strings"
 
-	"github.com/gofrs/uuid"
 	"github.com/santhosh-tekuri/jsonschema/v5"
 	"google.golang.org/protobuf/types/known/structpb"
 
@@ -47,7 +46,7 @@ func (s *service) checkRecipe(recipePermalink *datamodel.Recipe) ([]*pb.Pipeline
 		switch comp.Type {
 		default:
 
-			def, err := s.component.GetDefinitionByUID(uuid.FromStringOrNil(comp.Type), nil, nil)
+			def, err := s.component.GetDefinitionByID(comp.Type, nil, nil)
 			if err != nil {
 				return nil, err
 			}
@@ -58,7 +57,7 @@ func (s *service) checkRecipe(recipePermalink *datamodel.Recipe) ([]*pb.Pipeline
 			nestedValidationErrors := []*pb.PipelineValidationError{}
 			for nestedID, nestedComp := range comp.Component {
 				if nestedComp.Type != datamodel.Iterator {
-					def, err := s.component.GetDefinitionByUID(uuid.FromStringOrNil(nestedComp.Type), nil, nil)
+					def, err := s.component.GetDefinitionByID(nestedComp.Type, nil, nil)
 					if err != nil {
 						return nil, err
 					}


### PR DESCRIPTION
Because

- We are going to support pipeline recipes in YAML format. We will return the recipe in YAML format in the response and also allow users to create/update recipes using YAML format.
- Previously, we converted the component definition ID in the recipe into UID when writing it to the database. Now, since we will directly store this raw recipe in the database, we won't do this conversion anymore. In the future, we'll migrate recipes if the component definition ID changes.

This commit

- Exposes the `raw_recipe` field in the pipeline and pipeline_release endpoints, the original `recipe` in JSON format is still workable.
- Removes the component definition ID to UID conversion when reading/writing the recipe from/to the database.

Note

- Regarding the component definition ID to UID conversion, database migration is needed. We'll open another PR to address this soon.
- We only added the most basic integration test for the YAML recipe in this PR. More comprehensive tests will be added after we implement the event trigger pipeline.