### PR TITLE
chore: support generic component in connector-definition endpoints

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/iancoleman/strcase v0.3.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
 	github.com/instill-ai/component v0.23.0-beta.0.20240728105521-927995ddac85
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240728054535-94bc4482c55d
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240728161838-c43213a27f50
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha
 	github.com/jackc/pgx/v5 v5.5.5

--- a/go.sum
+++ b/go.sum
@@ -1223,8 +1223,8 @@ github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
 github.com/instill-ai/component v0.23.0-beta.0.20240728105521-927995ddac85 h1:kymhII0BLk1VLps1ZGj79NPWHaS7V94zXaCbLgtwIoc=
 github.com/instill-ai/component v0.23.0-beta.0.20240728105521-927995ddac85/go.mod h1:u0a9z9u2nfZ7A0SpG2E8Sb6kMhIB+aGunv8RLc/sx2U=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240728054535-94bc4482c55d h1:g+myl44XmerPUONSkXKdnZ2PSBCixqSCqah0dQtBkeI=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240728054535-94bc4482c55d/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240728161838-c43213a27f50 h1:rUBiqaZqlA+Q5yWgZyLLF3yLFSBF1v7l+crUWFpDbPs=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240728161838-c43213a27f50/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a/go.mod h1:EpX3Yr661uWULtZf5UnJHfr5rw2PDyX8ku4Kx0UtYFw=
 github.com/instill-ai/x v0.4.0-alpha h1:zQV2VLbSHjMv6gyBN/2mwwrvWk0/mJM6ZKS12AzjfQg=

--- a/pkg/service/component_definition.go
+++ b/pkg/service/component_definition.go
@@ -251,7 +251,8 @@ func (s *service) implementedConnectorDefinitions(ctx context.Context) ([]*pb.Co
 
 	implemented := make([]*pb.ConnectorDefinition, 0, len(allDefs))
 	for _, def := range allDefs {
-		if def.Type == pb.ComponentType_COMPONENT_TYPE_AI || def.Type == pb.ComponentType_COMPONENT_TYPE_DATA || def.Type == pb.ComponentType_COMPONENT_TYPE_APPLICATION {
+		if def.Type == pb.ComponentType_COMPONENT_TYPE_AI || def.Type == pb.ComponentType_COMPONENT_TYPE_DATA ||
+			def.Type == pb.ComponentType_COMPONENT_TYPE_APPLICATION || def.Type == pb.ComponentType_COMPONENT_TYPE_GENERIC {
 			if implementedReleaseStages[def.GetReleaseStage()] {
 				implemented = append(implemented, convertComponentDefToConnectorDef(def))
 			}
@@ -355,7 +356,8 @@ func (s *service) GetConnectorDefinitionByID(ctx context.Context, id string) (*p
 	switch compDef.Type {
 	case pb.ComponentType_COMPONENT_TYPE_AI,
 		pb.ComponentType_COMPONENT_TYPE_DATA,
-		pb.ComponentType_COMPONENT_TYPE_APPLICATION:
+		pb.ComponentType_COMPONENT_TYPE_APPLICATION,
+		pb.ComponentType_COMPONENT_TYPE_GENERIC:
 		return convertComponentDefToConnectorDef(compDef), nil
 
 	default:
@@ -382,6 +384,8 @@ func convertComponentDefToConnectorDef(compDef *pb.ComponentDefinition) *pb.Conn
 				return pb.ConnectorType_CONNECTOR_TYPE_DATA
 			case pb.ComponentType_COMPONENT_TYPE_APPLICATION:
 				return pb.ConnectorType_CONNECTOR_TYPE_APPLICATION
+			case pb.ComponentType_COMPONENT_TYPE_GENERIC:
+				return pb.ConnectorType_CONNECTOR_TYPE_GENERIC
 			}
 			return pb.ConnectorType_CONNECTOR_TYPE_UNSPECIFIED
 

--- a/pkg/service/convert.go
+++ b/pkg/service/convert.go
@@ -431,6 +431,7 @@ var ConnectorTypeToComponentType = map[pb.ConnectorType]pb.ComponentType{
 	pb.ConnectorType_CONNECTOR_TYPE_AI:          pb.ComponentType_COMPONENT_TYPE_AI,
 	pb.ConnectorType_CONNECTOR_TYPE_APPLICATION: pb.ComponentType_COMPONENT_TYPE_APPLICATION,
 	pb.ConnectorType_CONNECTOR_TYPE_DATA:        pb.ComponentType_COMPONENT_TYPE_DATA,
+	pb.ConnectorType_CONNECTOR_TYPE_GENERIC:     pb.ComponentType_COMPONENT_TYPE_GENERIC,
 }
 
 // ConvertPipelineToPB converts db data model to protobuf data model


### PR DESCRIPTION
Because

- We are introducing a new generic component type.

This commit

- Supports the new generic component type in the deprecated connector-definition endpoints, as Console is still using them.