### PR TITLE
feat: add profile_image and several profile fields for pipeline

### DIFF
--- a/cmd/init/presetdownloader/downloader.go
+++ b/cmd/init/presetdownloader/downloader.go
@@ -103,14 +103,14 @@ func DownloadPresetPipelines(ctx context.Context, repo repository.Repository) er
 		defer mgmtPrivateServiceClientConn.Close()
 	}
 
-	converter := service.NewConverter(mgmtPrivateServiceClient, redisClient, &aclClient, repo)
+	converter := service.NewConverter(mgmtPrivateServiceClient, redisClient, &aclClient, repo, "")
 
 	if config.Config.InstillCloud.Host == "" {
 		// Skip the download process if the Instill Cloud host is not set.
 		return nil
 	}
 
-	clientConn, err := grpc.Dial(fmt.Sprintf("%s:%d", config.Config.InstillCloud.Host, config.Config.InstillCloud.Port), // nolint: staticcheck
+	clientConn, err := grpc.NewClient(fmt.Sprintf("%s:%d", config.Config.InstillCloud.Host, config.Config.InstillCloud.Port),
 		grpc.WithTransportCredentials(credentials.NewTLS((&tls.Config{}))),
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(constant.MaxPayloadSize), grpc.MaxCallSendMsgSize(constant.MaxPayloadSize)))
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -76,6 +76,7 @@ type ServerConfig struct {
 	}
 	InstanceID         string `koanf:"instanceid"`
 	DataChanBufferSize int    `koanf:"datachanbuffersize"`
+	InstillCoreHost    string `koanf:"instillcorehost"`
 }
 
 // ConnectorConfig defines the connector configurations

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -18,6 +18,7 @@ server:
     maxactivityretry: 1
   instanceid: "pipeline-backend"
   datachanbuffersize: 100
+  instillcorehost: http://localhost:8080
 connector:
 database:
   username: postgres
@@ -25,7 +26,7 @@ database:
   host: pg-sql
   port: 5432
   name: pipeline
-  version: 17
+  version: 18
   timezone: Etc/UTC
   pool:
     idleconnections: 5

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/gabriel-vasile/mimetype v1.4.3
 	github.com/go-redis/redismock/v9 v9.2.0
 	github.com/gofrs/uuid v4.4.0+incompatible
