### PR TITLE
chore: skip presetDownloader when Instill Cloud is unreachable

### DIFF
--- a/cmd/init/presetdownloader/downloader.go
+++ b/cmd/init/presetdownloader/downloader.go
@@ -105,11 +105,17 @@ func DownloadPresetPipelines(ctx context.Context, repo repository.Repository) er
 
 	converter := service.NewConverter(mgmtPrivateServiceClient, redisClient, &aclClient, repo)
 
+	if config.Config.InstillCloud.Host == "" {
+		// Skip the download process if the Instill Cloud host is not set.
+		return nil
+	}
+
 	clientConn, err := grpc.Dial(fmt.Sprintf("%s:%d", config.Config.InstillCloud.Host, config.Config.InstillCloud.Port),
 		grpc.WithTransportCredentials(credentials.NewTLS((&tls.Config{}))),
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(constant.MaxPayloadSize), grpc.MaxCallSendMsgSize(constant.MaxPayloadSize)))
 	if err != nil {
-		return err
+		// Skip the download process if Instill Cloud is unreachable.
+		return nil
 	}
 	defer clientConn.Close()
 


### PR DESCRIPTION
Because

- The network environment might prevent Instill Core from reaching Instill Cloud.

This commit

- Skips presetDownloader when Instill Cloud is unreachable.