### PR TITLE
fix: change the dependency to fix bugs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,9 +31,7 @@ RUN apk add --no-cache \
     build-base \
     python3-dev \
     libffi-dev \
-    libreoffice-common \
-    libreoffice-writer \
-    libreoffice-impress \
+    libreoffice \
     msttcorefonts-installer \
     font-noto \
     font-noto-cjk \


### PR DESCRIPTION
Because

- test failed at d0 with the dependency we installed to reduce the image size

This commit

- change back to the original dependency with full version of libreoffice
