### PR TITLE
feat: implement namespace endpoints

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/iancoleman/strcase v0.3.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
 	github.com/instill-ai/component v0.23.0-beta
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240724130416-27b3d8e33885
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240725032116-214c51b2e3bc
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha
 	github.com/jackc/pgx/v5 v5.5.5

--- a/go.sum
+++ b/go.sum
@@ -1204,8 +1204,8 @@ github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
 github.com/instill-ai/component v0.23.0-beta h1:NQB8Lvsb0Z4zu/5ULKvR2Wp48Wie7cxrh+1skfyfNh8=
 github.com/instill-ai/component v0.23.0-beta/go.mod h1:XBn0j9R7H/iAhr2OSCefxO8FDqOCzhxuZ/uILVcBSho=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240724130416-27b3d8e33885 h1:z8/nJ9DqF+qc/uPsd0+Bg2gD4+6/SR+HT/mkAu0hsAE=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240724130416-27b3d8e33885/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240725032116-214c51b2e3bc h1:Lqeu0CKe/XZiK8RxHQXcBGKqtz+e3ITpPkyq1WwQvOQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240725032116-214c51b2e3bc/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a/go.mod h1:EpX3Yr661uWULtZf5UnJHfr5rw2PDyX8ku4Kx0UtYFw=
 github.com/instill-ai/x v0.4.0-alpha h1:zQV2VLbSHjMv6gyBN/2mwwrvWk0/mJM6ZKS12AzjfQg=

--- a/pkg/handler/fieldannotation.go
+++ b/pkg/handler/fieldannotation.go
@@ -3,8 +3,8 @@ package handler
 // *RequiredFields are Protobuf message fields with REQUIRED field_behavior annotation
 var createPipelineRequiredFields = []string{}
 var lookUpPipelineRequiredFields = []string{"permalink"}
-var renamePipelineRequiredFields = []string{"name", "new_pipeline_id"}
-var triggerPipelineRequiredFields = []string{"name", "data"}
+var renamePipelineRequiredFields = []string{"pipeline_id", "new_pipeline_id"}
+var triggerPipelineRequiredFields = []string{"pipeline_id", "data"}
 
 // immutableFields are Protobuf message fields with IMMUTABLE field_behavior annotation
 var immutablePipelineFields = []string{"id"}
@@ -13,7 +13,7 @@ var immutablePipelineFields = []string{"id"}
 var outputOnlyPipelineFields = []string{"name", "uid", "owner", "create_time", "update_time"}
 
 var releaseCreateRequiredFields = []string{}
-var releaseRenameRequiredFields = []string{"name", "new_pipeline_release_id"}
+var releaseRenameRequiredFields = []string{"pipeline_id", "new_pipeline_release_id"}
 
 // outputOnlyFields are Protobuf message fields with OUTPUT_ONLY field_behavior annotation
 var releaseOutputOnlyFields = []string{"name", "uid", "create_time", "update_time"}

--- a/pkg/handler/main.go
+++ b/pkg/handler/main.go
@@ -33,7 +33,13 @@ type Streamer interface {
 }
 
 type TriggerPipelineRequestInterface interface {
-	GetName() string
+	GetNamespaceId() string
+	GetPipelineId() string
+}
+type TriggerPipelineReleaseRequestInterface interface {
+	GetNamespaceId() string
+	GetPipelineId() string
+	GetReleaseId() string
 }
 
 // NewPublicHandler initiates a handler instance
