### PR TITLE
chore: Update Go version to 1.22.5

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 # version
-GOLANG_VERSION=1.22.3
+GOLANG_VERSION=1.22.5
 K6_VERSION=0.42.0
 
 # service

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$TARGETPLATFORM golang:1.22.3 AS build
+FROM --platform=$TARGETPLATFORM golang:1.22.5 AS build
 
 RUN apt update && apt install libtesseract-dev -y
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.22.3
+FROM golang:1.22.5
 
 ARG SERVICE_NAME
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/instill-ai/pipeline-backend
 
-go 1.22.3
+go 1.22.5
 
 require (
 	cloud.google.com/go/longrunning v0.5.6


### PR DESCRIPTION
This PR updates the Go version to 1.22.5 in .env, Dockerfile, Dockerfile.dev, and go.mod.

Because:
- We'd like to adopt the latest features and bug fixes in the new Go version.

This pull request:
- Updates the Go version in .env, Dockerfile, Dockerfile.dev, and go.mod.