### PR TITLE
feat: return error message when using streaming

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -362,16 +362,6 @@ func main() {
 		TLSConfig: tlsConfig,
 	}
 
-	// Create a new HTTP server mux to wrap the sse handler func
-	sseMux := http.NewServeMux()
-
-	// Register the SSE handler at the "/sse/" endpoint
-	sseMux.HandleFunc("/sse/", handler.HandleSSEStreamResponse)
-
-	sseMux.Handle("/", publicServeMux)
-
-	// wrappedHandler := middleware.SSEStreamResponseMiddleware(sseMux)
-
 	publicHTTPServer := &http.Server{
 		Addr:      fmt.Sprintf(":%v", config.Config.Server.PublicPort),
 		Handler:   grpcHandlerFunc(publicGrpcS, publicServeMux),

--- a/go.mod
+++ b/go.mod
@@ -17,8 +17,8 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0
 	github.com/iancoleman/strcase v0.3.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/component v0.25.0-beta.0.20240823021656-21bebbd6d5a8
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240822142232-4ac40657b835
+	github.com/instill-ai/component v0.25.0-beta.0.20240825094027-aa605fabd788
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240823161910-354761b16f15
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha
 	github.com/jackc/pgx/v5 v5.5.5
@@ -81,7 +81,6 @@ require (
 	github.com/chromedp/chromedp v0.10.0 // indirect
 	github.com/chromedp/sysutil v1.0.0 // indirect
 	github.com/cohere-ai/cohere-go/v2 v2.8.5 // indirect
-	github.com/denisenkom/go-mssqldb v0.12.3 // indirect
 	github.com/dlclark/regexp2 v1.10.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/elastic/elastic-transport-go/v8 v8.6.0 // indirect
@@ -110,8 +109,6 @@ require (
 	github.com/gobwas/ws v1.4.0 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/gocolly/colly/v2 v2.1.0 // indirect
-	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
-	github.com/golang-sql/sqlexp v0.1.0 // indirect
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/mock v1.6.0 // indirect
@@ -159,9 +156,8 @@ require (
 	github.com/rivo/uniseg v0.4.4 // indirect
 	github.com/rs/xid v1.5.0 // indirect
 	github.com/saintfish/chardet v0.0.0-20230101081208-5e3ef4b5456d // indirect
-	github.com/sashabaranov/go-openai v1.28.2 // indirect
 	github.com/shopspring/decimal v1.2.0 // indirect
-	github.com/sijms/go-ora/v2 v2.8.19 // indirect
+	github.com/sijms/go-ora v1.3.2 // indirect
 	github.com/slack-go/slack v0.12.5 // indirect
 	github.com/temoto/robotstxt v1.1.2 // indirect
 	github.com/tink-ab/tempfile v0.0.0-20180226111222-33beb0518f1a // indirect

--- a/go.mod
+++ b/go.mod
@@ -221,7 +221,7 @@ require (
 	github.com/gogo/googleapis v1.4.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
-	github.com/google/uuid v1.6.0
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 // indirect

--- a/go.sum
+++ b/go.sum
@@ -408,9 +408,6 @@ gioui.org v0.0.0-20210308172011-57750fc8a0a6/go.mod h1:RSH6KIUZ0p2xy5zHDxgAM4zum
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20210715213245-6c3934b029d8/go.mod h1:CzsSbkDixRphAF5hS6wbMKq0eI6ccJRb7/A0M6JBnwg=
 github.com/Azure/azure-pipeline-go v0.2.3/go.mod h1:x841ezTBIMG6O3lAcl8ATHnsOPVl2bqk7S3ta6S6u4k=
 github.com/Azure/azure-sdk-for-go v16.2.1+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.19.0/go.mod h1:h6H6c8enJmmocHUbLiiGY6sx7f9i+X3m1CHdd5c6Rdw=
-github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.11.0/go.mod h1:HcM1YX14R7CJcghJGOYCgdezslRSVzqwLf/q+4Y2r/0=
-github.com/Azure/azure-sdk-for-go/sdk/internal v0.7.0/go.mod h1:yqy467j36fJxcRV2TzfVZ1pCb5vxm4BtZPUdYWe/Xo8=
 github.com/Azure/azure-storage-blob-go v0.14.0/go.mod h1:SMqIBi+SuiQH32bvyjngEewEeXoPfKMgWlBDaYf6fck=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/Azure/go-ansiterm v0.0.0-20210608223527-2377c96fe795/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
@@ -778,8 +775,6 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/deepmap/oapi-codegen v1.8.2 h1:SegyeYGcdi0jLLrpbCMoJxnUUn8GBXHsvr4rbzjuhfU=
 github.com/deepmap/oapi-codegen v1.8.2/go.mod h1:YLgSKSDv/bZQB7N4ws6luhozi3cEdRktEqrX88CvjIw=
 github.com/denisenkom/go-mssqldb v0.10.0/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
-github.com/denisenkom/go-mssqldb v0.12.3 h1:pBSGx9Tq67pBOTLmxNuirNTeB8Vjmf886Kx+8Y+8shw=
-github.com/denisenkom/go-mssqldb v0.12.3/go.mod h1:k0mtMFOnU+AihqFxPMiF05rtiDrorD1Vrm1KEz5hxDo=
 github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba/go.mod h1:dV8lFg6daOBZbT6/BDGIz6Y3WFGn8juu6G+CQ6LHtl0=
 github.com/dgrijalva/jwt-go v0.0.0-20170104182250-a601269ab70c/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
@@ -794,7 +789,6 @@ github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5
 github.com/dlclark/regexp2 v1.10.0 h1:+/GIL799phkJqYW+3YbOd8LCcbHzT0Pbo8zl70MHsq0=
 github.com/dlclark/regexp2 v1.10.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
-github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
 github.com/docker/cli v0.0.0-20191017083524-a8ff7f821017/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v0.0.0-20190905152932-14b96e55d84c/go.mod h1:0+TTO4EOBfRPhZXAeF1Vu+W3hHZ8eLp8PgKVZlcvtFY=
 github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
@@ -1277,10 +1271,10 @@ github.com/influxdata/influxdb-client-go/v2 v2.12.3 h1:28nRlNMRIV4QbtIUvxhWqaxn0
 github.com/influxdata/influxdb-client-go/v2 v2.12.3/go.mod h1:IrrLUbCjjfkmRuaCiGQg4m2GbkaeJDcuWoxiWdQEbA0=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/instill-ai/component v0.25.0-beta.0.20240823021656-21bebbd6d5a8 h1:65vwfK6WwaunfQfIBs5YRft1mFBdx2bgb14SY8KPErY=
-github.com/instill-ai/component v0.25.0-beta.0.20240823021656-21bebbd6d5a8/go.mod h1:fJH5Wc6XQi18FYeRcKz6VRVOuD8crY6ZOnDRYbvaaDw=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240822142232-4ac40657b835 h1:94GfO0zgQ7YhdKzyrDXkvTjy2tXTMn9JrCyT+shWBnU=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240822142232-4ac40657b835/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
+github.com/instill-ai/component v0.25.0-beta.0.20240825094027-aa605fabd788 h1:3mG7IyWfAVkq2urY4x2503/VBKbJhI+HGdxtlqsQ8w0=
+github.com/instill-ai/component v0.25.0-beta.0.20240825094027-aa605fabd788/go.mod h1:6OW4uu948rEHhPGMDjjIff8RI9uElgm1ZUA10BRuGoU=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240823161910-354761b16f15 h1:4nFVI3TCq8Iu/lDz2YOAM/koNdjUktXUG16YEEpnXBo=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240823161910-354761b16f15/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a/go.mod h1:EpX3Yr661uWULtZf5UnJHfr5rw2PDyX8ku4Kx0UtYFw=
 github.com/instill-ai/x v0.4.0-alpha h1:zQV2VLbSHjMv6gyBN/2mwwrvWk0/mJM6ZKS12AzjfQg=
@@ -1572,7 +1566,6 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/modocache/gover v0.0.0-20171022184752-b58185e213c5/go.mod h1:caMODM3PzxT8aQXRPkAt8xlV/e7d7w8GM5g0fa5F0D8=
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9M+97sNutRR1RKhG96O6jWumTTnw=
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
@@ -1685,7 +1678,6 @@ github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi
 github.com/pierrec/lz4/v4 v4.1.8/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pierrec/lz4/v4 v4.1.18 h1:xaKrnTkyoqfh1YItXl56+6KJNVYWlEEPuAQW9xsplYQ=
 github.com/pierrec/lz4/v4 v4.1.18/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
-github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4/go.mod h1:4OwLy04Bl9Ef3GJJCoec+30X3LQs/0/m4HFRt/2LUSA=
 github.com/pkg/browser v0.0.0-20210706143420-7d21f8c997e2/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
@@ -1780,8 +1772,6 @@ github.com/saintfish/chardet v0.0.0-20230101081208-5e3ef4b5456d h1:hrujxIzL1woJ7
 github.com/saintfish/chardet v0.0.0-20230101081208-5e3ef4b5456d/go.mod h1:uugorj2VCxiV1x+LzaIdVa9b4S4qGAcH6cbhh4qVxOU=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
-github.com/sashabaranov/go-openai v1.28.2 h1:Q3pi34SuNYNN7YrqpHlHbpeYlf75ljgHOAVM/r1yun0=
-github.com/sashabaranov/go-openai v1.28.2/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sclevine/agouti v3.0.0+incompatible/go.mod h1:b4WX9W9L1sfQKXeJf1mUTLZKJ48R1S7H23Ji7oFO5Bw=
 github.com/sclevine/spec v1.2.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
@@ -1798,8 +1788,8 @@ github.com/shopspring/decimal v0.0.0-20200227202807-02e2044944cc/go.mod h1:DKyhr
 github.com/shopspring/decimal v1.2.0 h1:abSATXmQEYyShuxI4/vyW3tV1MrKAJzCZ/0zLUXYbsQ=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
-github.com/sijms/go-ora/v2 v2.8.19 h1:7LoKZatDYGi18mkpQTR/gQvG9yOdtc7hPAex96Bqisc=
-github.com/sijms/go-ora/v2 v2.8.19/go.mod h1:EHxlY6x7y9HAsdfumurRfTd+v8NrEOTR3Xl4FWlH6xk=
+github.com/sijms/go-ora v1.3.2 h1:v9Ca63acRbrE5vYlHpABzlOvt8bI1Sj5PCVDwaAJjp8=
+github.com/sijms/go-ora v1.3.2/go.mod h1:ZGVmJgxUfyGIVmYgA7MVGEq6BX5aoFECRMtHW5DEcs4=
 github.com/simplereach/timeutils v1.2.0/go.mod h1:VVbQDfN/FHRZa1LSqcwo4kNZ62OOyqLLGQKYB3pB0Q8=
 github.com/sirupsen/logrus v1.0.4-0.20170822132746-89742aefa4b2/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.0.6/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
@@ -2090,13 +2080,11 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.16.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
 golang.org/x/crypto v0.19.0/go.mod h1:Iy9bg/ha4yyC70EfRS8jz+B6ybOBKMaSxLj6P6oBDfU=
 golang.org/x/crypto v0.21.0/go.mod h1:0BP7YvVV9gBbVKyeTG0Gyn+gZm94bibOW5BjDEYAOMs=
@@ -2222,12 +2210,10 @@ golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20210505024714-0287a6fb4125/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210520170846-37e1c6afe023/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20210610132358-84b48f89b13b/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210825183410-e898025ed96a/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210916014120-12bc252f5db8/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211209124913-491a49abca63/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211216030914-fe4d6282115f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220111093109-d55c255bac03/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=

--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -31,8 +31,10 @@ const (
 	HeaderInstillCodeKey  = "Instill-Share-Code"
 	HeaderReturnTracesKey = "Instill-Return-Traces"
 
-	HeaderUserAgentKey  = "Instill-User-Agent"
-	HeaderInstillUseSSE = "Instill-Use-SSE"
+	HeaderUserAgentKey = "Instill-User-Agent"
+
+	HeaderAccept           = "Accept"
+	HeaderValueEventStream = "text/event-stream"
 
 	SegMemory    = "memory"
 	SegVariable  = "variable"

--- a/pkg/data/array.go
+++ b/pkg/data/array.go
@@ -19,7 +19,7 @@ func NewArray(v []Value) (arr *Array) {
 
 func (Array) isValue() {}
 
-func (a *Array) ToStructValue() (v *structpb.Value, err error) {
+func (a Array) ToStructValue() (v *structpb.Value, err error) {
 	arr := &structpb.ListValue{Values: make([]*structpb.Value, len(a.Values))}
 	for idx, v := range a.Values {
 		if v == nil {

--- a/pkg/data/audio.go
+++ b/pkg/data/audio.go
@@ -4,7 +4,7 @@ type Audio struct {
 	File
 }
 
-func (*Audio) isValue() {}
+func (Audio) isValue() {}
 
 func NewAudioFromBytes(b []byte, contentType, fileName string) (audio *Audio, err error) {
 	f, err := NewFileFromBytes(b, contentType, fileName, nil)

--- a/pkg/data/boolean.go
+++ b/pkg/data/boolean.go
@@ -10,13 +10,13 @@ func NewBoolean(b bool) *Boolean {
 	return &Boolean{Raw: b}
 }
 
-func (*Boolean) isValue() {}
+func (Boolean) isValue() {}
 
 func (b *Boolean) GetBoolean() bool {
 	return b.Raw
 }
 
-func (b *Boolean) ToStructValue() (v *structpb.Value, err error) {
+func (b Boolean) ToStructValue() (v *structpb.Value, err error) {
 	v = structpb.NewBoolValue(b.Raw)
 	return
 }

--- a/pkg/data/bytearray.go
+++ b/pkg/data/bytearray.go
@@ -14,13 +14,13 @@ func NewByteArray(b []byte) *ByteArray {
 	return &ByteArray{Raw: b}
 }
 
-func (*ByteArray) isValue() {}
+func (ByteArray) isValue() {}
 
 func (b *ByteArray) GetByteArray() []byte {
 	return b.Raw
 }
 
-func (b *ByteArray) ToStructValue() (v *structpb.Value, err error) {
+func (b ByteArray) ToStructValue() (v *structpb.Value, err error) {
 	v = structpb.NewStringValue(base64.StdEncoding.EncodeToString(b.Raw))
 	return
 }

--- a/pkg/data/data.go
+++ b/pkg/data/data.go
@@ -16,6 +16,8 @@ type Value interface {
 func NewValue(in any) (val Value, err error) {
 
 	switch in := in.(type) {
+	case nil:
+		return NewNull(), nil
 	case bool:
 		return NewBoolean(in), nil
 	case float64:
@@ -117,6 +119,7 @@ func NewValueFromStruct(in *structpb.Value) (val Value, err error) {
 func init() {
 	gob.Register(&Map{})
 	gob.Register(&Array{})
+	gob.Register(&Null{})
 	gob.Register(&Boolean{})
 	gob.Register(&Number{})
 	gob.Register(&String{})

--- a/pkg/data/document.go
+++ b/pkg/data/document.go
@@ -16,7 +16,7 @@ const PPTX = "application/vnd.openxmlformats-officedocument.presentationml.prese
 const HTML = "text/html"
 const PDF = "application/pdf"
 
-func (*Document) isValue() {}
+func (Document) isValue() {}
 
 func NewDocumentFromBytes(b []byte, contentType, fileName string) (doc *Document, err error) {
 	f, err := NewFileFromBytes(b, contentType, fileName, nil)

--- a/pkg/data/file.go
+++ b/pkg/data/file.go
@@ -144,7 +144,7 @@ func (f *File) Get(path string) (v Value, err error) {
 	return nil, fmt.Errorf("wrong path")
 }
 
-func (f *File) ToStructValue() (v *structpb.Value, err error) {
+func (f File) ToStructValue() (v *structpb.Value, err error) {
 	d, err := f.GetDataURL(f.ContentType)
 	if err != nil {
 		return nil, err

--- a/pkg/data/image.go
+++ b/pkg/data/image.go
@@ -16,7 +16,7 @@ type Image struct {
 	Height int
 }
 
-func (*Image) isValue() {}
+func (Image) isValue() {}
 
 const JPEG = "image/jpeg"
 const PNG = "image/png"

--- a/pkg/data/map.go
+++ b/pkg/data/map.go
@@ -17,20 +17,19 @@ func NewMap(m map[string]Value) (mp *Map) {
 	}
 }
 
-func (*Map) isValue() {}
+func (Map) isValue() {}
 
-func (m *Map) ToStructValue() (v *structpb.Value, err error) {
+func (m Map) ToStructValue() (v *structpb.Value, err error) {
 	mp := &structpb.Struct{Fields: make(map[string]*structpb.Value)}
 	for k, v := range m.Fields {
-		if v == nil {
-			mp.Fields[k] = structpb.NewNullValue()
-		} else {
+		switch v := v.(type) {
+		case Null:
+		default:
 			mp.Fields[k], err = v.ToStructValue()
 			if err != nil {
 				return nil, err
 			}
 		}
-
 	}
 	return structpb.NewStructValue(mp), nil
 }

--- a/pkg/data/map.go
+++ b/pkg/data/map.go
@@ -22,12 +22,14 @@ func (Map) isValue() {}
 func (m Map) ToStructValue() (v *structpb.Value, err error) {
 	mp := &structpb.Struct{Fields: make(map[string]*structpb.Value)}
 	for k, v := range m.Fields {
-		switch v := v.(type) {
-		case Null:
-		default:
-			mp.Fields[k], err = v.ToStructValue()
-			if err != nil {
-				return nil, err
+		if v != nil {
+			switch v := v.(type) {
+			case Null:
+			default:
+				mp.Fields[k], err = v.ToStructValue()
+				if err != nil {
+					return nil, err
+				}
 			}
 		}
 	}

--- a/pkg/data/null.go
+++ b/pkg/data/null.go
@@ -9,8 +9,8 @@ func NewNull() *Null {
 	return &Null{}
 }
 
-func (*Null) isValue() {}
+func (Null) isValue() {}
 
-func (b *Null) ToStructValue() (v *structpb.Value, err error) {
+func (n Null) ToStructValue() (v *structpb.Value, err error) {
 	return structpb.NewNullValue(), nil
 }

--- a/pkg/data/null.go
+++ b/pkg/data/null.go
@@ -1,0 +1,16 @@
+package data
+
+import "google.golang.org/protobuf/types/known/structpb"
+
+type Null struct {
+}
+
+func NewNull() *Null {
+	return &Null{}
+}
+
+func (*Null) isValue() {}
+
+func (b *Null) ToStructValue() (v *structpb.Value, err error) {
+	return structpb.NewNullValue(), nil
+}

--- a/pkg/data/number.go
+++ b/pkg/data/number.go
@@ -14,7 +14,7 @@ func NewNumberFromInteger(i int) *Number {
 	return &Number{Raw: float64(i)}
 }
 
-func (*Number) isValue() {}
+func (Number) isValue() {}
 
 func (n *Number) GetInteger() int {
 	return int(n.Raw)
@@ -24,7 +24,7 @@ func (n *Number) GetFloat() float64 {
 	return n.Raw
 }
 
-func (n *Number) ToStructValue() (v *structpb.Value, err error) {
+func (n Number) ToStructValue() (v *structpb.Value, err error) {
 	v = structpb.NewNumberValue(n.Raw)
 	return
 }

--- a/pkg/data/string.go
+++ b/pkg/data/string.go
@@ -6,7 +6,7 @@ type String struct {
 	Raw string
 }
 
-func (*String) isValue() {}
+func (String) isValue() {}
 
 func NewString(t string) *String {
 	return &String{Raw: t}
@@ -16,7 +16,7 @@ func (s *String) GetString() string {
 	return s.Raw
 }
 
-func (s *String) ToStructValue() (v *structpb.Value, err error) {
+func (s String) ToStructValue() (v *structpb.Value, err error) {
 	v = structpb.NewStringValue(s.Raw)
 	return
 }

--- a/pkg/data/video.go
+++ b/pkg/data/video.go
@@ -4,7 +4,7 @@ type Video struct {
 	File
 }
 
-func (*Video) isValue() {}
+func (Video) isValue() {}
 
 func NewVideoFromBytes(b []byte, contentType, fileName string) (video *Video, err error) {
 	f, err := NewFileFromBytes(b, contentType, fileName, nil)

--- a/pkg/datamodel/datamodel.go
+++ b/pkg/datamodel/datamodel.go
@@ -149,7 +149,7 @@ type ComponentMap map[string]*Component
 type Recipe struct {
 	Version   string               `json:"version,omitempty" yaml:"version,omitempty"`
 	On        *On                  `json:"on,omitempty" yaml:"on,omitempty"`
-	Component ComponentMap         `json:"component" yaml:"component,omitempty"`
+	Component ComponentMap         `json:"component,omitempty" yaml:"component,omitempty"`
 	Variable  map[string]*Variable `json:"variable,omitempty" yaml:"variable,omitempty"`
 	Secret    map[string]string    `json:"secret,omitempty" yaml:"secret,omitempty"`
 	Output    map[string]*Output   `json:"output,omitempty" yaml:"output,omitempty"`
@@ -189,6 +189,9 @@ func (c *ComponentMap) UnmarshalYAML(node *yaml.Node) error {
 
 	for _, content := range node.Content {
 		if _, ok := result[content.Value]; ok {
+			if result[content.Value] == nil {
+				result[content.Value] = &Component{}
+			}
 			headCommentLines := strings.Split(content.HeadComment, "\n")
 			for i := range headCommentLines {
 				headCommentLines[i] = strings.TrimLeft(headCommentLines[i], "# ")
@@ -326,7 +329,7 @@ type Component struct {
 	Definition *Definition    `json:"definition,omitempty" yaml:"-"`
 
 	// Fields for iterators
-	Component         ComponentMap          `json:"component" yaml:"component,omitempty"`
+	Component         ComponentMap          `json:"component,omitempty" yaml:"component,omitempty"`
 	OutputElements    map[string]string     `json:"outputElements,omitempty" yaml:"output-elements,omitempty"`
 	DataSpecification *pb.DataSpecification `json:"dataSpecification,omitempty" yaml:"-"`
 }

--- a/pkg/handler/main.go
+++ b/pkg/handler/main.go
@@ -3,11 +3,7 @@ package handler
 import (
 	"context"
 	"errors"
-	"fmt"
-	"net/http"
 	"strings"
-	"sync"
-	"time"
 
 	"go.opentelemetry.io/otel"
 
@@ -125,71 +121,4 @@ func (h *PublicHandler) CheckName(ctx context.Context, req *pipelinepb.CheckName
 	return &pipelinepb.CheckNameResponse{
 		Availability: pipelinepb.CheckNameResponse_NAME_UNAVAILABLE,
 	}, nil
-}
-
-// DataChanMap is used to store data channels by session UUID.
-var DataChanMap sync.Map //TODO tillknuesting: Cleanup mechanism when a chan is closed or not used
-
-func HandleSSEStreamResponse(w http.ResponseWriter, r *http.Request) {
-	// Get the session UUID from the request URL
-	sessionUUID := r.URL.Path[len("/sse/"):]
-
-	// Get the data channel for the session UUID
-	dataChanValue, ok := DataChanMap.Load(sessionUUID)
-	if !ok {
-		http.Error(w, "Invalid session UUID", http.StatusBadRequest)
-		return
-	}
-	dataChan, ok := dataChanValue.(chan []byte)
-	if !ok {
-		http.Error(w, "Invalid data channel", http.StatusInternalServerError)
-		return
-	}
-
-	// Set the response headers for SSE
-	w.Header().Set("Content-Type", "text/event-stream")
-	w.Header().Set("Cache-Control", "no-cache")
-	w.Header().Set("Connection", "keep-alive")
-
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-
-	var lastTimestamp int64 = 0
-	var eventIDCounter int64 = 0
-
-	// Send the data chunks as SSE events
-	for data := range dataChan {
-		timestamp := time.Now().UnixNano()
-		if timestamp == lastTimestamp {
-			eventIDCounter++
-		} else {
-			eventIDCounter = 0
-		}
-		lastTimestamp = timestamp
-
-		fmt.Fprintf(w, "event: output\n")
-		fmt.Fprintf(w, "id: %d:%d\n", timestamp, eventIDCounter)
-		fmt.Fprintf(w, "data: %s\n\n", data)
-
-		if flusher, ok := w.(http.Flusher); ok {
-			flusher.Flush()
-		}
-	}
-
-	// Send the "done" event
-	currentTimestamp := time.Now().UnixNano()
-	if currentTimestamp == lastTimestamp {
-		eventIDCounter++
-	} else {
-		eventIDCounter = 0
-	}
-
-	fmt.Fprintf(w, "event: done\n")
-	fmt.Fprintf(w, "id: %d:%d\n", currentTimestamp, eventIDCounter)
-	fmt.Fprintf(w, "data: {}\n\n")
-	if flusher, ok := w.(http.Flusher); ok {
-		flusher.Flush()
-	}
-
-	// Remove the data channel from the map when the SSE connection is closed
-	DataChanMap.Delete(sessionUUID)
 }

--- a/pkg/handler/triggerhandler.go
+++ b/pkg/handler/triggerhandler.go
@@ -207,11 +207,11 @@ func convertFormData(ctx context.Context, req *http.Request) ([]*pb.TriggerData,
 // HandleTrigger
 func HandleTrigger(mux *runtime.ServeMux, client pb.PipelinePublicServiceClient, w http.ResponseWriter, req *http.Request, pathParams map[string]string, rc *redis.Client) {
 
-	var sh streamingHandlerFunc
-	if req.Header.Get(constant.HeaderInstillUseSSE) == "true" {
-		sh = func(triggerID string) (err error) {
+	ctx := req.Context()
 
-			ctx, cancel := context.WithCancel(context.Background())
+	var sh streamingHandlerFunc
+	if req.Header.Get(constant.HeaderAccept) == "text/event-stream" {
+		sh = func(triggerID string) (err error) {
 
 			pubsub := rc.Subscribe(ctx, triggerID)
 			defer pubsub.Close()
@@ -222,7 +222,7 @@ func HandleTrigger(mux *runtime.ServeMux, client pb.PipelinePublicServiceClient,
 			w.Header().Set("Cache-Control", "no-cache")
 			w.Header().Set("Connection", "keep-alive")
 
-			defer cancel()
+			// defer cancel()
 			closed := false
 			for !closed {
 				select {
@@ -259,9 +259,6 @@ func HandleTrigger(mux *runtime.ServeMux, client pb.PipelinePublicServiceClient,
 
 		}
 	}
-
-	ctx, cancel := context.WithCancel(req.Context())
-	defer cancel()
 
 	inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
 	var err error
@@ -300,8 +297,7 @@ func HandleTrigger(mux *runtime.ServeMux, client pb.PipelinePublicServiceClient,
 // HandleTriggerAsync
 func HandleTriggerAsync(mux *runtime.ServeMux, client pb.PipelinePublicServiceClient, w http.ResponseWriter, req *http.Request, pathParams map[string]string, rc *redis.Client) {
 
-	ctx, cancel := context.WithCancel(req.Context())
-	defer cancel()
+	ctx := req.Context()
 
 	inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
 	var err error
@@ -529,11 +525,10 @@ func request_PipelinePublicService_TriggerAsyncNamespacePipeline_0_form(ctx cont
 // HandleTrigger
 func HandleTriggerRelease(mux *runtime.ServeMux, client pb.PipelinePublicServiceClient, w http.ResponseWriter, req *http.Request, pathParams map[string]string, rc *redis.Client) {
 
+	ctx := req.Context()
 	var sh streamingHandlerFunc
-	if req.Header.Get(constant.HeaderInstillUseSSE) == "true" {
+	if req.Header.Get(constant.HeaderAccept) == "text/event-stream" {
 		sh = func(triggerID string) (err error) {
-
-			ctx, cancel := context.WithCancel(context.Background())
 
 			pubsub := rc.Subscribe(ctx, triggerID)
 			defer pubsub.Close()
@@ -544,7 +539,6 @@ func HandleTriggerRelease(mux *runtime.ServeMux, client pb.PipelinePublicService
 			w.Header().Set("Cache-Control", "no-cache")
 			w.Header().Set("Connection", "keep-alive")
 
-			defer cancel()
 			closed := false
 			for !closed {
 				select {
@@ -581,9 +575,6 @@ func HandleTriggerRelease(mux *runtime.ServeMux, client pb.PipelinePublicService
 
 		}
 	}
-
-	ctx, cancel := context.WithCancel(req.Context())
-	defer cancel()
 
 	inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
 	var err error
@@ -622,8 +613,7 @@ func HandleTriggerRelease(mux *runtime.ServeMux, client pb.PipelinePublicService
 // HandleTriggerAsync
 func HandleTriggerAsyncRelease(mux *runtime.ServeMux, client pb.PipelinePublicServiceClient, w http.ResponseWriter, req *http.Request, pathParams map[string]string, rc *redis.Client) {
 
-	ctx, cancel := context.WithCancel(req.Context())
-	defer cancel()
+	ctx := req.Context()
 
 	inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
 	var err error

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -2,23 +2,18 @@ package middleware
 
 import (
 	"context"
-	"crypto/sha256"
 	"encoding/base64"
-	"encoding/json"
-	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
-	"github.com/instill-ai/pipeline-backend/config"
-	"github.com/instill-ai/pipeline-backend/pkg/handler"
+	"github.com/redis/go-redis/v9"
+
 	"github.com/instill-ai/pipeline-backend/pkg/repository"
 	"github.com/instill-ai/pipeline-backend/pkg/service"
+
 	pb "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
-	"github.com/redis/go-redis/v9"
 )
 
 type fn func(*runtime.ServeMux, pb.PipelinePublicServiceClient, http.ResponseWriter, *http.Request, map[string]string, *redis.Client)
@@ -29,126 +24,6 @@ func AppendCustomHeaderMiddleware(mux *runtime.ServeMux, client pb.PipelinePubli
 	return runtime.HandlerFunc(func(w http.ResponseWriter, r *http.Request, pathParams map[string]string) {
 		next(mux, client, w, r, pathParams, rc)
 	})
-}
-
-// SessionMetadata holds the session ID and source instance ID.
-type SessionMetadata struct {
-	SessionUUID string `json:"sessionUUID"`
-	// Source instance identifier is used for network routing scenarios
-	// for example could be included as header in the SSE request to make sure
-	// it is getting routed to the initiating server e.g. running a pod
-	SourceInstanceID string `json:"sourceInstanceID"`
-}
-
-// generateSecureSessionID generated a cryptographic secure session token to be used
-// to the url of the sse handler.
-func generateSecureSessionID() string {
-	generatedUUID := uuid.New().String()
-	hash := sha256.Sum256([]byte(generatedUUID))
-	return fmt.Sprintf("%x", hash)
-}
-
-// sseResponseStreamingMiddleware intercepts requests with X-Use-SSE header present
-// and gives back immediately a session token. It continues calling the grpc-gateway
-// endpoint and streams data to the SSE handler using the session ID token.
-func SSEStreamResponseMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("Instill-Use-SSE") == "true" {
-			dataChanBufferSize := config.Config.Server.DataChanBufferSize
-			if dataChanBufferSize <= 0 {
-				dataChanBufferSize = 1
-			}
-			dataChan := make(chan []byte, dataChanBufferSize)
-
-			sessionUUID := generateSecureSessionID()
-
-			handler.DataChanMap.Store(sessionUUID, dataChan)
-			defer close(dataChan)
-
-			sessionData := SessionMetadata{
-				SessionUUID:      sessionUUID,
-				SourceInstanceID: config.Config.Server.InstanceID,
-			}
-
-			responseData, err := json.Marshal(sessionData)
-			if err != nil {
-				http.Error(w, "failed to generate session", http.StatusInternalServerError)
-				return
-			}
-
-			// Get the underlying connection using http.Hijacker
-			hijacker, ok := w.(http.Hijacker)
-			if !ok {
-				http.Error(w, "hijacking not supported", http.StatusInternalServerError)
-				return
-			}
-
-			conn, bufw, err := hijacker.Hijack()
-			if err != nil {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-				return
-			}
-
-			// Set the response headers
-			if _, err := bufw.WriteString("HTTP/1.1 200 OK\r\n"); err != nil {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-				return
-			}
-			if _, err := bufw.WriteString("Content-Type: application/json\r\n"); err != nil {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-				return
-			}
-			if _, err := bufw.WriteString("Connection: close\r\n\r\n"); err != nil {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-				return
-			}
-
-			// Write the initial response
-			if _, err := bufw.WriteString(string(responseData) + "\n\n"); err != nil {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-				return
-			}
-			if err := bufw.Flush(); err != nil {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-				return
-			}
-			if err := conn.Close(); err != nil {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-				return
-			}
-
-			// Create a new request with the new context
-			newReq := r.Clone(context.Background())
-
-			sw := &captureResponseWriter{
-				ResponseWriter: httptest.NewRecorder(),
-				DataChan:       dataChan,
-			}
-
-			next.ServeHTTP(sw, newReq)
-			return
-		}
-
-		next.ServeHTTP(w, r)
-	})
-}
-
-type captureResponseWriter struct {
-	http.ResponseWriter
-	DataChan chan []byte
-}
-
-func (mw *captureResponseWriter) Write(b []byte) (int, error) {
-	if len(b) > 1 {
-		mw.DataChan <- b
-	}
-	return mw.ResponseWriter.Write(b)
-}
-
-// Unwrap is used by the ResponseController in the grpc-gateway runtime to flush
-// if method is not present there would be a server error.
-func (mw *captureResponseWriter) Unwrap() http.ResponseWriter {
-	return mw.ResponseWriter
 }
 
 func HandleProfileImage(srv service.Service, repo repository.Repository) runtime.HandlerFunc {

--- a/pkg/middleware/misc.go
+++ b/pkg/middleware/misc.go
@@ -155,6 +155,8 @@ func CustomMatcher(key string) (string, bool) {
 	}
 
 	switch key {
+	case "Accept":
+		return key, true
 	case "request-id":
 		return key, true
 	case "X-B3-Traceid", "X-B3-Spanid", "X-B3-Sampled":

--- a/pkg/recipe/dag.go
+++ b/pkg/recipe/dag.go
@@ -223,10 +223,13 @@ func Render(ctx context.Context, template data.Value, batchIdx int, wfm memory.W
 		var err error
 		mp := data.NewMap(nil)
 		for k, v := range input.Fields {
-			mp.Fields[k], err = Render(ctx, v, batchIdx, wfm)
-			if err != nil {
-				return nil, err
+			if _, isNull := v.(*data.Null); !isNull {
+				mp.Fields[k], err = Render(ctx, v, batchIdx, wfm)
+				if err != nil {
+					return nil, err
+				}
 			}
+
 		}
 		return mp, nil
 	case *data.Array:
@@ -239,6 +242,8 @@ func Render(ctx context.Context, template data.Value, batchIdx int, wfm memory.W
 			}
 		}
 		return arr, nil
+	case *data.Null:
+		return nil, nil
 	default:
 		return input, nil
 	}

--- a/pkg/service/convert.go
+++ b/pkg/service/convert.go
@@ -171,15 +171,19 @@ func (c *converter) includeComponentDetail(ctx context.Context, ownerPermalink s
 			Setup: c.processSetup(ctx, ownerPermalink, comp.Setup),
 		})
 		if err != nil {
-			return err
+			comp.Definition = nil
+		} else {
+			comp.Definition = &datamodel.Definition{ComponentDefinition: def}
 		}
-		comp.Definition = &datamodel.Definition{ComponentDefinition: def}
+
 	} else {
 		def, err := c.component.GetDefinitionByID(comp.Type, nil, nil)
 		if err != nil {
-			return err
+			comp.Definition = nil
+		} else {
+			comp.Definition = &datamodel.Definition{ComponentDefinition: def}
 		}
-		comp.Definition = &datamodel.Definition{ComponentDefinition: def}
+
 	}
 
 	return nil

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -1279,7 +1279,7 @@ func (s *service) triggerAsyncPipeline(
 	if requesterUID.IsNil() {
 		requesterUID = userUID
 	}
-	isStreaming := resource.GetRequestSingleHeader(ctx, constant.HeaderInstillUseSSE) == "true"
+	isStreaming := resource.GetRequestSingleHeader(ctx, constant.HeaderAccept) == "text/event-stream"
 
 	runSource := datamodel.RunSource(runpb.RunSource_RUN_SOURCE_API)
 	userAgentValue, ok := runpb.RunSource_value[resource.GetRequestSingleHeader(ctx, constant.HeaderUserAgentKey)]
@@ -1380,15 +1380,15 @@ func (s *service) getOutputsAndMetadata(ctx context.Context, pipelineTriggerID s
 	}
 
 	var metadata *pipelinepb.TriggerMetadata
-	if returnTraces {
-		traces, err := recipe.GenerateTraces(ctx, wfm)
-		if err != nil {
-			return nil, nil, err
-		}
-		metadata = &pipelinepb.TriggerMetadata{
-			Traces: traces,
-		}
+
+	traces, err := recipe.GenerateTraces(ctx, wfm, returnTraces)
+	if err != nil {
+		return nil, nil, err
 	}
+	metadata = &pipelinepb.TriggerMetadata{
+		Traces: traces,
+	}
+
 	return pipelineOutputs, metadata, nil
 }
 

--- a/pkg/service/secret.go
+++ b/pkg/service/secret.go
@@ -138,13 +138,13 @@ func (s *service) checkSecret(ctx context.Context, components datamodel.Componen
 		default:
 
 			c, err := s.component.GetDefinitionByID(comp.Type, nil, nil)
-			if err != nil {
-				return err
+			if err == nil {
+				err := s.checkSecretFields(ctx, uuid.FromStringOrNil(c.Uid), comp.Setup, "")
+				if err != nil {
+					return err
+				}
 			}
-			err = s.checkSecretFields(ctx, uuid.FromStringOrNil(c.Uid), comp.Setup, "")
-			if err != nil {
-				return err
-			}
+
 		case datamodel.Iterator:
 			err := s.checkSecret(ctx, comp.Component)
 			if err != nil {

--- a/pkg/worker/workflow.go
+++ b/pkg/worker/workflow.go
@@ -524,21 +524,21 @@ func (w *worker) OutputActivity(ctx context.Context, param *ComponentActivityPar
 
 	wfm, err := w.memoryStore.GetWorkflowMemory(ctx, param.WorkflowID)
 	if err != nil {
-		return temporal.NewApplicationErrorWithCause("failed to load pipeline memory", outputActivityErrorType, err)
+		return temporal.NewApplicationErrorWithCause("loading pipeline memory", outputActivityErrorType, err)
 	}
 
 	for idx := range wfm.GetBatchSize() {
 		output, err := wfm.Get(ctx, idx, string(memory.PipelineOutputTemplate))
 		if err != nil {
-			return temporal.NewApplicationErrorWithCause("failed to load pipeline output", outputActivityErrorType, err)
+			return temporal.NewApplicationErrorWithCause("loading pipeline output", outputActivityErrorType, err)
 		}
 		output, err = recipe.Render(ctx, output, idx, wfm)
 		if err != nil {
-			return temporal.NewApplicationErrorWithCause("failed to render pipeline output", outputActivityErrorType, err)
+			return temporal.NewApplicationErrorWithCause("loading pipeline output", outputActivityErrorType, err)
 		}
 		err = wfm.SetPipelineData(ctx, idx, memory.PipelineOutput, output)
 		if err != nil {
-			return temporal.NewApplicationErrorWithCause("failed to store pipeline output", outputActivityErrorType, err)
+			return temporal.NewApplicationErrorWithCause("loading pipeline output", outputActivityErrorType, err)
 		}
 	}
 
@@ -740,19 +740,19 @@ func (w *worker) CloneToMemoryStoreActivity(ctx context.Context, param *MemoryCo
 
 	wfm, err := w.memoryStore.LoadWorkflowMemoryFromRedis(ctx, param.WorkflowID)
 	if err != nil {
-		return temporal.NewApplicationErrorWithCause("failed to load pipeline memory", cloneToMemoryStoreActivityErrorType, err)
+		return temporal.NewApplicationErrorWithCause("loading pipeline memory", cloneToMemoryStoreActivityErrorType, err)
 	}
 	var recipe *datamodel.Recipe
 	if param.SystemVariables.PipelineReleaseUID.IsNil() {
 		pipeline, err := w.repository.GetPipelineByUIDAdmin(ctx, param.SystemVariables.PipelineUID, false, false)
 		if err != nil {
-			return temporal.NewApplicationErrorWithCause("failed to load pipeline recipe", cloneToMemoryStoreActivityErrorType, err)
+			return temporal.NewApplicationErrorWithCause("loading pipeline recipe", cloneToMemoryStoreActivityErrorType, err)
 		}
 		recipe = pipeline.Recipe
 	} else {
 		release, err := w.repository.GetPipelineReleaseByUIDAdmin(ctx, param.SystemVariables.PipelineReleaseUID, false)
 		if err != nil {
-			return temporal.NewApplicationErrorWithCause("failed to load pipeline recipe", cloneToMemoryStoreActivityErrorType, err)
+			return temporal.NewApplicationErrorWithCause("loading pipeline recipe", cloneToMemoryStoreActivityErrorType, err)
 		}
 		recipe = release.Recipe
 	}
@@ -766,7 +766,7 @@ func (w *worker) CloneToMemoryStoreActivity(ctx context.Context, param *MemoryCo
 		var secrets []*datamodel.Secret
 		secrets, _, pt, err = w.repository.ListNamespaceSecrets(ctx, ownerPermalink, 100, pt, filtering.Filter{})
 		if err != nil {
-			return temporal.NewApplicationErrorWithCause("failed to load pipeline secret memory", cloneToMemoryStoreActivityErrorType, err)
+			return temporal.NewApplicationErrorWithCause("loading pipeline secret memory", cloneToMemoryStoreActivityErrorType, err)
 		}
 
 		for _, secret := range secrets {
@@ -782,7 +782,7 @@ func (w *worker) CloneToMemoryStoreActivity(ctx context.Context, param *MemoryCo
 	for idx := range wfm.GetBatchSize() {
 		pipelineSecrets, err := wfm.Get(ctx, idx, constant.SegSecret)
 		if err != nil {
-			return temporal.NewApplicationErrorWithCause("failed to load pipeline secret memory", cloneToMemoryStoreActivityErrorType, err)
+			return temporal.NewApplicationErrorWithCause("loading pipeline secret memory", cloneToMemoryStoreActivityErrorType, err)
 		}
 
 		for _, secret := range nsSecrets {
@@ -798,18 +798,18 @@ func (w *worker) CloneToMemoryStoreActivity(ctx context.Context, param *MemoryCo
 
 			inputVal, err := data.NewValue(comp.Input)
 			if err != nil {
-				return temporal.NewApplicationErrorWithCause("failed to init pipeline input memory", cloneToMemoryStoreActivityErrorType, err)
+				return temporal.NewApplicationErrorWithCause("initializing pipeline input memory", cloneToMemoryStoreActivityErrorType, err)
 			}
 			if err := wfm.SetComponentData(ctx, idx, compID, memory.ComponentDataInput, inputVal); err != nil {
-				return temporal.NewApplicationErrorWithCause("failed to init pipeline input memory", cloneToMemoryStoreActivityErrorType, err)
+				return temporal.NewApplicationErrorWithCause("initializing pipeline input memory", cloneToMemoryStoreActivityErrorType, err)
 			}
 
 			setupVal, err := data.NewValue(comp.Setup)
 			if err != nil {
-				return temporal.NewApplicationErrorWithCause("failed to init pipeline setup memory", cloneToMemoryStoreActivityErrorType, err)
+				return temporal.NewApplicationErrorWithCause("initializing pipeline setup memory", cloneToMemoryStoreActivityErrorType, err)
 			}
 			if err := wfm.SetComponentData(ctx, idx, compID, memory.ComponentDataSetup, setupVal); err != nil {
-				return temporal.NewApplicationErrorWithCause("failed to init pipeline setup memory", cloneToMemoryStoreActivityErrorType, err)
+				return temporal.NewApplicationErrorWithCause("initializing pipeline setup memory", cloneToMemoryStoreActivityErrorType, err)
 			}
 		}
 		output := data.NewMap(nil)
@@ -819,7 +819,7 @@ func (w *worker) CloneToMemoryStoreActivity(ctx context.Context, param *MemoryCo
 		}
 		err = wfm.SetPipelineData(ctx, idx, memory.PipelineOutputTemplate, output)
 		if err != nil {
-			return temporal.NewApplicationErrorWithCause("failed to clone pipeline memory", cloneToMemoryStoreActivityErrorType, err)
+			return temporal.NewApplicationErrorWithCause("initializing pipeline memory", cloneToMemoryStoreActivityErrorType, err)
 		}
 	}
 
@@ -827,11 +827,11 @@ func (w *worker) CloneToMemoryStoreActivity(ctx context.Context, param *MemoryCo
 		for batchIdx := range wfm.GetBatchSize() {
 			variable, err := wfm.Get(ctx, batchIdx, "variable")
 			if err != nil {
-				return temporal.NewApplicationErrorWithCause("failed to send event", cloneToMemoryStoreActivityErrorType, err)
+				return temporal.NewApplicationErrorWithCause("sending event", cloneToMemoryStoreActivityErrorType, err)
 			}
 			variableStruct, err := variable.ToStructValue()
 			if err != nil {
-				return temporal.NewApplicationErrorWithCause("failed to send event", cloneToMemoryStoreActivityErrorType, err)
+				return temporal.NewApplicationErrorWithCause("sending event", cloneToMemoryStoreActivityErrorType, err)
 			}
 			variableJSON := map[string]any{}
 			b, _ := protojson.Marshal(variableStruct)
@@ -849,7 +849,7 @@ func (w *worker) CloneToMemoryStoreActivity(ctx context.Context, param *MemoryCo
 				},
 			)
 			if err != nil {
-				return temporal.NewApplicationErrorWithCause("failed to send event", cloneToMemoryStoreActivityErrorType, err)
+				return temporal.NewApplicationErrorWithCause("sending event", cloneToMemoryStoreActivityErrorType, err)
 			}
 		}
 	}
@@ -866,7 +866,33 @@ func (w *worker) CloneToRedisActivity(ctx context.Context, param *MemoryCopyPara
 
 	err := w.memoryStore.WriteWorkflowMemoryToRedis(ctx, param.WorkflowID)
 	if err != nil {
-		return temporal.NewApplicationErrorWithCause("failed to clone pipeline memory", cloneToRedisActivityErrorType, err)
+		return temporal.NewApplicationErrorWithCause("loading pipeline memory", cloneToRedisActivityErrorType, err)
+	}
+	wfm, err := w.memoryStore.LoadWorkflowMemoryFromRedis(ctx, param.WorkflowID)
+	if err != nil {
+		return temporal.NewApplicationErrorWithCause("loading pipeline memory", cloneToRedisActivityErrorType, err)
+	}
+	for batchIdx := range wfm.GetBatchSize() {
+		output, err := wfm.GetPipelineData(ctx, batchIdx, memory.PipelineOutput)
+		if err != nil {
+			return temporal.NewApplicationErrorWithCause("loading pipeline memory", cloneToRedisActivityErrorType, err)
+		}
+
+		err = w.memoryStore.SendWorkflowStatusEvent(
+			ctx,
+			param.WorkflowID,
+			memory.Event{
+				Event: memory.PipelineCompleted,
+				Data: memory.PipelineCompletedEventData{
+					UpdateTime: time.Now(),
+					BatchIndex: batchIdx,
+					Output:     output,
+				},
+			},
+		)
+		if err != nil {
+			return temporal.NewApplicationErrorWithCause("sending event", cloneToRedisActivityErrorType, err)
+		}
 	}
 
 	logger.Info("CloneToRedisActivity completed")


### PR DESCRIPTION
Because

- Previously, the streaming API didn’t return any error messages and didn’t support partial errors. If one component failed, the entire pipeline would fail. This design isn’t ideal, as other components should still be able to execute if they are not downstream of the failed component.

This commit

- Returns error messages in the stream.
- Allows partial errors in pipeline triggers and includes error messages in the metadata.