### PR TITLE
feat: download preset pipelines from Instill Cloud

### DIFF
--- a/cmd/init/main.go
+++ b/cmd/init/main.go
@@ -8,9 +8,11 @@ import (
 	"go.opentelemetry.io/otel"
 
 	"github.com/instill-ai/pipeline-backend/cmd/init/definitionupdater"
+	"github.com/instill-ai/pipeline-backend/cmd/init/presetdownloader"
 	"github.com/instill-ai/pipeline-backend/config"
-	database "github.com/instill-ai/pipeline-backend/pkg/db"
 	"github.com/instill-ai/pipeline-backend/pkg/repository"
+
+	database "github.com/instill-ai/pipeline-backend/pkg/db"
 )
 
 func main() {
@@ -37,4 +39,8 @@ func main() {
 	if err := definitionupdater.UpdateComponentDefinitionIndex(ctx, repo); err != nil {
 		log.Fatal(err)
 	}
+	if err := presetdownloader.DownloadPresetPipelines(ctx, repo); err != nil {
+		log.Fatal(err)
+	}
+
 }

--- a/cmd/init/presetdownloader/downloader.go
+++ b/cmd/init/presetdownloader/downloader.go
@@ -1,0 +1,210 @@
+package presetdownloader
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+
+	"github.com/gofrs/uuid"
+	"github.com/redis/go-redis/v9"
+	"go.temporal.io/sdk/client"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/status"
+
+	openfga "github.com/openfga/api/proto/openfga/v1"
+
+	"github.com/instill-ai/pipeline-backend/config"
+	"github.com/instill-ai/pipeline-backend/pkg/acl"
+	"github.com/instill-ai/pipeline-backend/pkg/constant"
+	"github.com/instill-ai/pipeline-backend/pkg/external"
+	"github.com/instill-ai/pipeline-backend/pkg/logger"
+	"github.com/instill-ai/pipeline-backend/pkg/repository"
+	"github.com/instill-ai/pipeline-backend/pkg/resource"
+	"github.com/instill-ai/pipeline-backend/pkg/service"
+	"github.com/instill-ai/x/temporal"
+	"github.com/instill-ai/x/zapadapter"
+
+	database "github.com/instill-ai/pipeline-backend/pkg/db"
+	pipelinepb "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
+)
+
+// The ID and UID within the preset namespace must consistently match between
+// mgmt and pipeline-backend.
+const PresetNamespaceID = "preset"
+const PresetNamespaceUID = "63196cec-1c95-49e8-9bf6-9f9497a15f72"
+
+func DownloadPresetPipelines(ctx context.Context, repo repository.Repository) error {
+	// In Instill Cloud, we have a special organization called `preset`, which
+	// stores all the preset pipelines that users can use or clone. We also want
+	// to provide these preset pipelines in Instill Core. Thus, we have
+	// implemented this download logic here.
+	// Note: The implementation here is temporary. We need to refactor it to
+	// have a better structure and handle use cases such as when the preset is
+	// deleted.
+
+	logger, _ := logger.GetZapLogger(ctx)
+
+	db := database.GetSharedConnection()
+	defer database.Close(db)
+
+	var temporalClientOptions client.Options
+	var err error
+	if config.Config.Temporal.Ca != "" && config.Config.Temporal.Cert != "" && config.Config.Temporal.Key != "" {
+		if temporalClientOptions, err = temporal.GetTLSClientOption(
+			config.Config.Temporal.HostPort,
+			config.Config.Temporal.Namespace,
+			zapadapter.NewZapAdapter(logger),
+			config.Config.Temporal.Ca,
+			config.Config.Temporal.Cert,
+			config.Config.Temporal.Key,
+			config.Config.Temporal.ServerName,
+			true,
+		); err != nil {
+			logger.Fatal(fmt.Sprintf("Unable to get Temporal client options: %s", err))
+		}
+	} else {
+		if temporalClientOptions, err = temporal.GetClientOption(
+			config.Config.Temporal.HostPort,
+			config.Config.Temporal.Namespace,
+			zapadapter.NewZapAdapter(logger)); err != nil {
+			logger.Fatal(fmt.Sprintf("Unable to get Temporal client options: %s", err))
+		}
+	}
+
+	temporalClient, err := client.Dial(temporalClientOptions)
+	if err != nil {
+		logger.Fatal(fmt.Sprintf("Unable to create client: %s", err))
+	}
+	defer temporalClient.Close()
+
+	redisClient := redis.NewClient(&config.Config.Cache.Redis.RedisOptions)
+	defer redisClient.Close()
+
+	fgaClient, fgaClientConn := acl.InitOpenFGAClient(ctx, config.Config.OpenFGA.Host, config.Config.OpenFGA.Port)
+	if fgaClientConn != nil {
+		defer fgaClientConn.Close()
+	}
+	var fgaReplicaClient openfga.OpenFGAServiceClient
+	var fgaReplicaClientConn *grpc.ClientConn
+	if config.Config.OpenFGA.Replica.Host != "" {
+
+		fgaReplicaClient, fgaReplicaClientConn = acl.InitOpenFGAClient(ctx, config.Config.OpenFGA.Replica.Host, config.Config.OpenFGA.Replica.Port)
+		if fgaReplicaClientConn != nil {
+			defer fgaReplicaClientConn.Close()
+		}
+	}
+
+	aclClient := acl.NewACLClient(fgaClient, fgaReplicaClient, redisClient)
+
+	mgmtPrivateServiceClient, mgmtPrivateServiceClientConn := external.InitMgmtPrivateServiceClient(ctx)
+	if mgmtPrivateServiceClientConn != nil {
+		defer mgmtPrivateServiceClientConn.Close()
+	}
+
+	converter := service.NewConverter(mgmtPrivateServiceClient, redisClient, &aclClient, repo)
+
+	clientConn, err := grpc.Dial(fmt.Sprintf("%s:%d", config.Config.InstillCloud.Host, config.Config.InstillCloud.Port),
+		grpc.WithTransportCredentials(credentials.NewTLS((&tls.Config{}))),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(constant.MaxPayloadSize), grpc.MaxCallSendMsgSize(constant.MaxPayloadSize)))
+	if err != nil {
+		return err
+	}
+	defer clientConn.Close()
+
+	cloudPipelineClient := pipelinepb.NewPipelinePublicServiceClient(clientConn)
+
+	ns := resource.Namespace{
+		NsType: resource.Organization,
+		NsID:   PresetNamespaceID,
+		NsUID:  uuid.FromStringOrNil(PresetNamespaceUID),
+	}
+	pageToken := ""
+	for {
+		resp, err := cloudPipelineClient.ListOrganizationPipelines(ctx, &pipelinepb.ListOrganizationPipelinesRequest{
+			Parent:    fmt.Sprintf("organizations/%s", PresetNamespaceID),
+			View:      pipelinepb.Pipeline_VIEW_RECIPE.Enum(),
+			PageToken: &pageToken,
+		})
+		if err != nil {
+			if status.Code(err) == codes.NotFound {
+				// If the preset organization does not exist, we skip the download process.
+				return nil
+			}
+			return err
+		}
+		for _, pipeline := range resp.Pipelines {
+			dbPipeline, err := converter.ConvertPipelineToDB(ctx, ns, pipeline)
+			if err != nil {
+				return err
+			}
+			p, err := repo.GetNamespacePipelineByID(ctx, ns.Permalink(), dbPipeline.ID, true, false)
+			if err == nil {
+				if err := repo.UpdateNamespacePipelineByUID(ctx, p.UID, dbPipeline); err != nil {
+					return err
+				}
+				err = aclClient.SetOwner(ctx, "pipeline", dbPipeline.UID, "organization", ns.NsUID)
+				if err != nil {
+					return err
+				}
+				// TODO: use OpenFGA as single source of truth
+				err = aclClient.SetPipelinePermissionMap(ctx, dbPipeline)
+				if err != nil {
+					return err
+				}
+			} else {
+				if err := repo.CreateNamespacePipeline(ctx, ns.Permalink(), dbPipeline); err != nil {
+					return err
+				}
+				err = aclClient.SetOwner(ctx, "pipeline", dbPipeline.UID, "organization", ns.NsUID)
+				if err != nil {
+					return err
+				}
+				// TODO: use OpenFGA as single source of truth
+				err = aclClient.SetPipelinePermissionMap(ctx, dbPipeline)
+				if err != nil {
+					return err
+				}
+			}
+
+			releasePageToken := ""
+			for {
+				releaseResp, err := cloudPipelineClient.ListOrganizationPipelineReleases(ctx, &pipelinepb.ListOrganizationPipelineReleasesRequest{
+					Parent:    fmt.Sprintf("organizations/%s/pipelines/%s", PresetNamespaceID, dbPipeline.ID),
+					View:      pipelinepb.Pipeline_VIEW_RECIPE.Enum(),
+					PageToken: &releasePageToken,
+				})
+				if err != nil {
+					return err
+				}
+				for _, release := range releaseResp.Releases {
+					dbRelease, err := converter.ConvertPipelineReleaseToDB(ctx, dbPipeline.UID, release)
+					if err != nil {
+						return err
+					}
+					_, err = repo.GetNamespacePipelineReleaseByID(ctx, ns.Permalink(), dbPipeline.UID, dbRelease.ID, true)
+					if err != nil {
+						if err := repo.CreateNamespacePipelineRelease(ctx, ns.Permalink(), dbPipeline.UID, dbRelease); err != nil {
+							return err
+						}
+					}
+
+				}
+				if releasePageToken == "" {
+					break
+				}
+
+				releasePageToken = releaseResp.NextPageToken
+			}
+
+		}
+		if pageToken == "" {
+			break
+		}
+		pageToken = resp.NextPageToken
+
+	}
+
+	return nil
+}

