### PR TITLE
feat: add requester information to pipeline metrics

### DIFF
--- a/pkg/worker/utils.go
+++ b/pkg/worker/utils.go
@@ -10,9 +10,7 @@ import (
 )
 
 func (w *worker) writeNewDataPoint(ctx context.Context, data utils.PipelineUsageMetricData) error {
-
 	if config.Config.Server.Usage.Enabled {
-
 		bData, err := json.Marshal(data)
 		if err != nil {
 			return err

--- a/pkg/worker/workflow.go
+++ b/pkg/worker/workflow.go
@@ -154,7 +154,9 @@ func (w *worker) TriggerPipelineWorkflow(ctx workflow.Context, param *TriggerPip
 		OwnerUID:           param.SystemVariables.PipelineOwnerUID.String(),
 		OwnerType:          ownerType,
 		UserUID:            param.SystemVariables.PipelineUserUID.String(),
-		UserType:           mgmtpb.OwnerType_OWNER_TYPE_USER, // TODO: currently only support /users type, will change after beta
+		UserType:           mgmtpb.OwnerType_OWNER_TYPE_USER,
+		RequesterUID:       param.SystemVariables.PipelineRequesterUID.String(),
+		RequesterType:      mgmtpb.OwnerType_OWNER_TYPE_USER,
 		TriggerMode:        param.Mode,
 		PipelineID:         param.SystemVariables.PipelineID,
 		PipelineUID:        param.SystemVariables.PipelineUID.String(),
@@ -162,6 +164,14 @@ func (w *worker) TriggerPipelineWorkflow(ctx workflow.Context, param *TriggerPip
 		PipelineReleaseUID: param.SystemVariables.PipelineReleaseUID.String(),
 		PipelineTriggerUID: workflow.GetInfo(ctx).WorkflowExecution.ID,
 		TriggerTime:        startTime.Format(time.RFC3339Nano),
+	}
+
+	// This is a simplistic check that relies on the only supported
+	// namespace switch (user->organization). If other types of impersonation
+	// are supported, the requester type should be provided in the system
+	// variables.
+	if dataPoint.UserUID != dataPoint.RequesterUID {
+		dataPoint.RequesterType = mgmtpb.OwnerType_OWNER_TYPE_ORGANIZATION
 	}
 
 	ao := workflow.ActivityOptions{


### PR DESCRIPTION
Because

- In the dashboard, we'll want to display the triggers requested by a namespace (right now we're displaying the triggers on pipelines owned by the namespace). Therefore, we need to add the requester information to the metrics.

This commit

- Adds requester information to pipeline metrics
- Additionally, all the data we might filter / group by is sent as tags. Right now these are fields (not indexed on InfluxDB). When queried, the data is pivoted in order to filter and group.
