### PR TITLE
fix: send old and new pipeline trigger measurements

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -26,7 +26,7 @@ const (
 	RenameEvent     string = "Rename"
 	ExecuteEvent    string = "Execute"
 
-	pipelineMeasurement = "pipeline.trigger"
+	pipelineMeasurement = "pipeline.trigger.v1"
 )
 
 func IsAuditEvent(eventName string) bool {
@@ -102,6 +102,33 @@ func NewPipelineDataPoint(data PipelineUsageMetricData) *write.Point {
 	}
 
 	return influxdb2.NewPoint(pipelineMeasurement, tags, fields, time.Now())
+}
+
+// DeprecatedNewPipelineDatapoint transforms the information of a pipeline
+// triger into an InfluxDB datapoint. This measurement is deprecated and will
+// be retired with the new dashboard implementation.
+func DeprecatedNewPipelineDatapoint(data PipelineUsageMetricData) *write.Point {
+	return influxdb2.NewPoint(
+		"pipeline.trigger",
+		map[string]string{
+			"status":       data.Status.String(),
+			"trigger_mode": data.TriggerMode.String(),
+		},
+		map[string]any{
+			"owner_uid":             data.OwnerUID,
+			"owner_type":            data.OwnerType,
+			"user_uid":              data.UserUID,
+			"user_type":             data.UserType,
+			"pipeline_id":           data.PipelineID,
+			"pipeline_uid":          data.PipelineUID,
+			"pipeline_release_id":   data.PipelineReleaseID,
+			"pipeline_release_uid":  data.PipelineReleaseUID,
+			"pipeline_trigger_id":   data.PipelineTriggerUID,
+			"trigger_time":          data.TriggerTime,
+			"compute_time_duration": data.ComputeTimeDuration,
+		},
+		time.Now(),
+	)
 }
 
 type ConnectorUsageMetricData struct {

--- a/pkg/worker/utils.go
+++ b/pkg/worker/utils.go
@@ -20,6 +20,7 @@ func (w *worker) writeNewDataPoint(ctx context.Context, data utils.PipelineUsage
 	}
 
 	w.influxDBWriteClient.WritePoint(utils.NewPipelineDataPoint(data))
+	w.influxDBWriteClient.WritePoint(utils.DeprecatedNewPipelineDatapoint(data))
 
 	return nil
 }


### PR DESCRIPTION
Because

- The measurement introduced for the new dashboard endpoints introduced breaking changes that the clients haven't kept up with for this release.
This commit

- Restores the old measurement and sends the new one with a different measurement name in order to keep backwards-compatible and start filling information before the new dashboard is ready.
  - Because the measurement name is changed, this commit shouldn't be reverted for the new dashboard implementation, only the deprecated method should be deleted.
