### PR TITLE
feat: check trigger permissions when impersonating an organization

### DIFF
--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -14,11 +14,23 @@ const MaxPayloadSize = 1024 * 1024 * 32
 // Constants for resource owner
 const DefaultUserID string = "admin"
 
-const HeaderUserUIDKey = "Instill-User-Uid"
-const HeaderVisitorUIDKey = "Instill-Visitor-Uid"
-const HeaderAuthTypeKey = "Instill-Auth-Type"
-const HeaderInstillCodeKey = "Instill-Share-Code"
-const HeaderReturnTracesKey = "Instill-Return-Traces"
+const (
+	// HeaderUserUIDKey is the context key for the authenticated user.
+	HeaderUserUIDKey = "Instill-User-Uid"
+	// HeaderRequesterUIDKey is the context key for the requester. An
+	// authenticated user can use different namespaces (e.g. an organization
+	// they belong to) to make requests, as long as they have permissions.
+	HeaderRequesterUIDKey = "Instill-Requester-Uid"
+	// HeaderVisitorUIDKey is the context key for the visitor UID when requests
+	// are made without authentication.
+	HeaderVisitorUIDKey = "Instill-Visitor-Uid"
+	// HeaderAuthTypeKey is the context key the authentication type (user or
+	// visitor).
+	HeaderAuthTypeKey = "Instill-Auth-Type"
+
+	HeaderInstillCodeKey  = "Instill-Share-Code"
+	HeaderReturnTracesKey = "Instill-Return-Traces"
+)
 
 // GlobalSecretKey can be used to reference a global secret in the
 // configuration of a component (i.e, ${secrets.INSTILL_SECRET}).

--- a/pkg/datamodel/datamodel.go
+++ b/pkg/datamodel/datamodel.go
@@ -92,6 +92,22 @@ type Pipeline struct {
 	NumberOfClones int
 }
 
+// IsPublic returns the visibility of the pipeline based on its sharing
+// configuration.
+func (p Pipeline) IsPublic() bool {
+	publicSharing, hasPublicSharing := p.Sharing.Users["*/*"]
+	if !hasPublicSharing {
+		return false
+	}
+
+	return publicSharing.Enabled
+}
+
+// OwnerUID returns the UID of the pipeline owner.
+func (p Pipeline) OwnerUID() uuid.UUID {
+	return uuid.FromStringOrNil(strings.Split(p.Owner, "/")[1])
+}
+
 type Tag struct {
 	PipelineUID string
 	TagName     string

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -21,4 +21,7 @@ var (
 	// valid. The format should be `<user-id>/<pipeline-id>` or
 	// `<org-id>/<pipeline-id>`.
 	ErrInvalidCloneTarget = fmt.Errorf("invalid target")
+	// ErrUnauthorized is used when a request can't be performed due to
+	// insufficient permissions.
+	ErrUnauthorized = fmt.Errorf("unauthorized")
 )

--- a/pkg/handler/pipeline.go
+++ b/pkg/handler/pipeline.go
@@ -954,7 +954,6 @@ func (h *PublicHandler) TriggerOrganizationPipeline(ctx context.Context, req *pb
 }
 
 func (h *PublicHandler) triggerNamespacePipeline(ctx context.Context, req TriggerNamespacePipelineRequestInterface) (outputs []*structpb.Struct, metadata *pb.TriggerMetadata, err error) {
-
 	eventName := "TriggerNamespacePipeline"
 
 	ctx, span := tracer.Start(ctx, eventName,

--- a/pkg/handler/utils.go
+++ b/pkg/handler/utils.go
@@ -15,13 +15,15 @@ func authenticateUser(ctx context.Context, allowVisitor bool) error {
 			return service.ErrUnauthenticated
 		}
 		return nil
-	} else {
-		if !allowVisitor {
-			return service.ErrUnauthenticated
-		}
-		if resource.GetRequestSingleHeader(ctx, constant.HeaderVisitorUIDKey) == "" {
-			return service.ErrUnauthenticated
-		}
-		return nil
 	}
+
+	if !allowVisitor {
+		return service.ErrUnauthenticated
+	}
+
+	if resource.GetRequestSingleHeader(ctx, constant.HeaderVisitorUIDKey) == "" {
+		return service.ErrUnauthenticated
+	}
+
+	return nil
 }

--- a/pkg/middleware/interceptor.go
+++ b/pkg/middleware/interceptor.go
@@ -111,7 +111,7 @@ func AsGRPCError(err error) error {
 
 		code = codes.InvalidArgument
 	case
-		errors.Is(err, service.ErrNoPermission),
+		errors.Is(err, errdomain.ErrUnauthorized),
 		errors.Is(err, service.ErrCanNotTriggerNonLatestPipelineRelease):
 
 		code = codes.PermissionDenied

--- a/pkg/middleware/interceptor_test.go
+++ b/pkg/middleware/interceptor_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+	errdomain "github.com/instill-ai/pipeline-backend/pkg/errors"
 	"github.com/instill-ai/x/errmsg"
 	"github.com/jackc/pgconn"
 	"google.golang.org/grpc/codes"
@@ -71,6 +72,12 @@ func TestAsGRPCError(t *testing.T) {
 			),
 			wantCode:    codes.FailedPrecondition,
 			wantMessage: "Invalid recipe in pipeline",
+		},
+		{
+			name:        "unauthorized",
+			in:          fmt.Errorf("checking requester permission: %w", errdomain.ErrUnauthorized),
+			wantCode:    codes.PermissionDenied,
+			wantMessage: "checking requester permission: unauthorized",
 		},
 	}
 

