### PR TITLE
chore: add migration script for TASK_CONVERT_TO_TEXT

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0
 	github.com/iancoleman/strcase v0.3.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/component v0.23.0-beta.0.20240728084148-c08ce6f1e2b9
+	github.com/instill-ai/component v0.23.0-beta.0.20240728105521-927995ddac85
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240728054535-94bc4482c55d
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha

--- a/go.sum
+++ b/go.sum
@@ -1221,8 +1221,8 @@ github.com/influxdata/influxdb-client-go/v2 v2.12.3 h1:28nRlNMRIV4QbtIUvxhWqaxn0
 github.com/influxdata/influxdb-client-go/v2 v2.12.3/go.mod h1:IrrLUbCjjfkmRuaCiGQg4m2GbkaeJDcuWoxiWdQEbA0=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/instill-ai/component v0.23.0-beta.0.20240728084148-c08ce6f1e2b9 h1:760KykuDbi6z1HxBeQTWtYBJSslSmTErjVw6bGdODdY=
-github.com/instill-ai/component v0.23.0-beta.0.20240728084148-c08ce6f1e2b9/go.mod h1:u0a9z9u2nfZ7A0SpG2E8Sb6kMhIB+aGunv8RLc/sx2U=
+github.com/instill-ai/component v0.23.0-beta.0.20240728105521-927995ddac85 h1:kymhII0BLk1VLps1ZGj79NPWHaS7V94zXaCbLgtwIoc=
+github.com/instill-ai/component v0.23.0-beta.0.20240728105521-927995ddac85/go.mod h1:u0a9z9u2nfZ7A0SpG2E8Sb6kMhIB+aGunv8RLc/sx2U=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240728054535-94bc4482c55d h1:g+myl44XmerPUONSkXKdnZ2PSBCixqSCqah0dQtBkeI=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240728054535-94bc4482c55d/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=

