### PR TITLE
feat: add requirements.txt to manage python dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN apk add --no-cache \
     ffmpeg \
     leptonica \
     chromium \
-    gperftools \
+    gperftools --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community\
     pkgconfig \
     && update-ms-fonts \
     && fc-cache -f \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ RUN --mount=target=. --mount=type=cache,target=/root/.cache/go-build --mount=typ
 
 FROM node:22.5.1-alpine3.19
 
+COPY requirements.txt .
+
 RUN apk add --no-cache \
     curl \
     poppler-utils \

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN apk add --no-cache \
     ffmpeg \
     leptonica \
     chromium \
-    pkg-config \
+    pkgconfig \
     && update-ms-fonts \
     && fc-cache -f \
     && python3 -m venv /opt/venv \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,9 @@ FROM node:22.5.1-alpine3.19
 
 COPY requirements.txt requirements.txt
 
+RUN apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community \
+    gperftools 
+
 RUN apk add --no-cache \
     curl \
     poppler-utils \
@@ -40,7 +43,7 @@ RUN apk add --no-cache \
     ffmpeg \
     leptonica \
     chromium \
-    gperftools --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community\
+    gperftools \
     pkgconfig \
     && update-ms-fonts \
     && fc-cache -f \

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN apk add --no-cache \
     ffmpeg \
     leptonica \
     chromium \
-    gperftools \
+    gperftools-dev \
     pkgconfig \
     && update-ms-fonts \
     && fc-cache -f \

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN apk add --no-cache \
     && fc-cache -f \
     && python3 -m venv /opt/venv \
     && /opt/venv/bin/pip install --upgrade pip \