--- a/pkg/recipe/variable.go
+++ b/pkg/recipe/variable.go
@@ -12,25 +12,37 @@ import (
 	"github.com/instill-ai/pipeline-backend/pkg/resource"
 )
 
+// SystemVariables contain information about a pipeline trigger.
 type SystemVariables struct {
-	PipelineID          string                 `json:"__PIPELINE_ID"`
-	PipelineUID         uuid.UUID              `json:"__PIPELINE_UID"`
-	PipelineReleaseID   string                 `json:"__PIPELINE_RELEASE_ID"`
-	PipelineReleaseUID  uuid.UUID              `json:"__PIPELINE_RELEASE_UID"`
-	PipelineRecipe      *datamodel.Recipe      `json:"__PIPELINE_RECIPE"`
-	PipelineOwnerType   resource.NamespaceType `json:"__PIPELINE_OWNER_TYPE"`
-	PipelineOwnerUID    uuid.UUID              `json:"__PIPELINE_OWNER_UID"`
-	PipelineUserUID     uuid.UUID              `json:"__PIPELINE_USER_UID"`
-	HeaderAuthorization string                 `json:"__PIPELINE_HEADER_AUTHORIZATION"`
-	ModelBackend        string                 `json:"__MODEL_BACKEND"`
-	MgmtBackend         string                 `json:"__MGMT_BACKEND"`
+	PipelineID         string                 `json:"__PIPELINE_ID"`
+	PipelineUID        uuid.UUID              `json:"__PIPELINE_UID"`
+	PipelineReleaseID  string                 `json:"__PIPELINE_RELEASE_ID"`
+	PipelineReleaseUID uuid.UUID              `json:"__PIPELINE_RELEASE_UID"`
+	PipelineRecipe     *datamodel.Recipe      `json:"__PIPELINE_RECIPE"`
+	PipelineOwnerType  resource.NamespaceType `json:"__PIPELINE_OWNER_TYPE"`
+	PipelineOwnerUID   uuid.UUID              `json:"__PIPELINE_OWNER_UID"`
+
+	// PipelineUserUID is the authenticated user executing a pipeline.
+	PipelineUserUID uuid.UUID `json:"__PIPELINE_USER_UID"`
+	// PipelineRequesterUID is the entity requesting the pipeline execution.
+	PipelineRequesterUID uuid.UUID `json:"__PIPELINE_REQUESTER_UID"`
+
+	HeaderAuthorization string `json:"__PIPELINE_HEADER_AUTHORIZATION"`
+	ModelBackend        string `json:"__MODEL_BACKEND"`
+	MgmtBackend         string `json:"__MGMT_BACKEND"`
 }
 