--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -16,8 +16,9 @@ import (
 	grpcmiddleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpczap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
 	grpcrecovery "github.com/grpc-ecosystem/go-grpc-middleware/recovery"
-	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	openfga "github.com/openfga/api/proto/openfga/v1"
+
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/redis/go-redis/v9"
 	"go.opentelemetry.io/contrib/propagators/b3"
 	"go.opentelemetry.io/otel"
@@ -34,18 +35,19 @@ import (
 	"github.com/instill-ai/pipeline-backend/config"
 	"github.com/instill-ai/pipeline-backend/pkg/acl"
 	"github.com/instill-ai/pipeline-backend/pkg/constant"
-	database "github.com/instill-ai/pipeline-backend/pkg/db"
 	"github.com/instill-ai/pipeline-backend/pkg/external"
 	"github.com/instill-ai/pipeline-backend/pkg/handler"
 	"github.com/instill-ai/pipeline-backend/pkg/logger"
-	customotel "github.com/instill-ai/pipeline-backend/pkg/logger/otel"
 	"github.com/instill-ai/pipeline-backend/pkg/middleware"
 	"github.com/instill-ai/pipeline-backend/pkg/repository"
 	"github.com/instill-ai/pipeline-backend/pkg/service"
 	"github.com/instill-ai/pipeline-backend/pkg/usage"
-	pb "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 	"github.com/instill-ai/x/temporal"
 	"github.com/instill-ai/x/zapadapter"
+
+	database "github.com/instill-ai/pipeline-backend/pkg/db"
+	customotel "github.com/instill-ai/pipeline-backend/pkg/logger/otel"
+	pb "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
 
 var propagator propagation.TextMapPropagator

--- a/config/config.go
+++ b/config/config.go
@@ -32,6 +32,13 @@ type AppConfig struct {
 	MgmtBackend  MgmtBackendConfig  `koanf:"mgmtbackend"`
 	ModelBackend ModelBackendConfig `koanf:"modelbackend"`
 	OpenFGA      OpenFGAConfig      `koanf:"openfga"`
+	InstillCloud InstillCloudConfig `koanf:"instillcloud"`
+}
+
+// InstillCloud config
+type InstillCloudConfig struct {
+	Host string `koanf:"host"`
+	Port int    `koanf:"port"`
 }
 
 // OpenFGA config

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -71,3 +71,6 @@ modelbackend:
 openfga:
   host: openfga
   port: 8081
+instillcloud:
+  host: api.instill.tech
+  port: 443

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -343,7 +343,7 @@ func (s *service) UpdateNamespacePipelineByID(ctx context.Context, ns resource.N
 	if err != nil {
 		return nil, err
 	}
-	pipeline, err := s.converter.ConvertPipelineToPB(ctx, dbPipelineUpdated, pipelinepb.Pipeline_VIEW_RECIPE, false, true)
+	pipeline, err := s.converter.ConvertPipelineToPB(ctx, dbPipelineUpdated, pipelinepb.Pipeline_VIEW_FULL, false, true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Because

- In Instill Cloud, there is a special organization called `preset` that stores all preset pipelines available for users to use or clone. We also aim to make these preset pipelines available in Instill Core.

This commit

- Implements the functionality to download preset pipelines.
