### PR TITLE
fix: block user saving secret fields as plaintext in pipeline

### DIFF
--- a/pkg/service/secret.go
+++ b/pkg/service/secret.go
@@ -136,8 +136,12 @@ func (s *service) checkSecret(ctx context.Context, components datamodel.Componen
 	for _, comp := range components {
 		switch comp.Type {
 		default:
-			defUID := uuid.FromStringOrNil(comp.Type)
-			err := s.checkSecretFields(ctx, defUID, comp.Setup, "")
+
+			c, err := s.component.GetDefinitionByID(comp.Type, nil, nil)
+			if err != nil {
+				return err
+			}
+			err = s.checkSecretFields(ctx, uuid.FromStringOrNil(c.Uid), comp.Setup, "")
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Because

- We should block users from saving secret fields as plaintext in pipelines. The mechanism worked before, but in the recent revamp, we changed to store the component definition with ID instead of the UID in the recipe, which broke the mechanism.

This commit

- Fixes the bug.