### PR TITLE
feat: support case-insensitive search for pipelines and components

### DIFF
--- a/integration-test/pipeline/rest-component-definition.js
+++ b/integration-test/pipeline/rest-component-definition.js
@@ -90,6 +90,13 @@ export function CheckList() {
       [`GET /v1beta/component-definitions?pageSize=1&filter=qTitle="JSO" title is JSON`]: (r) => r.json().componentDefinitions[0].title === "JSON",
     });
 
+    // Filter (fuzzy and case-insensitive) title
+    check(http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?pageSize=1&filter=qTitle="jso"`, null, null), {
+      [`GET /v1beta/component-definitions?pageSize=1&filter=qTitle="jso" response status 200`]: (r) => r.status === 200,
+      [`GET /v1beta/component-definitions?pageSize=1&filter=qTitle="jso" single result`]: (r) => r.json().totalSize === 1,
+      [`GET /v1beta/component-definitions?pageSize=1&filter=qTitle="jso" title is JSON`]: (r) => r.json().componentDefinitions[0].title === "JSON",
+    });
+
     // Filter component type
     check(http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?pageSize=1&filter=componentType=COMPONENT_TYPE_OPERATOR`, null, null), {
       "GET /v1beta/component-definitions?pageSize=1&filter=componentType=COMPONENT_TYPE_OPERATOR response status 200": (r) => r.status === 200,

--- a/pkg/repository/transpiler.go
+++ b/pkg/repository/transpiler.go
@@ -183,10 +183,10 @@ func (t *transpiler) transpileComparisonCallExpr(e *expr.Expr, op interface{}) (
 		switch ident.SQL {
 		// TODO we should support wildcards without special filter names
 		case "q":
-			sql = fmt.Sprintf("%s LIKE ?", "id")
+			sql = fmt.Sprintf("LOWER(%s) LIKE LOWER(?)", "id")
 			vars = append(vars, fmt.Sprintf("%%%s%%", con.Vars[0]))
 		case "q_title":
-			sql = fmt.Sprintf("%s LIKE ?", "title")
+			sql = fmt.Sprintf("LOWER(%s) LIKE LOWER(?)", "title")
 			vars = append(vars, fmt.Sprintf("%%%s%%", con.Vars[0]))
 		case "tag":
 			sql = "tag.tag_name = ?"


### PR DESCRIPTION
Because

- When performing fuzzy searches on pipelines and components, case-insensitivity should be allowed.

This commit

- Supports case-insensitive searches for pipelines and components.