### PR TITLE
feat: use pdf2md in document operator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM --platform=$TARGETPLATFORM golang:1.22.5 AS build
+FROM --platform=$TARGETPLATFORM golang:1.22.5-alpine3.19 AS build
 
-RUN apt update && apt install libtesseract-dev -y
+RUN apk add --no-cache build-base leptonica-dev tesseract-ocr-dev
 
 WORKDIR /src
 
@@ -17,7 +17,7 @@ RUN --mount=target=. --mount=type=cache,target=/root/.cache/go-build --mount=typ
 RUN --mount=target=. --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /${SERVICE_NAME}-migrate ./cmd/migration
 RUN --mount=target=. --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /${SERVICE_NAME}-init ./cmd/init
 
-FROM alpine:3.16
+FROM node:22.5.1-alpine3.19
 
 RUN apk add --no-cache \
     curl \
@@ -36,6 +36,7 @@ RUN apk add --no-cache \
     font-noto \
     font-noto-cjk \
     ffmpeg \
+    leptonica \
     && update-ms-fonts \
     && fc-cache -f \
     && python3 -m venv /opt/venv \
@@ -46,6 +47,8 @@ RUN apk add --no-cache \
 ARG TARGETARCH
 ARG BUILDARCH
 RUN apk add unrtf --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community
+
+RUN npm install -g @opendocsg/pdf2md
 
 USER nobody:nogroup
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -10,10 +10,25 @@ ARG TARGETOS TARGETARCH K6_VERSION
 
 # Install Python, create virtual environment, and install pdfplumber
 RUN apt update && \
-    apt install -y python3 python3-venv poppler-utils wv unrtf tidy tesseract-ocr libtesseract-dev libreoffice ffmpeg && \
+    apt install -y python3 python3-venv poppler-utils wv unrtf tidy tesseract-ocr libtesseract-dev libreoffice ffmpeg curl && \
     python3 -m venv /opt/venv && \
     /opt/venv/bin/pip install pdfplumber mistral-common tokenizers transformers torch && \
     rm -rf /var/lib/apt/lists/*
+
+# nvm environment variables
+ENV NVM_DIR /usr/local/nvm
+ENV NODE_VERSION 22.5.1
+RUN mkdir -p $NVM_DIR && curl --silent -o- https://raw.githubusercontent.com/creationix/nvm/v0.40.0/install.sh | bash
+
+RUN echo "source $NVM_DIR/nvm.sh && \
+    nvm install $NODE_VERSION && \
+    nvm alias default $NODE_VERSION && \
+    nvm use default" | bash
+
+# add node and npm to path so the commands are available
+ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
+ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
+RUN npm install -g @opendocsg/pdf2md
 
 # air
 RUN --mount=target=. --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg GOOS=$TARGETOS GOARCH=$TARGETARCH go install github.com/cosmtrek/air@v1.49

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0
 	github.com/iancoleman/strcase v0.3.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/component v0.24.0-beta.0.20240811005353-b4ab24a99622
+	github.com/instill-ai/component v0.24.0-beta.0.20240811040743-07360d13b70f
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240808093014-75008c807ea7
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha

--- a/go.sum
+++ b/go.sum
@@ -1261,8 +1261,8 @@ github.com/influxdata/influxdb-client-go/v2 v2.12.3 h1:28nRlNMRIV4QbtIUvxhWqaxn0
 github.com/influxdata/influxdb-client-go/v2 v2.12.3/go.mod h1:IrrLUbCjjfkmRuaCiGQg4m2GbkaeJDcuWoxiWdQEbA0=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/instill-ai/component v0.24.0-beta.0.20240811005353-b4ab24a99622 h1:MwurZEYoBE2PJRbIJJWsdGNZeCZjYRXl0E+sys1jKHw=
-github.com/instill-ai/component v0.24.0-beta.0.20240811005353-b4ab24a99622/go.mod h1:iIxkDsnuKPqX5Cxwtc5lBSGT3SxXPLV0sl9bJNQlJNk=
+github.com/instill-ai/component v0.24.0-beta.0.20240811040743-07360d13b70f h1:bGqK4LhBgaTe8LE7nYXIq0uqsjiZRxzkqFTwkMHWLgQ=
+github.com/instill-ai/component v0.24.0-beta.0.20240811040743-07360d13b70f/go.mod h1:iIxkDsnuKPqX5Cxwtc5lBSGT3SxXPLV0sl9bJNQlJNk=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240808093014-75008c807ea7 h1:2uF3AxjNM8EgRIVViitAoX6qr/aTaO2wrr8pk9CCp+I=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240808093014-75008c807ea7/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=


### PR DESCRIPTION
Because:

- The `pdf2md` provide a better result for PDF to Markdown conversion.

This commit:

- Includes `pdf2md` in Dockerfile.
- Updates component package.