@@ -95,7 +101,7 @@ func (h *PrivateHandler) SetService(s service.Service) {
 func (h *PublicHandler) CheckName(ctx context.Context, req *pipelinepb.CheckNameRequest) (resp *pipelinepb.CheckNameResponse, err error) {
 	name := req.GetName()
 
-	ns, id, err := h.service.GetRscNamespaceAndNameID(ctx, name)
+	ns, err := h.service.GetRscNamespace(ctx, name)
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +111,7 @@ func (h *PublicHandler) CheckName(ctx context.Context, req *pipelinepb.CheckName
 	rscType := strings.Split(name, "/")[2]
 
 	if rscType == "pipelines" {
-		_, err := h.service.GetNamespacePipelineByID(ctx, ns, id, pipelinepb.Pipeline_VIEW_BASIC)
+		_, err := h.service.GetNamespacePipelineByID(ctx, ns, name, pipelinepb.Pipeline_VIEW_BASIC)
 		if err != nil && errors.Is(err, errdomain.ErrNotFound) {
 			return &pipelinepb.CheckNameResponse{
 				Availability: pipelinepb.CheckNameResponse_NAME_AVAILABLE,

--- a/pkg/handler/utils.go
+++ b/pkg/handler/utils.go
@@ -6,7 +6,6 @@ import (
 	"github.com/instill-ai/pipeline-backend/pkg/constant"
 	"github.com/instill-ai/pipeline-backend/pkg/resource"
 	"github.com/instill-ai/pipeline-backend/pkg/service"
-	// pb "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
 
 func authenticateUser(ctx context.Context, allowVisitor bool) error {

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -155,19 +155,19 @@ func HandleProfileImage(srv service.Service, repo repository.Repository) runtime
 	return runtime.HandlerFunc(func(w http.ResponseWriter, r *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 		defer cancel()
-		if v, ok := pathParams["name"]; !ok || len(strings.Split(v, "/")) < 4 {
+		if v, ok := pathParams["namespaceID"]; !ok || len(strings.Split(v, "/")) < 4 {
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}
 
-		ns, id, err := srv.GetRscNamespaceAndNameID(ctx, pathParams["name"])
+		ns, err := srv.GetRscNamespace(ctx, pathParams["namespaceID"])
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
 
 		profileImageBase64 := ""
-		dbModel, err := repo.GetNamespacePipelineByID(ctx, ns.Permalink(), id, true, true)
+		dbModel, err := repo.GetNamespacePipelineByID(ctx, ns.Permalink(), ns.NsID, true, true)
 		if err != nil {
 			w.WriteHeader(http.StatusNotFound)
 			return

--- a/pkg/mock/mgmt_private_service_client_mock.gen.go
+++ b/pkg/mock/mgmt_private_service_client_mock.gen.go
@@ -24,6 +24,12 @@ type MgmtPrivateServiceClientMock struct {
 	beforeCheckNamespaceAdminCounter uint64
 	CheckNamespaceAdminMock          mMgmtPrivateServiceClientMockCheckNamespaceAdmin
 
+	funcCheckNamespaceByUIDAdmin          func(ctx context.Context, in *mm_mgmtv1beta.CheckNamespaceByUIDAdminRequest, opts ...grpc.CallOption) (cp1 *mm_mgmtv1beta.CheckNamespaceByUIDAdminResponse, err error)
+	inspectFuncCheckNamespaceByUIDAdmin   func(ctx context.Context, in *mm_mgmtv1beta.CheckNamespaceByUIDAdminRequest, opts ...grpc.CallOption)
+	afterCheckNamespaceByUIDAdminCounter  uint64
+	beforeCheckNamespaceByUIDAdminCounter uint64
+	CheckNamespaceByUIDAdminMock          mMgmtPrivateServiceClientMockCheckNamespaceByUIDAdmin
+
 	funcGetOrganizationAdmin          func(ctx context.Context, in *mm_mgmtv1beta.GetOrganizationAdminRequest, opts ...grpc.CallOption) (gp1 *mm_mgmtv1beta.GetOrganizationAdminResponse, err error)
 	inspectFuncGetOrganizationAdmin   func(ctx context.Context, in *mm_mgmtv1beta.GetOrganizationAdminRequest, opts ...grpc.CallOption)
 	afterGetOrganizationAdminCounter  uint64
@@ -95,6 +101,9 @@ func NewMgmtPrivateServiceClientMock(t minimock.Tester) *MgmtPrivateServiceClien
 
 	m.CheckNamespaceAdminMock = mMgmtPrivateServiceClientMockCheckNamespaceAdmin{mock: m}
 	m.CheckNamespaceAdminMock.callArgs = []*MgmtPrivateServiceClientMockCheckNamespaceAdminParams{}
+
+	m.CheckNamespaceByUIDAdminMock = mMgmtPrivateServiceClientMockCheckNamespaceByUIDAdmin{mock: m}
+	m.CheckNamespaceByUIDAdminMock.callArgs = []*MgmtPrivateServiceClientMockCheckNamespaceByUIDAdminParams{}
 
 	m.GetOrganizationAdminMock = mMgmtPrivateServiceClientMockGetOrganizationAdmin{mock: m}
 	m.GetOrganizationAdminMock.callArgs = []*MgmtPrivateServiceClientMockGetOrganizationAdminParams{}
@@ -477,6 +486,355 @@ func (m *MgmtPrivateServiceClientMock) MinimockCheckNamespaceAdminInspect() {
 	if !m.CheckNamespaceAdminMock.invocationsDone() && afterCheckNamespaceAdminCounter > 0 {
 		m.t.Errorf("Expected %d calls to MgmtPrivateServiceClientMock.CheckNamespaceAdmin but found %d calls",
 			mm_atomic.LoadUint64(&m.CheckNamespaceAdminMock.expectedInvocations), afterCheckNamespaceAdminCounter)
+	}
+}
+
+type mMgmtPrivateServiceClientMockCheckNamespaceByUIDAdmin struct {
+	optional           bool
+	mock               *MgmtPrivateServiceClientMock
+	defaultExpectation *MgmtPrivateServiceClientMockCheckNamespaceByUIDAdminExpectation
+	expectations       []*MgmtPrivateServiceClientMockCheckNamespaceByUIDAdminExpectation
+
+	callArgs []*MgmtPrivateServiceClientMockCheckNamespaceByUIDAdminParams
+	mutex    sync.RWMutex
+
+	expectedInvocations uint64
+}
+
+// MgmtPrivateServiceClientMockCheckNamespaceByUIDAdminExpectation specifies expectation struct of the MgmtPrivateServiceClient.CheckNamespaceByUIDAdmin
+type MgmtPrivateServiceClientMockCheckNamespaceByUIDAdminExpectation struct {
+	mock      *MgmtPrivateServiceClientMock
+	params    *MgmtPrivateServiceClientMockCheckNamespaceByUIDAdminParams
+	paramPtrs *MgmtPrivateServiceClientMockCheckNamespaceByUIDAdminParamPtrs
+	results   *MgmtPrivateServiceClientMockCheckNamespaceByUIDAdminResults
+	Counter   uint64
+}
+
+// MgmtPrivateServiceClientMockCheckNamespaceByUIDAdminParams contains parameters of the MgmtPrivateServiceClient.CheckNamespaceByUIDAdmin
+type MgmtPrivateServiceClientMockCheckNamespaceByUIDAdminParams struct {
+	ctx  context.Context
+	in   *mm_mgmtv1beta.CheckNamespaceByUIDAdminRequest
+	opts []grpc.CallOption
+}
+
+// MgmtPrivateServiceClientMockCheckNamespaceByUIDAdminParamPtrs contains pointers to parameters of the MgmtPrivateServiceClient.CheckNamespaceByUIDAdmin
+type MgmtPrivateServiceClientMockCheckNamespaceByUIDAdminParamPtrs struct {
+	ctx  *context.Context
+	in   **mm_mgmtv1beta.CheckNamespaceByUIDAdminRequest
+	opts *[]grpc.CallOption
+}
+
+// MgmtPrivateServiceClientMockCheckNamespaceByUIDAdminResults contains results of the MgmtPrivateServiceClient.CheckNamespaceByUIDAdmin
+type MgmtPrivateServiceClientMockCheckNamespaceByUIDAdminResults struct {
+	cp1 *mm_mgmtv1beta.CheckNamespaceByUIDAdminResponse
+	err error
+}
+
+// Marks this method to be optional. The default behavior of any method with Return() is '1 or more', meaning
+// the test will fail minimock's automatic final call check if the mocked method was not called at least once.
+// Optional() makes method check to work in '0 or more' mode.
+// It is NOT RECOMMENDED to use this option by default unless you really need it, as it helps to
+// catch the problems when the expected method call is totally skipped during test run.
+func (mmCheckNamespaceByUIDAdmin *mMgmtPrivateServiceClientMockCheckNamespaceByUIDAdmin) Optional() *mMgmtPrivateServiceClientMockCheckNamespaceByUIDAdmin {
+	mmCheckNamespaceByUIDAdmin.optional = true
+	return mmCheckNamespaceByUIDAdmin
+}
+
+// Expect sets up expected params for MgmtPrivateServiceClient.CheckNamespaceByUIDAdmin
+func (mmCheckNamespaceByUIDAdmin *mMgmtPrivateServiceClientMockCheckNamespaceByUIDAdmin) Expect(ctx context.Context, in *mm_mgmtv1beta.CheckNamespaceByUIDAdminRequest, opts ...grpc.CallOption) *mMgmtPrivateServiceClientMockCheckNamespaceByUIDAdmin {
+	if mmCheckNamespaceByUIDAdmin.mock.funcCheckNamespaceByUIDAdmin != nil {
+		mmCheckNamespaceByUIDAdmin.mock.t.Fatalf("MgmtPrivateServiceClientMock.CheckNamespaceByUIDAdmin mock is already set by Set")
+	}
+
+	if mmCheckNamespaceByUIDAdmin.defaultExpectation == nil {
+		mmCheckNamespaceByUIDAdmin.defaultExpectation = &MgmtPrivateServiceClientMockCheckNamespaceByUIDAdminExpectation{}
+	}
+
+	if mmCheckNamespaceByUIDAdmin.defaultExpectation.paramPtrs != nil {
+		mmCheckNamespaceByUIDAdmin.mock.t.Fatalf("MgmtPrivateServiceClientMock.CheckNamespaceByUIDAdmin mock is already set by ExpectParams functions")
+	}
+
+	mmCheckNamespaceByUIDAdmin.defaultExpectation.params = &MgmtPrivateServiceClientMockCheckNamespaceByUIDAdminParams{ctx, in, opts}
+	for _, e := range mmCheckNamespaceByUIDAdmin.expectations {
+		if minimock.Equal(e.params, mmCheckNamespaceByUIDAdmin.defaultExpectation.params) {
+			mmCheckNamespaceByUIDAdmin.mock.t.Fatalf("Expectation set by When has same params: %#v", *mmCheckNamespaceByUIDAdmin.defaultExpectation.params)
+		}
+	}
+
+	return mmCheckNamespaceByUIDAdmin
+}
+
+// ExpectCtxParam1 sets up expected param ctx for MgmtPrivateServiceClient.CheckNamespaceByUIDAdmin
+func (mmCheckNamespaceByUIDAdmin *mMgmtPrivateServiceClientMockCheckNamespaceByUIDAdmin) ExpectCtxParam1(ctx context.Context) *mMgmtPrivateServiceClientMockCheckNamespaceByUIDAdmin {
+	if mmCheckNamespaceByUIDAdmin.mock.funcCheckNamespaceByUIDAdmin != nil {
+		mmCheckNamespaceByUIDAdmin.mock.t.Fatalf("MgmtPrivateServiceClientMock.CheckNamespaceByUIDAdmin mock is already set by Set")
+	}
+
+	if mmCheckNamespaceByUIDAdmin.defaultExpectation == nil {
+		mmCheckNamespaceByUIDAdmin.defaultExpectation = &MgmtPrivateServiceClientMockCheckNamespaceByUIDAdminExpectation{}
+	}
+
+	if mmCheckNamespaceByUIDAdmin.defaultExpectation.params != nil {
+		mmCheckNamespaceByUIDAdmin.mock.t.Fatalf("MgmtPrivateServiceClientMock.CheckNamespaceByUIDAdmin mock is already set by Expect")
+	}
+
+	if mmCheckNamespaceByUIDAdmin.defaultExpectation.paramPtrs == nil {
+		mmCheckNamespaceByUIDAdmin.defaultExpectation.paramPtrs = &MgmtPrivateServiceClientMockCheckNamespaceByUIDAdminParamPtrs{}
+	}
+	mmCheckNamespaceByUIDAdmin.defaultExpectation.paramPtrs.ctx = &ctx
+
+	return mmCheckNamespaceByUIDAdmin
+}
+
+// ExpectInParam2 sets up expected param in for MgmtPrivateServiceClient.CheckNamespaceByUIDAdmin
+func (mmCheckNamespaceByUIDAdmin *mMgmtPrivateServiceClientMockCheckNamespaceByUIDAdmin) ExpectInParam2(in *mm_mgmtv1beta.CheckNamespaceByUIDAdminRequest) *mMgmtPrivateServiceClientMockCheckNamespaceByUIDAdmin {
+	if mmCheckNamespaceByUIDAdmin.mock.funcCheckNamespaceByUIDAdmin != nil {
+		mmCheckNamespaceByUIDAdmin.mock.t.Fatalf("MgmtPrivateServiceClientMock.CheckNamespaceByUIDAdmin mock is already set by Set")
+	}
+
+	if mmCheckNamespaceByUIDAdmin.defaultExpectation == nil {
+		mmCheckNamespaceByUIDAdmin.defaultExpectation = &MgmtPrivateServiceClientMockCheckNamespaceByUIDAdminExpectation{}
+	}
+
+	if mmCheckNamespaceByUIDAdmin.defaultExpectation.params != nil {
+		mmCheckNamespaceByUIDAdmin.mock.t.Fatalf("MgmtPrivateServiceClientMock.CheckNamespaceByUIDAdmin mock is already set by Expect")
+	}
+
+	if mmCheckNamespaceByUIDAdmin.defaultExpectation.paramPtrs == nil {
+		mmCheckNamespaceByUIDAdmin.defaultExpectation.paramPtrs = &MgmtPrivateServiceClientMockCheckNamespaceByUIDAdminParamPtrs{}
+	}
+	mmCheckNamespaceByUIDAdmin.defaultExpectation.paramPtrs.in = &in
+
+	return mmCheckNamespaceByUIDAdmin
+}
+
+// ExpectOptsParam3 sets up expected param opts for MgmtPrivateServiceClient.CheckNamespaceByUIDAdmin
+func (mmCheckNamespaceByUIDAdmin *mMgmtPrivateServiceClientMockCheckNamespaceByUIDAdmin) ExpectOptsParam3(opts ...grpc.CallOption) *mMgmtPrivateServiceClientMockCheckNamespaceByUIDAdmin {
+	if mmCheckNamespaceByUIDAdmin.mock.funcCheckNamespaceByUIDAdmin != nil {
+		mmCheckNamespaceByUIDAdmin.mock.t.Fatalf("MgmtPrivateServiceClientMock.CheckNamespaceByUIDAdmin mock is already set by Set")
+	}
+
+	if mmCheckNamespaceByUIDAdmin.defaultExpectation == nil {
+		mmCheckNamespaceByUIDAdmin.defaultExpectation = &MgmtPrivateServiceClientMockCheckNamespaceByUIDAdminExpectation{}
+	}
+
+	if mmCheckNamespaceByUIDAdmin.defaultExpectation.params != nil {
+		mmCheckNamespaceByUIDAdmin.mock.t.Fatalf("MgmtPrivateServiceClientMock.CheckNamespaceByUIDAdmin mock is already set by Expect")
+	}
+
+	if mmCheckNamespaceByUIDAdmin.defaultExpectation.paramPtrs == nil {
+		mmCheckNamespaceByUIDAdmin.defaultExpectation.paramPtrs = &MgmtPrivateServiceClientMockCheckNamespaceByUIDAdminParamPtrs{}
+	}
+	mmCheckNamespaceByUIDAdmin.defaultExpectation.paramPtrs.opts = &opts
+
+	return mmCheckNamespaceByUIDAdmin
+}
+
+// Inspect accepts an inspector function that has same arguments as the MgmtPrivateServiceClient.CheckNamespaceByUIDAdmin
+func (mmCheckNamespaceByUIDAdmin *mMgmtPrivateServiceClientMockCheckNamespaceByUIDAdmin) Inspect(f func(ctx context.Context, in *mm_mgmtv1beta.CheckNamespaceByUIDAdminRequest, opts ...grpc.CallOption)) *mMgmtPrivateServiceClientMockCheckNamespaceByUIDAdmin {
+	if mmCheckNamespaceByUIDAdmin.mock.inspectFuncCheckNamespaceByUIDAdmin != nil {
+		mmCheckNamespaceByUIDAdmin.mock.t.Fatalf("Inspect function is already set for MgmtPrivateServiceClientMock.CheckNamespaceByUIDAdmin")
+	}
+
+	mmCheckNamespaceByUIDAdmin.mock.inspectFuncCheckNamespaceByUIDAdmin = f
+
+	return mmCheckNamespaceByUIDAdmin
+}
+
+// Return sets up results that will be returned by MgmtPrivateServiceClient.CheckNamespaceByUIDAdmin
+func (mmCheckNamespaceByUIDAdmin *mMgmtPrivateServiceClientMockCheckNamespaceByUIDAdmin) Return(cp1 *mm_mgmtv1beta.CheckNamespaceByUIDAdminResponse, err error) *MgmtPrivateServiceClientMock {
+	if mmCheckNamespaceByUIDAdmin.mock.funcCheckNamespaceByUIDAdmin != nil {
+		mmCheckNamespaceByUIDAdmin.mock.t.Fatalf("MgmtPrivateServiceClientMock.CheckNamespaceByUIDAdmin mock is already set by Set")
+	}
+
+	if mmCheckNamespaceByUIDAdmin.defaultExpectation == nil {
+		mmCheckNamespaceByUIDAdmin.defaultExpectation = &MgmtPrivateServiceClientMockCheckNamespaceByUIDAdminExpectation{mock: mmCheckNamespaceByUIDAdmin.mock}
+	}
+	mmCheckNamespaceByUIDAdmin.defaultExpectation.results = &MgmtPrivateServiceClientMockCheckNamespaceByUIDAdminResults{cp1, err}
+	return mmCheckNamespaceByUIDAdmin.mock
+}
+
+// Set uses given function f to mock the MgmtPrivateServiceClient.CheckNamespaceByUIDAdmin method
+func (mmCheckNamespaceByUIDAdmin *mMgmtPrivateServiceClientMockCheckNamespaceByUIDAdmin) Set(f func(ctx context.Context, in *mm_mgmtv1beta.CheckNamespaceByUIDAdminRequest, opts ...grpc.CallOption) (cp1 *mm_mgmtv1beta.CheckNamespaceByUIDAdminResponse, err error)) *MgmtPrivateServiceClientMock {
+	if mmCheckNamespaceByUIDAdmin.defaultExpectation != nil {
+		mmCheckNamespaceByUIDAdmin.mock.t.Fatalf("Default expectation is already set for the MgmtPrivateServiceClient.CheckNamespaceByUIDAdmin method")
+	}
+
+	if len(mmCheckNamespaceByUIDAdmin.expectations) > 0 {
+		mmCheckNamespaceByUIDAdmin.mock.t.Fatalf("Some expectations are already set for the MgmtPrivateServiceClient.CheckNamespaceByUIDAdmin method")
+	}
+
+	mmCheckNamespaceByUIDAdmin.mock.funcCheckNamespaceByUIDAdmin = f
+	return mmCheckNamespaceByUIDAdmin.mock
+}
+
+// When sets expectation for the MgmtPrivateServiceClient.CheckNamespaceByUIDAdmin which will trigger the result defined by the following
+// Then helper
+func (mmCheckNamespaceByUIDAdmin *mMgmtPrivateServiceClientMockCheckNamespaceByUIDAdmin) When(ctx context.Context, in *mm_mgmtv1beta.CheckNamespaceByUIDAdminRequest, opts ...grpc.CallOption) *MgmtPrivateServiceClientMockCheckNamespaceByUIDAdminExpectation {
+	if mmCheckNamespaceByUIDAdmin.mock.funcCheckNamespaceByUIDAdmin != nil {
+		mmCheckNamespaceByUIDAdmin.mock.t.Fatalf("MgmtPrivateServiceClientMock.CheckNamespaceByUIDAdmin mock is already set by Set")
+	}
+
+	expectation := &MgmtPrivateServiceClientMockCheckNamespaceByUIDAdminExpectation{
+		mock:   mmCheckNamespaceByUIDAdmin.mock,
+		params: &MgmtPrivateServiceClientMockCheckNamespaceByUIDAdminParams{ctx, in, opts},
+	}
+	mmCheckNamespaceByUIDAdmin.expectations = append(mmCheckNamespaceByUIDAdmin.expectations, expectation)
+	return expectation
+}
+
+// Then sets up MgmtPrivateServiceClient.CheckNamespaceByUIDAdmin return parameters for the expectation previously defined by the When method
+func (e *MgmtPrivateServiceClientMockCheckNamespaceByUIDAdminExpectation) Then(cp1 *mm_mgmtv1beta.CheckNamespaceByUIDAdminResponse, err error) *MgmtPrivateServiceClientMock {
+	e.results = &MgmtPrivateServiceClientMockCheckNamespaceByUIDAdminResults{cp1, err}
+	return e.mock
+}
+
+// Times sets number of times MgmtPrivateServiceClient.CheckNamespaceByUIDAdmin should be invoked
+func (mmCheckNamespaceByUIDAdmin *mMgmtPrivateServiceClientMockCheckNamespaceByUIDAdmin) Times(n uint64) *mMgmtPrivateServiceClientMockCheckNamespaceByUIDAdmin {
+	if n == 0 {
+		mmCheckNamespaceByUIDAdmin.mock.t.Fatalf("Times of MgmtPrivateServiceClientMock.CheckNamespaceByUIDAdmin mock can not be zero")
+	}
+	mm_atomic.StoreUint64(&mmCheckNamespaceByUIDAdmin.expectedInvocations, n)
+	return mmCheckNamespaceByUIDAdmin
+}
+
+func (mmCheckNamespaceByUIDAdmin *mMgmtPrivateServiceClientMockCheckNamespaceByUIDAdmin) invocationsDone() bool {
+	if len(mmCheckNamespaceByUIDAdmin.expectations) == 0 && mmCheckNamespaceByUIDAdmin.defaultExpectation == nil && mmCheckNamespaceByUIDAdmin.mock.funcCheckNamespaceByUIDAdmin == nil {
+		return true
+	}
+
+	totalInvocations := mm_atomic.LoadUint64(&mmCheckNamespaceByUIDAdmin.mock.afterCheckNamespaceByUIDAdminCounter)
+	expectedInvocations := mm_atomic.LoadUint64(&mmCheckNamespaceByUIDAdmin.expectedInvocations)
+
+	return totalInvocations > 0 && (expectedInvocations == 0 || expectedInvocations == totalInvocations)
+}
+
+// CheckNamespaceByUIDAdmin implements mgmtv1beta.MgmtPrivateServiceClient
+func (mmCheckNamespaceByUIDAdmin *MgmtPrivateServiceClientMock) CheckNamespaceByUIDAdmin(ctx context.Context, in *mm_mgmtv1beta.CheckNamespaceByUIDAdminRequest, opts ...grpc.CallOption) (cp1 *mm_mgmtv1beta.CheckNamespaceByUIDAdminResponse, err error) {
+	mm_atomic.AddUint64(&mmCheckNamespaceByUIDAdmin.beforeCheckNamespaceByUIDAdminCounter, 1)
+	defer mm_atomic.AddUint64(&mmCheckNamespaceByUIDAdmin.afterCheckNamespaceByUIDAdminCounter, 1)
+
+	if mmCheckNamespaceByUIDAdmin.inspectFuncCheckNamespaceByUIDAdmin != nil {
+		mmCheckNamespaceByUIDAdmin.inspectFuncCheckNamespaceByUIDAdmin(ctx, in, opts...)
+	}
+
+	mm_params := MgmtPrivateServiceClientMockCheckNamespaceByUIDAdminParams{ctx, in, opts}
+
+	// Record call args
+	mmCheckNamespaceByUIDAdmin.CheckNamespaceByUIDAdminMock.mutex.Lock()
+	mmCheckNamespaceByUIDAdmin.CheckNamespaceByUIDAdminMock.callArgs = append(mmCheckNamespaceByUIDAdmin.CheckNamespaceByUIDAdminMock.callArgs, &mm_params)
+	mmCheckNamespaceByUIDAdmin.CheckNamespaceByUIDAdminMock.mutex.Unlock()
+
+	for _, e := range mmCheckNamespaceByUIDAdmin.CheckNamespaceByUIDAdminMock.expectations {
+		if minimock.Equal(*e.params, mm_params) {
+			mm_atomic.AddUint64(&e.Counter, 1)
+			return e.results.cp1, e.results.err
+		}
+	}
+
+	if mmCheckNamespaceByUIDAdmin.CheckNamespaceByUIDAdminMock.defaultExpectation != nil {
+		mm_atomic.AddUint64(&mmCheckNamespaceByUIDAdmin.CheckNamespaceByUIDAdminMock.defaultExpectation.Counter, 1)
+		mm_want := mmCheckNamespaceByUIDAdmin.CheckNamespaceByUIDAdminMock.defaultExpectation.params
+		mm_want_ptrs := mmCheckNamespaceByUIDAdmin.CheckNamespaceByUIDAdminMock.defaultExpectation.paramPtrs
+
+		mm_got := MgmtPrivateServiceClientMockCheckNamespaceByUIDAdminParams{ctx, in, opts}
+
+		if mm_want_ptrs != nil {
+
+			if mm_want_ptrs.ctx != nil && !minimock.Equal(*mm_want_ptrs.ctx, mm_got.ctx) {
+				mmCheckNamespaceByUIDAdmin.t.Errorf("MgmtPrivateServiceClientMock.CheckNamespaceByUIDAdmin got unexpected parameter ctx, want: %#v, got: %#v%s\n", *mm_want_ptrs.ctx, mm_got.ctx, minimock.Diff(*mm_want_ptrs.ctx, mm_got.ctx))
+			}
+
+			if mm_want_ptrs.in != nil && !minimock.Equal(*mm_want_ptrs.in, mm_got.in) {
+				mmCheckNamespaceByUIDAdmin.t.Errorf("MgmtPrivateServiceClientMock.CheckNamespaceByUIDAdmin got unexpected parameter in, want: %#v, got: %#v%s\n", *mm_want_ptrs.in, mm_got.in, minimock.Diff(*mm_want_ptrs.in, mm_got.in))
+			}
+
+			if mm_want_ptrs.opts != nil && !minimock.Equal(*mm_want_ptrs.opts, mm_got.opts) {
+				mmCheckNamespaceByUIDAdmin.t.Errorf("MgmtPrivateServiceClientMock.CheckNamespaceByUIDAdmin got unexpected parameter opts, want: %#v, got: %#v%s\n", *mm_want_ptrs.opts, mm_got.opts, minimock.Diff(*mm_want_ptrs.opts, mm_got.opts))
+			}
+
+		} else if mm_want != nil && !minimock.Equal(*mm_want, mm_got) {
+			mmCheckNamespaceByUIDAdmin.t.Errorf("MgmtPrivateServiceClientMock.CheckNamespaceByUIDAdmin got unexpected parameters, want: %#v, got: %#v%s\n", *mm_want, mm_got, minimock.Diff(*mm_want, mm_got))
+		}
+
+		mm_results := mmCheckNamespaceByUIDAdmin.CheckNamespaceByUIDAdminMock.defaultExpectation.results
+		if mm_results == nil {
+			mmCheckNamespaceByUIDAdmin.t.Fatal("No results are set for the MgmtPrivateServiceClientMock.CheckNamespaceByUIDAdmin")
+		}
+		return (*mm_results).cp1, (*mm_results).err
+	}
+	if mmCheckNamespaceByUIDAdmin.funcCheckNamespaceByUIDAdmin != nil {
+		return mmCheckNamespaceByUIDAdmin.funcCheckNamespaceByUIDAdmin(ctx, in, opts...)
+	}
+	mmCheckNamespaceByUIDAdmin.t.Fatalf("Unexpected call to MgmtPrivateServiceClientMock.CheckNamespaceByUIDAdmin. %v %v %v", ctx, in, opts)
+	return
+}
+
+// CheckNamespaceByUIDAdminAfterCounter returns a count of finished MgmtPrivateServiceClientMock.CheckNamespaceByUIDAdmin invocations
+func (mmCheckNamespaceByUIDAdmin *MgmtPrivateServiceClientMock) CheckNamespaceByUIDAdminAfterCounter() uint64 {
+	return mm_atomic.LoadUint64(&mmCheckNamespaceByUIDAdmin.afterCheckNamespaceByUIDAdminCounter)
+}
+
+// CheckNamespaceByUIDAdminBeforeCounter returns a count of MgmtPrivateServiceClientMock.CheckNamespaceByUIDAdmin invocations
+func (mmCheckNamespaceByUIDAdmin *MgmtPrivateServiceClientMock) CheckNamespaceByUIDAdminBeforeCounter() uint64 {
+	return mm_atomic.LoadUint64(&mmCheckNamespaceByUIDAdmin.beforeCheckNamespaceByUIDAdminCounter)
+}
+
+// Calls returns a list of arguments used in each call to MgmtPrivateServiceClientMock.CheckNamespaceByUIDAdmin.
+// The list is in the same order as the calls were made (i.e. recent calls have a higher index)
+func (mmCheckNamespaceByUIDAdmin *mMgmtPrivateServiceClientMockCheckNamespaceByUIDAdmin) Calls() []*MgmtPrivateServiceClientMockCheckNamespaceByUIDAdminParams {
+	mmCheckNamespaceByUIDAdmin.mutex.RLock()
+
+	argCopy := make([]*MgmtPrivateServiceClientMockCheckNamespaceByUIDAdminParams, len(mmCheckNamespaceByUIDAdmin.callArgs))
+	copy(argCopy, mmCheckNamespaceByUIDAdmin.callArgs)
+
+	mmCheckNamespaceByUIDAdmin.mutex.RUnlock()
+
+	return argCopy
+}
+
+// MinimockCheckNamespaceByUIDAdminDone returns true if the count of the CheckNamespaceByUIDAdmin invocations corresponds
+// the number of defined expectations
+func (m *MgmtPrivateServiceClientMock) MinimockCheckNamespaceByUIDAdminDone() bool {
+	if m.CheckNamespaceByUIDAdminMock.optional {
+		// Optional methods provide '0 or more' call count restriction.
+		return true
+	}
+
+	for _, e := range m.CheckNamespaceByUIDAdminMock.expectations {
+		if mm_atomic.LoadUint64(&e.Counter) < 1 {
+			return false
+		}
+	}
+
+	return m.CheckNamespaceByUIDAdminMock.invocationsDone()
+}
+
+// MinimockCheckNamespaceByUIDAdminInspect logs each unmet expectation
+func (m *MgmtPrivateServiceClientMock) MinimockCheckNamespaceByUIDAdminInspect() {
+	for _, e := range m.CheckNamespaceByUIDAdminMock.expectations {
+		if mm_atomic.LoadUint64(&e.Counter) < 1 {
+			m.t.Errorf("Expected call to MgmtPrivateServiceClientMock.CheckNamespaceByUIDAdmin with params: %#v", *e.params)
+		}
+	}
+
+	afterCheckNamespaceByUIDAdminCounter := mm_atomic.LoadUint64(&m.afterCheckNamespaceByUIDAdminCounter)
+	// if default expectation was set then invocations count should be greater than zero
+	if m.CheckNamespaceByUIDAdminMock.defaultExpectation != nil && afterCheckNamespaceByUIDAdminCounter < 1 {
+		if m.CheckNamespaceByUIDAdminMock.defaultExpectation.params == nil {
+			m.t.Error("Expected call to MgmtPrivateServiceClientMock.CheckNamespaceByUIDAdmin")
+		} else {
+			m.t.Errorf("Expected call to MgmtPrivateServiceClientMock.CheckNamespaceByUIDAdmin with params: %#v", *m.CheckNamespaceByUIDAdminMock.defaultExpectation.params)
+		}
+	}
+	// if func was set then invocations count should be greater than zero
+	if m.funcCheckNamespaceByUIDAdmin != nil && afterCheckNamespaceByUIDAdminCounter < 1 {
+		m.t.Error("Expected call to MgmtPrivateServiceClientMock.CheckNamespaceByUIDAdmin")
+	}
+
+	if !m.CheckNamespaceByUIDAdminMock.invocationsDone() && afterCheckNamespaceByUIDAdminCounter > 0 {
+		m.t.Errorf("Expected %d calls to MgmtPrivateServiceClientMock.CheckNamespaceByUIDAdmin but found %d calls",
+			mm_atomic.LoadUint64(&m.CheckNamespaceByUIDAdminMock.expectedInvocations), afterCheckNamespaceByUIDAdminCounter)
 	}
 }
 
@@ -3976,6 +4334,8 @@ func (m *MgmtPrivateServiceClientMock) MinimockFinish() {
 		if !m.minimockDone() {
 			m.MinimockCheckNamespaceAdminInspect()
 
+			m.MinimockCheckNamespaceByUIDAdminInspect()
+
 			m.MinimockGetOrganizationAdminInspect()
 
 			m.MinimockGetOrganizationSubscriptionAdminInspect()
@@ -4020,6 +4380,7 @@ func (m *MgmtPrivateServiceClientMock) minimockDone() bool {
 	done := true
 	return done &&
 		m.MinimockCheckNamespaceAdminDone() &&
+		m.MinimockCheckNamespaceByUIDAdminDone() &&
 		m.MinimockGetOrganizationAdminDone() &&
 		m.MinimockGetOrganizationSubscriptionAdminDone() &&
 		m.MinimockGetRemainingCreditAdminDone() &&

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -56,6 +56,9 @@ const (
 	Organization NamespaceType = "organizations"
 )
 
+// TODO: We should neutralize the namespace type in the pipeline-backend, as it
+// doesn't matter whether the namespace belongs to a user or organization. This
+// refactor should be completed by August 2024.
 type Namespace struct {
 	NsType NamespaceType
 	NsID   string

--- a/pkg/service/main.go
+++ b/pkg/service/main.go
@@ -63,9 +63,7 @@ type Service interface {
 	GetOperation(ctx context.Context, workflowID string) (*longrunningpb.Operation, error)
 
 	GetCtxUserNamespace(ctx context.Context) (resource.Namespace, error)
-	GetRscNamespaceAndNameID(ctx context.Context, path string) (resource.Namespace, string, error)
-	GetRscNamespaceAndPermalinkUID(ctx context.Context, path string) (resource.Namespace, uuid.UUID, error)
-	GetRscNamespaceAndNameIDAndReleaseID(ctx context.Context, path string) (resource.Namespace, string, string, error)
+	GetRscNamespace(ctx context.Context, namespaceID string) (resource.Namespace, error)
 
 	ListComponentDefinitions(context.Context, *pb.ListComponentDefinitionsRequest) (*pb.ListComponentDefinitionsResponse, error)
 	ListOperatorDefinitions(context.Context, *pb.ListOperatorDefinitionsRequest) (*pb.ListOperatorDefinitionsResponse, error)

--- a/pkg/service/utils.go
+++ b/pkg/service/utils.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/instill-ai/pipeline-backend/pkg/constant"
 	"github.com/instill-ai/pipeline-backend/pkg/resource"
+	mgmtpb "github.com/instill-ai/protogen-go/core/mgmt/v1beta"
 
 	errdomain "github.com/instill-ai/pipeline-backend/pkg/errors"
 )
@@ -64,80 +65,26 @@ func (s *service) GetCtxUserNamespace(ctx context.Context) (resource.Namespace, 
 		NsUID:  uid,
 	}, nil
 }
-func (s *service) GetRscNamespaceAndNameID(ctx context.Context, path string) (resource.Namespace, string, error) {
+func (s *service) GetRscNamespace(ctx context.Context, namespaceID string) (resource.Namespace, error) {
 
-	if strings.HasPrefix(path, "user/") {
-
-		uid := uuid.FromStringOrNil(resource.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey))
-		splits := strings.Split(path, "/")
-
-		name, err := s.converter.ConvertOwnerPermalinkToName(ctx, fmt.Sprintf("users/%s", uid))
-		if err != nil {
-			return resource.Namespace{}, "", fmt.Errorf("namespace error")
-		}
-
-		return resource.Namespace{
-			NsType: resource.NamespaceType("users"),
-			NsID:   strings.Split(name, "/")[1],
-			NsUID:  uid,
-		}, splits[2], nil
-	}
-
-	splits := strings.Split(path, "/")
-	if len(splits) < 2 {
-		return resource.Namespace{}, "", fmt.Errorf("namespace error")
-	}
-	uidStr, err := s.converter.ConvertOwnerNameToPermalink(ctx, fmt.Sprintf("%s/%s", splits[0], splits[1]))
-
+	resp, err := s.mgmtPrivateServiceClient.CheckNamespaceAdmin(ctx, &mgmtpb.CheckNamespaceAdminRequest{
+		Id: namespaceID,
+	})
 	if err != nil {
-		return resource.Namespace{}, "", fmt.Errorf("namespace error %w", err)
+		return resource.Namespace{}, err
 	}
-	if len(splits) < 4 {
+	if resp.Type == mgmtpb.CheckNamespaceAdminResponse_NAMESPACE_USER {
 		return resource.Namespace{
-			NsType: resource.NamespaceType(splits[0]),
-			NsID:   splits[1],
-			NsUID:  uuid.FromStringOrNil(strings.Split(uidStr, "/")[1]),
-		}, "", nil
-	}
-	return resource.Namespace{
-		NsType: resource.NamespaceType(splits[0]),
-		NsID:   splits[1],
-		NsUID:  uuid.FromStringOrNil(strings.Split(uidStr, "/")[1]),
-	}, splits[3], nil
-}
-
-func (s *service) GetRscNamespaceAndPermalinkUID(ctx context.Context, path string) (resource.Namespace, uuid.UUID, error) {
-	splits := strings.Split(path, "/")
-	if len(splits) < 2 {
-		return resource.Namespace{}, uuid.Nil, fmt.Errorf("namespace error")
-	}
-	uidStr, err := s.converter.ConvertOwnerNameToPermalink(ctx, fmt.Sprintf("%s/%s", splits[0], splits[1]))
-	if err != nil {
-		return resource.Namespace{}, uuid.Nil, fmt.Errorf("namespace error")
-	}
-	if len(splits) < 4 {
+			NsType: resource.User,
+			NsID:   namespaceID,
+			NsUID:  uuid.FromStringOrNil(resp.Uid),
+		}, nil
+	} else if resp.Type == mgmtpb.CheckNamespaceAdminResponse_NAMESPACE_ORGANIZATION {
 		return resource.Namespace{
-			NsType: resource.NamespaceType(splits[0]),
-			NsID:   splits[1],
-			NsUID:  uuid.FromStringOrNil(strings.Split(uidStr, "/")[1]),
-		}, uuid.Nil, nil
+			NsType: resource.Organization,
+			NsID:   namespaceID,
+			NsUID:  uuid.FromStringOrNil(resp.Uid),
+		}, nil
 	}
-	return resource.Namespace{
-		NsType: resource.NamespaceType(splits[0]),
-		NsID:   splits[1],
-		NsUID:  uuid.FromStringOrNil(strings.Split(uidStr, "/")[1]),
-	}, uuid.FromStringOrNil(splits[3]), nil
-}
-
-func (s *service) GetRscNamespaceAndNameIDAndReleaseID(ctx context.Context, path string) (resource.Namespace, string, string, error) {
-	ns, pipelineID, err := s.GetRscNamespaceAndNameID(ctx, path)
-	if err != nil {
-		return ns, pipelineID, "", err
-	}
-	splits := strings.Split(path, "/")
-
-	if len(splits) < 6 {
-		return ns, pipelineID, "", fmt.Errorf("path error")
-	}
-	return ns, pipelineID, splits[5], err
+	return resource.Namespace{}, fmt.Errorf("namespace error")
 }


### PR DESCRIPTION
Because

- We'd like to simplify the API endpoints by merging users and organization endpoints into namespace endpoints.

This commit

- Introduces new namespace endpoints.