### PR TITLE
chore: remove MaxConcurrentActivityExecutionSize setting

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -152,8 +152,7 @@ func main() {
 	)
 
 	w := worker.New(temporalClient, pipelineWorker.TaskQueue, worker.Options{
-		MaxConcurrentActivityExecutionSize: 2,
-		WorkflowPanicPolicy:                worker.FailWorkflow,
+		WorkflowPanicPolicy: worker.FailWorkflow,
 	})
 
 	w.RegisterWorkflow(cw.TriggerPipelineWorkflow)


### PR DESCRIPTION
Because

- Currently, we set a very small `MaxConcurrentActivityExecutionSize`. When there are long-running activities being executed, the third activity will be blocked and wait in the queue.

This commit

- Removes the `MaxConcurrentActivityExecutionSize` setting, making the default concurrency 1000.