-// System variables are available to all component
+// GenerateSystemVariables fills SystemVariable fields with information from
+// the context and instance configuration.
 func GenerateSystemVariables(ctx context.Context, sysVar SystemVariables) (map[string]any, error) {
-
-	if sysVar.PipelineUserUID == uuid.Nil {
+	if sysVar.PipelineUserUID.IsNil() {
 		sysVar.PipelineUserUID = uuid.FromStringOrNil(resource.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey))
+	}
+	if sysVar.PipelineRequesterUID.IsNil() {
+		sysVar.PipelineRequesterUID = uuid.FromStringOrNil(resource.GetRequestSingleHeader(ctx, constant.HeaderRequesterUIDKey))
+		if sysVar.PipelineRequesterUID.IsNil() {
+			sysVar.PipelineRequesterUID = sysVar.PipelineUserUID
+		}
 	}
 	if sysVar.HeaderAuthorization == "" {
 		sysVar.HeaderAuthorization = resource.GetRequestSingleHeader(ctx, "Authorization")

--- a/pkg/recipe/variable.go
+++ b/pkg/recipe/variable.go
@@ -14,6 +14,7 @@ import (
 
 // SystemVariables contain information about a pipeline trigger.
 type SystemVariables struct {
+	PipelineTriggerID  string                 `json:"__PIPELINE_TRIGGER_ID"`
 	PipelineID         string                 `json:"__PIPELINE_ID"`
 	PipelineUID        uuid.UUID              `json:"__PIPELINE_UID"`
 	PipelineReleaseID  string                 `json:"__PIPELINE_RELEASE_ID"`

--- a/pkg/service/convert.go
+++ b/pkg/service/convert.go
@@ -459,7 +459,7 @@ func (c *converter) ConvertPipelineToPB(ctx context.Context, dbPipelineOrigin *d
 
 	pbPipeline.Permission = &pb.Permission{}
 	if checkPermission {
-		if strings.Split(dbPipeline.Owner, "/")[1] == ctxUserUID {
+		if dbPipeline.OwnerUID().String() == ctxUserUID {
 			pbPipeline.Permission.CanEdit = true
 			pbPipeline.Permission.CanRelease = true
 			pbPipeline.Permission.CanTrigger = true
@@ -505,10 +505,8 @@ func (c *converter) ConvertPipelineToPB(ctx context.Context, dbPipelineOrigin *d
 	pbPipeline.Releases = pbReleases
 
 	pbPipeline.Visibility = pb.Pipeline_VISIBILITY_PRIVATE
-	if u, ok := pbPipeline.Sharing.Users["*/*"]; ok {
-		if u.Enabled {
-			pbPipeline.Visibility = pb.Pipeline_VISIBILITY_PUBLIC
-		}
+	if dbPipeline.IsPublic() {
+		pbPipeline.Visibility = pb.Pipeline_VISIBILITY_PUBLIC
 	}
 	return &pbPipeline, nil
 }

--- a/pkg/service/errors.go
+++ b/pkg/service/errors.go
@@ -8,7 +8,6 @@ import (
 	errdomain "github.com/instill-ai/pipeline-backend/pkg/errors"
 )
 
-var ErrNoPermission = fmt.Errorf("no permission")
 var ErrUnauthenticated = fmt.Errorf("unauthenticated")
 var ErrRateLimiting = fmt.Errorf("rate limiting")
 var ErrCanNotTriggerNonLatestPipelineRelease = fmt.Errorf("can not trigger non-latest pipeline release")

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -996,6 +996,10 @@ func (s *service) triggerPipeline(
 	}
 
 	userUID := uuid.FromStringOrNil(resource.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey))
+	requesterUID := uuid.FromStringOrNil(resource.GetRequestSingleHeader(ctx, constant.HeaderRequesterUIDKey))
+	if requesterUID.IsNil() {
+		requesterUID = userUID
+	}
 
 	we, err := s.temporalClient.ExecuteWorkflow(
 		ctx,
@@ -1005,15 +1009,16 @@ func (s *service) triggerPipeline(
 			BatchSize:        len(pipelineData),
 			MemoryStorageKey: memoryKey,
 			SystemVariables: recipe.SystemVariables{
-				PipelineID:          pipelineID,
-				PipelineUID:         pipelineUID,
-				PipelineReleaseID:   pipelineReleaseID,
-				PipelineReleaseUID:  pipelineReleaseUID,
-				PipelineRecipe:      r,
-				PipelineOwnerType:   ns.NsType,
-				PipelineOwnerUID:    ns.NsUID,
-				PipelineUserUID:     userUID,
-				HeaderAuthorization: resource.GetRequestSingleHeader(ctx, "authorization"),
+				PipelineID:           pipelineID,
+				PipelineUID:          pipelineUID,
+				PipelineReleaseID:    pipelineReleaseID,
+				PipelineReleaseUID:   pipelineReleaseUID,
+				PipelineRecipe:       r,
+				PipelineOwnerType:    ns.NsType,
+				PipelineOwnerUID:     ns.NsUID,
+				PipelineUserUID:      userUID,
+				PipelineRequesterUID: requesterUID,
+				HeaderAuthorization:  resource.GetRequestSingleHeader(ctx, "authorization"),
 			},
 			Mode: mgmtpb.Mode_MODE_SYNC,
 		})
@@ -1070,6 +1075,11 @@ func (s *service) triggerAsyncPipeline(
 	}
 
 	userUID := uuid.FromStringOrNil(resource.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey))
+	requesterUID := uuid.FromStringOrNil(resource.GetRequestSingleHeader(ctx, constant.HeaderRequesterUIDKey))
+	if requesterUID.IsNil() {
+		requesterUID = userUID
+	}
+
 	we, err := s.temporalClient.ExecuteWorkflow(
 		ctx,
 		workflowOptions,
@@ -1078,15 +1088,16 @@ func (s *service) triggerAsyncPipeline(
 			BatchSize:        len(pipelineData),
 			MemoryStorageKey: memoryKey,
 			SystemVariables: recipe.SystemVariables{
-				PipelineID:          pipelineID,
-				PipelineUID:         pipelineUID,
-				PipelineReleaseID:   pipelineReleaseID,
-				PipelineReleaseUID:  pipelineReleaseUID,
-				PipelineRecipe:      r,
-				PipelineOwnerType:   ns.NsType,
-				PipelineOwnerUID:    ns.NsUID,
-				PipelineUserUID:     userUID,
-				HeaderAuthorization: resource.GetRequestSingleHeader(ctx, "authorization"),
+				PipelineID:           pipelineID,
+				PipelineUID:          pipelineUID,
+				PipelineReleaseID:    pipelineReleaseID,
+				PipelineReleaseUID:   pipelineReleaseUID,
+				PipelineRecipe:       r,
+				PipelineOwnerType:    ns.NsType,
+				PipelineOwnerUID:     ns.NsUID,
+				PipelineUserUID:      userUID,
+				PipelineRequesterUID: requesterUID,
+				HeaderAuthorization:  resource.GetRequestSingleHeader(ctx, "authorization"),
 			},
 			Mode: mgmtpb.Mode_MODE_ASYNC,
 		})

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -1009,6 +1009,7 @@ func (s *service) triggerPipeline(
 			BatchSize:        len(pipelineData),
 			MemoryStorageKey: memoryKey,
 			SystemVariables: recipe.SystemVariables{
+				PipelineTriggerID:    pipelineTriggerID,
 				PipelineID:           pipelineID,
 				PipelineUID:          pipelineUID,
 				PipelineReleaseID:    pipelineReleaseID,
@@ -1088,6 +1089,7 @@ func (s *service) triggerAsyncPipeline(
 			BatchSize:        len(pipelineData),
 			MemoryStorageKey: memoryKey,
 			SystemVariables: recipe.SystemVariables{
+				PipelineTriggerID:    pipelineTriggerID,
 				PipelineID:           pipelineID,
 				PipelineUID:          pipelineUID,
 				PipelineReleaseID:    pipelineReleaseID,

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -133,11 +133,11 @@ func (s *service) CreateNamespacePipeline(ctx context.Context, ns resource.Names
 			return nil, err
 		}
 		if !granted {
-			return nil, ErrNoPermission
+			return nil, errdomain.ErrUnauthorized
 		}
 	} else {
 		if ns.NsUID != uuid.FromStringOrNil(resource.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey)) {
-			return nil, ErrNoPermission
+			return nil, errdomain.ErrUnauthorized
 		}
 	}
 
@@ -306,7 +306,7 @@ func (s *service) UpdateNamespacePipelineByID(ctx context.Context, ns resource.N
 	if granted, err := s.aclClient.CheckPermission(ctx, "pipeline", dbPipeline.UID, "admin"); err != nil {
 		return nil, err
 	} else if !granted {
-		return nil, ErrNoPermission
+		return nil, errdomain.ErrUnauthorized
 	}
 
 	var existingPipeline *datamodel.Pipeline
@@ -371,7 +371,7 @@ func (s *service) DeleteNamespacePipelineByID(ctx context.Context, ns resource.N
 	if granted, err := s.aclClient.CheckPermission(ctx, "pipeline", dbPipeline.UID, "admin"); err != nil {
 		return err
 	} else if !granted {
-		return ErrNoPermission
+		return errdomain.ErrUnauthorized
 	}
 
 	// TODO: pagination
@@ -514,7 +514,7 @@ func (s *service) ValidateNamespacePipelineByID(ctx context.Context, ns resource
 	if granted, err := s.aclClient.CheckPermission(ctx, "pipeline", dbPipeline.UID, "executor"); err != nil {
 		return nil, err
 	} else if !granted {
-		return nil, ErrNoPermission
+		return nil, errdomain.ErrUnauthorized
 	}
 
 	validateErrs, err := s.checkRecipe(dbPipeline.Recipe)
@@ -544,7 +544,7 @@ func (s *service) UpdateNamespacePipelineIDByID(ctx context.Context, ns resource
 	if granted, err := s.aclClient.CheckPermission(ctx, "pipeline", dbPipeline.UID, "admin"); err != nil {
 		return nil, err
 	} else if !granted {
-		return nil, ErrNoPermission
+		return nil, errdomain.ErrUnauthorized
 	}
 
 	if err := s.repository.UpdateNamespacePipelineIDByID(ctx, ownerPermalink, id, newID); err != nil {
@@ -756,7 +756,7 @@ func (s *service) CreateNamespacePipelineRelease(ctx context.Context, ns resourc
 	if granted, err := s.aclClient.CheckPermission(ctx, "pipeline", dbPipeline.UID, "admin"); err != nil {
 		return nil, err
 	} else if !granted {
-		return nil, ErrNoPermission
+		return nil, errdomain.ErrUnauthorized
 	}
 
 	dbPipelineReleaseToCreate, err := s.converter.ConvertPipelineReleaseToDB(ctx, pipelineUID, pipelineRelease)
@@ -842,7 +842,7 @@ func (s *service) UpdateNamespacePipelineReleaseByID(ctx context.Context, ns res
 	if granted, err := s.aclClient.CheckPermission(ctx, "pipeline", dbPipeline.UID, "admin"); err != nil {
 		return nil, err
 	} else if !granted {
-		return nil, ErrNoPermission
+		return nil, errdomain.ErrUnauthorized
 	}
 
 	if _, err := s.GetNamespacePipelineReleaseByID(ctx, ns, pipelineUID, id, pipelinepb.Pipeline_VIEW_BASIC); err != nil {
@@ -882,7 +882,7 @@ func (s *service) UpdateNamespacePipelineReleaseIDByID(ctx context.Context, ns r
 	if granted, err := s.aclClient.CheckPermission(ctx, "pipeline", dbPipeline.UID, "admin"); err != nil {
 		return nil, err
 	} else if !granted {
-		return nil, ErrNoPermission
+		return nil, errdomain.ErrUnauthorized
 	}
 
 	// Validation: Pipeline existence
@@ -920,7 +920,7 @@ func (s *service) DeleteNamespacePipelineReleaseByID(ctx context.Context, ns res
 	if granted, err := s.aclClient.CheckPermission(ctx, "pipeline", dbPipeline.UID, "admin"); err != nil {
 		return err
 	} else if !granted {
-		return ErrNoPermission
+		return errdomain.ErrUnauthorized
 	}
 
 	return s.repository.DeleteNamespacePipelineReleaseByID(ctx, ownerPermalink, pipelineUID, id)
@@ -942,7 +942,7 @@ func (s *service) RestoreNamespacePipelineReleaseByID(ctx context.Context, ns re
 	if granted, err := s.aclClient.CheckPermission(ctx, "pipeline", uuid.FromStringOrNil(pipeline.GetUid()), "admin"); err != nil {
 		return err
 	} else if !granted {
-		return ErrNoPermission
+		return errdomain.ErrUnauthorized
 	}
 
 	dbPipelineRelease, err := s.repository.GetNamespacePipelineReleaseByID(ctx, ownerPermalink, pipelineUID, id, false)
@@ -1154,7 +1154,7 @@ func (s *service) checkTriggerPermission(ctx context.Context, pipelineUID uuid.U
 	if granted, err := s.aclClient.CheckPermission(ctx, "pipeline", pipelineUID, "executor"); err != nil {
 		return false, err
 	} else if !granted {
-		return false, ErrNoPermission
+		return false, errdomain.ErrUnauthorized
 	}
 
 	if isAdmin, err = s.aclClient.CheckPermission(ctx, "pipeline", pipelineUID, "admin"); err != nil {
@@ -1164,7 +1164,6 @@ func (s *service) checkTriggerPermission(ctx context.Context, pipelineUID uuid.U
 }
 
 func (s *service) TriggerNamespacePipelineByID(ctx context.Context, ns resource.Namespace, id string, data []*pipelinepb.TriggerData, pipelineTriggerID string, returnTraces bool) ([]*structpb.Struct, *pipelinepb.TriggerMetadata, error) {
-
 	ownerPermalink := ns.Permalink()
 
 	dbPipeline, err := s.repository.GetNamespacePipelineByID(ctx, ownerPermalink, id, false, true)

--- a/pkg/service/utils.go
+++ b/pkg/service/utils.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/instill-ai/pipeline-backend/pkg/constant"
 	"github.com/instill-ai/pipeline-backend/pkg/resource"
+
+	errdomain "github.com/instill-ai/pipeline-backend/pkg/errors"
 )
 
 const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
@@ -38,11 +40,11 @@ func (s *service) checkNamespacePermission(ctx context.Context, ns resource.Name
 			return err
 		}
 		if !granted {
-			return ErrNoPermission
+			return errdomain.ErrUnauthorized
 		}
 	} else {
 		if ns.NsUID != uuid.FromStringOrNil(resource.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey)) {
-			return ErrNoPermission
+			return errdomain.ErrUnauthorized
 		}
 	}
 	return nil


### PR DESCRIPTION
Because

- Users can provide the `Instill-Requester-Uid` in order to trigger pipelines on
  behalf of an organization.

This commit

- Limits the execution permissions when an organization namespace is used to
  trigger a pipeline (by release or ID, sync or async). It checks:
    - User can impersonate the organization
    - If an organization is the requester and doesn't own the pipeline, either the pipeline is public or a shareable link is used.
