### PR TITLE
chore: use explicit operation_id for GetOperation endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/iancoleman/strcase v0.3.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
 	github.com/instill-ai/component v0.23.0-beta
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240725032116-214c51b2e3bc
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240725080302-882cb706e504
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha
 	github.com/jackc/pgx/v5 v5.5.5

--- a/go.sum
+++ b/go.sum
@@ -1204,8 +1204,8 @@ github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
 github.com/instill-ai/component v0.23.0-beta h1:NQB8Lvsb0Z4zu/5ULKvR2Wp48Wie7cxrh+1skfyfNh8=
 github.com/instill-ai/component v0.23.0-beta/go.mod h1:XBn0j9R7H/iAhr2OSCefxO8FDqOCzhxuZ/uILVcBSho=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240725032116-214c51b2e3bc h1:Lqeu0CKe/XZiK8RxHQXcBGKqtz+e3ITpPkyq1WwQvOQ=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240725032116-214c51b2e3bc/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240725080302-882cb706e504 h1:xzwR0C4g54tQFOPsPnANbMfpdUj9SJtVs81nBf2HDrE=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240725080302-882cb706e504/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a/go.mod h1:EpX3Yr661uWULtZf5UnJHfr5rw2PDyX8ku4Kx0UtYFw=
 github.com/instill-ai/x v0.4.0-alpha h1:zQV2VLbSHjMv6gyBN/2mwwrvWk0/mJM6ZKS12AzjfQg=

--- a/pkg/handler/pipeline.go
+++ b/pkg/handler/pipeline.go
@@ -2051,11 +2051,7 @@ func (h *PublicHandler) TriggerAsyncNamespacePipelineRelease(ctx context.Context
 
 func (h *PublicHandler) GetOperation(ctx context.Context, req *pb.GetOperationRequest) (*pb.GetOperationResponse, error) {
 
-	operationID, err := resource.GetOperationID(req.Name)
-	if err != nil {
-		return &pb.GetOperationResponse{}, err
-	}
-	operation, err := h.service.GetOperation(ctx, operationID)
+	operation, err := h.service.GetOperation(ctx, req.OperationId)
 	if err != nil {
 		return &pb.GetOperationResponse{}, err
 	}


### PR DESCRIPTION
Because

- We should avoid using ambiguous name parameter in operation endpoint requests.

This commit

- Uses explicit `operation_id` for GetOperation endpoint.