+	github.com/gogo/status v1.1.1
 	github.com/gojuno/minimock/v3 v3.3.11
 	github.com/golang-migrate/migrate/v4 v4.15.2
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
@@ -17,7 +18,7 @@ require (
 	github.com/iancoleman/strcase v0.3.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
 	github.com/instill-ai/component v0.21.0-beta.0.20240708043833-e27e46c0876b
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240627022558-b70559ea17ce
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240710034515-e4450d31ea05
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha
 	github.com/jackc/pgx/v5 v5.5.5
@@ -39,6 +40,7 @@ require (
 	go.temporal.io/api v1.16.0
 	go.temporal.io/sdk v1.21.0
 	go.uber.org/zap v1.26.0
+	golang.org/x/image v0.18.0
 	golang.org/x/mod v0.17.0
 	golang.org/x/net v0.26.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20240513163218-0867130af1f8
@@ -73,7 +75,6 @@ require (
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/gocolly/colly/v2 v2.1.0 // indirect
-	github.com/gogo/status v1.1.1 // indirect
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/mock v1.6.0 // indirect
@@ -118,7 +119,6 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.24.0 // indirect
 	go.opentelemetry.io/otel/metric v1.24.0 // indirect
-	golang.org/x/image v0.18.0 // indirect
 	golang.org/x/oauth2 v0.20.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect
 	golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d // indirect

--- a/go.sum
+++ b/go.sum
@@ -1193,8 +1193,8 @@ github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
 github.com/instill-ai/component v0.21.0-beta.0.20240708043833-e27e46c0876b h1:lxgr+muzeIzcv6I7gQDW55CsDwgwW3Tfd3soFQqvgWg=
 github.com/instill-ai/component v0.21.0-beta.0.20240708043833-e27e46c0876b/go.mod h1:BYWEZ7yljCFujwaCuHvhBCK1uF2l62JyekuWk7FACaA=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240627022558-b70559ea17ce h1:3ewdsZt7F/6T/K5eFLuGSCpAu8JuuOXGu+nObRY5dwQ=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240627022558-b70559ea17ce/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240710034515-e4450d31ea05 h1:BqqrY5XUspCvtY5eFxDyosqBHo+aGqVPKWZGbSvWc5I=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240710034515-e4450d31ea05/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a/go.mod h1:EpX3Yr661uWULtZf5UnJHfr5rw2PDyX8ku4Kx0UtYFw=
 github.com/instill-ai/x v0.4.0-alpha h1:zQV2VLbSHjMv6gyBN/2mwwrvWk0/mJM6ZKS12AzjfQg=

--- a/pkg/acl/acl.go
+++ b/pkg/acl/acl.go
@@ -82,7 +82,7 @@ func NewACLClient(wc openfga.OpenFGAServiceClient, rc openfga.OpenFGAServiceClie
 func InitOpenFGAClient(ctx context.Context, host string, port int) (openfga.OpenFGAServiceClient, *grpc.ClientConn) {
 	clientDialOpts := grpc.WithTransportCredentials(insecure.NewCredentials())
 
-	clientConn, err := grpc.Dial(fmt.Sprintf("%v:%v", host, port), clientDialOpts, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(constant.MaxPayloadSize), grpc.MaxCallSendMsgSize(constant.MaxPayloadSize))) // nolint: staticcheck
+	clientConn, err := grpc.NewClient(fmt.Sprintf("%v:%v", host, port), clientDialOpts, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(constant.MaxPayloadSize), grpc.MaxCallSendMsgSize(constant.MaxPayloadSize)))
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/datamodel/datamodel.go
+++ b/pkg/datamodel/datamodel.go
@@ -84,6 +84,10 @@ type Pipeline struct {
 	ShareCode         string
 	Metadata          datatypes.JSON `gorm:"type:jsonb"`
 	Readme            string
+	SourceURL         sql.NullString
+	DocumentationURL  sql.NullString
+	License           sql.NullString
+	ProfileImage      sql.NullString
 	Releases          []*PipelineRelease
 	Tags              []*Tag
 

--- a/pkg/db/migration/000018_init.down.sql
+++ b/pkg/db/migration/000018_init.down.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+ALTER TABLE public.pipeline DROP COLUMN source_url;
+ALTER TABLE public.pipeline DROP COLUMN documentation_url;
+ALTER TABLE public.pipeline DROP COLUMN license;
+ALTER TABLE public.pipeline DROP COLUMN profile_image;
+
+COMMIT;

--- a/pkg/db/migration/000018_init.up.sql
+++ b/pkg/db/migration/000018_init.up.sql
@@ -1,0 +1,10 @@
+BEGIN;
+
+ALTER TABLE public.pipeline ADD COLUMN IF NOT EXISTS source_url VARCHAR(255) DEFAULT '';
+ALTER TABLE public.pipeline ADD COLUMN IF NOT EXISTS documentation_url VARCHAR(255) DEFAULT '';
+ALTER TABLE public.pipeline ADD COLUMN IF NOT EXISTS license VARCHAR(255) DEFAULT '';
+
+-- `profile_image` stores the profile image of the pipeline in base64 format.
+ALTER TABLE public.pipeline ADD COLUMN IF NOT EXISTS profile_image TEXT DEFAULT NULL;
+
+COMMIT;

--- a/pkg/external/external.go
+++ b/pkg/external/external.go
@@ -32,7 +32,7 @@ func InitMgmtPrivateServiceClient(ctx context.Context) (mgmtpb.MgmtPrivateServic
 		clientDialOpts = grpc.WithTransportCredentials(insecure.NewCredentials())
 	}
 
-	clientConn, err := grpc.Dial(fmt.Sprintf("%v:%v", config.Config.MgmtBackend.Host, config.Config.MgmtBackend.PrivatePort), clientDialOpts, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(constant.MaxPayloadSize), grpc.MaxCallSendMsgSize(constant.MaxPayloadSize))) // nolint: staticcheck
+	clientConn, err := grpc.NewClient(fmt.Sprintf("%v:%v", config.Config.MgmtBackend.Host, config.Config.MgmtBackend.PrivatePort), clientDialOpts, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(constant.MaxPayloadSize), grpc.MaxCallSendMsgSize(constant.MaxPayloadSize)))
 	if err != nil {
 		logger.Error(err.Error())
 		return nil, nil
@@ -54,7 +54,7 @@ func InitUsageServiceClient(ctx context.Context) (usagepb.UsageServiceClient, *g
 		clientDialOpts = grpc.WithTransportCredentials(insecure.NewCredentials())
 	}
 
-	clientConn, err := grpc.Dial(fmt.Sprintf("%v:%v", config.Config.Server.Usage.Host, config.Config.Server.Usage.Port), clientDialOpts, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(constant.MaxPayloadSize), grpc.MaxCallSendMsgSize(constant.MaxPayloadSize))) // nolint: staticcheck
+	clientConn, err := grpc.NewClient(fmt.Sprintf("%v:%v", config.Config.Server.Usage.Host, config.Config.Server.Usage.Port), clientDialOpts, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(constant.MaxPayloadSize), grpc.MaxCallSendMsgSize(constant.MaxPayloadSize)))
 	if err != nil {
 		logger.Error(err.Error())
 		return nil, nil


### PR DESCRIPTION
Because

- We'll allow users to store some pipeline profile data, including `profile image`, `source_url`, `documentation_url`, and `license`.

This commit

- Follows the implementation from model-backend and adds `profile_image` and several profile fields for the pipeline.
- Updates the deprecated `grpc.Dial` to `grpc.NewClient`.