### PR TITLE
feat: use explicit `user_id` and `organization_id` in mgmt request

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -41,7 +41,6 @@ jobs:
           push: true
           build-args: |
             SERVICE_NAME=pipeline-backend
-            GOLANG_VERSION=${{ env.GOLANG_VERSION }}
           tags: instill/pipeline-backend:latest
           cache-from: type=registry,ref=instill/pipeline-backend:buildcache
           cache-to: type=registry,ref=instill/pipeline-backend:buildcache,mode=max
@@ -66,7 +65,6 @@ jobs:
           push: true
           build-args: |
             SERVICE_NAME=pipeline-backend
-            GOLANG_VERSION=${{ env.GOLANG_VERSION }}
           tags: instill/pipeline-backend:${{steps.set_version.outputs.no_v_tag}}
           cache-from: type=registry,ref=instill/pipeline-backend:buildcache
           cache-to: type=registry,ref=instill/pipeline-backend:buildcache,mode=max

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -65,7 +65,6 @@ jobs:
           load: true
           build-args: |
             SERVICE_NAME=pipeline-backend
-            GOLANG_VERSION=${{ env.GOLANG_VERSION }}
           tags: instill/pipeline-backend:latest
 
       - name: Checkout repo (instill-core)

--- a/cmd/init/presetdownloader/downloader.go
+++ b/cmd/init/presetdownloader/downloader.go
@@ -128,6 +128,7 @@ func DownloadPresetPipelines(ctx context.Context, repo repository.Repository) er
 	}
 	pageToken := ""
 	for {
+		//nolint:staticcheck
 		resp, err := cloudPipelineClient.ListOrganizationPipelines(ctx, &pipelinepb.ListOrganizationPipelinesRequest{
 			Parent:    fmt.Sprintf("organizations/%s", PresetNamespaceID),
 			View:      pipelinepb.Pipeline_VIEW_RECIPE.Enum(),
@@ -176,6 +177,7 @@ func DownloadPresetPipelines(ctx context.Context, repo repository.Repository) er
 
 			releasePageToken := ""
 			for {
+				//nolint:staticcheck
 				releaseResp, err := cloudPipelineClient.ListOrganizationPipelineReleases(ctx, &pipelinepb.ListOrganizationPipelineReleasesRequest{
 					Parent:    fmt.Sprintf("organizations/%s/pipelines/%s", PresetNamespaceID, dbPipeline.ID),
 					View:      pipelinepb.Pipeline_VIEW_RECIPE.Enum(),

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/iancoleman/strcase v0.3.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
 	github.com/instill-ai/component v0.23.0-beta
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240710034515-e4450d31ea05
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240724130416-27b3d8e33885
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha
 	github.com/jackc/pgx/v5 v5.5.5

--- a/go.sum
+++ b/go.sum
@@ -1204,8 +1204,8 @@ github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
 github.com/instill-ai/component v0.23.0-beta h1:NQB8Lvsb0Z4zu/5ULKvR2Wp48Wie7cxrh+1skfyfNh8=
 github.com/instill-ai/component v0.23.0-beta/go.mod h1:XBn0j9R7H/iAhr2OSCefxO8FDqOCzhxuZ/uILVcBSho=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240710034515-e4450d31ea05 h1:BqqrY5XUspCvtY5eFxDyosqBHo+aGqVPKWZGbSvWc5I=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240710034515-e4450d31ea05/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240724130416-27b3d8e33885 h1:z8/nJ9DqF+qc/uPsd0+Bg2gD4+6/SR+HT/mkAu0hsAE=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240724130416-27b3d8e33885/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a/go.mod h1:EpX3Yr661uWULtZf5UnJHfr5rw2PDyX8ku4Kx0UtYFw=
 github.com/instill-ai/x v0.4.0-alpha h1:zQV2VLbSHjMv6gyBN/2mwwrvWk0/mJM6ZKS12AzjfQg=

--- a/integration-test/proto/core/mgmt/v1beta/metric.proto
+++ b/integration-test/proto/core/mgmt/v1beta/metric.proto
@@ -29,26 +29,13 @@ enum Status {
 
 // ========== Pipeline endpoints
 
-// PipelineTriggerRecord represents a pipeline execution event.
-message PipelineTriggerRecord {
-  // The moment when the pipeline was triggered.
-  google.protobuf.Timestamp trigger_time = 1;
-  // UUID of the trigger.
-  string pipeline_trigger_id = 2;
-  // Pipeline ID.
-  string pipeline_id = 3;
-  // Pipeline UUID.
-  string pipeline_uid = 4;
-  // Trigger mode.
-  Mode trigger_mode = 5;
-  // Total execution duration.
-  float compute_time_duration = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Final status.
-  Status status = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // If a release of the pipeline was triggered, pipeline version.
-  string pipeline_release_id = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // If a release of the pipeline was triggered, release UUID.
-  string pipeline_release_uid = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
+// PipelineTriggerCount represents a pipeline execution count with some
+// aggregation params (e.g. trigger status).
+message PipelineTriggerCount {
+  // Number og triggers
+  int32 trigger_count = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // This field will be present when results are grouped by trigger status;
+  optional Status status = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // PipelineTriggerTableRecord contains pipeline trigger metrics, aggregated by
@@ -68,93 +55,142 @@ message PipelineTriggerTableRecord {
   string pipeline_release_uid = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// PipelineTriggerChartRecord contains pipeline trigger metrics, aggregated by
+// PipelineTriggerChartRecord represents a timeline of pipeline triggers. It
+// contains a collection of (timestamp, count) pairs that represent the total
+// pipeline triggers in a given time bucket.
 // pipeline ID and time frame.
 message PipelineTriggerChartRecord {
-  // Pipeline ID.
-  string pipeline_id = 1;
-  // Pipeline UUID.
-  string pipeline_uid = 2;
-  // Trigger mode.
-  Mode trigger_mode = 3;
-  // Final status.
-  Status status = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // This field will be present present when the information is grouped by pipeline.
+  optional string pipeline_id = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // 2 is reserved for the pipeline UUID.
+  reserved 2;
+  // 3 is reserved for the trigger mode. The server wasn't grouping results by this
+  // field.
+  reserved 3;
+  // 4 is reserved for the trigger status. The server wasn't grouping results
+  // by this field.
+  reserved 4;
   // Time buckets.
   repeated google.protobuf.Timestamp time_buckets = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Aggregated trigger count in each time bucket.
   repeated int32 trigger_counts = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Total computation time duration in each time bucket.
-  repeated float compute_time_duration = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Version for the triggered pipeline if it is a release pipeline.
-  string pipeline_release_id = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Release UUID for the triggered pipeline if it is a release pipeline.
-  string pipeline_release_uid = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // 7 is reserved for the trigger execution duration.
+  reserved 7;
+  // 8 is reserved for the pipeline release ID. The server wasn't grouping
+  // results by this field.
+  reserved 8;
+  // 9 is reserved for the pipeline release UUID. The server wasn't grouping
+  // results by this field.
+  reserved 9;
+  // Trigger requester ID, e.g. `users/specialist-wombat`.
+  string requester = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// ListPipelineTriggerRecordsRequest represents a request to list the triggers
-// of a pipeline.
-message ListPipelineTriggerRecordsRequest {
-  // The maximum number of triggers to return. If this parameter is unspecified,
-  // at most 100 pipelines will be returned. The cap value for this parameter is
-  // 1000 (i.e. any value above that will be coerced to 100).
-  optional int32 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
-  // Page token.
-  optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
-  // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
-  // expression.
-  // - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
-  optional string filter = 3 [(google.api.field_behavior) = OPTIONAL];
+// GetPipelineTriggerCountRequest represents a request to fetch the trigger
+// count of a requester over a time period.
+message GetPipelineTriggerCountRequest {
+  // The ID of the pipeline trigger requester.
+  // Format: `{[users|organizations]}/{id}`.
+  string requester = 1 [(google.api.field_behavior) = REQUIRED];
+  // Aggregation window. The value is a positive duration string, i.e. a
+  // sequence of decimal numbers, each with optional fraction and a unit
+  // suffix, such as "300ms", "1.5h" or "2h45m".
+  // The minimum (and default) window is 1h.
+  optional string aggregation_window = 2;
+  // Beginning of the time range from which the records will be fetched.
+  // The default value is the beginning of the current day, in UTC.
+  optional google.protobuf.Timestamp start = 3;
+  // End of the time range from which the records will be fetched.
+  // The default value is the current timestamp.
+  optional google.protobuf.Timestamp stop = 4;
 }
 
-// ListPipelineTriggerRecordsResponse contains a list of pipeline triggers.
-message ListPipelineTriggerRecordsResponse {
-  // A list of pipeline triggers.
-  repeated PipelineTriggerRecord pipeline_trigger_records = 1;
-  // Next page token.
-  string next_page_token = 2;
-  // Total number of pipeline triggers.
-  int32 total_size = 3;
-}
-
-// ListPipelineTriggerTableRecordsRequest represents a request to list the
-// pipeline triggers metrics, aggregated by pipeline ID.
-message ListPipelineTriggerTableRecordsRequest {
-  // The maximum number of results to return. If this parameter is unspecified,
-  // at most 100 pipelines will be returned. The cap value for this parameter
-  // is 1000 (i.e. any value above that will be coerced to 1000).
-  optional int32 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
-  // Page token.
-  optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
-  // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
-  // expression.
-  // - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
-  optional string filter = 3 [(google.api.field_behavior) = OPTIONAL];
-}
-
-// ListPipelineTriggerTableRecordsResponse contains the pipeline metrics.
-message ListPipelineTriggerTableRecordsResponse {
-  // A list of pipeline trigger tables.
-  repeated PipelineTriggerTableRecord pipeline_trigger_table_records = 1;
-  // Next page token.
-  string next_page_token = 2;
-  // Total number of pipeline trigger records
-  int32 total_size = 3;
+// GetPipelineTriggerCountResponse contains the trigger count, grouped by
+// trigger status.
+message GetPipelineTriggerCountResponse {
+  // The trigger counts, grouped by status.
+  repeated PipelineTriggerCount pipeline_trigger_counts = 1;
 }
 
 // ListPipelineTriggerChartRecordsRequest represents a request to list pipeline
-// trigger metrics, aggregated by pipeline ID and time frame.
+// trigger chart records for a given requester, grouped by time buckets.
 message ListPipelineTriggerChartRecordsRequest {
-  // Aggregation window in nanoseconds.
-  int32 aggregation_window = 1;
-  // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
-  // expression.
-  // - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
-  optional string filter = 2 [(google.api.field_behavior) = OPTIONAL];
+  // 1 is reserved for the aggregation window in nanoseconds. This is
+  // deprecated in favour of an aggregation window string that represents a
+  // duration.
+  reserved 1;
+  // 2 is reserved for the filter. For now, this endpoint won't allow filtering
+  // but in the future we might implement a filter to show the trigger count of
+  // only certain pipelines and to group by the pipeline ID.
+  reserved 2;
+
+  // The ID of the pipeline trigger requester.
+  // Format: `{[users|organizations]}/{id}`.
+  string requester = 3 [(google.api.field_behavior) = REQUIRED];
+  // Aggregation window. The value is a positive duration string, i.e. a
+  // sequence of decimal numbers, each with optional fraction and a unit
+  // suffix, such as "300ms", "1.5h" or "2h45m".
+  // The minimum (and default) window is 1h.
+  optional string aggregation_window = 4;
+  // Beginning of the time range from which the records will be fetched.
+  // The default value is the beginning of the current day, in UTC.
+  optional google.protobuf.Timestamp start = 5;
+  // End of the time range from which the records will be fetched.
+  // The default value is the current timestamp.
+  optional google.protobuf.Timestamp stop = 6;
 }
 
 // ListPipelineTriggerChartRecordsResponse contains a list of pipeline trigger
 // chart records.
 message ListPipelineTriggerChartRecordsResponse {
-  // A list of pipeline trigger records.
+  // Pipeline trigger counts. Until we allow filtering or grouping by fields
+  // like pipeline ID, this list will contain only one element with the
+  // timeline of trigger counts for a given requester, regardless the pipeline
+  // ID, trigger mode, final status or other fields.
   repeated PipelineTriggerChartRecord pipeline_trigger_chart_records = 1;
+}
+
+// CreditConsumptionChartRecord represents a timeline of Instill Credit
+// consumption. It contains a collection of (timestamp, amount) pairs that
+// represent the total credit consumption in a given time bucket.
+message CreditConsumptionChartRecord {
+  // Credit owner ID, e.g. `users/chef-wombat`.
+  string credit_owner = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Time buckets.
+  repeated google.protobuf.Timestamp time_buckets = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Total credit consumed in each time bucket.
+  repeated float amount = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Credit consumption source (e.g. "pipeline", "model").
+  string source = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// ListCreditConsumptionChartRecordsRequest represents a request to list credit
+// consumption chart records for a given owner, grouped by time buckets and
+// consumption sources.
+message ListCreditConsumptionChartRecordsRequest {
+  // The user or organization to which the credit belongs.
+  // Format: `{[users|organizations]}/{id}`.
+  string owner = 1 [(google.api.field_behavior) = REQUIRED];
+  // Aggregation window. The value is a positive duration string, i.e. a
+  // sequence of decimal numbers, each with optional fraction and a unit
+  // suffix, such as "300ms", "1.5h" or "2h45m".
+  // The minimum (and default) window is 1h.
+  optional string aggregation_window = 2;
+  // Beginning of the time range from which the records will be fetched.
+  // The default value is the beginning of the current day, in UTC.
+  optional google.protobuf.Timestamp start = 3;
+  // End of the time range from which the records will be fetched.
+  // The default value is the current timestamp.
+  optional google.protobuf.Timestamp stop = 4;
+}
+
+// ListCreditConsumptionChartRecordsResponse contains a list of credit consumption
+// chart records.
+message ListCreditConsumptionChartRecordsResponse {
+  // Credit consumption timelines, aggregated by source.
+  repeated CreditConsumptionChartRecord credit_consumption_chart_records = 1;
+  // 2 is reserved for the total amount consumed in the time range specified in
+  // the request. This won't be returned anymore as we need to aggregate the
+  // consumption by source.
+  reserved 2;
 }

--- a/integration-test/proto/core/mgmt/v1beta/mgmt.proto
+++ b/integration-test/proto/core/mgmt/v1beta/mgmt.proto
@@ -22,7 +22,7 @@ message LivenessRequest {
 // LivenessResponse represents a response for a service liveness status
 message LivenessResponse {
   // HealthCheckResponse message
-  common.healthcheck.v1beta.HealthCheckResponse health_check_response = 1;
+  common.healthcheck.v1beta.HealthCheckResponse health_check_response = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // ReadinessRequest represents a request to check a service readiness status
@@ -34,7 +34,7 @@ message ReadinessRequest {
 // ReadinessResponse represents a response for a service readiness status
 message ReadinessResponse {
   // HealthCheckResponse message
-  common.healthcheck.v1beta.HealthCheckResponse health_check_response = 1;
+  common.healthcheck.v1beta.HealthCheckResponse health_check_response = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // View defines how a resource is presented. It can be used as a parameter in a
@@ -57,6 +57,12 @@ enum OwnerType {
   OWNER_TYPE_USER = 1;
   // OwnerType: ORGANIZATION
   OWNER_TYPE_ORGANIZATION = 2;
+}
+
+// Permission defines how a resource can be used.
+message Permission {
+  // Defines whether the resource can be modified.
+  bool can_edit = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // MembershipState describes the state of a user membership to an organization.
@@ -158,7 +164,7 @@ message AuthenticatedUser {
   // Onboarding Status.
   OnboardingStatus onboarding_status = 17 [(google.api.field_behavior) = OPTIONAL];
   // Profile.
-  UserProfile profile = 18;
+  UserProfile profile = 18 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // Owner is a wrapper for User and Organization, used to embed owner information in other resources.
@@ -186,14 +192,14 @@ message User {
   string name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
   // User UUID. This field is optionally set by users on creation (it will be
   // server-generated if unspecified).
-  optional string uid = 2 [(google.api.field_behavior) = IMMUTABLE];
+  optional string uid = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Resource ID (used in `name` as the last segment). This conforms to
   // RFC-1034, which restricts to letters, numbers, and hyphen, with the first
   // character a letter, the last a letter or a number, and a 63 character
   // maximum.
   //
   // Note that the ID can be updated.
-  string id = 3 [(google.api.field_behavior) = REQUIRED];
+  string id = 3 [(google.api.field_behavior) = IMMUTABLE];
   // Creation time.
   google.protobuf.Timestamp create_time = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Update time.
@@ -230,17 +236,12 @@ message ListUsersAdminResponse {
 
 // GetUserAdminRequest represents a request to query a user by admin
 message GetUserAdminRequest {
-  // Resource name of a user. For example:
-  // "users/local-user"
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "api.instill.tech/User",
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user_name"}
-    }
-  ];
+  // Reserved for `user_id``
+  reserved 1;
   // View allows clients to specify the desired resource view in the response.
-  optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
+  optional View view = 2;
+  // User ID
+  string user_id = 3;
 }
 
 // GetUserAdminResponse represents a response for a user resource
@@ -252,11 +253,12 @@ message GetUserAdminResponse {
 // LookUpUserAdminRequest represents a request to query a user via permalink by
 // admin
 message LookUpUserAdminRequest {
-  // Permalink of a user. For example:
-  // "users/{uid}"
-  string permalink = 1 [(google.api.field_behavior) = REQUIRED];
+  // Reserved for `permalink`
+  reserved 1;
   // View allows clients to specify the desired resource view in the response.
-  optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
+  optional View view = 2;
+  // User UUID
+  string user_uid = 3;
 }
 
 // LookUpUserAdminResponse represents a response for a user resource by admin
@@ -270,15 +272,15 @@ message ListOrganizationsAdminRequest {
   // The maximum number of organizations to return. If this parameter is
   // unspecified, at most 10 pipelines will be returned. The cap value for this
   // parameter is 100 (i.e. any value above that will be coerced to 100).
-  optional int32 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
+  optional int32 page_size = 1;
   // Page token.
-  optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
+  optional string page_token = 2;
   // View allows clients to specify the desired resource view in the response.
-  optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
+  optional View view = 3;
   // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
   // expression.
   // - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
-  optional string filter = 4 [(google.api.field_behavior) = OPTIONAL];
+  optional string filter = 4;
 }
 
 // ListOrganizationsAdminResponse represents a response for a list of organizations
@@ -293,17 +295,12 @@ message ListOrganizationsAdminResponse {
 
 // GetOrganizationAdminRequest represents a request to query a organization by admin
 message GetOrganizationAdminRequest {
-  // Resource name of a organization. For example:
-  // "organizations/local-organization"
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "api.instill.tech/Organization",
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization_name"}
-    }
-  ];
+  // Reserved for `name``
+  reserved 1;
   // View allows clients to specify the desired resource view in the response.
-  optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
+  optional View view = 2;
+  // Organization ID
+  string organization_id = 3;
 }
 
 // GetOrganizationAdminResponse represents a response for a organization resource
@@ -315,11 +312,12 @@ message GetOrganizationAdminResponse {
 // LookUpOrganizationAdminRequest represents a request to query a organization via permalink by
 // admin
 message LookUpOrganizationAdminRequest {
-  // Permalink of a organization. For example:
-  // "organizations/{uid}"
-  string permalink = 1 [(google.api.field_behavior) = REQUIRED];
+  // Reserved for `permalink``
+  reserved 1;
   // View allows clients to specify the desired resource view in the response.
-  optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
+  optional View view = 2;
+  // Organization UID
+  string organization_uid = 3;
 }
 
 // LookUpOrganizationAdminResponse represents a response for a organization resource by admin
@@ -347,32 +345,31 @@ message ListUsersRequest {
 // ListUsersResponse contains a list of users.
 message ListUsersResponse {
   // A list of user resources.
-  repeated User users = 1;
+  repeated User users = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Next page token.
-  string next_page_token = 2;
+  string next_page_token = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Total number of users.
-  int32 total_size = 3;
+  int32 total_size = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // GetUserRequest represents a request to fetch the details of a user.
 message GetUserRequest {
-  // The resource name of the user, which allows its access by ID.
-  // - Format: `users/{user.id}`.
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "api.instill.tech/User",
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user_name"}
-    }
-  ];
+  // Reserverd for `name`
+  reserved 1;
+
   // View allows clients to specify the desired resource view in the response.
   optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
+  // User ID
+  string user_id = 3 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "api.instill.tech/User"
+  ];
 }
 
 // GetUserResponse contains the requested user.
 message GetUserResponse {
   // The user resource.
-  User user = 1;
+  User user = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // GetAuthenticatedUserRequest represents a request to get the
@@ -382,14 +379,14 @@ message GetAuthenticatedUserRequest {}
 // GetAuthenticatedUserResponse contains the requested authenticated user.
 message GetAuthenticatedUserResponse {
   // The authenticated user resource.
-  AuthenticatedUser user = 1;
+  AuthenticatedUser user = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // PatchAuthenticatedUserRequest represents a request to update the
 // authenticated user.
 message PatchAuthenticatedUserRequest {
   // The user fields that will replace the existing ones.
-  AuthenticatedUser user = 1;
+  AuthenticatedUser user = 1 [(google.api.field_behavior) = REQUIRED];
   // The update mask specifies the subset of fields that should be modified.
   //
   // For more information about this field, see
@@ -401,7 +398,7 @@ message PatchAuthenticatedUserRequest {
 // the authenticated user resource
 message PatchAuthenticatedUserResponse {
   // The updated user resource.
-  AuthenticatedUser user = 1;
+  AuthenticatedUser user = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // CheckNamespaceRequest represents a request to verify if a namespace is
@@ -432,15 +429,44 @@ message CheckNamespaceResponse {
   Namespace type = 1;
 }
 
+// CheckNamespaceAdminRequest represents a request to verify if a namespace is
+// available.
+message CheckNamespaceAdminRequest {
+  // The namespace ID to be checked.
+  string id = 1 [(google.api.field_behavior) = REQUIRED];
+}
+
+// CheckNamespaceAdminResponse contains the availability of a namespace or the type
+// of resource that's using it.
+message CheckNamespaceAdminResponse {
+  // Namespace contains information about the availability of a namespace.
+  enum Namespace {
+    // Unspecified.
+    NAMESPACE_UNSPECIFIED = 0;
+    // Available.
+    NAMESPACE_AVAILABLE = 1;
+    // Namespace belongs to a user.
+    NAMESPACE_USER = 2;
+    // Namespace belongs to an organization.
+    NAMESPACE_ORGANIZATION = 3;
+    // Reserved.
+    NAMESPACE_RESERVED = 4;
+  }
+
+  // Namespace type.
+  Namespace type = 1;
+  // Namespace UID.
+  string uid = 2;
+}
+
 // API tokens allow users to make requests to the Instill AI API.
 message ApiToken {
-  option (google.api.resource) = {
-    type: "api.instill.tech/ApiToken"
-    pattern: "tokens/{token.name}"
-  };
+  option (google.api.resource) = {type: "api.instill.tech/ApiToken"};
 
-  // google.protobuf.Timestamp last_use_time = 6;
-  reserved 6;
+  // When users trigger a pipeline which uses an API token, the token is
+  // updated with the current time. This field is used to track the last time
+  // the token was used.
+  google.protobuf.Timestamp last_use_time = 6;
 
   // State describes the state of an API token.
   enum State {
@@ -498,7 +524,7 @@ message CreateTokenRequest {
 // CreateTokenResponse contains the created token.
 message CreateTokenResponse {
   // The created API token resource.
-  ApiToken token = 1;
+  ApiToken token = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // ListTokensRequest represents a request to list the API tokens of a user.
@@ -523,33 +549,29 @@ message ListTokensResponse {
 
 // GetTokenRequest represents a request to fetch the details of an API token
 message GetTokenRequest {
-  // The resource name of the token, which allows its access by ID.
-  // - Format: `tokens/{token.id}`.
-  string name = 1 [
+  // Reserverd for `name`
+  reserved 1;
+  // Token ID
+  string token_id = 2 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {type: "api.instill.tech/ApiToken"},
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "token_name"}
-    }
+    (google.api.resource_reference) = {type: "api.instill.tech/ApiToken"}
   ];
 }
 
 // GetTokenResponse contains the requested token.
 message GetTokenResponse {
   // The API token resource.
-  ApiToken token = 1;
+  ApiToken token = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // DeleteTokenRequest represents a request to delete an API token resource.
 message DeleteTokenRequest {
-  // The resource name of the token, which allows its access by ID.
-  // - Format: `tokens/{token.id}`.
-  string name = 1 [
+  // Reserverd for `name`
+  reserved 1;
+  // Token ID
+  string token_id = 2 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {type: "api.instill.tech/ApiToken"},
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "token_name"}
-    }
+    (google.api.resource_reference) = {type: "api.instill.tech/ApiToken"}
   ];
 }
 
@@ -568,36 +590,59 @@ message ValidateTokenResponse {
 // GetRemainingCreditRequest represents a request to get the remaining credit
 // of a user or organization.
 message GetRemainingCreditRequest {
-  // The user or organization to which the credit belongs.
-  // Format: `{[users|organizations]}/{id}`.
-  string owner = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "owner_name"}
-    }
-  ];
+  // Reserverd for `owner`
+  reserved 1;
+  // Namespace ID
+  string namespace_id = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
 // GetRemainingCreditResponse contains the remaining credit of a user or
 // organization.
 message GetRemainingCreditResponse {
+  // 1 is reserved for the previous endpoint version, where only the total
+  // amount was returned.
+  reserved 1;
+  // Amount of perishable credit, i.e. credit with an expiration date.
+  float perishable = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Amount of imperishable credit, e.g. purchased credit, which doesn't
+  // expire.
+  float imperishable = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Total remaining credit.
+  float total = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// GetRemainingCreditAdminRequest represents a request to get the remaining
+// credit of a user or organization without authentication.
+message GetRemainingCreditAdminRequest {
+  // Reserverd for `owner`
+  reserved 1;
+  // Namespace UID
+  string namespace_uid = 2;
+}
+
+// GetRemainingCreditAdminResponse contains the remaining credit of a user or
+// organization.
+message GetRemainingCreditAdminResponse {
   // The requested credit.
   float amount = 1;
 }
 
-// SubtractCreditRequest represents a request to subtract Instill Credit from
+// SubtractCreditAdminRequest represents a request to subtract Instill Credit from
 // an account.
-message SubtractCreditRequest {
-  // The user or organization to which the credit belongs.
-  // Format: `{[users|organizations]}/{id}`.
-  string owner = 1 [(google.api.field_behavior) = REQUIRED];
+message SubtractCreditAdminRequest {
+  // Reserverd for `owner`
+  reserved 1;
   // The credit amount to subtract.
   float amount = 2;
+  // The description of the entry, for traceability.
+  string concept = 3;
+  // Namespace UID
+  string namespace_uid = 4;
 }
 
 // SubtractCreditResponse contains the remaining credit of an account after the
 // subtraction.
-message SubtractCreditResponse {
+message SubtractCreditAdminResponse {
   // The remaining credit.
   float amount = 1;
 }
@@ -674,17 +719,11 @@ message Organization {
   option (google.api.resource) = {
     type: "api.instill.tech/Organization"
     pattern: "organizations/{organization.id}"
-    pattern: "organizations/{organization.uid}"
   };
 
   // The name of the organization, defined by its ID.
   // - Format: `organization/{organization.id}`.
-  string name = 1 [
-    (google.api.field_behavior) = OUTPUT_ONLY,
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization_name"}
-    }
-  ];
+  string name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // Organization UUID.
   string uid = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
@@ -694,7 +733,7 @@ message Organization {
   // maximum.
   //
   // Note that the ID can be updated.
-  string id = 3 [(google.api.field_behavior) = REQUIRED];
+  string id = 3 [(google.api.field_behavior) = IMMUTABLE];
   // Creation time.
   google.protobuf.Timestamp create_time = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Update time.
@@ -702,7 +741,9 @@ message Organization {
   // The user that owns the organization.
   User owner = 11 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Profile.
-  OrganizationProfile profile = 12;
+  OrganizationProfile profile = 12 [(google.api.field_behavior) = REQUIRED];
+  // Permission
+  Permission permission = 13 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // ListOrganizationsRequest represents a request to list all organizations
@@ -724,11 +765,11 @@ message ListOrganizationsRequest {
 // ListOrganizationsResponse represents a response for a list of organizations
 message ListOrganizationsResponse {
   // A list of organizations
-  repeated Organization organizations = 1;
+  repeated Organization organizations = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Next page token.
-  string next_page_token = 2;
+  string next_page_token = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Total number of organizations.
-  int32 total_size = 3;
+  int32 total_size = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // CreateOrganizationRequest represents a request to create an organization.
@@ -740,58 +781,56 @@ message CreateOrganizationRequest {
 // CreateOrganizationResponse contains the created organization.
 message CreateOrganizationResponse {
   // The organization resource.
-  Organization organization = 1;
+  Organization organization = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // GetOrganizationRequest represents a request to fetch the details of an
 // organization.
 message GetOrganizationRequest {
-  // The resource name of the organization, which allows its access by ID.
-  // - Format: `organizations/{organization.id}`.
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "api.instill.tech/Organization",
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization_name"}
-    }
-  ];
+  // Reserverd for `name`
+  reserved 1;
   // View allows clients to specify the desired resource view in the response.
   optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
+  // Organization ID
+  string organization_id = 3 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "api.instill.tech/Organization"
+  ];
 }
 
 // GetOrganizationResponse contains the requested organization.
 message GetOrganizationResponse {
   // The organization resource.
-  Organization organization = 1;
+  Organization organization = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // UpdateOrganizationRequest represents a request to update an organization.
 message UpdateOrganizationRequest {
   // The organization fields that will replace the existing ones.
-  Organization organization = 1 [(google.api.field_behavior) = REQUIRED];
+  Organization organization = 1;
   // The update mask specifies the subset of fields that should be modified.
   //
   // For more information about this field, see
   // https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#field-mask.
   google.protobuf.FieldMask update_mask = 2 [(google.api.field_behavior) = REQUIRED];
+  // Organization ID
+  string organization_id = 3 [(google.api.field_behavior) = REQUIRED];
 }
 
 // UpdateOrganizationResponse contains the updated organization.
 message UpdateOrganizationResponse {
   // The organization resource.
-  Organization organization = 1;
+  Organization organization = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // DeleteOrganizationRequest represents a request to delete an organization.
 message DeleteOrganizationRequest {
-  // The resource name of the organization, which allows its access by ID.
-  // - Format: `organizations/{organization.id}`.
-  string name = 1 [
+  // Reserverd for `name`
+  reserved 1;
+  // Organization ID
+  string organization_id = 2 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "api.instill.tech/Organization",
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization_name"}
-    }
+    (google.api.resource_reference).type = "api.instill.tech/Organization"
   ];
 }
 
@@ -847,43 +886,35 @@ message UserMembership {
 // ListUserMembershipsRequest represents a request to list the memberships of a
 // user.
 message ListUserMembershipsRequest {
-  // The parent resource, i.e., the user to which the memberships belong.
-  // Format: `users/{user.id}`.
-  string parent = 5 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {child_type: "api.instill.tech/Organization"},
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user_name"}
-    }
-  ];
+  // Reserverd for `parent`
+  reserved 5;
+
+  // User ID
+  string user_id = 6 [(google.api.field_behavior) = REQUIRED];
 }
 
 // ListUserMembershipsResponse contains a list of memberships.
 message ListUserMembershipsResponse {
   // The user memberships, i.e., the organizations the user belongs to.
-  repeated UserMembership memberships = 1;
+  repeated UserMembership memberships = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // GetUserMembershipRequest represents a request to query a user's membership.
 message GetUserMembershipRequest {
-  // The resource name of the membership, which allows its access by user and
-  // organization ID.
-  // - Format: `users/{user.id}/memberships/{organization.id}`.
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {type: "api.instill.tech/UserMembership"},
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user_membership_name"}
-    }
-  ];
+  // Reserverd for `name`
+  reserved 1;
   // View allows clients to specify the desired resource view in the response.
   optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
+  // User ID
+  string user_id = 3 [(google.api.field_behavior) = REQUIRED];
+  // Organization ID
+  string organization_id = 4 [(google.api.field_behavior) = REQUIRED];
 }
 
 // GetUserMembershipResponse contains the user membership.
 message GetUserMembershipResponse {
   // The requested user membership.
-  UserMembership membership = 1;
+  UserMembership membership = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // UpdateUserMembershipRequest represents a request to update a user membership.
@@ -895,27 +926,27 @@ message UpdateUserMembershipRequest {
   // For more information about this field, see
   // https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#field-mask.
   google.protobuf.FieldMask update_mask = 2 [(google.api.field_behavior) = REQUIRED];
+  // User ID
+  string user_id = 3 [(google.api.field_behavior) = REQUIRED];
+  // Organization ID
+  string organization_id = 4 [(google.api.field_behavior) = REQUIRED];
 }
 
 // UpdateUserMembershipResponse contains the updated membership.
 message UpdateUserMembershipResponse {
   // The updated membership resource.
-  UserMembership membership = 1;
+  UserMembership membership = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // DeleteUserMembershipRequest represents a request to delete a user
 // membership.
 message DeleteUserMembershipRequest {
-  // The resource name of the membership, which allows its access by user and
-  // organization ID.
-  // - Format: `users/{user.id}/memberships/{organization.id}`.
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {type: "api.instill.tech/UserMembership"},
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user_membership_name"}
-    }
-  ];
+  // Reserved for `name`
+  reserved 1;
+  // User ID
+  string user_id = 2 [(google.api.field_behavior) = REQUIRED];
+  // Organization ID
+  string organization_id = 3 [(google.api.field_behavior) = REQUIRED];
 }
 
 // DeleteUserMembershipResponse is an empty response.
@@ -924,46 +955,38 @@ message DeleteUserMembershipResponse {}
 // ListOrganizationMembershipsRequest represents a request to list the
 // memberships of an organization.
 message ListOrganizationMembershipsRequest {
-  // The parent resource, i.e., the organization to which the memberships
-  // belong.
-  // Format: `organizations/{organization.id}`.
-  string parent = 5 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {child_type: "api.instill.tech/Organization"},
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization_name"}
-    }
-  ];
+  // Reserved for `parent`
+  reserved 5;
+  // Organization ID
+  string organization_id = 6 [(google.api.field_behavior) = REQUIRED];
 }
 
 // ListOrganizationMembershipsResponse contains a list of memberships.
 message ListOrganizationMembershipsResponse {
   // The organization memberships, i.e., the users that belong to the
   // organization.
-  repeated OrganizationMembership memberships = 1;
+  repeated OrganizationMembership memberships = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // GetOrganizationMembershipRequest represents a request to query a user's
 // membership to an organization.
 message GetOrganizationMembershipRequest {
-  // The resource name of the membership, which allows its access by
-  // organization and user ID.
-  // - Format: `organizations/{organization.id}/memberships/{user.id}`.
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {type: "api.instill.tech/OrganizationMembership"},
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization_membership_name"}
-    }
-  ];
+  // Reserved for `name`
+  reserved 1;
+
   // View allows clients to specify the desired resource view in the response.
   optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
+
+  // Organization ID
+  string organization_id = 3 [(google.api.field_behavior) = REQUIRED];
+  // User ID
+  string user_id = 4 [(google.api.field_behavior) = REQUIRED];
 }
 
 // GetOrganizationMembershipResponse contains the organization membership.
 message GetOrganizationMembershipResponse {
   // The requested organization membership.
-  OrganizationMembership membership = 1;
+  OrganizationMembership membership = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // UpdateOrganizationMembershipRequest represents a request to update an
@@ -976,27 +999,27 @@ message UpdateOrganizationMembershipRequest {
   // For more information about this field, see
   // https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#field-mask.
   google.protobuf.FieldMask update_mask = 2 [(google.api.field_behavior) = REQUIRED];
+  // Organization ID
+  string organization_id = 3 [(google.api.field_behavior) = REQUIRED];
+  // User ID
+  string user_id = 4 [(google.api.field_behavior) = REQUIRED];
 }
 
 // UpdateOrganizationMembershipResponse contains the updated membership.
 message UpdateOrganizationMembershipResponse {
   // The updated membership resource.
-  OrganizationMembership membership = 1;
+  OrganizationMembership membership = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // DeleteOrganizationMembershipRequest represents a request to delete an
 // organization membership.
 message DeleteOrganizationMembershipRequest {
-  // The resource name of the membership, which allows its access by
-  // organization and user ID.
-  // - Format: `organizations/{organization.id}/memberships/{user.id}`.
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {type: "api.instill.tech/OrganizationMembership"},
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization_membership_name"}
-    }
-  ];
+  // Reserverd for `name`
+  reserved 1;
+  // Organization ID
+  string organization_id = 2 [(google.api.field_behavior) = REQUIRED];
+  // User ID
+  string user_id = 3 [(google.api.field_behavior) = REQUIRED];
 }
 
 // DeleteOrganizationMembershipResponse is an empty response.
@@ -1027,21 +1050,21 @@ message StripeSubscriptionDetail {
   }
 
   // Product name associated with the subscription in Stripe.
-  string product_name = 1;
+  string product_name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Unique identifier for the subscription.
-  string id = 2;
+  string id = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Identifier for the specific item within the subscription.
-  string item_id = 3;
+  string item_id = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Price of the subscription.
-  float price = 4;
+  float price = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Optional timestamp indicating when the subscription was canceled, if applicable.
-  optional int32 canceled_at = 5;
+  optional int32 canceled_at = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Optional timestamp indicating when the trial ended, if applicable.
-  optional int32 trial_end = 6;
+  optional int32 trial_end = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Status of the subscription.
-  Status status = 7;
+  Status status = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Description of the subscription.
-  string description = 8;
+  string description = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // UserSubscription details describe the plan (i.e., features) a user has access to.
@@ -1050,16 +1073,16 @@ message UserSubscription {
   enum Plan {
     // Unspecified plan.
     PLAN_UNSPECIFIED = 0;
-    // Freemium plan.
-    PLAN_FREEMIUM = 1;
-    // Pro plan.
-    PLAN_PRO = 2;
+    // Free plan.
+    PLAN_FREE = 1;
+    // Starter plan.
+    PLAN_STARTER = 2;
   }
 
   // Plan identifier.
-  Plan plan = 1;
+  Plan plan = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Details of the associated Stripe subscription.
-  StripeSubscriptionDetail detail = 2;
+  StripeSubscriptionDetail detail = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // OrganizationSubscription details describe the plan (i.e., features) an organization has access to.
@@ -1068,22 +1091,24 @@ message OrganizationSubscription {
   enum Plan {
     // Unspecified plan.
     PLAN_UNSPECIFIED = 0;
-    // Freemium plan.
-    PLAN_FREEMIUM = 1;
+    // Unpaid.
+    PLAN_UNPAID = 1;
     // Team plan.
     PLAN_TEAM = 2;
     // Enterprise plan.
     PLAN_ENTERPRISE = 3;
+    // Team pro plan.
+    PLAN_TEAM_PRO = 4;
   }
 
   // Plan identifier.
-  Plan plan = 1;
+  Plan plan = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Details of the associated Stripe subscription.
-  StripeSubscriptionDetail detail = 2;
+  StripeSubscriptionDetail detail = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Maximum number of seats allowed.
-  int32 max_seats = 3;
+  int32 max_seats = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Number of used seats within the organization subscription.
-  int32 used_seats = 4;
+  int32 used_seats = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // GetAuthenticatedUserSubscriptionRequest represents a query to fetch the subscription
@@ -1093,37 +1118,30 @@ message GetAuthenticatedUserSubscriptionRequest {}
 // GetAuthenticatedUserSubscriptionResponse contains the requested subscription.
 message GetAuthenticatedUserSubscriptionResponse {
   // The subscription resource.
-  UserSubscription subscription = 1;
+  UserSubscription subscription = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // GetOrganizationSubscriptionRequest represents a query to fetch the
 // subscription details of an organization.
 message GetOrganizationSubscriptionRequest {
-  // The parent resource, i.e., the organization to which the subscription
-  // refers.
-  // Format: `organizations/{organization.id}`.
-  string parent = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {child_type: "api.instill.tech/Organization"},
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization_name"}
-    }
-  ];
+  // Resever for `parant`
+  reserved 1;
+  // Oragnization ID
+  string organization_id = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
 // GetOrganizationSubscriptionResponse contains the requested subscription.
 message GetOrganizationSubscriptionResponse {
   // The subscription resource.
-  OrganizationSubscription subscription = 1;
+  OrganizationSubscription subscription = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // GetUserSubscriptionAdminRequest
 message GetUserSubscriptionAdminRequest {
-  // parent
-  string parent = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {child_type: "api.instill.tech/User"}
-  ];
+  // Resever for `parant`
+  reserved 1;
+  // User ID
+  string user_id = 2;
 }
 
 // GetUserSubscriptionAdminResponse
@@ -1134,11 +1152,10 @@ message GetUserSubscriptionAdminResponse {
 
 // GetOrganizationSubscriptionAdminRequest
 message GetOrganizationSubscriptionAdminRequest {
-  // parent
-  string parent = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {child_type: "api.instill.tech/Organization"}
-  ];
+  // Resever for `parant`
+  reserved 1;
+  // Oragnization ID
+  string organization_id = 2;
 }
 
 // GetOrganizationSubscriptionAdminResponse

--- a/integration-test/proto/core/mgmt/v1beta/mgmt_private_service.proto
+++ b/integration-test/proto/core/mgmt/v1beta/mgmt_private_service.proto
@@ -3,64 +3,38 @@ syntax = "proto3";
 package core.mgmt.v1beta;
 
 import "../../../core/mgmt/v1beta/mgmt.proto";
-// Google API
-import "google/api/annotations.proto";
-import "google/api/client.proto";
-import "google/api/visibility.proto";
 
 // Mgmt service responds to internal access
 service MgmtPrivateService {
   // ListUsersAdmin method receives a ListUsersAdminRequest message and returns
   // a ListUsersAdminResponse message.
-  rpc ListUsersAdmin(ListUsersAdminRequest) returns (ListUsersAdminResponse) {
-    option (google.api.http) = {get: "/v1beta/admin/users"};
-  }
+  rpc ListUsersAdmin(ListUsersAdminRequest) returns (ListUsersAdminResponse) {}
 
   // GetUserAdmin method receives a GetUserAdminRequest message and returns
   // a GetUserAdminResponse message.
-  rpc GetUserAdmin(GetUserAdminRequest) returns (GetUserAdminResponse) {
-    option (google.api.http) = {get: "/v1beta/admin/{name=users/*}"};
-    option (google.api.method_signature) = "name";
-  }
+  rpc GetUserAdmin(GetUserAdminRequest) returns (GetUserAdminResponse) {}
 
   // LookUpUserAdmin method receives a LookUpUserAdminRequest message and
   // returns a LookUpUserAdminResponse
-  rpc LookUpUserAdmin(LookUpUserAdminRequest) returns (LookUpUserAdminResponse) {
-    option (google.api.http) = {get: "/v1beta/admin/{permalink=users/*}/lookUp"};
-    option (google.api.method_signature) = "permalink";
-  }
+  rpc LookUpUserAdmin(LookUpUserAdminRequest) returns (LookUpUserAdminResponse) {}
 
   // ListOrganizationsAdmin method receives a ListOrganizationsAdminRequest message and returns
   // a ListOrganizationsAdminResponse message.
-  rpc ListOrganizationsAdmin(ListOrganizationsAdminRequest) returns (ListOrganizationsAdminResponse) {
-    option (google.api.http) = {get: "/v1beta/admin/organizations"};
-  }
+  rpc ListOrganizationsAdmin(ListOrganizationsAdminRequest) returns (ListOrganizationsAdminResponse) {}
 
   // GetOrganizationAdmin method receives a GetOrganizationAdminRequest message and returns
   // a GetOrganizationAdminResponse message.
-  rpc GetOrganizationAdmin(GetOrganizationAdminRequest) returns (GetOrganizationAdminResponse) {
-    option (google.api.http) = {get: "/v1beta/admin/{name=organizations/*}"};
-    option (google.api.method_signature) = "name";
-  }
+  rpc GetOrganizationAdmin(GetOrganizationAdminRequest) returns (GetOrganizationAdminResponse) {}
 
   // LookUpOrganizationAdmin method receives a LookUpOrganizationAdminRequest message and
   // returns a LookUpOrganizationAdminResponse
-  rpc LookUpOrganizationAdmin(LookUpOrganizationAdminRequest) returns (LookUpOrganizationAdminResponse) {
-    option (google.api.http) = {get: "/v1beta/admin/{permalink=organizations/*}/lookUp"};
-    option (google.api.method_signature) = "permalink";
-  }
+  rpc LookUpOrganizationAdmin(LookUpOrganizationAdminRequest) returns (LookUpOrganizationAdminResponse) {}
 
   // GetUserSubscriptionAdmin
-  rpc GetUserSubscriptionAdmin(GetUserSubscriptionAdminRequest) returns (GetUserSubscriptionAdminResponse) {
-    option (google.api.http) = {get: "/v1beta/admin/{parent=users/*}/subscription"};
-    option (google.api.method_signature) = "parent";
-  }
+  rpc GetUserSubscriptionAdmin(GetUserSubscriptionAdminRequest) returns (GetUserSubscriptionAdminResponse) {}
 
   // GetOrganizationSubscriptionAdmin
-  rpc GetOrganizationSubscriptionAdmin(GetOrganizationSubscriptionAdminRequest) returns (GetOrganizationSubscriptionAdminResponse) {
-    option (google.api.http) = {get: "/v1beta/admin/{parent=organizations/*}/subscription"};
-    option (google.api.method_signature) = "parent";
-  }
+  rpc GetOrganizationSubscriptionAdmin(GetOrganizationSubscriptionAdminRequest) returns (GetOrganizationSubscriptionAdminResponse) {}
 
   // Subtract Instill Credit from a user or organization account.
   //
@@ -71,10 +45,20 @@ service MgmtPrivateService {
   // requested amount, it will be subtracted anyways, leaving the account
   // credit at zero. A ResourceExhausted error will be returned in this case.
   //
-  // On Instill Core, this endpoint will return a 404 Not Found status.
-  rpc SubtractCredit(SubtractCreditRequest) returns (SubtractCreditResponse) {
-    option (google.api.method_signature) = "owner,amount";
-  }
+  // On Instill Core, this endpoint will return an Unimplemented status.
+  rpc SubtractCreditAdmin(SubtractCreditAdminRequest) returns (SubtractCreditAdminResponse) {}
 
-  option (google.api.api_visibility).restriction = "INTERNAL";
+  // Get the remaining Instill Credit by owner UID
+  //
+  // This endpoint fetches the remaining unexpired credit of a user or
+  // organization, referenced by UID.
+  //
+  // On Instill Core, this endpoint will return a 404 Not Found status.
+  rpc GetRemainingCreditAdmin(GetRemainingCreditAdminRequest) returns (GetRemainingCreditAdminResponse) {}
+
+  // Check if a namespace is in use
+  //
+  // Returns the availability of a namespace or, alternatively, the type of
+  // resource that is using it.
+  rpc CheckNamespaceAdmin(CheckNamespaceAdminRequest) returns (CheckNamespaceAdminResponse) {}
 }

--- a/integration-test/proto/core/mgmt/v1beta/mgmt_public_service.proto
+++ b/integration-test/proto/core/mgmt/v1beta/mgmt_public_service.proto
@@ -5,9 +5,8 @@ package core.mgmt.v1beta;
 // Core definitions
 import "../../../core/mgmt/v1beta/metric.proto";
 import "../../../core/mgmt/v1beta/mgmt.proto";
-// Google API
 import "google/api/annotations.proto";
-import "google/api/client.proto";
+// Google API
 import "google/api/visibility.proto";
 // OpenAPI definition
 import "protoc-gen-openapiv2/options/annotations.proto";
@@ -18,14 +17,6 @@ import "protoc-gen-openapiv2/options/annotations.proto";
 // manage user resources.
 service MgmtPublicService {
   option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_tag) = {description: "Public Core endpoints"};
-
-  // Delete an organization membership
-  //
-  // Deletes a user membership within an organization.
-  rpc DeleteOrganizationMembership(DeleteOrganizationMembershipRequest) returns (DeleteOrganizationMembershipResponse) {
-    option (google.api.http) = {delete: "/v1beta/{name=organizations/*/memberships/*}"};
-    option (google.api.method_signature) = "name";
-  }
 
   // Check if the MGMT server is alive
   //
@@ -51,24 +42,12 @@ service MgmtPublicService {
     option (google.api.method_visibility).restriction = "INTERNAL";
   }
 
-  // Check if a namespace is in use
-  //
-  // Returns the availability of a namespace or, alternatively, the type of
-  // resource that is using it.
-  rpc CheckNamespace(CheckNamespaceRequest) returns (CheckNamespaceResponse) {
-    option (google.api.http) = {
-      post: "/v1beta/check-namespace"
-      body: "*"
-    };
-    option (google.api.method_signature) = "namespace";
-  }
-
   // Get the authenticated user
   //
   // Returns the details of the authenticated user.
   rpc GetAuthenticatedUser(GetAuthenticatedUserRequest) returns (GetAuthenticatedUserResponse) {
     option (google.api.http) = {get: "/v1beta/user"};
-    option (google.api.method_signature) = "user,update_mask";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "User"};
   }
 
   // Update the authenticated user
@@ -82,7 +61,7 @@ service MgmtPublicService {
       patch: "/v1beta/user"
       body: "user"
     };
-    option (google.api.method_signature) = "user,update_mask";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "User"};
   }
 
   // List users
@@ -90,57 +69,15 @@ service MgmtPublicService {
   // Returns a paginated list of users.
   rpc ListUsers(ListUsersRequest) returns (ListUsersResponse) {
     option (google.api.http) = {get: "/v1beta/users"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "User"};
   }
 
   // Get a user
   //
   // Returns the details of a user by their ID.
   rpc GetUser(GetUserRequest) returns (GetUserResponse) {
-    option (google.api.http) = {get: "/v1beta/{name=users/*}"};
-    option (google.api.method_signature) = "name";
-  }
-
-  // List user memberships
-  //
-  // Returns the memberships of a user.
-  rpc ListUserMemberships(ListUserMembershipsRequest) returns (ListUserMembershipsResponse) {
-    option (google.api.http) = {get: "/v1beta/{parent=users/*}/memberships"};
-    option (google.api.method_signature) = "parent";
-  }
-
-  // Get a user membership
-  //
-  // Returns the details of the relationship between a user and an
-  // organization. The authenticated must match the membership parent.
-  rpc GetUserMembership(GetUserMembershipRequest) returns (GetUserMembershipResponse) {
-    option (google.api.http) = {get: "/v1beta/{name=users/*/memberships/*}"};
-    option (google.api.method_signature) = "name";
-  }
-
-  // Update a user membership
-  //
-  // Accesses and updates a user membership by parent and membership IDs.
-  rpc UpdateUserMembership(UpdateUserMembershipRequest) returns (UpdateUserMembershipResponse) {
-    option (google.api.http) = {
-      put: "/v1beta/{membership.name=users/*/memberships/*}"
-      body: "membership"
-    };
-    option (google.api.method_signature) = "membership,update_mask";
-  }
-
-  // Delete a user membership
-  //
-  // Accesses and deletes a user membership by parent and membership IDs.
-  rpc DeleteUserMembership(DeleteUserMembershipRequest) returns (DeleteUserMembershipResponse) {
-    option (google.api.http) = {delete: "/v1beta/{name=users/*/memberships/*}"};
-    option (google.api.method_signature) = "name";
-  }
-
-  // List organizations
-  //
-  // Returns a paginated list of organizations.
-  rpc ListOrganizations(ListOrganizationsRequest) returns (ListOrganizationsResponse) {
-    option (google.api.http) = {get: "/v1beta/organizations"};
+    option (google.api.http) = {get: "/v1beta/users/{user_id}"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "User"};
   }
 
   // Create an organization
@@ -151,15 +88,23 @@ service MgmtPublicService {
       post: "/v1beta/organizations"
       body: "organization"
     };
-    option (google.api.method_signature) = "organization";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Organization"};
+  }
+
+  // List organizations
+  //
+  // Returns a paginated list of organizations.
+  rpc ListOrganizations(ListOrganizationsRequest) returns (ListOrganizationsResponse) {
+    option (google.api.http) = {get: "/v1beta/organizations"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Organization"};
   }
 
   // Get an organization
   //
   // Returns the organization details by its ID.
   rpc GetOrganization(GetOrganizationRequest) returns (GetOrganizationResponse) {
-    option (google.api.http) = {get: "/v1beta/{name=organizations/*}"};
-    option (google.api.method_signature) = "name";
+    option (google.api.http) = {get: "/v1beta/organizations/{organization_id}"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Organization"};
   }
 
   // Update an organization
@@ -170,34 +115,70 @@ service MgmtPublicService {
   // account when updating the resource.
   rpc UpdateOrganization(UpdateOrganizationRequest) returns (UpdateOrganizationResponse) {
     option (google.api.http) = {
-      patch: "/v1beta/{organization.name=organizations/*}"
+      patch: "/v1beta/organizations/{organization_id}"
       body: "organization"
     };
-    option (google.api.method_signature) = "organization,update_mask";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Organization"};
   }
 
   // Delete an organization
   //
   // Accesses and deletes an organization by ID.
   rpc DeleteOrganization(DeleteOrganizationRequest) returns (DeleteOrganizationResponse) {
-    option (google.api.http) = {delete: "/v1beta/{name=organizations/*}"};
-    option (google.api.method_signature) = "name";
+    option (google.api.http) = {delete: "/v1beta/organizations/{organization_id}"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Organization"};
+  }
+
+  // List user memberships
+  //
+  // Returns the memberships of a user.
+  rpc ListUserMemberships(ListUserMembershipsRequest) returns (ListUserMembershipsResponse) {
+    option (google.api.http) = {get: "/v1beta/users/{user_id}/memberships"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Membership"};
+  }
+
+  // Get a user membership
+  //
+  // Returns the details of the relationship between a user and an
+  // organization. The authenticated must match the membership parent.
+  rpc GetUserMembership(GetUserMembershipRequest) returns (GetUserMembershipResponse) {
+    option (google.api.http) = {get: "/v1beta/users/{user_id}/memberships/{organization_id}"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Membership"};
+  }
+
+  // Update a user membership
+  //
+  // Accesses and updates a user membership by parent and membership IDs.
+  rpc UpdateUserMembership(UpdateUserMembershipRequest) returns (UpdateUserMembershipResponse) {
+    option (google.api.http) = {
+      put: "/v1beta/users/{user_id}/memberships/{organization_id}"
+      body: "membership"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Membership"};
+  }
+
+  // Delete a user membership
+  //
+  // Accesses and deletes a user membership by parent and membership IDs.
+  rpc DeleteUserMembership(DeleteUserMembershipRequest) returns (DeleteUserMembershipResponse) {
+    option (google.api.http) = {delete: "/v1beta/users/{user_id}/memberships/{organization_id}"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Membership"};
   }
 
   // List organization memberships
   //
   // Returns a paginated list of the user memberships in an organization.
   rpc ListOrganizationMemberships(ListOrganizationMembershipsRequest) returns (ListOrganizationMembershipsResponse) {
-    option (google.api.http) = {get: "/v1beta/{parent=organizations/*}/memberships"};
-    option (google.api.method_signature) = "parent";
+    option (google.api.http) = {get: "/v1beta/organizations/{organization_id}/memberships"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Membership"};
   }
 
   // Get a an organization membership
   //
   // Returns the details of a user membership within an organization.
   rpc GetOrganizationMembership(GetOrganizationMembershipRequest) returns (GetOrganizationMembershipResponse) {
-    option (google.api.http) = {get: "/v1beta/{name=organizations/*/memberships/*}"};
-    option (google.api.method_signature) = "name";
+    option (google.api.http) = {get: "/v1beta/organizations/{organization_id}/memberships/{user_id}"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Membership"};
   }
 
   // Uppdate an organization membership
@@ -205,10 +186,18 @@ service MgmtPublicService {
   // Updates a user membership within an organization.
   rpc UpdateOrganizationMembership(UpdateOrganizationMembershipRequest) returns (UpdateOrganizationMembershipResponse) {
     option (google.api.http) = {
-      put: "/v1beta/{membership.name=organizations/*/memberships/*}"
+      put: "/v1beta/organizations/{organization_id}/memberships/{user_id}"
       body: "membership"
     };
-    option (google.api.method_signature) = "membership,update_mask";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Membership"};
+  }
+
+  // Delete an organization membership
+  //
+  // Deletes a user membership within an organization.
+  rpc DeleteOrganizationMembership(DeleteOrganizationMembershipRequest) returns (DeleteOrganizationMembershipResponse) {
+    option (google.api.http) = {delete: "/v1beta/organizations/{organization_id}/memberships/{user_id}"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Membership"};
   }
 
   // Get the subscription of the authenticated user
@@ -216,14 +205,15 @@ service MgmtPublicService {
   // Returns the subscription details of the authenticated user.
   rpc GetAuthenticatedUserSubscription(GetAuthenticatedUserSubscriptionRequest) returns (GetAuthenticatedUserSubscriptionResponse) {
     option (google.api.http) = {get: "/v1beta/user/subscription"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Subscription"};
   }
 
-  // Get an organization subscription
+  // Get the subscription of an organization
   //
   // Returns the subscription details of an organization.
   rpc GetOrganizationSubscription(GetOrganizationSubscriptionRequest) returns (GetOrganizationSubscriptionResponse) {
-    option (google.api.http) = {get: "/v1beta/{parent=organizations/*}/subscription"};
-    option (google.api.method_signature) = "parent";
+    option (google.api.http) = {get: "/v1beta/organizations/{organization_id}/subscription"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Subscription"};
   }
 
   // Create an API token
@@ -234,7 +224,7 @@ service MgmtPublicService {
       post: "/v1beta/tokens"
       body: "token"
     };
-    option (google.api.method_signature) = "token";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Token"};
   }
 
   // List API tokens
@@ -242,68 +232,85 @@ service MgmtPublicService {
   // Returns a paginated list of the API tokens of the authenticated user.
   rpc ListTokens(ListTokensRequest) returns (ListTokensResponse) {
     option (google.api.http) = {get: "/v1beta/tokens"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Token"};
   }
 
   // Get an API token
   //
   // Returns the details of an API token.
   rpc GetToken(GetTokenRequest) returns (GetTokenResponse) {
-    option (google.api.http) = {get: "/v1beta/{name=tokens/*}"};
-    option (google.api.method_signature) = "name";
+    option (google.api.http) = {get: "/v1beta/tokens/{token_id}"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Token"};
   }
 
   // Delete an API token
   //
   // Deletes an API token.
   rpc DeleteToken(DeleteTokenRequest) returns (DeleteTokenResponse) {
-    option (google.api.http) = {delete: "/v1beta/{name=tokens/*}"};
-    option (google.api.method_signature) = "name";
+    option (google.api.http) = {delete: "/v1beta/tokens/{token_id}"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Token"};
   }
 
-  // Validate an API token.
+  // Validate an API token
   //
   // Validates an API token.
   rpc ValidateToken(ValidateTokenRequest) returns (ValidateTokenResponse) {
     option (google.api.http) = {post: "/v1beta/validate_token"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Token"};
   }
 
   // Get the remaining Instill Credit
   //
-  // On Instill Cloud, users can use Instill Credit to execute pre-configured
-  // AI connectors. This simplifies the pipeline setup, removing the need to
-  // subscribe to third-party AI services. This endpoint returns the remaining
-  // Instill Credit of a given user or organization. The requested credit owner
-  // must be either the authenticated user or an organization they belong to.
+  // This endpoint returns the remaining [Instill Credit](https://www.instill.tech/docs/vdp/credit) of a given user or
+  // organization. The requested credit owner must be either the authenticated
+  // user or an organization they belong to.
   //
   // On Instill Core, this endpoint will return a 404 Not Found status.
   rpc GetRemainingCredit(GetRemainingCreditRequest) returns (GetRemainingCreditResponse) {
-    option (google.api.http) = {get: "/v1beta/{owner=*/*}/credit"};
-    option (google.api.method_signature) = "owner";
-    // TODO we'll wait until the Credit feature is completed but this should be
-    // publicly available.
-    option (google.api.method_visibility).restriction = "INTERNAL";
+    option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/credit"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Credit"};
   }
 
-  // List pipeline triggers
+  // Check if a namespace is in use
   //
-  // Returns a paginated list of pipeline executions.
-  rpc ListPipelineTriggerRecords(ListPipelineTriggerRecordsRequest) returns (ListPipelineTriggerRecordsResponse) {
-    option (google.api.http) = {get: "/v1beta/metrics/vdp/pipeline/triggers"};
+  // Returns the availability of a namespace or, alternatively, the type of
+  // resource that is using it.
+  rpc CheckNamespace(CheckNamespaceRequest) returns (CheckNamespaceResponse) {
+    option (google.api.http) = {
+      post: "/v1beta/check-namespace"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Utils"};
   }
 
-  // List pipeline trigger metrics
+  // Get pipeline trigger count
   //
-  // Returns a paginated list of pipeline executions aggregated by pipeline ID.
-  rpc ListPipelineTriggerTableRecords(ListPipelineTriggerTableRecordsRequest) returns (ListPipelineTriggerTableRecordsResponse) {
-    option (google.api.http) = {get: "/v1beta/metrics/vdp/pipeline/tables"};
+  // Returns the pipeline trigger count of a given requester within a timespan.
+  // Results are grouped by trigger status.
+  rpc GetPipelineTriggerCount(GetPipelineTriggerCountRequest) returns (GetPipelineTriggerCountResponse) {
+    option (google.api.http) = {get: "/v1beta/metrics/vdp/pipeline/trigger-count"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Metric"};
   }
 
-  // List pipeline trigger computation time charts
+  // List pipeline trigger time charts
   //
-  // Returns a paginated list with pipeline trigger execution times, aggregated
-  // by pipeline and time frames.
+  // Returns a timeline of pipline trigger counts for a given requester. The
+  // response will contain one set of records (datapoints), representing the
+  // amount of triggers in a time bucket.
   rpc ListPipelineTriggerChartRecords(ListPipelineTriggerChartRecordsRequest) returns (ListPipelineTriggerChartRecordsResponse) {
     option (google.api.http) = {get: "/v1beta/metrics/vdp/pipeline/charts"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Metric"};
+  }
+
+  // List Instill Credit consumption time charts
+  //
+  // Returns a timeline of Instill Credit consumption for a given owner. The
+  // response will contain one set of records (datapoints) per consumption
+  // source (e.g. "pipeline", "model"). Each datapoint represents the amount
+  // consumed in a time bucket.
+  rpc ListCreditConsumptionChartRecords(ListCreditConsumptionChartRecordsRequest) returns (ListCreditConsumptionChartRecordsResponse) {
+    option (google.api.http) = {get: "/v1beta/metrics/credit/charts"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Metric"};
   }
 
   // Auth endpoints are only used in the community edition and the OpenAPI
@@ -315,7 +322,7 @@ service MgmtPublicService {
   // Returns the auth token issuer details. This operation requires admin permissions.
   rpc AuthTokenIssuer(AuthTokenIssuerRequest) returns (AuthTokenIssuerResponse) {
     option (google.api.http) = {
-      post: "/v1beta/auth/token_issuer",
+      post: "/v1beta/auth/token_issuer"
       body: "*"
     };
     option (google.api.method_visibility).restriction = "INTERNAL";
@@ -342,7 +349,7 @@ service MgmtPublicService {
   // Updates the password of a user.
   rpc AuthChangePassword(AuthChangePasswordRequest) returns (AuthChangePasswordResponse) {
     option (google.api.http) = {
-      post: "/v1beta/auth/change_password",
+      post: "/v1beta/auth/change_password"
       body: "*"
     };
     option (google.api.method_visibility).restriction = "INTERNAL";

--- a/integration-test/proto/core/mgmt/v1beta/protoc-gen-openapiv2/options/openapiv2.proto
+++ b/integration-test/proto/core/mgmt/v1beta/protoc-gen-openapiv2/options/openapiv2.proto
@@ -26,7 +26,7 @@ enum Scheme {
 //    info: {
 //      title: "Echo API";
 //      version: "1.0";
-//      description: ";
+//      description: "";
 //      contact: {
 //        name: "gRPC-Gateway project";
 //        url: "https://github.com/grpc-ecosystem/grpc-gateway";
@@ -34,7 +34,7 @@ enum Scheme {
 //      };
 //      license: {
 //        name: "BSD 3-Clause License";
-//        url: "https://github.com/grpc-ecosystem/grpc-gateway/blob/master/LICENSE.txt";
+//        url: "https://github.com/grpc-ecosystem/grpc-gateway/blob/main/LICENSE";
 //      };
 //    };
 //    schemes: HTTPS;
@@ -92,12 +92,14 @@ message Swagger {
   // (that is, there is a logical OR between the security requirements).
   // Individual operations can override this definition.
   repeated SecurityRequirement security = 12;
-  // field 13 is reserved for 'tags', which are supposed to be exposed as and
-  // customizable as proto services. TODO(ivucica): add processing of proto
-  // service objects into OpenAPI v2 Tag objects.
-  reserved 13;
+  // A list of tags for API documentation control. Tags can be used for logical
+  // grouping of operations by resources or any other qualifier.
+  repeated Tag tags = 13;
   // Additional external documentation.
   ExternalDocumentation external_docs = 14;
+  // Custom properties that start with "x-" such as "x-foo" used to describe
+  // extra functionality that is not covered by the standard OpenAPI Specification.
+  // See: https://swagger.io/docs/specification/2-0/swagger-extensions/
   map<string, google.protobuf.Value> extensions = 15;
 }
 
@@ -169,7 +171,55 @@ message Operation {
   // definition overrides any declared top-level security. To remove a top-level
   // security declaration, an empty array can be used.
   repeated SecurityRequirement security = 12;
+  // Custom properties that start with "x-" such as "x-foo" used to describe
+  // extra functionality that is not covered by the standard OpenAPI Specification.
+  // See: https://swagger.io/docs/specification/2-0/swagger-extensions/
   map<string, google.protobuf.Value> extensions = 13;
+  // Custom parameters such as HTTP request headers.
+  // See: https://swagger.io/docs/specification/2-0/describing-parameters/
+  // and https://swagger.io/specification/v2/#parameter-object.
+  Parameters parameters = 14;
+}
+
+// `Parameters` is a representation of OpenAPI v2 specification's parameters object.
+// Note: This technically breaks compatibility with the OpenAPI 2 definition structure as we only
+// allow header parameters to be set here since we do not want users specifying custom non-header
+// parameters beyond those inferred from the Protobuf schema.
+// See: https://swagger.io/specification/v2/#parameter-object
+message Parameters {
+  // `Headers` is one or more HTTP header parameter.
+  // See: https://swagger.io/docs/specification/2-0/describing-parameters/#header-parameters
+  repeated HeaderParameter headers = 1;
+}
+
+// `HeaderParameter` a HTTP header parameter.
+// See: https://swagger.io/specification/v2/#parameter-object
+message HeaderParameter {
+  // `Type` is a supported HTTP header type.
+  // See https://swagger.io/specification/v2/#parameterType.
+  enum Type {
+    UNKNOWN = 0;
+    STRING = 1;
+    NUMBER = 2;
+    INTEGER = 3;
+    BOOLEAN = 4;
+  }
+
+  // `Name` is the header name.
+  string name = 1;
+  // `Description` is a short description of the header.
+  string description = 2;
+  // `Type` is the type of the object. The value MUST be one of "string", "number", "integer", or "boolean". The "array" type is not supported.
+  // See: https://swagger.io/specification/v2/#parameterType.
+  Type type = 3;
+  // `Format` The extending format for the previously mentioned type.
+  string format = 4;
+  // `Required` indicates if the header is optional
+  bool required = 5;
+  // field 6 is reserved for 'items', but in OpenAPI-specific way.
+  reserved 6;
+  // field 7 is reserved `Collection Format`. Determines the format of the array if type array is used.
+  reserved 7;
 }
 
 // `Header` is a representation of OpenAPI v2 specification's Header object.
@@ -235,6 +285,9 @@ message Response {
   // `Examples` gives per-mimetype response examples.
   // See: https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/2.0.md#example-object
   map<string, string> examples = 4;
+  // Custom properties that start with "x-" such as "x-foo" used to describe
+  // extra functionality that is not covered by the standard OpenAPI Specification.
+  // See: https://swagger.io/docs/specification/2-0/swagger-extensions/
   map<string, google.protobuf.Value> extensions = 5;
 }
 
@@ -248,7 +301,7 @@ message Response {
 //    info: {
 //      title: "Echo API";
 //      version: "1.0";
-//      description: ";
+//      description: "";
 //      contact: {
 //        name: "gRPC-Gateway project";
 //        url: "https://github.com/grpc-ecosystem/grpc-gateway";
@@ -256,7 +309,7 @@ message Response {
 //      };
 //      license: {
 //        name: "BSD 3-Clause License";
-//        url: "https://github.com/grpc-ecosystem/grpc-gateway/blob/master/LICENSE.txt";
+//        url: "https://github.com/grpc-ecosystem/grpc-gateway/blob/main/LICENSE";
 //      };
 //    };
 //    ...
@@ -277,6 +330,9 @@ message Info {
   // Provides the version of the application API (not to be confused
   // with the specification version).
   string version = 6;
+  // Custom properties that start with "x-" such as "x-foo" used to describe
+  // extra functionality that is not covered by the standard OpenAPI Specification.
+  // See: https://swagger.io/docs/specification/2-0/swagger-extensions/
   map<string, google.protobuf.Value> extensions = 7;
 }
 
@@ -321,7 +377,7 @@ message Contact {
 //      ...
 //      license: {
 //        name: "BSD 3-Clause License";
-//        url: "https://github.com/grpc-ecosystem/grpc-gateway/blob/master/LICENSE.txt";
+//        url: "https://github.com/grpc-ecosystem/grpc-gateway/blob/main/LICENSE";
 //      };
 //      ...
 //    };
@@ -518,6 +574,9 @@ message JSONSchema {
     // for overlapping paths.
     string path_param_name = 47;
   }
+  // Custom properties that start with "x-" such as "x-foo" used to describe
+  // extra functionality that is not covered by the standard OpenAPI Specification.
+  // See: https://swagger.io/docs/specification/2-0/swagger-extensions/
   map<string, google.protobuf.Value> extensions = 48;
 }
 
@@ -526,20 +585,19 @@ message JSONSchema {
 // See: https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/2.0.md#tagObject
 //
 message Tag {
-  // field 1 is reserved for 'name'. In our generator, this is (to be) extracted
-  // from the name of proto service, and thus not exposed to the user, as
-  // changing tag object's name would break the link to the references to the
-  // tag in individual operation specifications.
-  //
-  // TODO(ivucica): Add 'name' property. Use it to allow override of the name of
+  // The name of the tag. Use it to allow override of the name of a
   // global Tag object, then use that name to reference the tag throughout the
   // OpenAPI file.
-  reserved 1;
+  string name = 1;
   // A short description for the tag. GFM syntax can be used for rich text
   // representation.
   string description = 2;
   // Additional external documentation for this tag.
   ExternalDocumentation external_docs = 3;
+  // Custom properties that start with "x-" such as "x-foo" used to describe
+  // extra functionality that is not covered by the standard OpenAPI Specification.
+  // See: https://swagger.io/docs/specification/2-0/swagger-extensions/
+  map<string, google.protobuf.Value> extensions = 4;
 }
 
 // `SecurityDefinitions` is a representation of OpenAPI v2 specification's
@@ -619,6 +677,9 @@ message SecurityScheme {
   // The available scopes for the OAuth2 security scheme.
   // Valid for oauth2.
   Scopes scopes = 8;
+  // Custom properties that start with "x-" such as "x-foo" used to describe
+  // extra functionality that is not covered by the standard OpenAPI Specification.
+  // See: https://swagger.io/docs/specification/2-0/swagger-extensions/
   map<string, google.protobuf.Value> extensions = 9;
 }
 

--- a/integration-test/proto/vdp/pipeline/v1beta/common.proto
+++ b/integration-test/proto/vdp/pipeline/v1beta/common.proto
@@ -16,7 +16,7 @@ enum Role {
 
 // Sharing contains the information to share a resource with other users.
 //
-// For more information, see [Share Pipelines](https://www.instill.tech/docs/latest/vdp/share).
+// For more information, see [Share Pipelines](https://www.instill.tech/docs/vdp/share).
 message Sharing {
   // Describes the sharing configuration with a given user.
   message User {

--- a/integration-test/proto/vdp/pipeline/v1beta/component_definition.proto
+++ b/integration-test/proto/vdp/pipeline/v1beta/component_definition.proto
@@ -130,9 +130,9 @@ message ComponentDefinition {
 // DataSpecification describes the JSON schema of component input and output.
 message DataSpecification {
   // JSON schema describing the component input data.
-  google.protobuf.Struct input = 1;
+  google.protobuf.Struct input = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
   // JSON schema describing the component output data.
-  google.protobuf.Struct output = 2;
+  google.protobuf.Struct output = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // ConnectorSpec represents a specification data model.
@@ -175,7 +175,7 @@ enum ConnectorType {
 // ConnectorDefinition describes a certain type of Connector.
 //
 // For more information, see
-// [Component](https://www.instill.tech/docs/latest/core/concepts/pipeline#pipeline-component)
+// [Component](https://www.instill.tech/docs/component/introduction)
 // in the official documentation.
 message ConnectorDefinition {
   option (google.api.resource) = {
@@ -250,7 +250,7 @@ message OperatorSpec {
 // manipulation. OperatorDefinition describes a certain type of operator.
 //
 // For more information, see
-// [Component](https://www.instill.tech/docs/latest/core/concepts/pipeline#pipeline-component)
+// [Component](https://www.instill.tech/docs/component/introduction)
 // in the official documentation.
 message OperatorDefinition {
   option (google.api.resource) = {

--- a/integration-test/proto/vdp/pipeline/v1beta/pipeline.proto
+++ b/integration-test/proto/vdp/pipeline/v1beta/pipeline.proto
@@ -58,16 +58,9 @@ enum State {
 // A Pipeline is an end-to-end workflow that automates a sequence of components
 // to process data.
 //
-// For more information, see
-// [Pipeline](https://www.instill.tech/docs/latest/core/concepts/pipeline) in
+// For more information, see [Pipeline](https://www.instill.tech/docs/vdp/introduction) in
 // the official documentation.
 message Pipeline {
-  option (google.api.resource) = {
-    type: "api.instill.tech/Pipeline"
-    pattern: "users/{user.id}/pipelines/{pipeline.id}"
-    pattern: "pipelines/{pipeline.uid}"
-  };
-
   // View defines how a Pipeline is presented.
   enum View {
     // Unspecified, equivalent to BASIC.
@@ -93,19 +86,16 @@ message Pipeline {
   // Statistic data
   message Stats {
     // Number of pipeline runs.
-    int32 number_of_runs = 1;
+    int32 number_of_runs = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
     // Last run time.
-    google.protobuf.Timestamp last_run_time = 2;
+    google.protobuf.Timestamp last_run_time = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+    // Number of times this pipeline has been cloned.
+    int32 number_of_clones = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
   }
 
   // The name of the pipeline, defined by its parent and ID.
   // - Format: `{parent_type}/{parent.id}/pipelines/{pipeline.id}`.
-  string name = 1 [
-    (google.api.field_behavior) = OUTPUT_ONLY,
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "pipeline_name"}
-    }
-  ];
+  string name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // Pipeline UUID.
   string uid = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
@@ -117,7 +107,7 @@ message Pipeline {
   // Pipeline description.
   optional string description = 4 [(google.api.field_behavior) = OPTIONAL];
   // Recipe describes the components of a Pipeline and how they are connected.
-  google.protobuf.Struct recipe = 5 [(google.api.field_behavior) = IMMUTABLE];
+  google.protobuf.Struct recipe = 5 [(google.api.field_behavior) = REQUIRED];
   // Pipeline creation time.
   google.protobuf.Timestamp create_time = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Pipeline update time.
@@ -127,9 +117,9 @@ message Pipeline {
   // Pipeline delete time.
   google.protobuf.Timestamp delete_time = 14 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Pipeline sharing information.
-  Sharing sharing = 15;
+  Sharing sharing = 15 [(google.api.field_behavior) = OPTIONAL];
   // Metadata holds console-related data such as the pipeline builder layout.
-  google.protobuf.Struct metadata = 16;
+  google.protobuf.Struct metadata = 16 [(google.api.field_behavior) = OPTIONAL];
   // Owner Name.
   string owner_name = 17 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Deleted Fields.
@@ -143,26 +133,31 @@ message Pipeline {
   // Pipeline visibility.
   Visibility visibility = 22 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Pipeline owner.
-  optional core.mgmt.v1beta.Owner owner = 23 [
-    (google.api.field_behavior) = OPTIONAL,
-    (google.api.field_behavior) = OUTPUT_ONLY
-  ];
+  optional core.mgmt.v1beta.Owner owner = 23 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Data specifications.
   DataSpecification data_specification = 24 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Tags.
-  repeated string tags = 25 [(google.api.field_behavior) = OUTPUT_ONLY];
+  repeated string tags = 25 [(google.api.field_behavior) = OPTIONAL];
   // Statistic data.
-  Stats stats = 26;
+  Stats stats = 26 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Recipe in YAML format describes the components of a pipeline and how they
   // are connected.
   string raw_recipe = 27 [(google.api.field_behavior) = OPTIONAL];
+  // A link to the source code of the pipeline (e.g. to a GitHub repository).
+  optional string source_url = 28 [(google.api.field_behavior) = OPTIONAL];
+  // A link to any extra information.
+  optional string documentation_url = 29 [(google.api.field_behavior) = OPTIONAL];
+  // License under which the pipeline is distributed.
+  optional string license = 30 [(google.api.field_behavior) = OPTIONAL];
+  // Pipeline profile image in base64 format.
+  optional string profile_image = 31 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // TriggerMetadata contains the traces of the pipeline inference.
 message TriggerMetadata {
   // Each key in the `traces` object is a component ID. The value is a Trace
   // object containing the execution details.
-  map<string, Trace> traces = 1;
+  map<string, Trace> traces = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // Trace contains the execution details of a component.
@@ -179,15 +174,15 @@ message Trace {
     STATUS_ERROR = 3;
   }
   // Statuses contains an execution status per input.
-  repeated Status statuses = 1;
+  repeated Status statuses = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Component inputs.
-  repeated google.protobuf.Struct inputs = 2;
+  repeated google.protobuf.Struct inputs = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Component outputs.
-  repeated google.protobuf.Struct outputs = 3;
+  repeated google.protobuf.Struct outputs = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Error details.
-  google.protobuf.Struct error = 4;
+  google.protobuf.Struct error = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Computation time in seconds.
-  float compute_time_in_seconds = 5;
+  float compute_time_in_seconds = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // GetHubStatsRequest represents a request to get hub stats.
@@ -196,27 +191,17 @@ message GetHubStatsRequest {}
 // GetHubStatsResponse represents a response to get hub stats.
 message GetHubStatsResponse {
   // Total number of public pipelines.
-  int32 number_of_public_pipelines = 1;
+  int32 number_of_public_pipelines = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Total number of featured pipelines.
-  int32 number_of_featured_pipelines = 2;
+  int32 number_of_featured_pipelines = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // Pipeline releases contain the version control information of a pipeline.
 // This allows users to track changes in the pipeline over time.
 message PipelineRelease {
-  option (google.api.resource) = {
-    type: "api.instill.tech/Release"
-    pattern: "users/{user.id}/pipelines/{pipeline.id}/releases/{release.id}"
-  };
-
   // The name of the release, defined by its parent and ID.
   // - Format: `{parent_type}/{parent.id}/pipelines/{pipeline.id}/releases/{release.id}`.
-  string name = 1 [
-    (google.api.field_behavior) = OUTPUT_ONLY,
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "pipeline_release_name"}
-    }
-  ];
+  string name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Release UUID.
   string uid = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Release resource ID (used in `name` as the last segment). It must be a
@@ -276,11 +261,48 @@ message ListPipelinesRequest {
 // ListPipelinesResponse contains a list of pipelines.
 message ListPipelinesResponse {
   // A list of pipeline resources.
-  repeated Pipeline pipelines = 1;
+  repeated Pipeline pipelines = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Next page token.
-  string next_page_token = 2;
+  string next_page_token = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Total number of pipelines.
-  int32 total_size = 3;
+  int32 total_size = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// ListNamespacePipelinesRequest represents a request to list pipelines.
+message ListNamespacePipelinesRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // The maximum number of pipelines to return. If this parameter is
+  // unspecified, at most 10 pipelines will be returned. The cap value for this
+  // parameter is 100 (i.e. any value above that will be coerced to 100).
+  optional int32 page_size = 2 [(google.api.field_behavior) = OPTIONAL];
+  // Page token.
+  optional string page_token = 3 [(google.api.field_behavior) = OPTIONAL];
+  // View allows clients to specify the desired pipeline view in the response.
+  optional Pipeline.View view = 4 [(google.api.field_behavior) = OPTIONAL];
+  // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
+  // expression.
+  // - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
+  // - Example:
+  // `recipe.components.definition_name:"operator-definitions/2ac8be70-0f7a-4b61-a33d-098b8acfa6f3"`.
+  optional string filter = 5 [(google.api.field_behavior) = OPTIONAL];
+  // Include soft-deleted pipelines in the result.
+  optional bool show_deleted = 6 [(google.api.field_behavior) = OPTIONAL];
+  // Limit results to pipelines with the specified visibility.
+  optional Pipeline.Visibility visibility = 7 [(google.api.field_behavior) = OPTIONAL];
+  // Order by field, with options for ordering by `id`, `create_time` or `update_time`.
+  // Format: `order_by=id` or `order_by=create_time desc`, default is `asc`.
+  optional string order_by = 8 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// ListNamespacePipelinesResponse contains a list of pipelines.
+message ListNamespacePipelinesResponse {
+  // A list of pipeline resources.
+  repeated Pipeline pipelines = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Next page token.
+  string next_page_token = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Total number of pipelines.
+  int32 total_size = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // LookUpPipelineRequest represents a request to query a pipeline by its UID.
@@ -295,7 +317,401 @@ message LookUpPipelineRequest {
 // LookUpPipelineResponse contains the requested pipeline.
 message LookUpPipelineResponse {
   // The requested pipeline.
-  Pipeline pipeline = 1;
+  Pipeline pipeline = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// CreateNamespacePipelineRequest represents a request from a namespace to create a
+// pipeline.
+message CreateNamespacePipelineRequest {
+  // The namespace that creates the pipeline.
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // The properties of the pipeline to be created.
+  Pipeline pipeline = 2;
+}
+
+// CreateNamespacePipelineResponse contains the created pipeline.
+message CreateNamespacePipelineResponse {
+  // The created pipeline resource.
+  Pipeline pipeline = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// GetNamespacePipelineRequest represents a request to fetch the details of a
+// pipeline owned by a namespace.
+message GetNamespacePipelineRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Pipeline ID
+  string pipeline_id = 2 [(google.api.field_behavior) = REQUIRED];
+  // View allows clients to specify the desired pipeline view in the response.
+  optional Pipeline.View view = 3 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// GetNamespacePipelineResponse contains the requested pipeline.
+message GetNamespacePipelineResponse {
+  // The pipeline resource.
+  Pipeline pipeline = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// UpdateNamespacePipelineRequest represents a request to update a pipeline owned by
+// a namespace.
+message UpdateNamespacePipelineRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Pipeline ID
+  string pipeline_id = 2 [(google.api.field_behavior) = REQUIRED];
+  // The pipeline fields that will replace the existing ones.
+  Pipeline pipeline = 3;
+  // The update mask specifies the subset of fields that should be modified.
+  //
+  // For more information about this field, see
+  // https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#field-mask.
+  google.protobuf.FieldMask update_mask = 4 [(google.api.field_behavior) = REQUIRED];
+}
+
+// UpdateNamespacePipelineResponse contains the updated pipeline.
+message UpdateNamespacePipelineResponse {
+  // The updated pipeline resource.
+  Pipeline pipeline = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// DeleteNamespacePipelineRequest represents a request to delete a pipeline owned by
+// a namespace.
+message DeleteNamespacePipelineRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Pipeline ID
+  string pipeline_id = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// DeleteNamespacePipelineResponse is an empty response.
+message DeleteNamespacePipelineResponse {}
+
+// ValidateNamespacePipelineRequest represents a request to validate a pipeline
+// owned by a user.
+message ValidateNamespacePipelineRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Pipeline ID
+  string pipeline_id = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// ValidateNamespacePipelineResponse contains a validated pipeline.
+message ValidateNamespacePipelineResponse {
+  // Success
+  bool success = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // The validated pipeline resource.
+  repeated PipelineValidationError errors = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// RenameNamespacePipelineRequest represents a request to rename the name of a
+// pipeline owned by a namespace.
+message RenameNamespacePipelineRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Pipeline ID
+  string pipeline_id = 2 [(google.api.field_behavior) = REQUIRED];
+  // The new resource ID. This will transform the resource name into
+  // `namespaces/{namespace.id}/pipelines/{new_pipeline_id}`.
+  string new_pipeline_id = 3 [(google.api.field_behavior) = REQUIRED];
+}
+
+// RenameNamespacePipelineResponse contains a renamed pipeline.
+message RenameNamespacePipelineResponse {
+  // The renamed pipeline resource.
+  Pipeline pipeline = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// CloneNamespacePipelineRequest represents a request to clone a pipeline owned by a
+// user.
+message CloneNamespacePipelineRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Pipeline ID
+  string pipeline_id = 2 [(google.api.field_behavior) = REQUIRED];
+  // The target pipeline. It can be under a user or an organization
+  // namespace, so the following formats are accepted:
+  // - `{user.id}/{pipeline.id}`
+  // - `{organization.id}/{pipeline.id}`
+  string target = 3 [(google.api.field_behavior) = REQUIRED];
+  // Pipeline description.
+  string description = 4 [(google.api.field_behavior) = OPTIONAL];
+  // Pipeline sharing information.
+  Sharing sharing = 5 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// CloneNamespacePipelineResponse contains a cloned pipeline.
+message CloneNamespacePipelineResponse {}
+
+// CloneNamespacePipelineReleaseRequest represents a request to clone a pipeline
+// release owned by a user.
+message CloneNamespacePipelineReleaseRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Pipeline ID
+  string pipeline_id = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // Release ID
+  string release_id = 3 [(google.api.field_behavior) = REQUIRED];
+
+  // The target pipeline. It can be under a user or an organization
+  // namespace, so the following formats are accepted:
+  // - `{user.id}/{pipeline.id}`
+  // - `{organization.id}/{pipeline.id}`
+  string target = 4 [(google.api.field_behavior) = REQUIRED];
+  // Pipeline description.
+  string description = 5 [(google.api.field_behavior) = OPTIONAL];
+  // Pipeline sharing information.
+  Sharing sharing = 6 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// CloneNamespacePipelineReleaseResponse contains a cloned pipeline.
+message CloneNamespacePipelineReleaseResponse {}
+
+// TriggerNamespacePipelineRequest represents a request to trigger a user-owned
+// pipeline synchronously.
+message TriggerNamespacePipelineRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Pipeline ID
+  string pipeline_id = 2 [(google.api.field_behavior) = REQUIRED];
+  // Pipeline input parameters, it will be deprecated soon.
+  repeated google.protobuf.Struct inputs = 3 [(google.api.field_behavior) = REQUIRED];
+  // Data
+  repeated TriggerData data = 4 [(google.api.field_behavior) = REQUIRED];
+}
+
+// TriggerNamespacePipelineResponse contains the pipeline execution results, i.e.,
+// the multiple model inference outputs.
+message TriggerNamespacePipelineResponse {
+  // Model inference outputs.
+  repeated google.protobuf.Struct outputs = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Traces of the pipeline inference.
+  TriggerMetadata metadata = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// TriggerNamespacePipelineWithStreamRequest represents a request to trigger a user-owned
+// pipeline synchronously and streams back the results.
+message TriggerNamespacePipelineWithStreamRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Pipeline ID
+  string pipeline_id = 2 [(google.api.field_behavior) = REQUIRED];
+  // Pipeline input parameters, it will be deprecated soon.
+  repeated google.protobuf.Struct inputs = 3 [(google.api.field_behavior) = OPTIONAL];
+  // Data
+  repeated TriggerData data = 4 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// TriggerNamespacePipelineWithStreamResponse contains the pipeline execution results, i.e.,
+// the multiple model inference outputs.
+message TriggerNamespacePipelineWithStreamResponse {
+  // Model inference outputs.
+  repeated google.protobuf.Struct outputs = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Traces of the pipeline inference.
+  TriggerMetadata metadata = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// TriggerNamespacePipelineRequest represents a request to trigger a user-owned
+// pipeline synchronously.
+message TriggerAsyncNamespacePipelineRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Pipeline ID
+  string pipeline_id = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // Pipeline input parameters, it will be deprecated soon.
+  repeated google.protobuf.Struct inputs = 3 [(google.api.field_behavior) = OPTIONAL];
+  // Data
+  repeated TriggerData data = 4 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// TriggerAsyncNamespacePipelineResponse contains the information to access the
+// status of an asynchronous pipeline execution.
+message TriggerAsyncNamespacePipelineResponse {
+  // Long-running operation information.
+  google.longrunning.Operation operation = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// CreateNamespacePipelineReleaseRequest represents a request to release a version
+// in a user-owned pipeline.
+message CreateNamespacePipelineReleaseRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Pipeline ID
+  string pipeline_id = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // The release information.
+  PipelineRelease release = 3;
+}
+
+// CreateNamespacePipelineReleaseResponse contains the created release.
+message CreateNamespacePipelineReleaseResponse {
+  // The created pipeline release object.
+  PipelineRelease release = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// ListNamespacePipelineReleasesRequest represents a request to list the releases in
+// a user-owned pipeline.
+message ListNamespacePipelineReleasesRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Pipeline ID
+  string pipeline_id = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // The maximum number of releases to return. If this parameter is
+  // unspecified, at most 10 pipelines will be returned. The cap value for this
+  // parameter is 100 (i.e. any value above that will be coerced to 100).
+  optional int32 page_size = 3 [(google.api.field_behavior) = OPTIONAL];
+  // Page token.
+  optional string page_token = 4 [(google.api.field_behavior) = OPTIONAL];
+  // View allows clients to specify the desired pipeline view in the response.
+  optional Pipeline.View view = 5 [(google.api.field_behavior) = OPTIONAL];
+  // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
+  // expression.
+  // - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
+  optional string filter = 6 [(google.api.field_behavior) = OPTIONAL];
+  // Include soft-deleted pipelines in the result.
+  optional bool show_deleted = 7 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// ListNamespacePipelineReleasesResponse contains a list of pipeline releases.
+message ListNamespacePipelineReleasesResponse {
+  // A list of pipeline release resources.
+  repeated PipelineRelease releases = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Next page token.
+  string next_page_token = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Total number of pipeline releases.
+  int32 total_size = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// GetNamespacePipelineReleaseRequest represents a request to fetchthe details of a
+// release in a user-owned pipeline.
+message GetNamespacePipelineReleaseRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Pipeline ID
+  string pipeline_id = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // Release ID
+  string release_id = 3 [(google.api.field_behavior) = REQUIRED];
+
+  // View allows clients to specify the desired pipeline view in the response.
+  optional Pipeline.View view = 4 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// GetNamespacePipelineReleaseResponse contains the requested pipeline release.
+message GetNamespacePipelineReleaseResponse {
+  // The pipeline release resource.
+  PipelineRelease release = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// UpdateNamespacePipelineReleaseRequest represents a request to update a user-owned
+// pipeline release.
+message UpdateNamespacePipelineReleaseRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Pipeline ID
+  string pipeline_id = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // Release ID
+  string release_id = 3 [(google.api.field_behavior) = REQUIRED];
+  // The pipeline release fields that will replace the existing ones.
+  // A pipeline release resource to update
+  PipelineRelease release = 4;
+  // The update mask specifies the subset of fields that should be modified.
+  //
+  // For more information about this field, see
+  // https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#field-mask.
+  google.protobuf.FieldMask update_mask = 5 [(google.api.field_behavior) = REQUIRED];
+}
+
+// UpdateNamespacePipelineReleaseResponse contains the updated pipeline release.
+message UpdateNamespacePipelineReleaseResponse {
+  // The updated pipeline release resource.
+  PipelineRelease release = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// DeleteNamespacePipelineReleaseRequest represents a request to delete a release in
+// a user-owned pipeline.
+message DeleteNamespacePipelineReleaseRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Pipeline ID
+  string pipeline_id = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // Release ID
+  string release_id = 3 [(google.api.field_behavior) = REQUIRED];
+}
+
+// DeleteNamespacePipelineReleaseResponse is an empty response.
+message DeleteNamespacePipelineReleaseResponse {}
+
+// TriggerNamespacePipelineReleaseRequest represents a request to trigger a pinned
+// release of a user-owned pipeline.
+message TriggerNamespacePipelineReleaseRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Pipeline ID
+  string pipeline_id = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // Release ID
+  string release_id = 3 [(google.api.field_behavior) = REQUIRED];
+
+  // Pipeline input parameters, it will be deprecated soon.
+  repeated google.protobuf.Struct inputs = 4 [(google.api.field_behavior) = OPTIONAL];
+  // Data
+  repeated TriggerData data = 5 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// TriggerNamespacePipelineReleaseResponse contains the pipeline execution results,
+// i.e., the multiple model inference outputs.
+message TriggerNamespacePipelineReleaseResponse {
+  // Model inference outputs.
+  repeated google.protobuf.Struct outputs = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Traces of the pipeline inference.
+  TriggerMetadata metadata = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// TriggerNamespacePipelineReleaseRequest represents a request to trigger a pinned
+// release of a user-owned pipeline asynchronously.
+message TriggerAsyncNamespacePipelineReleaseRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Pipeline ID
+  string pipeline_id = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // Release ID
+  string release_id = 3 [(google.api.field_behavior) = REQUIRED];
+
+  // Pipeline input parameters, it will be deprecated soon.
+  repeated google.protobuf.Struct inputs = 4 [(google.api.field_behavior) = OPTIONAL];
+
+  // Data
+  repeated TriggerData data = 5 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// TriggerAsyncNamespacePipelineReleaseResponse contains the information to access
+// the status of an asynchronous pipeline execution.
+message TriggerAsyncNamespacePipelineReleaseResponse {
+  // Long-running operation information.
+  google.longrunning.Operation operation = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // CreateUserPipelineRequest represents a request from a user to create a
@@ -492,18 +908,45 @@ message CloneUserPipelineRequest {
       field_configuration: {path_param_name: "user_pipeline_name"}
     }
   ];
-  // The target pipeline name. It can be under a user or an organization
+  // The target pipeline. It can be under a user or an organization
   // namespace, so the following formats are accepted:
-  // - `users/{user.id}/pipelines/{pipeline.id}`
-  // - `organizations/{organization.id}/pipelines/{pipeline.id}`
+  // - `{user.id}/{pipeline.id}`
+  // - `{organization.id}/{pipeline.id}`
   string target = 2 [(google.api.field_behavior) = REQUIRED];
+  // Pipeline description.
+  string description = 3 [(google.api.field_behavior) = OPTIONAL];
+  // Pipeline sharing information.
+  Sharing sharing = 4 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // CloneUserPipelineResponse contains a cloned pipeline.
-message CloneUserPipelineResponse {
-  // The cloned pipeline resource.
-  Pipeline pipeline = 1;
+message CloneUserPipelineResponse {}
+
+// CloneUserPipelineReleaseRequest represents a request to clone a pipeline
+// release owned by a user.
+message CloneUserPipelineReleaseRequest {
+  // The resource name of the pipeline release.
+  // - Format: `users/{user.id}/pipelines/{pipeline.id}/releases/{version}`.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"},
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration: {path_param_name: "user_pipeline_release_name"}
+    }
+  ];
+  // The target pipeline. It can be under a user or an organization
+  // namespace, so the following formats are accepted:
+  // - `{user.id}/{pipeline.id}`
+  // - `{organization.id}/{pipeline.id}`
+  string target = 2 [(google.api.field_behavior) = REQUIRED];
+  // Pipeline description.
+  string description = 3 [(google.api.field_behavior) = OPTIONAL];
+  // Pipeline sharing information.
+  Sharing sharing = 4 [(google.api.field_behavior) = OPTIONAL];
 }
+
+// CloneUserPipelineReleaseResponse contains a cloned pipeline.
+message CloneUserPipelineReleaseResponse {}
 
 // TriggerUserPipelineRequest represents a request to trigger a user-owned
 // pipeline synchronously.
@@ -999,21 +1442,48 @@ message CloneOrganizationPipelineRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user_pipeline_name"}
+      field_configuration: {path_param_name: "org_pipeline_name"}
     }
   ];
-  // The target pipeline name. It can be under a user or an organization
+  // The target pipeline. It can be under a user or an organization
   // namespace, so the following formats are accepted:
-  // - `users/{user.id}/pipelines/{pipeline.id}`
-  // - `organizations/{organization.id}/pipelines/{pipeline.id}`
+  // - `{user.id}/{pipeline.id}`
+  // - `{organization.id}/{pipeline.id}`
   string target = 2 [(google.api.field_behavior) = REQUIRED];
+  // Pipeline description.
+  string description = 3 [(google.api.field_behavior) = OPTIONAL];
+  // Pipeline sharing information.
+  Sharing sharing = 4 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // CloneOrganizationPipelineResponse contains a cloned pipeline.
-message CloneOrganizationPipelineResponse {
-  // The cloned pipeline resource.
-  Pipeline pipeline = 1;
+message CloneOrganizationPipelineResponse {}
+
+// CloneOrganizationPipelineReleaseRequest represents a request to clone a pipeline
+// release owned by an organization.
+message CloneOrganizationPipelineReleaseRequest {
+  // The resource name of the pipeline release
+  // - Format: `organizations/{org.id}/pipelines/{pipeline.id}/releases/{version}`.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"},
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration: {path_param_name: "org_pipeline_release_name"}
+    }
+  ];
+  // The target pipeline. It can be under a user or an organization
+  // namespace, so the following formats are accepted:
+  // - `{user.id}/{pipeline.id}`
+  // - `{organization.id}/{pipeline.id}`
+  string target = 2 [(google.api.field_behavior) = REQUIRED];
+  // Pipeline description.
+  string description = 3 [(google.api.field_behavior) = OPTIONAL];
+  // Pipeline sharing information.
+  Sharing sharing = 4 [(google.api.field_behavior) = OPTIONAL];
 }
+
+// CloneOrganizationPipelineReleaseResponse contains a cloned pipeline.
+message CloneOrganizationPipelineReleaseResponse {}
 
 // TriggerOrganizationPipelineRequest represents a request to trigger an
 // organization-owned pipeline synchronously.

--- a/integration-test/proto/vdp/pipeline/v1beta/pipeline_private_service.proto
+++ b/integration-test/proto/vdp/pipeline/v1beta/pipeline_private_service.proto
@@ -2,10 +2,6 @@ syntax = "proto3";
 
 package vdp.pipeline.v1beta;
 
-// Google API
-import "google/api/annotations.proto";
-import "google/api/client.proto";
-import "google/api/visibility.proto";
 // OpenAPI definition
 import "protoc-gen-openapiv2/options/annotations.proto";
 import "../../../vdp/pipeline/v1beta/pipeline.proto";
@@ -19,26 +15,17 @@ service PipelinePrivateService {
   //
   // This is a *private* method that allows admin users and internal clients to
   // list *all* pipeline resources.
-  rpc ListPipelinesAdmin(ListPipelinesAdminRequest) returns (ListPipelinesAdminResponse) {
-    option (google.api.http) = {get: "/v1beta/admin/pipelines"};
-  }
+  rpc ListPipelinesAdmin(ListPipelinesAdminRequest) returns (ListPipelinesAdminResponse) {}
 
   // Get a pipeline by UID (admin only)
   //
   // This is a *private* method that allows admin users to access any pipeline
   // resource by its UID.
-  rpc LookUpPipelineAdmin(LookUpPipelineAdminRequest) returns (LookUpPipelineAdminResponse) {
-    option (google.api.http) = {get: "/v1beta/admin/{permalink=pipelines/*}/lookUp"};
-    option (google.api.method_signature) = "permalink";
-  }
+  rpc LookUpPipelineAdmin(LookUpPipelineAdminRequest) returns (LookUpPipelineAdminResponse) {}
 
   // List pipeline releases (admin only)
   //
   // This is a *private* method that allows admin users to list *all* pipeline
   // releases.
-  rpc ListPipelineReleasesAdmin(ListPipelineReleasesAdminRequest) returns (ListPipelineReleasesAdminResponse) {
-    option (google.api.http) = {get: "/v1beta/admin/releases"};
-  }
-
-  option (google.api.api_visibility).restriction = "INTERNAL";
+  rpc ListPipelineReleasesAdmin(ListPipelineReleasesAdminRequest) returns (ListPipelineReleasesAdminResponse) {}
 }

--- a/integration-test/proto/vdp/pipeline/v1beta/pipeline_public_service.proto
+++ b/integration-test/proto/vdp/pipeline/v1beta/pipeline_public_service.proto
@@ -4,7 +4,6 @@ package vdp.pipeline.v1beta;
 
 // Google API
 import "google/api/annotations.proto";
-import "google/api/client.proto";
 import "google/api/visibility.proto";
 // OpenAPI definition
 import "protoc-gen-openapiv2/options/annotations.proto";
@@ -47,6 +46,7 @@ service PipelinePublicService {
   rpc GetHubStats(GetHubStatsRequest) returns (GetHubStatsResponse) {
     option (google.api.http) = {get: "/v1beta/hub-stats"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+    option (google.api.method_visibility).restriction = "INTERNAL";
   }
 
   // List accessible pipelines
@@ -63,9 +63,393 @@ service PipelinePublicService {
   // UID.
   rpc LookUpPipeline(LookUpPipelineRequest) returns (LookUpPipelineResponse) {
     option (google.api.http) = {get: "/v1beta/{permalink=pipelines/*}/lookUp"};
-    option (google.api.method_signature) = "permalink";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+    option (google.api.method_visibility).restriction = "INTERNAL";
+  }
+
+  // List namespace pipelines
+  //
+  // Returns a paginated list of pipelines of a namespace
+  rpc ListNamespacePipelines(ListNamespacePipelinesRequest) returns (ListNamespacePipelinesResponse) {
+    option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/pipelines"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
   }
+
+  // Create a new pipeline
+  //
+  // Creates a new pipeline under a namespace.
+  rpc CreateNamespacePipeline(CreateNamespacePipelineRequest) returns (CreateNamespacePipelineResponse) {
+    option (google.api.http) = {
+      post: "/v1beta/namespaces/{namespace_id}/pipelines"
+      body: "pipeline"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+  }
+
+  // Get a pipeline
+  //
+  // Returns the details of a pipeline.
+  rpc GetNamespacePipeline(GetNamespacePipelineRequest) returns (GetNamespacePipelineResponse) {
+    option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+  }
+
+  // Update a pipeline
+  //
+  // Udpates a pipeline, accessing it by its resource name, which is defined by
+  // the parent namespace and the ID of the pipeline. The authenticated namespace must be
+  // the parent of the pipeline in order to modify it.
+  //
+  // In REST requests, only the supplied pipeline fields will be taken into
+  // account when updating the resource.
+  rpc UpdateNamespacePipeline(UpdateNamespacePipelineRequest) returns (UpdateNamespacePipelineResponse) {
+    option (google.api.http) = {
+      patch: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}"
+      body: "pipeline"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+  }
+
+  // Delete a pipeline
+  //
+  // Deletes a pipeline, accesing it by its resource name, which is defined by
+  // the parent namespace and the ID of the pipeline. The authenticated namespace must be
+  // the parent of the pipeline in order to delete it.
+  rpc DeleteNamespacePipeline(DeleteNamespacePipelineRequest) returns (DeleteNamespacePipelineResponse) {
+    option (google.api.http) = {delete: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+  }
+
+  // Validate a pipeline
+  //
+  // Validates a pipeline by its resource name, which is defined by the parent
+  // namespace and the ID of the pipeline.
+  //
+  // Validation checks the recipe of the pipeline and the status of its components.
+  rpc ValidateNamespacePipeline(ValidateNamespacePipelineRequest) returns (ValidateNamespacePipelineResponse) {
+    option (google.api.http) = {
+      post: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/validate"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+  }
+
+  // Rename a pipeline
+  //
+  // Updates the ID of a pipeline. Since this is an output-only field, a custom
+  // method is required to modify it.
+  //
+  // The pipeline name will be updated accordingly, as it is  composed by the
+  // parent namespace and ID of the pipeline (e.g.
+  // `namespaces/luigi/pipelines/pizza-recipe-generator`).
+  //
+  // The authenticated namespace must be the parent of the pipeline in order to
+  // perform this action.
+  rpc RenameNamespacePipeline(RenameNamespacePipelineRequest) returns (RenameNamespacePipelineResponse) {
+    option (google.api.http) = {
+      post: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/rename"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+  }
+
+  // Clone a pipeline
+  //
+  // Clones a pipeline owned by a namespace. The new pipeline may have a different
+  // parent, and this can be either a namespace or an organization.
+  rpc CloneNamespacePipeline(CloneNamespacePipelineRequest) returns (CloneNamespacePipelineResponse) {
+    option (google.api.http) = {
+      post: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/clone"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+  }
+
+  // Trigger a pipeline
+  //
+  // Triggers the execution of a pipeline synchronously, i.e., the result is
+  // sent back to the namespace right after the data is processed. This method is
+  // intended for real-time inference when low latency is of concern.
+  //
+  // The pipeline is identified by its resource name, formed by the parent namespace
+  // and ID of the pipeline.
+  //
+  // For more information, see [Run NamespacePipeline](https://www.instill.tech/docs/vdp/run).
+  rpc TriggerNamespacePipeline(TriggerNamespacePipelineRequest) returns (TriggerNamespacePipelineResponse) {
+    option (google.api.http) = {
+      post: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/trigger"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Trigger"
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated namespace is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
+    };
+  }
+
+  // Trigger a pipeline via streaming
+  //
+  // Triggers the execution of a pipeline asynchronously and streams back the response.
+  // This method is intended for real-time inference when low latency is of concern
+  // and the response needs to be processed incrementally.
+  //
+  // The pipeline is identified by its resource name, formed by the parent namespace
+  // and ID of the pipeline.
+  rpc TriggerNamespacePipelineWithStream(TriggerNamespacePipelineWithStreamRequest) returns (stream TriggerNamespacePipelineWithStreamResponse) {
+    option (google.api.http) = {
+      post: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/trigger-stream"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Trigger"
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated namespace is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
+    };
+  }
+
+  // Trigger a pipeline asynchronously
+  //
+  // Triggers the execution of a pipeline asynchronously, i.e., the result
+  // contains the necessary information to access the result and status of the
+  // operation. This method is intended for cases that require long-running
+  // workloads.
+  //
+  // The pipeline is identified by its resource name, formed by the parent namespace
+  // and ID of the pipeline.
+  //
+  // For more information, see [Run NamespacePipeline](https://www.instill.tech/docs/vdp/run).
+  rpc TriggerAsyncNamespacePipeline(TriggerAsyncNamespacePipelineRequest) returns (TriggerAsyncNamespacePipelineResponse) {
+    option (google.api.http) = {
+      post: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/trigger-async"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Trigger"
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated namespace is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
+    };
+  }
+
+  // Create a pipeline release
+  //
+  // Commits the version of a pipeline, identified by its resource name, which
+  // is formed by the parent namespace and ID of the pipeline.
+  //
+  // The authenticated namespace must be the parent of the pipeline in order to
+  // perform this action.
+  rpc CreateNamespacePipelineRelease(CreateNamespacePipelineReleaseRequest) returns (CreateNamespacePipelineReleaseResponse) {
+    option (google.api.http) = {
+      post: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/releases"
+      body: "release"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
+  }
+
+  // List the releases in a pipeline
+  //
+  // Lists the commited versions of a pipeline, identified by its resource
+  // name, which is formed by the parent namespace and ID of the pipeline.
+  rpc ListNamespacePipelineReleases(ListNamespacePipelineReleasesRequest) returns (ListNamespacePipelineReleasesResponse) {
+    option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/releases"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
+  }
+
+  // Get a pipeline release
+  //
+  // Gets the details of a pipeline release, where the pipeline is identified
+  // by its resource name, formed by its parent namespace and ID.
+  rpc GetNamespacePipelineRelease(GetNamespacePipelineReleaseRequest) returns (GetNamespacePipelineReleaseResponse) {
+    option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/releases/{release_id}"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
+  }
+
+  // Update a pipeline release
+  //
+  // Updates the details of a pipeline release, where the pipeline is
+  // identified by its resource name, formed by its parent namespace and ID.
+  //
+  // The authenticated namespace must be the parent of the pipeline in order to
+  // perform this action.
+  rpc UpdateNamespacePipelineRelease(UpdateNamespacePipelineReleaseRequest) returns (UpdateNamespacePipelineReleaseResponse) {
+    option (google.api.http) = {
+      patch: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/releases/{release_id}"
+      body: "release"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
+  }
+
+  // Delete a pipeline release
+  //
+  // Deletes a pipeline release, where the pipeline is identified by its
+  // resource name, formed by its parent namespace and ID.
+  //
+  // The authenticated namespace must be the parent of the pipeline in order to
+  // perform this action.
+  rpc DeleteNamespacePipelineRelease(DeleteNamespacePipelineReleaseRequest) returns (DeleteNamespacePipelineReleaseResponse) {
+    option (google.api.http) = {delete: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/releases/{release_id}"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
+  }
+
+  // Clone a pipeline release
+  //
+  // Clones a pipeline release owned by a namespace. The new pipeline may have a different
+  // parent, and this can be either a namespace or an organization.
+  rpc CloneNamespacePipelineRelease(CloneNamespacePipelineReleaseRequest) returns (CloneNamespacePipelineReleaseResponse) {
+    option (google.api.http) = {
+      post: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/releases/{release_id}/clone"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
+  }
+
+  // Trigger a pipeline release
+  //
+  // Triggers the synchronous execution of of a pipeline. While the trigger
+  // endpoint (where the release version isn't specified) triggers the pipeline
+  // at its latest release, this method allows the client to specified any
+  // committed release.
+  //
+  // The pipeline is identified by its resource name, formed by its parent namespace
+  // and ID.
+  rpc TriggerNamespacePipelineRelease(TriggerNamespacePipelineReleaseRequest) returns (TriggerNamespacePipelineReleaseResponse) {
+    option (google.api.http) = {
+      post: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/releases/{release_id}/trigger"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Trigger"
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated namespace is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
+    };
+  }
+
+  // Trigger a pipeline release asynchronously
+  //
+  // Triggers the asynchronous execution of of a pipeline. While the trigger
+  // endpoint (where the release version isn't specified) triggers the pipeline
+  // at its latest release, this method allows the client to specified any
+  // committed release.
+  //
+  // The pipeline is identified by its resource name, formed by its parent namespace
+  // and ID.
+  rpc TriggerAsyncNamespacePipelineRelease(TriggerAsyncNamespacePipelineReleaseRequest) returns (TriggerAsyncNamespacePipelineReleaseResponse) {
+    option (google.api.http) = {
+      post: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/releases/{release_id}/trigger-async"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Trigger"
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated namespace is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
+    };
+  }
+
+  // Create a secret
+  //
+  // Creates a new secret under the parenthood of an namespace.
+  rpc CreateSecret(CreateSecretRequest) returns (CreateSecretResponse) {
+    option (google.api.http) = {
+      post: "/v1beta/namespaces/{namespace_id}/secrets"
+      body: "secret"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
+  }
+
+  // List secrets
+  //
+  // Returns a paginated list of secrets that belong to the specified
+  // namespace.
+  rpc ListSecrets(ListSecretsRequest) returns (ListSecretsResponse) {
+    option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/secrets"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
+  }
+
+  // Get a secret
+  //
+  // Returns the details of an namespace-owned secret by its resource name,
+  // which is defined by the parent namespace and the ID of the secret.
+  rpc GetSecret(GetSecretRequest) returns (GetSecretResponse) {
+    option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/secrets/{secret_id}"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
+  }
+
+  // Update a secret
+  //
+  // Udpates a secret, accessing it by its resource name, which is defined by
+  //
+  // In REST requests, only the supplied secret fields will be taken into
+  // account when updating the resource.
+  rpc UpdateSecret(UpdateSecretRequest) returns (UpdateSecretResponse) {
+    option (google.api.http) = {
+      patch: "/v1beta/namespaces/{namespace_id}/secrets/{secret_id}"
+      body: "secret"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
+  }
+
+  // Delete a secret
+  //
+  // Deletes a secret, accesing it by its resource name, which is defined by
+  // the parent namespace and the ID of the secret.
+  rpc DeleteSecret(DeleteSecretRequest) returns (DeleteSecretResponse) {
+    option (google.api.http) = {delete: "/v1beta/namespaces/{namespace_id}/secrets/{secret_id}"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
+  }
+
+  // List component definitions
+  //
+  // Returns a paginated list of component definitions, regardless their type.
+  // This offers a single source of truth, with pagination and filter
+  // capabilities, for the components that might be used in a VDP pipeline.
+  rpc ListComponentDefinitions(ListComponentDefinitionsRequest) returns (ListComponentDefinitionsResponse) {
+    option (google.api.http) = {get: "/v1beta/component-definitions"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Component"};
+  }
+
+  // Get the details of a long-running operation
+  //
+  // This method allows requesters to request the status and outcome of
+  // long-running operations such as asynchronous pipeline triggers.
+  rpc GetOperation(GetOperationRequest) returns (GetOperationResponse) {
+    option (google.api.http) = {get: "/v1beta/{name=operations/*}"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Trigger"
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
+    };
+  }
+
+  // The following endpoints are all deprecated
 
   // Create a new user pipeline
   //
@@ -77,8 +461,8 @@ service PipelinePublicService {
       post: "/v1beta/{parent=users/*}/pipelines"
       body: "pipeline"
     };
-    option (google.api.method_signature) = "parent,pipeline";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option deprecated = true;
   }
 
   // List user pipelines
@@ -89,8 +473,8 @@ service PipelinePublicService {
   // latter.
   rpc ListUserPipelines(ListUserPipelinesRequest) returns (ListUserPipelinesResponse) {
     option (google.api.http) = {get: "/v1beta/{parent=users/*}/pipelines"};
-    option (google.api.method_signature) = "parent";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option deprecated = true;
   }
 
   // Get a pipeline owned by a user
@@ -99,8 +483,8 @@ service PipelinePublicService {
   // by the parent user and the ID of the pipeline.
   rpc GetUserPipeline(GetUserPipelineRequest) returns (GetUserPipelineResponse) {
     option (google.api.http) = {get: "/v1beta/{name=users/*/pipelines/*}"};
-    option (google.api.method_signature) = "name";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option deprecated = true;
   }
 
   // Update a pipeline owned by a user
@@ -116,8 +500,8 @@ service PipelinePublicService {
       patch: "/v1beta/{pipeline.name=users/*/pipelines/*}"
       body: "pipeline"
     };
-    option (google.api.method_signature) = "pipeline,update_mask";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option deprecated = true;
   }
 
   // Delete a pipeline owned by a user
@@ -127,8 +511,8 @@ service PipelinePublicService {
   // the parent of the pipeline in order to delete it.
   rpc DeleteUserPipeline(DeleteUserPipelineRequest) returns (DeleteUserPipelineResponse) {
     option (google.api.http) = {delete: "/v1beta/{name=users/*/pipelines/*}"};
-    option (google.api.method_signature) = "name";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option deprecated = true;
   }
 
   // Validate a pipeline a pipeline owned by a user
@@ -142,8 +526,8 @@ service PipelinePublicService {
       post: "/v1beta/{name=users/*/pipelines/*}/validate"
       body: "*"
     };
-    option (google.api.method_signature) = "name";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option deprecated = true;
   }
 
   // Rename a pipeline owned by a user
@@ -162,8 +546,8 @@ service PipelinePublicService {
       post: "/v1beta/{name=users/*/pipelines/*}/rename"
       body: "*"
     };
-    option (google.api.method_signature) = "name,new_pipeline_id";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option deprecated = true;
   }
 
   // Clone a pipeline owned by a user
@@ -175,8 +559,21 @@ service PipelinePublicService {
       post: "/v1beta/{name=users/*/pipelines/*}/clone"
       body: "*"
     };
-    option (google.api.method_signature) = "name,target";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option deprecated = true;
+  }
+
+  // Clone a pipeline release owned by a user
+  //
+  // Clones a pipeline release owned by a user. The new pipeline may have a different
+  // parent, and this can be either a user or an organization.
+  rpc CloneUserPipelineRelease(CloneUserPipelineReleaseRequest) returns (CloneUserPipelineReleaseResponse) {
+    option (google.api.http) = {
+      post: "/v1beta/{name=users/*/pipelines/*/releases/*}/clone"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option deprecated = true;
   }
 
   // Trigger a pipeline owned by a user
@@ -188,15 +585,23 @@ service PipelinePublicService {
   // The pipeline is identified by its resource name, formed by the parent user
   // and ID of the pipeline.
   //
-  // For more information, see [Trigger
-  // Pipeline](https://www.instill.tech/docs/latest/core/concepts/pipeline#trigger-pipeline).
+  // For more information, see [Run Pipeline](https://www.instill.tech/docs/vdp/run).
   rpc TriggerUserPipeline(TriggerUserPipelineRequest) returns (TriggerUserPipelineResponse) {
     option (google.api.http) = {
       post: "/v1beta/{name=users/*/pipelines/*}/trigger"
       body: "*"
     };
-    option (google.api.method_signature) = "name,data";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Trigger (Deprecated)"
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
+    };
+    option deprecated = true;
   }
 
   // Trigger a pipeline owned by a user and stream back the response
@@ -212,8 +617,17 @@ service PipelinePublicService {
       post: "/v1beta/{name=users/*/pipelines/*}/trigger-stream"
       body: "*"
     };
-    option (google.api.method_signature) = "name,inputs";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Trigger (Deprecated)"
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
+    };
+    option deprecated = true;
   }
 
   // Trigger a pipeline owned by a user asynchronously
@@ -226,15 +640,23 @@ service PipelinePublicService {
   // The pipeline is identified by its resource name, formed by the parent user
   // and ID of the pipeline.
   //
-  // For more information, see [Trigger
-  // Pipeline](https://www.instill.tech/docs/latest/core/concepts/pipeline#trigger-pipeline).
+  // For more information, see [Run Pipeline](https://www.instill.tech/docs/vdp/run).
   rpc TriggerAsyncUserPipeline(TriggerAsyncUserPipelineRequest) returns (TriggerAsyncUserPipelineResponse) {
     option (google.api.http) = {
       post: "/v1beta/{name=users/*/pipelines/*}/triggerAsync"
       body: "*"
     };
-    option (google.api.method_signature) = "name,data";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Trigger (Deprecated)"
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
+    };
+    option deprecated = true;
   }
 
   // Release a version of a pipeline owned by a user
@@ -249,8 +671,8 @@ service PipelinePublicService {
       post: "/v1beta/{parent=users/*/pipelines/*}/releases"
       body: "release"
     };
-    option (google.api.method_signature) = "parent,release";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release (Deprecated)"};
+    option deprecated = true;
   }
 
   // List the releases in a pipeline owned by a user
@@ -259,8 +681,8 @@ service PipelinePublicService {
   // name, which is formed by the parent user and ID of the pipeline.
   rpc ListUserPipelineReleases(ListUserPipelineReleasesRequest) returns (ListUserPipelineReleasesResponse) {
     option (google.api.http) = {get: "/v1beta/{parent=users/*/pipelines/*}/releases"};
-    option (google.api.method_signature) = "pipelines";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release (Deprecated)"};
+    option deprecated = true;
   }
 
   // Get a release in a pipeline owned by a user
@@ -269,8 +691,8 @@ service PipelinePublicService {
   // by its resource name, formed by its parent user and ID.
   rpc GetUserPipelineRelease(GetUserPipelineReleaseRequest) returns (GetUserPipelineReleaseResponse) {
     option (google.api.http) = {get: "/v1beta/{name=users/*/pipelines/*/releases/*}"};
-    option (google.api.method_signature) = "name";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release (Deprecated)"};
+    option deprecated = true;
   }
 
   // Update a release in a pipeline owned by a user
@@ -285,8 +707,8 @@ service PipelinePublicService {
       patch: "/v1beta/{release.name=users/*/pipelines/*/releases/*}"
       body: "release"
     };
-    option (google.api.method_signature) = "release,update_mask";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release (Deprecated)"};
+    option deprecated = true;
   }
 
   // Delete a release in a pipeline owned by a user
@@ -298,8 +720,8 @@ service PipelinePublicService {
   // perform this action.
   rpc DeleteUserPipelineRelease(DeleteUserPipelineReleaseRequest) returns (DeleteUserPipelineReleaseResponse) {
     option (google.api.http) = {delete: "/v1beta/{name=users/*/pipelines/*/releases/*}"};
-    option (google.api.method_signature) = "name";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release (Deprecated)"};
+    option deprecated = true;
   }
 
   // Set the version of a pipeline owned by a user to a pinned release
@@ -313,8 +735,8 @@ service PipelinePublicService {
   // perform this action.
   rpc RestoreUserPipelineRelease(RestoreUserPipelineReleaseRequest) returns (RestoreUserPipelineReleaseResponse) {
     option (google.api.http) = {post: "/v1beta/{name=users/*/pipelines/*/releases/*}/restore"};
-    option (google.api.method_signature) = "name";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release (Deprecated)"};
+    option deprecated = true;
   }
 
   // Rename a release in a pipeline owned by a user
@@ -334,8 +756,8 @@ service PipelinePublicService {
       post: "/v1beta/{name=users/*/pipelines/*/releases/*}/rename"
       body: "*"
     };
-    option (google.api.method_signature) = "name,new_pipeline_release_id";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release (Deprecated)"};
+    option deprecated = true;
   }
 
   // Trigger a version of a pipeline owned by a user
@@ -352,8 +774,17 @@ service PipelinePublicService {
       post: "/v1beta/{name=users/*/pipelines/*/releases/*}/trigger"
       body: "*"
     };
-    option (google.api.method_signature) = "name,data";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Trigger (Deprecated)"
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
+    };
+    option deprecated = true;
   }
 
   // Trigger a version of a pipeline owned by a user asynchronously
@@ -370,8 +801,17 @@ service PipelinePublicService {
       post: "/v1beta/{name=users/*/pipelines/*/releases/*}/triggerAsync"
       body: "*"
     };
-    option (google.api.method_signature) = "name,data";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Trigger (Deprecated)"
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
+    };
+    option deprecated = true;
   }
 
   // Create a new organization pipeline
@@ -382,8 +822,8 @@ service PipelinePublicService {
       post: "/v1beta/{parent=organizations/*}/pipelines"
       body: "pipeline"
     };
-    option (google.api.method_signature) = "parent,pipeline";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option deprecated = true;
   }
 
   // List organization pipelines
@@ -392,8 +832,8 @@ service PipelinePublicService {
   // organization.
   rpc ListOrganizationPipelines(ListOrganizationPipelinesRequest) returns (ListOrganizationPipelinesResponse) {
     option (google.api.http) = {get: "/v1beta/{parent=organizations/*}/pipelines"};
-    option (google.api.method_signature) = "parent";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option deprecated = true;
   }
 
   // Get a pipeline owned by an organization
@@ -402,8 +842,8 @@ service PipelinePublicService {
   // which is defined by the parent organization and the ID of the pipeline.
   rpc GetOrganizationPipeline(GetOrganizationPipelineRequest) returns (GetOrganizationPipelineResponse) {
     option (google.api.http) = {get: "/v1beta/{name=organizations/*/pipelines/*}"};
-    option (google.api.method_signature) = "name";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option deprecated = true;
   }
 
   // Update a pipeline owned by an organization
@@ -417,8 +857,8 @@ service PipelinePublicService {
       patch: "/v1beta/{pipeline.name=organizations/*/pipelines/*}"
       body: "pipeline"
     };
-    option (google.api.method_signature) = "pipeline,update_mask";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option deprecated = true;
   }
 
   // Delete a pipeline owned by an organization
@@ -427,8 +867,8 @@ service PipelinePublicService {
   // the parent organization and the ID of the pipeline.
   rpc DeleteOrganizationPipeline(DeleteOrganizationPipelineRequest) returns (DeleteOrganizationPipelineResponse) {
     option (google.api.http) = {delete: "/v1beta/{name=organizations/*/pipelines/*}"};
-    option (google.api.method_signature) = "name";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option deprecated = true;
   }
 
   // Validate a pipeline a pipeline owned by an organization
@@ -443,8 +883,8 @@ service PipelinePublicService {
       post: "/v1beta/{name=organizations/*/pipelines/*}/validate"
       body: "*"
     };
-    option (google.api.method_signature) = "name";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option deprecated = true;
   }
 
   // Rename a pipeline owned by an organization
@@ -460,8 +900,8 @@ service PipelinePublicService {
       post: "/v1beta/{name=organizations/*/pipelines/*}/rename"
       body: "*"
     };
-    option (google.api.method_signature) = "name,new_pipeline_id";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option deprecated = true;
   }
 
   // Clone a pipeline owned by an organization
@@ -473,8 +913,21 @@ service PipelinePublicService {
       post: "/v1beta/{name=organizations/*/pipelines/*}/clone"
       body: "*"
     };
-    option (google.api.method_signature) = "name,target";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option deprecated = true;
+  }
+
+  // Clone a pipeline release owned by an organization
+  //
+  // Clones a pipeline release owned by an organization. The new pipeline may
+  // have a different parent, and this can be either a user or an organization.
+  rpc CloneOrganizationPipelineRelease(CloneOrganizationPipelineReleaseRequest) returns (CloneOrganizationPipelineReleaseResponse) {
+    option (google.api.http) = {
+      post: "/v1beta/{name=organizations/*/pipelines/*/releases/*}/clone"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option deprecated = true;
   }
 
   // Trigger a pipeline owned by an organization
@@ -486,15 +939,23 @@ service PipelinePublicService {
   // The pipeline is identified by its resource name, formed by the parent
   // organization and ID of the pipeline.
   //
-  // For more information, see [Trigger
-  // Pipeline](https://www.instill.tech/docs/latest/core/concepts/pipeline#trigger-pipeline).
+  // For more information, see [Run Pipeline](https://www.instill.tech/docs/vdp/run).
   rpc TriggerOrganizationPipelineStream(TriggerOrganizationPipelineStreamRequest) returns (stream TriggerOrganizationPipelineStreamResponse) {
     option (google.api.http) = {
       post: "/v1beta/{name=organizations/*/pipelines/*}/trigger-stream"
       body: "*"
     };
-    option (google.api.method_signature) = "name,data";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Trigger (Deprecated)"
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
+    };
+    option deprecated = true;
   }
 
   // Trigger a pipeline owned by an organization
@@ -506,15 +967,23 @@ service PipelinePublicService {
   // The pipeline is identified by its resource name, formed by the parent
   // organization and ID of the pipeline.
   //
-  // For more information, see [Trigger
-  // Pipeline](https://www.instill.tech/docs/latest/core/concepts/pipeline#trigger-pipeline).
+  // For more information, see [Run Pipeline](https://www.instill.tech/docs/vdp/run).
   rpc TriggerOrganizationPipeline(TriggerOrganizationPipelineRequest) returns (TriggerOrganizationPipelineResponse) {
     option (google.api.http) = {
       post: "/v1beta/{name=organizations/*/pipelines/*}/trigger"
       body: "*"
     };
-    option (google.api.method_signature) = "name,data";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Trigger (Deprecated)"
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
+    };
+    option deprecated = true;
   }
 
   // Trigger a pipeline owned by an organization asynchronously
@@ -527,15 +996,23 @@ service PipelinePublicService {
   // The pipeline is identified by its resource name, formed by the parent
   // organization and ID of the pipeline.
   //
-  // For more information, see [Trigger
-  // Pipeline](https://www.instill.tech/docs/latest/core/concepts/pipeline#trigger-pipeline).
+  // For more information, see [Run Pipeline](https://www.instill.tech/docs/vdp/run).
   rpc TriggerAsyncOrganizationPipeline(TriggerAsyncOrganizationPipelineRequest) returns (TriggerAsyncOrganizationPipelineResponse) {
     option (google.api.http) = {
       post: "/v1beta/{name=organizations/*/pipelines/*}/triggerAsync"
       body: "*"
     };
-    option (google.api.method_signature) = "name,data";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Trigger (Deprecated)"
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
+    };
+    option deprecated = true;
   }
 
   // Release a version of a pipeline owned by an organization
@@ -547,8 +1024,8 @@ service PipelinePublicService {
       post: "/v1beta/{parent=organizations/*/pipelines/*}/releases"
       body: "release"
     };
-    option (google.api.method_signature) = "parent,release";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release (Deprecated)"};
+    option deprecated = true;
   }
 
   // List the releases in a pipeline owned by an organization
@@ -557,8 +1034,8 @@ service PipelinePublicService {
   // which is formed by the parent organization and ID of the pipeline.
   rpc ListOrganizationPipelineReleases(ListOrganizationPipelineReleasesRequest) returns (ListOrganizationPipelineReleasesResponse) {
     option (google.api.http) = {get: "/v1beta/{parent=organizations/*/pipelines/*}/releases"};
-    option (google.api.method_signature) = "pipelines";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release (Deprecated)"};
+    option deprecated = true;
   }
 
   // Get a release in a pipeline owned by an organization
@@ -567,8 +1044,8 @@ service PipelinePublicService {
   // its resource name, formed by its parent organization and ID.
   rpc GetOrganizationPipelineRelease(GetOrganizationPipelineReleaseRequest) returns (GetOrganizationPipelineReleaseResponse) {
     option (google.api.http) = {get: "/v1beta/{name=organizations/*/pipelines/*/releases/*}"};
-    option (google.api.method_signature) = "name";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release (Deprecated)"};
+    option deprecated = true;
   }
 
   // Update a release in a pipeline owned by an organization
@@ -580,8 +1057,8 @@ service PipelinePublicService {
       patch: "/v1beta/{release.name=organizations/*/pipelines/*/releases/*}"
       body: "release"
     };
-    option (google.api.method_signature) = "release,update_mask";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release (Deprecated)"};
+    option deprecated = true;
   }
 
   // Delete a release in a pipeline owned by an organization
@@ -590,8 +1067,8 @@ service PipelinePublicService {
   // name, formed by its parent organization and ID.
   rpc DeleteOrganizationPipelineRelease(DeleteOrganizationPipelineReleaseRequest) returns (DeleteOrganizationPipelineReleaseResponse) {
     option (google.api.http) = {delete: "/v1beta/{name=organizations/*/pipelines/*/releases/*}"};
-    option (google.api.method_signature) = "name";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release (Deprecated)"};
+    option deprecated = true;
   }
 
   // Set the version of a pipeline owned by an organization to a pinned release
@@ -602,8 +1079,8 @@ service PipelinePublicService {
   // organization and ID.
   rpc RestoreOrganizationPipelineRelease(RestoreOrganizationPipelineReleaseRequest) returns (RestoreOrganizationPipelineReleaseResponse) {
     option (google.api.http) = {post: "/v1beta/{name=organizations/*/pipelines/*/releases/*}/restore"};
-    option (google.api.method_signature) = "name";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release (Deprecated)"};
+    option deprecated = true;
   }
 
   // Rename a release in a pipeline owned by an organization
@@ -620,8 +1097,8 @@ service PipelinePublicService {
       post: "/v1beta/{name=organizations/*/pipelines/*/releases/*}/rename"
       body: "*"
     };
-    option (google.api.method_signature) = "name,new_pipeline_release_id";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release (Deprecated)"};
+    option deprecated = true;
   }
 
   // Trigger a version of a pipeline owned by an organization
@@ -638,8 +1115,17 @@ service PipelinePublicService {
       post: "/v1beta/{name=organizations/*/pipelines/*/releases/*}/trigger"
       body: "*"
     };
-    option (google.api.method_signature) = "name,data";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Trigger (Deprecated)"
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
+    };
+    option deprecated = true;
   }
 
   // Trigger a version of a pipeline owned by an organization asynchronously
@@ -656,18 +1142,17 @@ service PipelinePublicService {
       post: "/v1beta/{name=organizations/*/pipelines/*/releases/*}/triggerAsync"
       body: "*"
     };
-    option (google.api.method_signature) = "name,data";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
-  }
-
-  // Get the details of a long-running operation
-  //
-  // This method allows requesters to request the status and outcome of
-  // long-running operations such as asynchronous pipeline triggers.
-  rpc GetOperation(GetOperationRequest) returns (GetOperationResponse) {
-    option (google.api.http) = {get: "/v1beta/{name=operations/*}"};
-    option (google.api.method_signature) = "name";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Trigger (Deprecated)"
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
+    };
+    option deprecated = true;
   }
 
   // List connector definitions
@@ -675,7 +1160,7 @@ service PipelinePublicService {
   // Returns a paginated list of connector definitions.
   rpc ListConnectorDefinitions(ListConnectorDefinitionsRequest) returns (ListConnectorDefinitionsResponse) {
     option (google.api.http) = {get: "/v1beta/connector-definitions"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Component"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Component (Deprecated)"};
     option deprecated = true;
   }
 
@@ -684,8 +1169,7 @@ service PipelinePublicService {
   // Returns the details of a connector definition.
   rpc GetConnectorDefinition(GetConnectorDefinitionRequest) returns (GetConnectorDefinitionResponse) {
     option (google.api.http) = {get: "/v1beta/{name=connector-definitions/*}"};
-    option (google.api.method_signature) = "name";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Component"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Component (Deprecated)"};
     option deprecated = true;
   }
 
@@ -694,18 +1178,8 @@ service PipelinePublicService {
   // Returns a paginated list of operator definitions.
   rpc ListOperatorDefinitions(ListOperatorDefinitionsRequest) returns (ListOperatorDefinitionsResponse) {
     option (google.api.http) = {get: "/v1beta/operator-definitions"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Component"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Component (Deprecated)"};
     option deprecated = true;
-  }
-
-  // List component definitions
-  //
-  // Returns a paginated list of component definitions, regardless their type.
-  // This offers a single source of truth, with pagination and filter
-  // capabilities, for the components that might be used in a VDP pipeline.
-  rpc ListComponentDefinitions(ListComponentDefinitionsRequest) returns (ListComponentDefinitionsResponse) {
-    option (google.api.http) = {get: "/v1beta/component-definitions"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Component"};
   }
 
   // Get operator definition
@@ -713,8 +1187,7 @@ service PipelinePublicService {
   // Returns the details of an operator definition.
   rpc GetOperatorDefinition(GetOperatorDefinitionRequest) returns (GetOperatorDefinitionResponse) {
     option (google.api.http) = {get: "/v1beta/{name=operator-definitions/*}"};
-    option (google.api.method_signature) = "name";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Component"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Component (Deprecated)"};
     option deprecated = true;
   }
 
@@ -727,8 +1200,8 @@ service PipelinePublicService {
       post: "/v1beta/check-name"
       body: "*"
     };
-    option (google.api.method_signature) = "name";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Utils"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Utils (Deprecated)"};
+    option deprecated = true;
   }
 
   // Create a new user secret
@@ -739,8 +1212,8 @@ service PipelinePublicService {
       post: "/v1beta/{parent=users/*}/secrets"
       body: "secret"
     };
-    option (google.api.method_signature) = "parent,secret";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret (Deprecated)"};
+    option deprecated = true;
   }
 
   // List user secrets
@@ -749,8 +1222,8 @@ service PipelinePublicService {
   // user.
   rpc ListUserSecrets(ListUserSecretsRequest) returns (ListUserSecretsResponse) {
     option (google.api.http) = {get: "/v1beta/{parent=users/*}/secrets"};
-    option (google.api.method_signature) = "parent";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret (Deprecated)"};
+    option deprecated = true;
   }
 
   // Get a secret owned by an user
@@ -759,8 +1232,8 @@ service PipelinePublicService {
   // which is defined by the parent user and the ID of the secret.
   rpc GetUserSecret(GetUserSecretRequest) returns (GetUserSecretResponse) {
     option (google.api.http) = {get: "/v1beta/{name=users/*/secrets/*}"};
-    option (google.api.method_signature) = "name";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret (Deprecated)"};
+    option deprecated = true;
   }
 
   // Update a secret owned by an user
@@ -774,8 +1247,8 @@ service PipelinePublicService {
       patch: "/v1beta/{secret.name=users/*/secrets/*}"
       body: "secret"
     };
-    option (google.api.method_signature) = "secret,update_mask";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret (Deprecated)"};
+    option deprecated = true;
   }
 
   // Delete a secret owned by an user
@@ -784,8 +1257,8 @@ service PipelinePublicService {
   // the parent user and the ID of the secret.
   rpc DeleteUserSecret(DeleteUserSecretRequest) returns (DeleteUserSecretResponse) {
     option (google.api.http) = {delete: "/v1beta/{name=users/*/secrets/*}"};
-    option (google.api.method_signature) = "name";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret (Deprecated)"};
+    option deprecated = true;
   }
 
   // Create a new organization secret
@@ -796,8 +1269,8 @@ service PipelinePublicService {
       post: "/v1beta/{parent=organizations/*}/secrets"
       body: "secret"
     };
-    option (google.api.method_signature) = "parent,secret";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret (Deprecated)"};
+    option deprecated = true;
   }
 
   // List organization secrets
@@ -806,8 +1279,8 @@ service PipelinePublicService {
   // organization.
   rpc ListOrganizationSecrets(ListOrganizationSecretsRequest) returns (ListOrganizationSecretsResponse) {
     option (google.api.http) = {get: "/v1beta/{parent=organizations/*}/secrets"};
-    option (google.api.method_signature) = "parent";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret (Deprecated)"};
+    option deprecated = true;
   }
 
   // Get a secret owned by an organization
@@ -816,8 +1289,8 @@ service PipelinePublicService {
   // which is defined by the parent organization and the ID of the secret.
   rpc GetOrganizationSecret(GetOrganizationSecretRequest) returns (GetOrganizationSecretResponse) {
     option (google.api.http) = {get: "/v1beta/{name=organizations/*/secrets/*}"};
-    option (google.api.method_signature) = "name";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret (Deprecated)"};
+    option deprecated = true;
   }
 
   // Update a secret owned by an organization
@@ -831,8 +1304,8 @@ service PipelinePublicService {
       patch: "/v1beta/{secret.name=organizations/*/secrets/*}"
       body: "secret"
     };
-    option (google.api.method_signature) = "secret,update_mask";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret (Deprecated)"};
+    option deprecated = true;
   }
 
   // Delete a secret owned by an organization
@@ -841,7 +1314,7 @@ service PipelinePublicService {
   // the parent organization and the ID of the secret.
   rpc DeleteOrganizationSecret(DeleteOrganizationSecretRequest) returns (DeleteOrganizationSecretResponse) {
     option (google.api.http) = {delete: "/v1beta/{name=organizations/*/secrets/*}"};
-    option (google.api.method_signature) = "name";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret (Deprecated)"};
+    option deprecated = true;
   }
 }

--- a/integration-test/proto/vdp/pipeline/v1beta/protoc-gen-openapiv2/options/openapiv2.proto
+++ b/integration-test/proto/vdp/pipeline/v1beta/protoc-gen-openapiv2/options/openapiv2.proto
@@ -26,7 +26,7 @@ enum Scheme {
 //    info: {
 //      title: "Echo API";
 //      version: "1.0";
-//      description: ";
+//      description: "";
 //      contact: {
 //        name: "gRPC-Gateway project";
 //        url: "https://github.com/grpc-ecosystem/grpc-gateway";
@@ -34,7 +34,7 @@ enum Scheme {
 //      };
 //      license: {
 //        name: "BSD 3-Clause License";
-//        url: "https://github.com/grpc-ecosystem/grpc-gateway/blob/master/LICENSE.txt";
+//        url: "https://github.com/grpc-ecosystem/grpc-gateway/blob/main/LICENSE";
 //      };
 //    };
 //    schemes: HTTPS;
@@ -92,12 +92,14 @@ message Swagger {
   // (that is, there is a logical OR between the security requirements).
   // Individual operations can override this definition.
   repeated SecurityRequirement security = 12;
-  // field 13 is reserved for 'tags', which are supposed to be exposed as and
-  // customizable as proto services. TODO(ivucica): add processing of proto
-  // service objects into OpenAPI v2 Tag objects.
-  reserved 13;
+  // A list of tags for API documentation control. Tags can be used for logical
+  // grouping of operations by resources or any other qualifier.
+  repeated Tag tags = 13;
   // Additional external documentation.
   ExternalDocumentation external_docs = 14;
+  // Custom properties that start with "x-" such as "x-foo" used to describe
+  // extra functionality that is not covered by the standard OpenAPI Specification.
+  // See: https://swagger.io/docs/specification/2-0/swagger-extensions/
   map<string, google.protobuf.Value> extensions = 15;
 }
 
@@ -169,7 +171,55 @@ message Operation {
   // definition overrides any declared top-level security. To remove a top-level
   // security declaration, an empty array can be used.
   repeated SecurityRequirement security = 12;
+  // Custom properties that start with "x-" such as "x-foo" used to describe
+  // extra functionality that is not covered by the standard OpenAPI Specification.
+  // See: https://swagger.io/docs/specification/2-0/swagger-extensions/
   map<string, google.protobuf.Value> extensions = 13;
+  // Custom parameters such as HTTP request headers.
+  // See: https://swagger.io/docs/specification/2-0/describing-parameters/
+  // and https://swagger.io/specification/v2/#parameter-object.
+  Parameters parameters = 14;
+}
+
+// `Parameters` is a representation of OpenAPI v2 specification's parameters object.
+// Note: This technically breaks compatibility with the OpenAPI 2 definition structure as we only
+// allow header parameters to be set here since we do not want users specifying custom non-header
+// parameters beyond those inferred from the Protobuf schema.
+// See: https://swagger.io/specification/v2/#parameter-object
+message Parameters {
+  // `Headers` is one or more HTTP header parameter.
+  // See: https://swagger.io/docs/specification/2-0/describing-parameters/#header-parameters
+  repeated HeaderParameter headers = 1;
+}
+
+// `HeaderParameter` a HTTP header parameter.
+// See: https://swagger.io/specification/v2/#parameter-object
+message HeaderParameter {
+  // `Type` is a supported HTTP header type.
+  // See https://swagger.io/specification/v2/#parameterType.
+  enum Type {
+    UNKNOWN = 0;
+    STRING = 1;
+    NUMBER = 2;
+    INTEGER = 3;
+    BOOLEAN = 4;
+  }
+
+  // `Name` is the header name.
+  string name = 1;
+  // `Description` is a short description of the header.
+  string description = 2;
+  // `Type` is the type of the object. The value MUST be one of "string", "number", "integer", or "boolean". The "array" type is not supported.
+  // See: https://swagger.io/specification/v2/#parameterType.
+  Type type = 3;
+  // `Format` The extending format for the previously mentioned type.
+  string format = 4;
+  // `Required` indicates if the header is optional
+  bool required = 5;
+  // field 6 is reserved for 'items', but in OpenAPI-specific way.
+  reserved 6;
+  // field 7 is reserved `Collection Format`. Determines the format of the array if type array is used.
+  reserved 7;
 }
 
 // `Header` is a representation of OpenAPI v2 specification's Header object.
@@ -235,6 +285,9 @@ message Response {
   // `Examples` gives per-mimetype response examples.
   // See: https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/2.0.md#example-object
   map<string, string> examples = 4;
+  // Custom properties that start with "x-" such as "x-foo" used to describe
+  // extra functionality that is not covered by the standard OpenAPI Specification.
+  // See: https://swagger.io/docs/specification/2-0/swagger-extensions/
   map<string, google.protobuf.Value> extensions = 5;
 }
 
@@ -248,7 +301,7 @@ message Response {
 //    info: {
 //      title: "Echo API";
 //      version: "1.0";
-//      description: ";
+//      description: "";
 //      contact: {
 //        name: "gRPC-Gateway project";
 //        url: "https://github.com/grpc-ecosystem/grpc-gateway";
@@ -256,7 +309,7 @@ message Response {
 //      };
 //      license: {
 //        name: "BSD 3-Clause License";
-//        url: "https://github.com/grpc-ecosystem/grpc-gateway/blob/master/LICENSE.txt";
+//        url: "https://github.com/grpc-ecosystem/grpc-gateway/blob/main/LICENSE";
 //      };
 //    };
 //    ...
@@ -277,6 +330,9 @@ message Info {
   // Provides the version of the application API (not to be confused
   // with the specification version).
   string version = 6;
+  // Custom properties that start with "x-" such as "x-foo" used to describe
+  // extra functionality that is not covered by the standard OpenAPI Specification.
+  // See: https://swagger.io/docs/specification/2-0/swagger-extensions/
   map<string, google.protobuf.Value> extensions = 7;
 }
 
@@ -321,7 +377,7 @@ message Contact {
 //      ...
 //      license: {
 //        name: "BSD 3-Clause License";
-//        url: "https://github.com/grpc-ecosystem/grpc-gateway/blob/master/LICENSE.txt";
+//        url: "https://github.com/grpc-ecosystem/grpc-gateway/blob/main/LICENSE";
 //      };
 //      ...
 //    };
@@ -518,6 +574,9 @@ message JSONSchema {
     // for overlapping paths.
     string path_param_name = 47;
   }
+  // Custom properties that start with "x-" such as "x-foo" used to describe
+  // extra functionality that is not covered by the standard OpenAPI Specification.
+  // See: https://swagger.io/docs/specification/2-0/swagger-extensions/
   map<string, google.protobuf.Value> extensions = 48;
 }
 
@@ -526,20 +585,19 @@ message JSONSchema {
 // See: https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/2.0.md#tagObject
 //
 message Tag {
-  // field 1 is reserved for 'name'. In our generator, this is (to be) extracted
-  // from the name of proto service, and thus not exposed to the user, as
-  // changing tag object's name would break the link to the references to the
-  // tag in individual operation specifications.
-  //
-  // TODO(ivucica): Add 'name' property. Use it to allow override of the name of
+  // The name of the tag. Use it to allow override of the name of a
   // global Tag object, then use that name to reference the tag throughout the
   // OpenAPI file.
-  reserved 1;
+  string name = 1;
   // A short description for the tag. GFM syntax can be used for rich text
   // representation.
   string description = 2;
   // Additional external documentation for this tag.
   ExternalDocumentation external_docs = 3;
+  // Custom properties that start with "x-" such as "x-foo" used to describe
+  // extra functionality that is not covered by the standard OpenAPI Specification.
+  // See: https://swagger.io/docs/specification/2-0/swagger-extensions/
+  map<string, google.protobuf.Value> extensions = 4;
 }
 
 // `SecurityDefinitions` is a representation of OpenAPI v2 specification's
@@ -619,6 +677,9 @@ message SecurityScheme {
   // The available scopes for the OAuth2 security scheme.
   // Valid for oauth2.
   Scopes scopes = 8;
+  // Custom properties that start with "x-" such as "x-foo" used to describe
+  // extra functionality that is not covered by the standard OpenAPI Specification.
+  // See: https://swagger.io/docs/specification/2-0/swagger-extensions/
   map<string, google.protobuf.Value> extensions = 9;
 }
 

--- a/integration-test/proto/vdp/pipeline/v1beta/secret.proto
+++ b/integration-test/proto/vdp/pipeline/v1beta/secret.proto
@@ -39,6 +39,90 @@ message Secret {
   string description = 7 [(google.api.field_behavior) = OPTIONAL];
 }
 
+// CreateSecretRequest represents a request to create a secret.
+message CreateSecretRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // Secret ID
+  string secret_id = 2 [(google.api.field_behavior) = REQUIRED];
+  // The properties of the secret to be created.
+  Secret secret = 3;
+}
+
+// CreateSecretResponse contains the created secret.
+message CreateSecretResponse {
+  // The created secret resource.
+  Secret secret = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// ListSecretsRequest represents a request to list the secrets of a namespace.
+message ListSecretsRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // The maximum number of secrets to return. If this parameter is unspecified,
+  // at most 10 pipelines will be returned. The cap value for this parameter is
+  // 100 (i.e. any value above that will be coerced to 100).
+  optional int32 page_size = 2 [(google.api.field_behavior) = OPTIONAL];
+  // Page secret.
+  optional string page_token = 3 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// ListSecretsResponse contains a list of secrets.
+message ListSecretsResponse {
+  // A list of secret resources.
+  repeated Secret secrets = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Next page secret.
+  string next_page_token = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Total number of secret resources.
+  int32 total_size = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// GetSecretRequest represents a request to fetch the details of a secret
+message GetSecretRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // Secret ID
+  string secret_id = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// GetSecretResponse contains the requested secret.
+message GetSecretResponse {
+  // The secret resource.
+  Secret secret = 1;
+}
+
+// UpdateSecretRequest represents a request to update a namespace secret.
+message UpdateSecretRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // Secret ID
+  string secret_id = 2 [(google.api.field_behavior) = REQUIRED];
+  // The secret fields to update.
+  Secret secret = 3;
+  // The update mask specifies the subset of fields that should be modified.
+  //
+  // For more information about this field, see
+  // https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#field-mask.
+  google.protobuf.FieldMask update_mask = 4 [(google.api.field_behavior) = REQUIRED];
+}
+
+// UpdateSecretResponse contains the updated secret.
+message UpdateSecretResponse {
+  // The updated secret resource.
+  Secret secret = 1;
+}
+
+// DeleteSecretRequest represents a request to delete a secret resource.
+message DeleteSecretRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // Secret ID
+  string secret_id = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// DeleteSecretResponse is an empty response.
+message DeleteSecretResponse {}
+
 // CreateUserSecretRequest represents a request to create a secret.
 message CreateUserSecretRequest {
   // The properties of the secret to be created.

--- a/pkg/handler/formdata_handler.go
+++ b/pkg/handler/formdata_handler.go
@@ -312,6 +312,7 @@ func request_PipelinePublicService_TriggerUserPipeline_0(ctx context.Context, ma
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "name", err)
 	}
 
+	//nolint:staticcheck
 	msg, err := client.TriggerUserPipeline(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 
@@ -338,6 +339,7 @@ func request_PipelinePublicService_TriggerUserPipeline_0_form(ctx context.Contex
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "name", err)
 	}
 
+	//nolint:staticcheck
 	msg, err := client.TriggerUserPipeline(ctx, protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 
@@ -372,6 +374,7 @@ func request_PipelinePublicService_TriggerAsyncUserPipeline_0(ctx context.Contex
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "name", err)
 	}
 
+	//nolint:staticcheck
 	msg, err := client.TriggerAsyncUserPipeline(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 
@@ -398,6 +401,7 @@ func request_PipelinePublicService_TriggerAsyncUserPipeline_0_form(ctx context.C
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "name", err)
 	}
 
+	//nolint:staticcheck
 	msg, err := client.TriggerAsyncUserPipeline(ctx, protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 
@@ -527,6 +531,7 @@ func request_PipelinePublicService_TriggerUserPipelineRelease_0(ctx context.Cont
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "name", err)
 	}
 
+	//nolint:staticcheck
 	msg, err := client.TriggerUserPipelineRelease(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 
@@ -553,6 +558,7 @@ func request_PipelinePublicService_TriggerUserPipelineRelease_0_form(ctx context
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "name", err)
 	}
 
+	//nolint:staticcheck
 	msg, err := client.TriggerUserPipelineRelease(ctx, protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 
@@ -587,6 +593,7 @@ func request_PipelinePublicService_TriggerAsyncUserPipelineRelease_0(ctx context
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "name", err)
 	}
 
+	//nolint:staticcheck
 	msg, err := client.TriggerAsyncUserPipelineRelease(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 
@@ -613,6 +620,7 @@ func request_PipelinePublicService_TriggerAsyncUserPipelineRelease_0_form(ctx co
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "name", err)
 	}
 
+	//nolint:staticcheck
 	msg, err := client.TriggerAsyncUserPipelineRelease(ctx, protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 

--- a/pkg/mock/repository_mock.gen.go
+++ b/pkg/mock/repository_mock.gen.go
@@ -215,12 +215,6 @@ type RepositoryMock struct {
 	beforeUpdateNamespaceSecretByIDCounter uint64
 	UpdateNamespaceSecretByIDMock          mRepositoryMockUpdateNamespaceSecretByID
 
-	funcUpdatePipelineRunStats          func(ctx context.Context, uid uuid.UUID) (err error)
-	inspectFuncUpdatePipelineRunStats   func(ctx context.Context, uid uuid.UUID)
-	afterUpdatePipelineRunStatsCounter  uint64
-	beforeUpdatePipelineRunStatsCounter uint64
-	UpdatePipelineRunStatsMock          mRepositoryMockUpdatePipelineRunStats
-
 	funcUpsertComponentDefinition          func(ctx context.Context, cp1 *pb.ComponentDefinition) (err error)
 	inspectFuncUpsertComponentDefinition   func(ctx context.Context, cp1 *pb.ComponentDefinition)
 	afterUpsertComponentDefinitionCounter  uint64
@@ -331,9 +325,6 @@ func NewRepositoryMock(t minimock.Tester) *RepositoryMock {
 
 	m.UpdateNamespaceSecretByIDMock = mRepositoryMockUpdateNamespaceSecretByID{mock: m}
 	m.UpdateNamespaceSecretByIDMock.callArgs = []*RepositoryMockUpdateNamespaceSecretByIDParams{}
-
-	m.UpdatePipelineRunStatsMock = mRepositoryMockUpdatePipelineRunStats{mock: m}
-	m.UpdatePipelineRunStatsMock.callArgs = []*RepositoryMockUpdatePipelineRunStatsParams{}
 
 	m.UpsertComponentDefinitionMock = mRepositoryMockUpsertComponentDefinition{mock: m}
 	m.UpsertComponentDefinitionMock.callArgs = []*RepositoryMockUpsertComponentDefinitionParams{}
@@ -12375,222 +12366,6 @@ func (m *RepositoryMock) MinimockUpdateNamespaceSecretByIDInspect() {
 	}
 }
 
-type mRepositoryMockUpdatePipelineRunStats struct {
-	mock               *RepositoryMock
-	defaultExpectation *RepositoryMockUpdatePipelineRunStatsExpectation
-	expectations       []*RepositoryMockUpdatePipelineRunStatsExpectation
-
-	callArgs []*RepositoryMockUpdatePipelineRunStatsParams
-	mutex    sync.RWMutex
-}
-
-// RepositoryMockUpdatePipelineRunStatsExpectation specifies expectation struct of the Repository.UpdatePipelineRunStats
-type RepositoryMockUpdatePipelineRunStatsExpectation struct {
-	mock    *RepositoryMock
-	params  *RepositoryMockUpdatePipelineRunStatsParams
-	results *RepositoryMockUpdatePipelineRunStatsResults
-	Counter uint64
-}
-
-// RepositoryMockUpdatePipelineRunStatsParams contains parameters of the Repository.UpdatePipelineRunStats
-type RepositoryMockUpdatePipelineRunStatsParams struct {
-	ctx context.Context
-	uid uuid.UUID
-}
-
-// RepositoryMockUpdatePipelineRunStatsResults contains results of the Repository.UpdatePipelineRunStats
-type RepositoryMockUpdatePipelineRunStatsResults struct {
-	err error
-}
-
-// Expect sets up expected params for Repository.UpdatePipelineRunStats
-func (mmUpdatePipelineRunStats *mRepositoryMockUpdatePipelineRunStats) Expect(ctx context.Context, uid uuid.UUID) *mRepositoryMockUpdatePipelineRunStats {
-	if mmUpdatePipelineRunStats.mock.funcUpdatePipelineRunStats != nil {
-		mmUpdatePipelineRunStats.mock.t.Fatalf("RepositoryMock.UpdatePipelineRunStats mock is already set by Set")
-	}
-
-	if mmUpdatePipelineRunStats.defaultExpectation == nil {
-		mmUpdatePipelineRunStats.defaultExpectation = &RepositoryMockUpdatePipelineRunStatsExpectation{}
-	}
-
-	mmUpdatePipelineRunStats.defaultExpectation.params = &RepositoryMockUpdatePipelineRunStatsParams{ctx, uid}
-	for _, e := range mmUpdatePipelineRunStats.expectations {
-		if minimock.Equal(e.params, mmUpdatePipelineRunStats.defaultExpectation.params) {
-			mmUpdatePipelineRunStats.mock.t.Fatalf("Expectation set by When has same params: %#v", *mmUpdatePipelineRunStats.defaultExpectation.params)
-		}
-	}
-
-	return mmUpdatePipelineRunStats
-}
-
-// Inspect accepts an inspector function that has same arguments as the Repository.UpdatePipelineRunStats
-func (mmUpdatePipelineRunStats *mRepositoryMockUpdatePipelineRunStats) Inspect(f func(ctx context.Context, uid uuid.UUID)) *mRepositoryMockUpdatePipelineRunStats {
-	if mmUpdatePipelineRunStats.mock.inspectFuncUpdatePipelineRunStats != nil {
-		mmUpdatePipelineRunStats.mock.t.Fatalf("Inspect function is already set for RepositoryMock.UpdatePipelineRunStats")
-	}
-
-	mmUpdatePipelineRunStats.mock.inspectFuncUpdatePipelineRunStats = f
-
-	return mmUpdatePipelineRunStats
-}
-
-// Return sets up results that will be returned by Repository.UpdatePipelineRunStats
-func (mmUpdatePipelineRunStats *mRepositoryMockUpdatePipelineRunStats) Return(err error) *RepositoryMock {
-	if mmUpdatePipelineRunStats.mock.funcUpdatePipelineRunStats != nil {
-		mmUpdatePipelineRunStats.mock.t.Fatalf("RepositoryMock.UpdatePipelineRunStats mock is already set by Set")
-	}
-
-	if mmUpdatePipelineRunStats.defaultExpectation == nil {
-		mmUpdatePipelineRunStats.defaultExpectation = &RepositoryMockUpdatePipelineRunStatsExpectation{mock: mmUpdatePipelineRunStats.mock}
-	}
-	mmUpdatePipelineRunStats.defaultExpectation.results = &RepositoryMockUpdatePipelineRunStatsResults{err}
-	return mmUpdatePipelineRunStats.mock
-}
-
-// Set uses given function f to mock the Repository.UpdatePipelineRunStats method
-func (mmUpdatePipelineRunStats *mRepositoryMockUpdatePipelineRunStats) Set(f func(ctx context.Context, uid uuid.UUID) (err error)) *RepositoryMock {
-	if mmUpdatePipelineRunStats.defaultExpectation != nil {
-		mmUpdatePipelineRunStats.mock.t.Fatalf("Default expectation is already set for the Repository.UpdatePipelineRunStats method")
-	}
-
-	if len(mmUpdatePipelineRunStats.expectations) > 0 {
-		mmUpdatePipelineRunStats.mock.t.Fatalf("Some expectations are already set for the Repository.UpdatePipelineRunStats method")
-	}
-
-	mmUpdatePipelineRunStats.mock.funcUpdatePipelineRunStats = f
-	return mmUpdatePipelineRunStats.mock
-}
-
-// When sets expectation for the Repository.UpdatePipelineRunStats which will trigger the result defined by the following
-// Then helper
-func (mmUpdatePipelineRunStats *mRepositoryMockUpdatePipelineRunStats) When(ctx context.Context, uid uuid.UUID) *RepositoryMockUpdatePipelineRunStatsExpectation {
-	if mmUpdatePipelineRunStats.mock.funcUpdatePipelineRunStats != nil {
-		mmUpdatePipelineRunStats.mock.t.Fatalf("RepositoryMock.UpdatePipelineRunStats mock is already set by Set")
-	}
-
-	expectation := &RepositoryMockUpdatePipelineRunStatsExpectation{
-		mock:   mmUpdatePipelineRunStats.mock,
-		params: &RepositoryMockUpdatePipelineRunStatsParams{ctx, uid},
-	}
-	mmUpdatePipelineRunStats.expectations = append(mmUpdatePipelineRunStats.expectations, expectation)
-	return expectation
-}
-
-// Then sets up Repository.UpdatePipelineRunStats return parameters for the expectation previously defined by the When method
-func (e *RepositoryMockUpdatePipelineRunStatsExpectation) Then(err error) *RepositoryMock {
-	e.results = &RepositoryMockUpdatePipelineRunStatsResults{err}
-	return e.mock
-}
-
-// UpdatePipelineRunStats implements repository.Repository
-func (mmUpdatePipelineRunStats *RepositoryMock) UpdatePipelineRunStats(ctx context.Context, uid uuid.UUID) (err error) {
-	mm_atomic.AddUint64(&mmUpdatePipelineRunStats.beforeUpdatePipelineRunStatsCounter, 1)
-	defer mm_atomic.AddUint64(&mmUpdatePipelineRunStats.afterUpdatePipelineRunStatsCounter, 1)
-
-	if mmUpdatePipelineRunStats.inspectFuncUpdatePipelineRunStats != nil {
-		mmUpdatePipelineRunStats.inspectFuncUpdatePipelineRunStats(ctx, uid)
-	}
-
-	mm_params := RepositoryMockUpdatePipelineRunStatsParams{ctx, uid}
-
-	// Record call args
-	mmUpdatePipelineRunStats.UpdatePipelineRunStatsMock.mutex.Lock()
-	mmUpdatePipelineRunStats.UpdatePipelineRunStatsMock.callArgs = append(mmUpdatePipelineRunStats.UpdatePipelineRunStatsMock.callArgs, &mm_params)
-	mmUpdatePipelineRunStats.UpdatePipelineRunStatsMock.mutex.Unlock()
-
-	for _, e := range mmUpdatePipelineRunStats.UpdatePipelineRunStatsMock.expectations {
-		if minimock.Equal(*e.params, mm_params) {
-			mm_atomic.AddUint64(&e.Counter, 1)
-			return e.results.err
-		}
-	}
-
-	if mmUpdatePipelineRunStats.UpdatePipelineRunStatsMock.defaultExpectation != nil {
-		mm_atomic.AddUint64(&mmUpdatePipelineRunStats.UpdatePipelineRunStatsMock.defaultExpectation.Counter, 1)
-		mm_want := mmUpdatePipelineRunStats.UpdatePipelineRunStatsMock.defaultExpectation.params
-		mm_got := RepositoryMockUpdatePipelineRunStatsParams{ctx, uid}
-		if mm_want != nil && !minimock.Equal(*mm_want, mm_got) {
-			mmUpdatePipelineRunStats.t.Errorf("RepositoryMock.UpdatePipelineRunStats got unexpected parameters, want: %#v, got: %#v%s\n", *mm_want, mm_got, minimock.Diff(*mm_want, mm_got))
-		}
-
-		mm_results := mmUpdatePipelineRunStats.UpdatePipelineRunStatsMock.defaultExpectation.results
-		if mm_results == nil {
-			mmUpdatePipelineRunStats.t.Fatal("No results are set for the RepositoryMock.UpdatePipelineRunStats")
-		}
-		return (*mm_results).err
-	}
-	if mmUpdatePipelineRunStats.funcUpdatePipelineRunStats != nil {
-		return mmUpdatePipelineRunStats.funcUpdatePipelineRunStats(ctx, uid)
-	}
-	mmUpdatePipelineRunStats.t.Fatalf("Unexpected call to RepositoryMock.UpdatePipelineRunStats. %v %v", ctx, uid)
-	return
-}
-
-// UpdatePipelineRunStatsAfterCounter returns a count of finished RepositoryMock.UpdatePipelineRunStats invocations
-func (mmUpdatePipelineRunStats *RepositoryMock) UpdatePipelineRunStatsAfterCounter() uint64 {
-	return mm_atomic.LoadUint64(&mmUpdatePipelineRunStats.afterUpdatePipelineRunStatsCounter)
-}
-
-// UpdatePipelineRunStatsBeforeCounter returns a count of RepositoryMock.UpdatePipelineRunStats invocations
-func (mmUpdatePipelineRunStats *RepositoryMock) UpdatePipelineRunStatsBeforeCounter() uint64 {
-	return mm_atomic.LoadUint64(&mmUpdatePipelineRunStats.beforeUpdatePipelineRunStatsCounter)
-}
-
-// Calls returns a list of arguments used in each call to RepositoryMock.UpdatePipelineRunStats.
-// The list is in the same order as the calls were made (i.e. recent calls have a higher index)
-func (mmUpdatePipelineRunStats *mRepositoryMockUpdatePipelineRunStats) Calls() []*RepositoryMockUpdatePipelineRunStatsParams {
-	mmUpdatePipelineRunStats.mutex.RLock()
-
-	argCopy := make([]*RepositoryMockUpdatePipelineRunStatsParams, len(mmUpdatePipelineRunStats.callArgs))
-	copy(argCopy, mmUpdatePipelineRunStats.callArgs)
-
-	mmUpdatePipelineRunStats.mutex.RUnlock()
-
-	return argCopy
-}
-
-// MinimockUpdatePipelineRunStatsDone returns true if the count of the UpdatePipelineRunStats invocations corresponds
-// the number of defined expectations
-func (m *RepositoryMock) MinimockUpdatePipelineRunStatsDone() bool {
-	for _, e := range m.UpdatePipelineRunStatsMock.expectations {
-		if mm_atomic.LoadUint64(&e.Counter) < 1 {
-			return false
-		}
-	}
-
-	// if default expectation was set then invocations count should be greater than zero
-	if m.UpdatePipelineRunStatsMock.defaultExpectation != nil && mm_atomic.LoadUint64(&m.afterUpdatePipelineRunStatsCounter) < 1 {
-		return false
-	}
-	// if func was set then invocations count should be greater than zero
-	if m.funcUpdatePipelineRunStats != nil && mm_atomic.LoadUint64(&m.afterUpdatePipelineRunStatsCounter) < 1 {
-		return false
-	}
-	return true
-}
-
-// MinimockUpdatePipelineRunStatsInspect logs each unmet expectation
-func (m *RepositoryMock) MinimockUpdatePipelineRunStatsInspect() {
-	for _, e := range m.UpdatePipelineRunStatsMock.expectations {
-		if mm_atomic.LoadUint64(&e.Counter) < 1 {
-			m.t.Errorf("Expected call to RepositoryMock.UpdatePipelineRunStats with params: %#v", *e.params)
-		}
-	}
-
-	// if default expectation was set then invocations count should be greater than zero
-	if m.UpdatePipelineRunStatsMock.defaultExpectation != nil && mm_atomic.LoadUint64(&m.afterUpdatePipelineRunStatsCounter) < 1 {
-		if m.UpdatePipelineRunStatsMock.defaultExpectation.params == nil {
-			m.t.Error("Expected call to RepositoryMock.UpdatePipelineRunStats")
-		} else {
-			m.t.Errorf("Expected call to RepositoryMock.UpdatePipelineRunStats with params: %#v", *m.UpdatePipelineRunStatsMock.defaultExpectation.params)
-		}
-	}
-	// if func was set then invocations count should be greater than zero
-	if m.funcUpdatePipelineRunStats != nil && mm_atomic.LoadUint64(&m.afterUpdatePipelineRunStatsCounter) < 1 {
-		m.t.Error("Expected call to RepositoryMock.UpdatePipelineRunStats")
-	}
-}
-
 type mRepositoryMockUpsertComponentDefinition struct {
 	optional           bool
 	mock               *RepositoryMock
@@ -12979,8 +12754,6 @@ func (m *RepositoryMock) MinimockFinish() {
 
 			m.MinimockUpdateNamespaceSecretByIDInspect()
 
-			m.MinimockUpdatePipelineRunStatsInspect()
-
 			m.MinimockUpsertComponentDefinitionInspect()
 			m.t.FailNow()
 		}
@@ -13038,6 +12811,5 @@ func (m *RepositoryMock) minimockDone() bool {
 		m.MinimockUpdateNamespacePipelineReleaseByIDDone() &&
 		m.MinimockUpdateNamespacePipelineReleaseIDByIDDone() &&
 		m.MinimockUpdateNamespaceSecretByIDDone() &&
-		m.MinimockUpdatePipelineRunStatsDone() &&
 		m.MinimockUpsertComponentDefinitionDone()
 }

--- a/pkg/service/convert.go
+++ b/pkg/service/convert.go
@@ -1056,14 +1056,14 @@ func (c *converter) ConvertOwnerPermalinkToName(ctx context.Context, permalink s
 	}
 
 	if nsType == "users" {
-		userResp, err := c.mgmtPrivateServiceClient.LookUpUserAdmin(ctx, &mgmtpb.LookUpUserAdminRequest{Permalink: permalink})
+		userResp, err := c.mgmtPrivateServiceClient.LookUpUserAdmin(ctx, &mgmtpb.LookUpUserAdminRequest{UserUid: uid})
 		if err != nil {
 			return "", fmt.Errorf("ConvertNamespaceToOwnerPath error")
 		}
 		c.redisClient.Set(ctx, key, userResp.User.Id, 24*time.Hour)
 		return fmt.Sprintf("users/%s", userResp.User.Id), nil
 	} else {
-		orgResp, err := c.mgmtPrivateServiceClient.LookUpOrganizationAdmin(ctx, &mgmtpb.LookUpOrganizationAdminRequest{Permalink: permalink})
+		orgResp, err := c.mgmtPrivateServiceClient.LookUpOrganizationAdmin(ctx, &mgmtpb.LookUpOrganizationAdminRequest{OrganizationUid: uid})
 		if err != nil {
 			return "", fmt.Errorf("ConvertNamespaceToOwnerPath error")
 		}
@@ -1081,9 +1081,10 @@ func (c *converter) fetchOwnerByPermalink(ctx context.Context, permalink string)
 			return owner, nil
 		}
 	}
+	uid := strings.Split(permalink, "/")[1]
 
 	if strings.HasPrefix(permalink, "users") {
-		resp, err := c.mgmtPrivateServiceClient.LookUpUserAdmin(ctx, &mgmtpb.LookUpUserAdminRequest{Permalink: permalink})
+		resp, err := c.mgmtPrivateServiceClient.LookUpUserAdmin(ctx, &mgmtpb.LookUpUserAdminRequest{UserUid: uid})
 		if err != nil {
 			return nil, fmt.Errorf("fetchOwnerByPermalink error")
 		}
@@ -1093,7 +1094,7 @@ func (c *converter) fetchOwnerByPermalink(ctx context.Context, permalink string)
 		}
 		return owner, nil
 	} else {
-		resp, err := c.mgmtPrivateServiceClient.LookUpOrganizationAdmin(ctx, &mgmtpb.LookUpOrganizationAdminRequest{Permalink: permalink})
+		resp, err := c.mgmtPrivateServiceClient.LookUpOrganizationAdmin(ctx, &mgmtpb.LookUpOrganizationAdminRequest{OrganizationUid: uid})
 		if err != nil {
 			return nil, fmt.Errorf("fetchOwnerByPermalink error")
 		}
@@ -1118,14 +1119,14 @@ func (c *converter) ConvertOwnerNameToPermalink(ctx context.Context, name string
 	}
 
 	if nsType == "users" {
-		userResp, err := c.mgmtPrivateServiceClient.GetUserAdmin(ctx, &mgmtpb.GetUserAdminRequest{Name: name})
+		userResp, err := c.mgmtPrivateServiceClient.GetUserAdmin(ctx, &mgmtpb.GetUserAdminRequest{UserId: id})
 		if err != nil {
 			return "", fmt.Errorf("convertOwnerNameToPermalink error %w", err)
 		}
 		c.redisClient.Set(ctx, key, *userResp.User.Uid, 24*time.Hour)
 		return fmt.Sprintf("users/%s", *userResp.User.Uid), nil
 	} else {
-		orgResp, err := c.mgmtPrivateServiceClient.GetOrganizationAdmin(ctx, &mgmtpb.GetOrganizationAdminRequest{Name: name})
+		orgResp, err := c.mgmtPrivateServiceClient.GetOrganizationAdmin(ctx, &mgmtpb.GetOrganizationAdminRequest{OrganizationId: id})
 		if err != nil {
 			return "", fmt.Errorf("convertOwnerNameToPermalink error %w", err)
 		}

--- a/pkg/usage/usage.go
+++ b/pkg/usage/usage.go
@@ -50,7 +50,7 @@ func NewUsage(ctx context.Context, r repository.Repository, mu mgmtPB.MgmtPrivat
 	}
 
 	var defaultOwnerUID string
-	if resp, err := mu.GetUserAdmin(ctx, &mgmtPB.GetUserAdminRequest{Name: constant.DefaultUserID}); err == nil {
+	if resp, err := mu.GetUserAdmin(ctx, &mgmtPB.GetUserAdminRequest{UserId: constant.DefaultUserID}); err == nil {
 		defaultOwnerUID = resp.GetUser().GetUid()
 	} else {
 		logger.Error(err.Error())
@@ -376,7 +376,7 @@ func (u *usage) StartReporter(ctx context.Context) {
 	logger, _ := logger.GetZapLogger(ctx)
 
 	var defaultOwnerUID string
-	if resp, err := u.mgmtPrivateServiceClient.GetUserAdmin(ctx, &mgmtPB.GetUserAdminRequest{Name: constant.DefaultUserID}); err == nil {
+	if resp, err := u.mgmtPrivateServiceClient.GetUserAdmin(ctx, &mgmtPB.GetUserAdminRequest{UserId: constant.DefaultUserID}); err == nil {
 		defaultOwnerUID = resp.GetUser().GetUid()
 	} else {
 		logger.Error(err.Error())
@@ -404,7 +404,7 @@ func (u *usage) TriggerSingleReporter(ctx context.Context) {
 	logger, _ := logger.GetZapLogger(ctx)
 
 	var defaultOwnerUID string
-	if resp, err := u.mgmtPrivateServiceClient.GetUserAdmin(ctx, &mgmtPB.GetUserAdminRequest{Name: constant.DefaultUserID}); err == nil {
+	if resp, err := u.mgmtPrivateServiceClient.GetUserAdmin(ctx, &mgmtPB.GetUserAdminRequest{UserId: constant.DefaultUserID}); err == nil {
 		defaultOwnerUID = resp.GetUser().GetUid()
 	} else {
 		logger.Error(err.Error())


### PR DESCRIPTION
Because

- Previously, we used a general `name` parameter in request parameters, e.g., `{name=users/*}`, which was ambiguous.

This commit

- Uses explicit `user_id` and `organization_id` in request parameters.
- Removes unnecessary environment variables.