### PR TITLE
feat: inject single usage handler creator in components

### DIFF
--- a/cmd/init/presetdownloader/downloader.go
+++ b/cmd/init/presetdownloader/downloader.go
@@ -160,7 +160,7 @@ func DownloadPresetPipelines(ctx context.Context, repo repository.Repository) er
 					return err
 				}
 			} else {
-				if err := repo.CreateNamespacePipeline(ctx, ns.Permalink(), dbPipeline); err != nil {
+				if err := repo.CreateNamespacePipeline(ctx, dbPipeline); err != nil {
 					return err
 				}
 				err = aclClient.SetOwner(ctx, "pipeline", dbPipeline.UID, "organization", ns.NsUID)

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -20,7 +20,6 @@ import (
 	"github.com/instill-ai/x/zapadapter"
 	"github.com/redis/go-redis/v9"
 
-	componentbase "github.com/instill-ai/component/base"
 	database "github.com/instill-ai/pipeline-backend/pkg/db"
 	customotel "github.com/instill-ai/pipeline-backend/pkg/logger/otel"
 	pipelineWorker "github.com/instill-ai/pipeline-backend/pkg/worker"
@@ -147,7 +146,7 @@ func main() {
 		redisClient,
 		timeseries.WriteAPI(),
 		config.Config.Connector.Secrets,
-		map[string]componentbase.UsageHandlerCreator{},
+		nil,
 	)
 
 	w := worker.New(temporalClient, pipelineWorker.TaskQueue, worker.Options{

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -160,7 +160,6 @@ func main() {
 	w.RegisterActivity(cw.PreIteratorActivity)
 	w.RegisterActivity(cw.PostIteratorActivity)
 	w.RegisterActivity(cw.UsageCollectActivity)
-	w.RegisterActivity(cw.UsageCheckActivity)
 
 	span.End()
 	err = w.Run(worker.InterruptCh())

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -148,7 +148,6 @@ func main() {
 		timeseries.WriteAPI(),
 		config.Config.Connector.Secrets,
 		map[string]componentbase.UsageHandlerCreator{},
-		nil,
 	)
 
 	w := worker.New(temporalClient, pipelineWorker.TaskQueue, worker.Options{
@@ -159,7 +158,7 @@ func main() {
 	w.RegisterActivity(cw.ComponentActivity)
 	w.RegisterActivity(cw.PreIteratorActivity)
 	w.RegisterActivity(cw.PostIteratorActivity)
-	w.RegisterActivity(cw.UsageCollectActivity)
+	w.RegisterActivity(cw.IncreasePipelineTriggerCountActivity)
 
 	span.End()
 	err = w.Run(worker.InterruptCh())

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0
 	github.com/iancoleman/strcase v0.3.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/component v0.21.0-beta.0.20240704151317-e3868be434eb // TODO update reference after merge to main
+	github.com/instill-ai/component v0.21.0-beta.0.20240708043833-e27e46c0876b
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240627022558-b70559ea17ce
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0
 	github.com/iancoleman/strcase v0.3.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/component v0.21.0-beta
+	github.com/instill-ai/component v0.21.0-beta.0.20240704151317-e3868be434eb // TODO update reference after merge to main
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240627022558-b70559ea17ce
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/PaesslerAG/jsonpath v0.1.1
 	github.com/frankban/quicktest v1.14.6
 	github.com/gabriel-vasile/mimetype v1.4.3
+	github.com/go-redis/redismock/v9 v9.2.0
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/golang-migrate/migrate/v4 v4.15.2
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1189,8 +1189,8 @@ github.com/influxdata/influxdb-client-go/v2 v2.12.3 h1:28nRlNMRIV4QbtIUvxhWqaxn0
 github.com/influxdata/influxdb-client-go/v2 v2.12.3/go.mod h1:IrrLUbCjjfkmRuaCiGQg4m2GbkaeJDcuWoxiWdQEbA0=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/instill-ai/component v0.21.0-beta.0.20240704151317-e3868be434eb h1:Xn+1Gj5kpuUq/CZTOaena1WKP9w+xNS4GTXcY7x+7OA=
-github.com/instill-ai/component v0.21.0-beta.0.20240704151317-e3868be434eb/go.mod h1:BYWEZ7yljCFujwaCuHvhBCK1uF2l62JyekuWk7FACaA=
+github.com/instill-ai/component v0.21.0-beta.0.20240708043833-e27e46c0876b h1:lxgr+muzeIzcv6I7gQDW55CsDwgwW3Tfd3soFQqvgWg=
+github.com/instill-ai/component v0.21.0-beta.0.20240708043833-e27e46c0876b/go.mod h1:BYWEZ7yljCFujwaCuHvhBCK1uF2l62JyekuWk7FACaA=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240627022558-b70559ea17ce h1:3ewdsZt7F/6T/K5eFLuGSCpAu8JuuOXGu+nObRY5dwQ=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240627022558-b70559ea17ce/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=

--- a/go.sum
+++ b/go.sum
@@ -1189,8 +1189,8 @@ github.com/influxdata/influxdb-client-go/v2 v2.12.3 h1:28nRlNMRIV4QbtIUvxhWqaxn0
 github.com/influxdata/influxdb-client-go/v2 v2.12.3/go.mod h1:IrrLUbCjjfkmRuaCiGQg4m2GbkaeJDcuWoxiWdQEbA0=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/instill-ai/component v0.21.0-beta h1:omUdwcusBC4s2U7WjiiqSKDh0Y7kdzTmpNw888XyYWU=
-github.com/instill-ai/component v0.21.0-beta/go.mod h1:BYWEZ7yljCFujwaCuHvhBCK1uF2l62JyekuWk7FACaA=
+github.com/instill-ai/component v0.21.0-beta.0.20240704151317-e3868be434eb h1:Xn+1Gj5kpuUq/CZTOaena1WKP9w+xNS4GTXcY7x+7OA=
+github.com/instill-ai/component v0.21.0-beta.0.20240704151317-e3868be434eb/go.mod h1:BYWEZ7yljCFujwaCuHvhBCK1uF2l62JyekuWk7FACaA=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240627022558-b70559ea17ce h1:3ewdsZt7F/6T/K5eFLuGSCpAu8JuuOXGu+nObRY5dwQ=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240627022558-b70559ea17ce/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=

--- a/go.sum
+++ b/go.sum
@@ -887,6 +887,8 @@ github.com/go-openapi/swag v0.0.0-20160704191624-1d0bd113de87/go.mod h1:DXUve3Dp
 github.com/go-openapi/swag v0.19.2/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-openapi/swag v0.19.14/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/eQntq43wQ=
+github.com/go-redis/redismock/v9 v9.2.0 h1:ZrMYQeKPECZPjOj5u9eyOjg8Nnb0BS9lkVIZ6IpsKLw=
+github.com/go-redis/redismock/v9 v9.2.0/go.mod h1:18KHfGDK4Y6c2R0H38EUGWAdc7ZQS9gfYxc94k7rWT0=
 github.com/go-resty/resty/v2 v2.0.0/go.mod h1:dZGr0i9PLlaaTD4H/hoZIDjQ+r6xq8mgbRzHZf7f2J8=
 github.com/go-resty/resty/v2 v2.12.0 h1:rsVL8P90LFvkUYq/V5BTVe203WfRIU4gvcf+yfzJzGA=
 github.com/go-resty/resty/v2 v2.12.0/go.mod h1:o0yGPrkS3lOe1+eFajk6kBW8ScXzwU3hD69/gt2yB/0=
@@ -1475,6 +1477,7 @@ github.com/neo4j/neo4j-go-driver v1.8.1-0.20200803113522-b626aa943eba/go.mod h1:
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/npillmayer/nestext v0.1.3/go.mod h1:h2lrijH8jpicr25dFY+oAJLyzlya6jhnuG+zWp9L0Uk=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
+github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
@@ -1494,6 +1497,8 @@ github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108
 github.com/onsi/ginkgo v1.13.0/go.mod h1:+REjRxOmWfHCjfv9TTWB1jD1Frx4XydAD3zm1lskyM0=
 github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
+github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
+github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
 github.com/onsi/gomega v0.0.0-20151007035656-2152b45fa28a/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -1503,6 +1508,8 @@ github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoT
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDsH8xc=
 github.com/onsi/gomega v1.15.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+tEHG0=
+github.com/onsi/gomega v1.25.0 h1:Vw7br2PCDYijJHSfBOWhov+8cAnUf8MfMaIOV323l6Y=
+github.com/onsi/gomega v1.25.0/go.mod h1:r+zV744Re+DiYCIPRlYOTxn0YkOLcAnW8k1xXdMPGhM=
 github.com/opencontainers/go-digest v0.0.0-20170106003457-a6d0ee40d420/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
@@ -2708,6 +2715,7 @@ gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/square/go-jose.v2 v2.2.2/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/square/go-jose.v2 v2.3.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/square/go-jose.v2 v2.5.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/pkg/repository/repository_test.go
+++ b/pkg/repository/repository_test.go
@@ -5,27 +5,39 @@ package repository
 
 import (
 	"context"
+	"os"
 	"testing"
+	"time"
 
+	"github.com/go-redis/redismock/v9"
 	"github.com/gofrs/uuid"
+	"gorm.io/gorm"
 
 	qt "github.com/frankban/quicktest"
 
 	"github.com/instill-ai/pipeline-backend/config"
 
+	"github.com/instill-ai/pipeline-backend/pkg/datamodel"
 	database "github.com/instill-ai/pipeline-backend/pkg/db"
 	pipelinepb "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
 
+var db *gorm.DB
+
+func TestMain(m *testing.M) {
+	if err := config.Init("../../config/config.yaml"); err != nil {
+		panic(err)
+	}
+
+	db = database.GetSharedConnection()
+	defer database.Close(db)
+
+	os.Exit(m.Run())
+}
+
 func TestRepository_ComponentDefinitionUIDs(t *testing.T) {
 	c := qt.New(t)
 	ctx := context.Background()
-
-	err := config.Init("../../config/config.yaml")
-	c.Assert(err, qt.IsNil)
-
-	db := database.GetSharedConnection()
-	defer database.Close(db)
 
 	tx := db.Begin()
 	c.Cleanup(func() { tx.Rollback() })
@@ -40,7 +52,7 @@ func TestRepository_ComponentDefinitionUIDs(t *testing.T) {
 		Public: true,
 	}
 
-	err = repo.UpsertComponentDefinition(ctx, cd)
+	err := repo.UpsertComponentDefinition(ctx, cd)
 	c.Check(err, qt.IsNil)
 
 	dbDef, err := repo.GetDefinitionByUID(ctx, uid)
@@ -53,4 +65,44 @@ func TestRepository_ComponentDefinitionUIDs(t *testing.T) {
 	c.Check(size, qt.Equals, int64(1))
 	c.Check(dbDefs, qt.HasLen, 1)
 	c.Check(dbDefs[0].UID.String(), qt.Equals, uid.String())
+}
+
+func TestRepository_AddPipelineRuns(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	tx := db.Begin()
+	c.Cleanup(func() { tx.Commit() })
+
+	cache, _ := redismock.NewClientMock()
+	repo := NewRepository(tx, cache)
+
+	t0 := time.Now().UTC()
+	pipelineUID, ownerUID := uuid.Must(uuid.NewV4()), uuid.Must(uuid.NewV4())
+	ownerPermalink := "users/" + ownerUID.String()
+
+	p := &datamodel.Pipeline{
+		Owner: ownerPermalink,
+		ID:    "test",
+		BaseDynamic: datamodel.BaseDynamic{
+			UID:        pipelineUID,
+			CreateTime: t0,
+			UpdateTime: t0,
+		},
+	}
+	err := repo.CreateNamespacePipeline(ctx, p)
+	c.Assert(err, qt.IsNil)
+
+	got, err := repo.GetNamespacePipelineByID(ctx, ownerPermalink, "test", true, false)
+	c.Assert(err, qt.IsNil)
+	c.Check(got.NumberOfRuns, qt.Equals, 0)
+	c.Check(got.LastRunTime.IsZero(), qt.IsTrue)
+
+	err = repo.AddPipelineRuns(ctx, got.UID)
+	c.Check(err, qt.IsNil)
+
+	got, err = repo.GetNamespacePipelineByID(ctx, ownerPermalink, "test", true, false)
+	c.Assert(err, qt.IsNil)
+	c.Check(got.NumberOfRuns, qt.Equals, 1)
+	c.Check(got.LastRunTime.After(t0), qt.IsTrue)
 }

--- a/pkg/service/component_definition.go
+++ b/pkg/service/component_definition.go
@@ -223,7 +223,6 @@ func (s *service) ListComponentDefinitions(ctx context.Context, req *pb.ListComp
 	}
 
 	for i, uid := range uids {
-
 		def, err := s.component.GetDefinitionByUID(uid.UID, vars, nil)
 		if err != nil {
 			return nil, err
@@ -232,7 +231,6 @@ func (s *service) ListComponentDefinitions(ctx context.Context, req *pb.ListComp
 			def.Spec = nil
 		}
 		defs[i] = def
-
 	}
 
 	resp := &pb.ListComponentDefinitionsResponse{

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -154,7 +154,7 @@ func (s *service) CreateNamespacePipeline(ctx context.Context, ns resource.Names
 		dbPipeline.ShareCode = generateShareCode()
 	}
 
-	if err := s.repository.CreateNamespacePipeline(ctx, ownerPermalink, dbPipeline); err != nil {
+	if err := s.repository.CreateNamespacePipeline(ctx, dbPipeline); err != nil {
 		return nil, err
 	}
 

--- a/pkg/usage/usage.go
+++ b/pkg/usage/usage.go
@@ -12,7 +12,6 @@ import (
 	"github.com/instill-ai/pipeline-backend/config"
 	"github.com/instill-ai/pipeline-backend/pkg/constant"
 	"github.com/instill-ai/pipeline-backend/pkg/logger"
-	"github.com/instill-ai/pipeline-backend/pkg/recipe"
 	"github.com/instill-ai/pipeline-backend/pkg/repository"
 	"github.com/instill-ai/pipeline-backend/pkg/utils"
 	"github.com/instill-ai/x/repo"
@@ -420,23 +419,4 @@ func (u *usage) TriggerSingleReporter(ctx context.Context) {
 	if err != nil {
 		logger.Error(fmt.Sprintf("unable to trigger single reporter: %v\n", err))
 	}
-}
-
-type PipelineUsageHandler interface {
-	Check(ctx context.Context, vars recipe.SystemVariables, numComponents int) error
-	Collect(ctx context.Context, vars recipe.SystemVariables, numComponents int) error
-}
-
-type noopPipelineUsageHandler struct{}
-
-func (h *noopPipelineUsageHandler) Check(_ context.Context, _ recipe.SystemVariables, _ int) error {
-	return nil
-}
-func (h *noopPipelineUsageHandler) Collect(_ context.Context, _ recipe.SystemVariables, _ int) error {
-	return nil
-}
-
-// NewNoopPipelineUsageHandler is a no-op usage handler initializer.
-func NewNoopPipelineUsageHandler() PipelineUsageHandler {
-	return new(noopPipelineUsageHandler)
 }

--- a/pkg/worker/main.go
+++ b/pkg/worker/main.go
@@ -25,7 +25,6 @@ type Worker interface {
 	PreIteratorActivity(ctx context.Context, param *PreIteratorActivityParam) (*PreIteratorActivityResult, error)
 	PostIteratorActivity(ctx context.Context, param *PostIteratorActivityParam) error
 	UsageCollectActivity(ctx context.Context, param *UsageCollectActivityParam) error
-	UsageCheckActivity(ctx context.Context, param *UsageCheckActivityParam) error
 }
 
 // worker represents resources required to run Temporal workflow and activity

--- a/pkg/worker/main.go
+++ b/pkg/worker/main.go
@@ -41,7 +41,7 @@ func NewWorker(
 	rd *redis.Client,
 	i api.WriteAPI,
 	cs componentstore.ComponentSecrets,
-	uh map[string]componentbase.UsageHandlerCreator,
+	uh componentbase.UsageHandlerCreator,
 ) Worker {
 	logger, _ := logger.GetZapLogger(context.Background())
 	return &worker{

--- a/pkg/worker/workflow.go
+++ b/pkg/worker/workflow.go
@@ -5,9 +5,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"go.uber.org/zap"
 	"go/parser"
 	"time"
+
+	"go.uber.org/zap"
 
 	"github.com/gofrs/uuid"
 	"go.opentelemetry.io/otel"
@@ -25,14 +26,14 @@ import (
 	"github.com/instill-ai/pipeline-backend/pkg/utils"
 	"github.com/instill-ai/x/errmsg"
 
-	mgmtPB "github.com/instill-ai/protogen-go/core/mgmt/v1beta"
+	mgmtpb "github.com/instill-ai/protogen-go/core/mgmt/v1beta"
 )
 
 type TriggerPipelineWorkflowParam struct {
 	BatchSize        int
 	MemoryStorageKey *recipe.BatchMemoryKey
 	SystemVariables  recipe.SystemVariables // TODO: we should store vars directly in trigger memory.
-	Mode             mgmtPB.Mode
+	Mode             mgmtpb.Mode
 	IsIterator       bool
 	IsStreaming      bool
 }
@@ -149,21 +150,21 @@ func (w *worker) TriggerPipelineWorkflow(ctx workflow.Context, param *TriggerPip
 		defer close(sChan)
 	}
 
-	var ownerType mgmtPB.OwnerType
+	var ownerType mgmtpb.OwnerType
 	switch param.SystemVariables.PipelineOwnerType {
 	case resource.Organization:
-		ownerType = mgmtPB.OwnerType_OWNER_TYPE_ORGANIZATION
+		ownerType = mgmtpb.OwnerType_OWNER_TYPE_ORGANIZATION
 	case resource.User:
-		ownerType = mgmtPB.OwnerType_OWNER_TYPE_USER
+		ownerType = mgmtpb.OwnerType_OWNER_TYPE_USER
 	default:
-		ownerType = mgmtPB.OwnerType_OWNER_TYPE_UNSPECIFIED
+		ownerType = mgmtpb.OwnerType_OWNER_TYPE_UNSPECIFIED
 	}
 
 	dataPoint := utils.PipelineUsageMetricData{
 		OwnerUID:           param.SystemVariables.PipelineOwnerUID.String(),
 		OwnerType:          ownerType,
 		UserUID:            param.SystemVariables.PipelineUserUID.String(),
-		UserType:           mgmtPB.OwnerType_OWNER_TYPE_USER, // TODO: currently only support /users type, will change after beta
+		UserType:           mgmtpb.OwnerType_OWNER_TYPE_USER, // TODO: currently only support /users type, will change after beta
 		TriggerMode:        param.Mode,
 		PipelineID:         param.SystemVariables.PipelineID,
 		PipelineUID:        param.SystemVariables.PipelineUID.String(),
@@ -278,7 +279,7 @@ func (w *worker) TriggerPipelineWorkflow(ctx workflow.Context, param *TriggerPip
 							BatchSize:        preIteratorResult.ElementSize[iter],
 							MemoryStorageKey: preIteratorResult.MemoryStorageKeys[iter],
 							SystemVariables:  param.SystemVariables,
-							Mode:             mgmtPB.Mode_MODE_SYNC,
+							Mode:             mgmtpb.Mode_MODE_SYNC,
 						}))
 
 				}
@@ -333,7 +334,7 @@ func (w *worker) TriggerPipelineWorkflow(ctx workflow.Context, param *TriggerPip
 	}
 
 	dataPoint.ComputeTimeDuration = time.Since(startTime).Seconds()
-	dataPoint.Status = mgmtPB.Status_STATUS_COMPLETED
+	dataPoint.Status = mgmtpb.Status_STATUS_COMPLETED
 
 	if !param.IsIterator {
 		// TODO: we should check whether to collect failed component or not
@@ -762,7 +763,7 @@ func (w *worker) processSetup(batchMemory []*recipe.Memory, setup map[string]any
 func (w *worker) writeErrorDataPoint(ctx context.Context, err error, span trace.Span, startTime time.Time, dataPoint *utils.PipelineUsageMetricData) {
 	span.SetStatus(1, err.Error())
 	dataPoint.ComputeTimeDuration = time.Since(startTime).Seconds()
-	dataPoint.Status = mgmtPB.Status_STATUS_ERRORED
+	dataPoint.Status = mgmtpb.Status_STATUS_ERRORED
 	_ = w.writeNewDataPoint(ctx, *dataPoint)
 }
 
@@ -790,7 +791,6 @@ const (
 	ConnectorActivityError    = "ConnectorActivityError"
 	PreIteratorActivityError  = "PreIteratorActivityError"
 	PostIteratorActivityError = "PostIteratorActivityError"
-	UsageCheckActivityError   = "UsageCheckActivityError"
 	UsageCollectActivityError = "UsageCollectActivityError"
 )
 


### PR DESCRIPTION
Because

- We have usage handlers for pipeline and component but the former only receives the number of components. We can merge them and simplify our logic.

This commit

- Removes the pipeline usage handler and injects only a component handler. The definition -> handler map is removed and the implementation is responsible of checking the component definition ID within its methods
