### PR TITLE
chore: use camelCase in SSE response

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1116,10 +1116,7 @@ github.com/grpc-ecosystem/go-grpc-middleware v1.3.0/go.mod h1:z0ButlSOZa5vEBq9m2
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
-github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
-github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1 h1:/c3QmbOGMGTOumP2iT/rCwB7b0QDGLKzqOmktBjT+Is=
-github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1/go.mod h1:5SN9VR2LTsRFsrEC6FHgRbTWrTHu6tqPeKxEQv15giM=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0 h1:bkypFPDjIYGfCYD5mRBvpqxfYX1YCS1PXdKYWi8FsN0=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0/go.mod h1:P+Lt/0by1T8bfcF3z737NnSbmxQAppXMRziHUxPOC8k=
 github.com/h2non/filetype v1.1.3 h1:FKkx9QbD7HR/zjK1Ia5XiBsq9zdLi5Kf3zGyFTAFkGg=

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -5,13 +5,14 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+
 	"github.com/google/uuid"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/instill-ai/pipeline-backend/config"
 	"github.com/instill-ai/pipeline-backend/pkg/handler"
 	pb "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
-	"net/http"
-	"net/http/httptest"
 )
 
 type fn func(*runtime.ServeMux, pb.PipelinePublicServiceClient, http.ResponseWriter, *http.Request, map[string]string)
@@ -26,11 +27,11 @@ func AppendCustomHeaderMiddleware(mux *runtime.ServeMux, client pb.PipelinePubli
 
 // SessionMetadata holds the session ID and source instance ID.
 type SessionMetadata struct {
-	SessionUUID string `json:"session_uuid"`
+	SessionUUID string `json:"sessionUUID"`
 	// Source instance identifier is used for network routing scenarios
 	// for example could be included as header in the SSE request to make sure
 	// it is getting routed to the initiating server e.g. running a pod
-	SourceInstanceID string `json:"source_instance_id"`
+	SourceInstanceID string `json:"sourceInstanceID"`
 }
 
 // generateSecureSessionID generated a cryptographic secure session token to be used


### PR DESCRIPTION
Because

- We need to standardize the naming style.

This commit

- uses camelCase in SSE response.