-    && /opt/venv/bin/pip install pdfplumber tokenizers \
+    && /opt/venv/bin/pip install -r requirements.txt \
     && rm -rf /var/cache/apk/* /var/cache/fontconfig/*
 
 ARG TARGETARCH

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN apk add --no-cache \
     tidyhtml \
     libc6-compat \
     tesseract-ocr \
-    python3.11 \
+    python3 \
     py3-pip \
     build-base \
     python3-dev \
@@ -43,7 +43,7 @@ RUN apk add --no-cache \
     pkg-config \
     && update-ms-fonts \
     && fc-cache -f \
-    && python3.11 -m venv /opt/venv \
+    && python3 -m venv /opt/venv \
     && /opt/venv/bin/pip install --upgrade pip \
     && /opt/venv/bin/pip install -r requirements.txt \
     && rm -rf /var/cache/apk/* /var/cache/fontconfig/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN apk add --no-cache \
     ffmpeg \
     leptonica \
     chromium \
-    gperftools-dev \
+    gperftools \
     pkgconfig \
     && update-ms-fonts \
     && fc-cache -f \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ FROM node:22.5.1-alpine3.19
 
 COPY requirements.txt requirements.txt
 
-RUN apk add --no-cache gperftools --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community 
+RUN apk add --no-cache gperftools --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing/
 
 RUN apk add --no-cache \
     curl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN apk add --no-cache \
     tidyhtml \
     libc6-compat \
     tesseract-ocr \
-    python3 \
+    python3.11 \
     py3-pip \
     build-base \
     python3-dev \
@@ -43,7 +43,7 @@ RUN apk add --no-cache \
     pkg-config \
     && update-ms-fonts \
     && fc-cache -f \
-    && python3 -m venv /opt/venv \
+    && python3.11 -m venv /opt/venv \
     && /opt/venv/bin/pip install --upgrade pip \
     && /opt/venv/bin/pip install -r requirements.txt \
     && rm -rf /var/cache/apk/* /var/cache/fontconfig/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN apk add --no-cache \
     ffmpeg \
     leptonica \
     chromium \
+    gperftools \
     pkgconfig \
     && update-ms-fonts \
     && fc-cache -f \

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN apk add --no-cache \
     ffmpeg \
     leptonica \
     chromium \
+    pkg-config \
     && update-ms-fonts \
     && fc-cache -f \
     && python3 -m venv /opt/venv \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,7 @@ FROM node:22.5.1-alpine3.19
 
 COPY requirements.txt requirements.txt
 
-RUN apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community \
-    gperftools 
+RUN apk add --no-cache gperftools --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community 
 
 RUN apk add --no-cache \
     curl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN --mount=target=. --mount=type=cache,target=/root/.cache/go-build --mount=typ
 
 FROM node:22.5.1-alpine3.19
 
-COPY requirements.txt .
+COPY requirements.txt requirements.txt
 
 RUN apk add --no-cache \
     curl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,8 +42,8 @@ RUN apk add --no-cache \
     ffmpeg \
     leptonica \
     chromium \
-    gperftools \
     pkgconfig \
+    cmake \
     && update-ms-fonts \
     && fc-cache -f \
     && python3 -m venv /opt/venv \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -13,7 +13,7 @@ COPY requirements.txt requirements.txt
 
 # Install Python, create virtual environment, and install pdfplumber
 RUN apt update && \
-    apt install -y python3 python3-venv poppler-utils wv unrtf tidy tesseract-ocr libtesseract-dev libreoffice ffmpeg curl chromium pkgconfig && \
+    apt install -y python3 python3-venv poppler-utils wv unrtf tidy tesseract-ocr libtesseract-dev libreoffice ffmpeg curl chromium gperftools pkgconfig && \
     python3 -m venv /opt/venv && \
     /opt/venv/bin/pip install --upgrade pip \
     /opt/venv/bin/pip install -r requirements.txt && \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -13,7 +13,7 @@ COPY requirements.txt requirements.txt
 
 # Install Python, create virtual environment, and install pdfplumber
 RUN apt update && \
-    apt install -y python3 python3-venv poppler-utils wv unrtf tidy tesseract-ocr libtesseract-dev libreoffice ffmpeg curl chromium gperftools pkgconfig && \
+    apt install -y python3 python3-venv poppler-utils wv unrtf tidy tesseract-ocr libtesseract-dev libreoffice ffmpeg curl chromium gperftools-dev pkgconfig && \
     python3 -m venv /opt/venv && \
     /opt/venv/bin/pip install --upgrade pip \
     /opt/venv/bin/pip install -r requirements.txt && \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -13,8 +13,8 @@ COPY requirements.txt requirements.txt
 
 # Install Python, create virtual environment, and install pdfplumber
 RUN apt update && \
-    apt install -y python3.11 python3-venv poppler-utils wv unrtf tidy tesseract-ocr libtesseract-dev libreoffice ffmpeg curl chromium pkg-config && \
-    python3.11 -m venv /opt/venv && \
+    apt install -y python3 python3-venv poppler-utils wv unrtf tidy tesseract-ocr libtesseract-dev libreoffice ffmpeg curl chromium pkg-config && \
+    python3 -m venv /opt/venv && \
     /opt/venv/bin/pip install --upgrade pip \
     /opt/venv/bin/pip install -r requirements.txt && \
     rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -12,7 +12,7 @@ ARG TARGETOS TARGETARCH K6_VERSION XK6_VERSION
 RUN apt update && \
     apt install -y python3 python3-venv poppler-utils wv unrtf tidy tesseract-ocr libtesseract-dev libreoffice ffmpeg curl chromium && \
     python3 -m venv /opt/venv && \
-    /opt/venv/bin/pip install pdfplumber mistral-common tokenizers && \
+    /opt/venv/bin/pip install -r requirements.txt && \
     rm -rf /var/lib/apt/lists/*
 
 # nvm environment variables

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -13,7 +13,7 @@ COPY requirements.txt requirements.txt
 
 # Install Python, create virtual environment, and install pdfplumber
 RUN apt update && \
-    apt install -y python3 python3-venv poppler-utils wv unrtf tidy tesseract-ocr libtesseract-dev libreoffice ffmpeg curl chromium && \
+    apt install -y python3 python3-venv poppler-utils wv unrtf tidy tesseract-ocr libtesseract-dev libreoffice ffmpeg curl chromium pkg-config && \
     python3 -m venv /opt/venv && \
     /opt/venv/bin/pip install --upgrade pip \
     /opt/venv/bin/pip install -r requirements.txt && \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -13,7 +13,7 @@ COPY requirements.txt requirements.txt
 
 # Install Python, create virtual environment, and install pdfplumber
 RUN apt update && \
-    apt install -y python3 python3-venv poppler-utils wv unrtf tidy tesseract-ocr libtesseract-dev libreoffice ffmpeg curl chromium pkg-config && \
+    apt install -y python3 python3-venv poppler-utils wv unrtf tidy tesseract-ocr libtesseract-dev libreoffice ffmpeg curl chromium pkgconfig && \
     python3 -m venv /opt/venv && \
     /opt/venv/bin/pip install --upgrade pip \
     /opt/venv/bin/pip install -r requirements.txt && \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -13,8 +13,8 @@ COPY requirements.txt requirements.txt
 
 # Install Python, create virtual environment, and install pdfplumber
 RUN apt update && \
-    apt install -y python3 python3-venv poppler-utils wv unrtf tidy tesseract-ocr libtesseract-dev libreoffice ffmpeg curl chromium pkg-config && \
-    python3 -m venv /opt/venv && \
+    apt install -y python3.11 python3-venv poppler-utils wv unrtf tidy tesseract-ocr libtesseract-dev libreoffice ffmpeg curl chromium pkg-config && \
+    python3.11 -m venv /opt/venv && \
     /opt/venv/bin/pip install --upgrade pip \
     /opt/venv/bin/pip install -r requirements.txt && \
     rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -8,6 +8,9 @@ WORKDIR /${SERVICE_NAME}
 
 ARG TARGETOS TARGETARCH K6_VERSION XK6_VERSION
 
+# -- Copy requirements.txt and install dependencies
+COPY requirements.txt .
+
 # Install Python, create virtual environment, and install pdfplumber
 RUN apt update && \
     apt install -y python3 python3-venv poppler-utils wv unrtf tidy tesseract-ocr libtesseract-dev libreoffice ffmpeg curl chromium && \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -13,7 +13,7 @@ COPY requirements.txt requirements.txt
 
 # Install Python, create virtual environment, and install pdfplumber
 RUN apt update && \
-    apt install -y python3 python3-venv poppler-utils wv unrtf tidy tesseract-ocr libtesseract-dev libreoffice ffmpeg curl chromium gperftools-dev pkgconfig && \
+    apt install -y python3 python3-venv poppler-utils wv unrtf tidy tesseract-ocr libtesseract-dev libreoffice ffmpeg curl chromium google-perftools pkgconfig && \
     python3 -m venv /opt/venv && \
     /opt/venv/bin/pip install --upgrade pip \
     /opt/venv/bin/pip install -r requirements.txt && \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -15,6 +15,7 @@ COPY requirements.txt requirements.txt
 RUN apt update && \
     apt install -y python3 python3-venv poppler-utils wv unrtf tidy tesseract-ocr libtesseract-dev libreoffice ffmpeg curl chromium && \
     python3 -m venv /opt/venv && \
+    /opt/venv/bin/pip install --upgrade pip \
     /opt/venv/bin/pip install -r requirements.txt && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -9,7 +9,7 @@ WORKDIR /${SERVICE_NAME}
 ARG TARGETOS TARGETARCH K6_VERSION XK6_VERSION
 
 # -- Copy requirements.txt and install dependencies
-COPY requirements.txt .
+COPY requirements.txt requirements.txt
 
 # Install Python, create virtual environment, and install pdfplumber
 RUN apt update && \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,3 @@
-# universal
-tokenizers==0.19.1
-torch==2.4.0
-transformers==4.44.0
-
-
 # components/ai/ai21labs
 ai21-tokenizer==0.11.3
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,6 @@ pdfplumber==0.11.3
 # components/operator/text
 mistral_common==1.3.3
 
+# misc
+sentencepiece==0.2.0
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # misc
-sentencepiece==0.2.0
+sentencepiece==0.2.0 # dependency of ai21-tokenizer, will take ~2 minutes to build, it also need cmake, gperftools and pkgconfig
 
 # components/ai/ai21labs
 ai21-tokenizer==0.11.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,15 @@
-pdfplumber==0.11.3
-ai21-tokenizer==0.11.3
+# universal
 tokenizers==0.19.1
+torch==2.4.0
+transformer==4.44.0
+
+
+# components/ai/ai21labs
+ai21-tokenizer==0.11.3
+
+# components/operator/document
+pdfplumber==0.11.3
+
+# components/operator/text
+mistral_common==1.3.3
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # universal
 tokenizers==0.19.1
 torch==2.4.0
-transformer==4.44.0
+transformers==4.44.0
 
 
 # components/ai/ai21labs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pdfplumber==0.11.3
+ai21-tokenizer==0.11.3
+tokenizers==0.19.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
+# misc
+sentencepiece==0.2.0
+
 # components/ai/ai21labs
 ai21-tokenizer==0.11.3
 
@@ -7,6 +10,5 @@ pdfplumber==0.11.3
 # components/operator/text
 mistral_common==1.3.3
 
-# misc
-sentencepiece==0.2.0
+
 


### PR DESCRIPTION
Because

- There are many components that requires specific python packages

This commit

- Make `pipeline-backend` to install python dependency with a unified `requirements.txt` file