--- a/pkg/db/migration/convert/convert000021/convert.go
+++ b/pkg/db/migration/convert/convert000021/convert.go
@@ -1,0 +1,125 @@
+package convert000021
+
+import (
+	"fmt"
+
+	"go.uber.org/zap"
+	"gopkg.in/yaml.v3"
+	"gorm.io/gorm"
+
+	"github.com/instill-ai/pipeline-backend/pkg/datamodel"
+)
+
+const batchSize = 100
+
+// ConvertToTextTaskConverter executes code along with the 21st database
+// schema revision.
+type ConvertToTextTaskConverter struct {
+	DB     *gorm.DB
+	Logger *zap.Logger
+}
+
+// Migrate `TASK_CONVERT_TO_TEXT` from the Text operator to the Document operator
+func (c *ConvertToTextTaskConverter) Migrate() error {
+	if err := c.migratePipeline(); err != nil {
+		return err
+	}
+
+	return c.migratePipelineRelease()
+}
+
+func (c *ConvertToTextTaskConverter) migratePipeline() error {
+	pipelines := make([]*datamodel.Pipeline, 0, batchSize)
+	return c.DB.Select("uid", "recipe_yaml", "recipe").FindInBatches(&pipelines, batchSize, func(tx *gorm.DB, _ int) error {
+		for _, p := range pipelines {
+			isRecipeUpdated := false
+			l := c.Logger.With(zap.String("pipelineUID", p.UID.String()))
+
+			for id, comp := range p.Recipe.Component {
+				isComponentUpdated, err := c.updateTask(comp)
+				if err != nil {
+					l.With(zap.String("componentID", id), zap.Error(err)).
+						Error("Failed to update pipeline.")
+
+					return fmt.Errorf("updating pipeline component: %w", err)
+				}
+
+				isRecipeUpdated = isComponentUpdated || isRecipeUpdated
+			}
+
+			if isRecipeUpdated {
+				recipeYAML, err := yaml.Marshal(p.Recipe)
+				if err != nil {
+					return fmt.Errorf("marshalling recipe: %w", err)
+				}
+				result := tx.Model(p).Where("uid = ?", p.UID).Update("recipe_yaml", string(recipeYAML))
+				if result.Error != nil {
+					l.Error("Failed to update pipeline release.")
+					return fmt.Errorf("updating pipeline recipe: %w", result.Error)
+				}
+			}
+		}
+
+		return nil
+	}).Error
+}
+
+func (c *ConvertToTextTaskConverter) migratePipelineRelease() error {
+	pipelineReleases := make([]*datamodel.PipelineRelease, 0, batchSize)
+	return c.DB.Select("uid", "recipe_yaml", "recipe").FindInBatches(&pipelineReleases, batchSize, func(tx *gorm.DB, _ int) error {
+		for _, pr := range pipelineReleases {
+			isRecipeUpdated := false
+			l := c.Logger.With(zap.String("pipelineReleaseUID", pr.UID.String()))
+
+			for id, comp := range pr.Recipe.Component {
+				isComponentUpdated, err := c.updateTask(comp)
+				if err != nil {
+					l.With(zap.String("componentID", id), zap.Error(err)).
+						Error("Failed to update pipeline release.")
+
+					return fmt.Errorf("updating pipeline release component: %w", err)
+				}
+
+				isRecipeUpdated = isComponentUpdated || isRecipeUpdated
+			}
+
+			if isRecipeUpdated {
+				recipeYAML, err := yaml.Marshal(pr.Recipe)
+				if err != nil {
+					return fmt.Errorf("marshalling recipe: %w", err)
+				}
+
+				result := tx.Model(pr).Where("uid = ?", pr.UID).Update("recipe_yaml", string(recipeYAML))
+				if result.Error != nil {
+					l.Error("Failed to update pipeline release.")
+					return fmt.Errorf("updating pipeline release recipe: %w", result.Error)
+				}
+			}
+		}
+
+		return nil
+	}).Error
+}
+
+func (c *ConvertToTextTaskConverter) updateTask(comp *datamodel.Component) (bool, error) {
+	if comp.Type == "iterator" {
+		isComponentUpdated := false
+		for _, comp := range comp.Component {
+			isSubComponentUpdated, err := c.updateTask(comp)
+			if err != nil {
+				return false, fmt.Errorf("updating iterator component: %w", err)
+			}
+
+			isComponentUpdated = isSubComponentUpdated || isComponentUpdated
+		}
+
+		return isComponentUpdated, nil
+	}
+
+	if comp.Type != "text" || comp.Task != "TASK_CONVERT_TO_TEXT" {
+		return false, nil
+	}
+
+	comp.Type = "document"
+	return true, nil
+}

--- a/pkg/db/migration/migration.go
+++ b/pkg/db/migration/migration.go
@@ -8,6 +8,7 @@ import (
 	"github.com/instill-ai/pipeline-backend/pkg/db/migration/convert/convert000016"
 	"github.com/instill-ai/pipeline-backend/pkg/db/migration/convert/convert000019"
 	"github.com/instill-ai/pipeline-backend/pkg/db/migration/convert/convert000020"
+	"github.com/instill-ai/pipeline-backend/pkg/db/migration/convert/convert000021"
 	"github.com/instill-ai/pipeline-backend/pkg/external"
 	"github.com/instill-ai/pipeline-backend/pkg/logger"
 
@@ -54,6 +55,11 @@ func Migrate(version uint) error {
 			DB:         db,
 			Logger:     l,
 			MgmtClient: mgmtPrivateServiceClient,
+		}
+	case 21:
+		m = &convert000021.ConvertToTextTaskConverter{
+			DB:     db,
+			Logger: l,
 		}
 	default:
 		return nil


### PR DESCRIPTION
Because

- We recategorized TASK_CONVERT_TO_TEXT from text operator to document operator.

This commit

- Adds migration script for `TASK_CONVERT_TO_TEXT`.
