### PR TITLE
fix: fix pipeline could not have more than one iterator

### DIFF
--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -360,8 +360,7 @@ func (s *service) setSchedulePipeline(ctx context.Context, ns resource.Namespace
 			Mode: mgmtpb.Mode_MODE_ASYNC,
 		}
 		_, err = s.temporalClient.ScheduleClient().Create(ctx, client.ScheduleOptions{
-			ID:                 scheduleID,
-			TriggerImmediately: true,
+			ID: scheduleID,
 			Spec: client.ScheduleSpec{
 				CronExpressions: crons,
 			},

--- a/pkg/worker/workflow.go
+++ b/pkg/worker/workflow.go
@@ -421,7 +421,7 @@ func (w *worker) PreIteratorActivity(ctx context.Context, param *PreIteratorActi
 		MemoryStorageKeys: make([]*recipe.BatchMemoryKey, len(m)),
 		ElementSize:       make([]int, len(m)),
 	}
-	recipeKey := fmt.Sprintf("%s:%s", param.WorkflowID, recipe.SegRecipe)
+	recipeKey := fmt.Sprintf("%s:%s:%s", param.WorkflowID, param.ID, recipe.SegRecipe)
 	err = recipe.WriteRecipe(ctx, w.redisClient, recipeKey, iteratorRecipe)
 	if err != nil {
 		return nil, componentActivityError(err, preIteratorActivityErrorType, param.ID)


### PR DESCRIPTION
Because

- The pipeline can not be triggered when there are more than one iterator.

This commit

- Fixes pipeline could not have more than one iterator.
- Adjusts run-on-schedule setting.
