### PR TITLE
feat: return component status in all component events

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0
 	github.com/iancoleman/strcase v0.3.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/component v0.25.0-beta.0.20240825094027-aa605fabd788
+	github.com/instill-ai/component v0.25.0-beta.0.20240826085103-da830bd57dcc
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240823161910-354761b16f15
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0
 	github.com/iancoleman/strcase v0.3.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/component v0.25.0-beta.0.20240826085103-da830bd57dcc
+	github.com/instill-ai/component v0.25.0-beta.0.20240826165932-7e7891778000
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240823161910-354761b16f15
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha

--- a/go.sum
+++ b/go.sum
@@ -1271,8 +1271,8 @@ github.com/influxdata/influxdb-client-go/v2 v2.12.3 h1:28nRlNMRIV4QbtIUvxhWqaxn0
 github.com/influxdata/influxdb-client-go/v2 v2.12.3/go.mod h1:IrrLUbCjjfkmRuaCiGQg4m2GbkaeJDcuWoxiWdQEbA0=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/instill-ai/component v0.25.0-beta.0.20240825094027-aa605fabd788 h1:3mG7IyWfAVkq2urY4x2503/VBKbJhI+HGdxtlqsQ8w0=
-github.com/instill-ai/component v0.25.0-beta.0.20240825094027-aa605fabd788/go.mod h1:6OW4uu948rEHhPGMDjjIff8RI9uElgm1ZUA10BRuGoU=
+github.com/instill-ai/component v0.25.0-beta.0.20240826085103-da830bd57dcc h1:k/c9w3CK+MFjjGwklDn5CLLUDY30JtuUF921oxOIPwk=
+github.com/instill-ai/component v0.25.0-beta.0.20240826085103-da830bd57dcc/go.mod h1:6OW4uu948rEHhPGMDjjIff8RI9uElgm1ZUA10BRuGoU=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240823161910-354761b16f15 h1:4nFVI3TCq8Iu/lDz2YOAM/koNdjUktXUG16YEEpnXBo=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240823161910-354761b16f15/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=

--- a/go.sum
+++ b/go.sum
@@ -1273,6 +1273,8 @@ github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
 github.com/instill-ai/component v0.25.0-beta.0.20240826085103-da830bd57dcc h1:k/c9w3CK+MFjjGwklDn5CLLUDY30JtuUF921oxOIPwk=
 github.com/instill-ai/component v0.25.0-beta.0.20240826085103-da830bd57dcc/go.mod h1:6OW4uu948rEHhPGMDjjIff8RI9uElgm1ZUA10BRuGoU=
+github.com/instill-ai/component v0.25.0-beta.0.20240826165932-7e7891778000 h1:teRzu+b//9/RHMEbVbiv923IAb0yTV1w6L2xmgdUsTg=
+github.com/instill-ai/component v0.25.0-beta.0.20240826165932-7e7891778000/go.mod h1:6OW4uu948rEHhPGMDjjIff8RI9uElgm1ZUA10BRuGoU=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240823161910-354761b16f15 h1:4nFVI3TCq8Iu/lDz2YOAM/koNdjUktXUG16YEEpnXBo=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240823161910-354761b16f15/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=

--- a/pkg/handler/triggerhandler.go
+++ b/pkg/handler/triggerhandler.go
@@ -237,7 +237,7 @@ func HandleTrigger(mux *runtime.ServeMux, client pb.PipelinePublicServiceClient,
 					if err != nil {
 						return err
 					}
-					if event.Event == memory.PipelineClosed {
+					if event.Event == string(memory.PipelineClosed) {
 						closed = true
 						break
 					}
@@ -553,7 +553,7 @@ func HandleTriggerRelease(mux *runtime.ServeMux, client pb.PipelinePublicService
 					if err != nil {
 						return err
 					}
-					if event.Event == memory.PipelineClosed {
+					if event.Event == string(memory.PipelineClosed) {
 						closed = true
 						break
 					}

--- a/pkg/memory/memory.go
+++ b/pkg/memory/memory.go
@@ -17,6 +17,7 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
+type PipelineStatusType string
 type PipelineDataType string
 type ComponentStatusType string
 type ComponentDataType string
@@ -36,6 +37,12 @@ const (
 	ComponentStatusSkipped   ComponentStatusType = "skipped"
 	ComponentStatusErrored   ComponentStatusType = "errored"
 	ComponentStatusCompleted ComponentStatusType = "completed"
+)
+
+const (
+	PipelineStatusStarted   PipelineStatusType = "started"
+	PipelineStatusErrored   PipelineStatusType = "errored"
+	PipelineStatusCompleted PipelineStatusType = "completed"
 )
 
 const (
@@ -98,67 +105,85 @@ type workflowMemory struct {
 	streaming   bool
 }
 
-type EventType string
+type ComponentEventType string
+type PipelineEventType string
+
 type Event struct {
-	Event EventType `json:"event"`
-	Data  any       `json:"data"`
+	Event string `json:"event"`
+	Data  any    `json:"data"`
 }
 
-type PipelineStartedEventData struct {
+type PipelineEventData struct {
 	UpdateTime time.Time `json:"updateTime"`
 	BatchIndex int       `json:"batchIndex"`
-	Variable   any       `json:"variable"`
+
+	Status map[PipelineStatusType]bool `json:"status"`
 }
 
-type PipelineCompletedEventData struct {
-	UpdateTime time.Time `json:"updateTime"`
-	BatchIndex int       `json:"batchIndex"`
-	Output     any       `json:"output"`
+type PipelineStatusUpdatedEventData struct {
+	PipelineEventData
+}
+
+type PipelineOutputUpdatedEventData struct {
+	PipelineEventData
+	Output any `json:"output"`
+}
+
+type PipelineErrorUpdatedEventData struct {
+	PipelineEventData
+	Error MessageError `json:"error"`
 }
 
 type ComponentEventData struct {
 	UpdateTime  time.Time `json:"updateTime"`
 	ComponentID string    `json:"componentID"`
 	BatchIndex  int       `json:"batchIndex"`
-}
 
-type ComponentStatusEventData struct {
-	ComponentEventData
 	Status map[ComponentStatusType]bool `json:"status"`
 }
 
-type ComponentInputEventData struct {
+type ComponentStatusUpdatedEventData struct {
+	ComponentEventData
+}
+
+type ComponentInputUpdatedEventData struct {
 	ComponentEventData
 	Input any `json:"input"`
 }
-type ComponentOutputEventData struct {
+type ComponentOutputUpdatedEventData struct {
 	ComponentEventData
 	Output any `json:"output"`
 }
 
-type ComponentErrorEventData struct {
+type ComponentErrorUpdatedEventData struct {
 	ComponentEventData
+	Error MessageError `json:"error"`
+}
+type MessageError struct {
 	Message string `json:"message"`
 }
 
 const (
-	PipelineStarted        EventType = "PIPELINE_STARTED"
-	PipelineOutputUpdated  EventType = "PIPELINE_OUTPUT_UPDATED"
-	PipelineCompleted      EventType = "PIPELINE_COMPLETED"
-	PipelineClosed         EventType = "PIPELINE_CLOSED"
-	ComponentStatusUpdated EventType = "COMPONENT_STATUS_UPDATED"
-	ComponentInputUpdated  EventType = "COMPONENT_INPUT_UPDATED"
-	ComponentOutputUpdated EventType = "COMPONENT_OUTPUT_UPDATED"
-	ComponentErrored       EventType = "COMPONENT_ERRORED"
+	PipelineStatusUpdated PipelineEventType = "PIPELINE_STATUS_UPDATED"
+	PipelineOutputUpdated PipelineEventType = "PIPELINE_OUTPUT_UPDATED"
+	PipelineErrorUpdated  PipelineEventType = "PIPELINE_ERROR_UPDATED"
+	PipelineClosed        PipelineEventType = "PIPELINE_CLOSED"
+
+	ComponentStatusUpdated ComponentEventType = "COMPONENT_STATUS_UPDATED"
+	ComponentInputUpdated  ComponentEventType = "COMPONENT_INPUT_UPDATED"
+	ComponentOutputUpdated ComponentEventType = "COMPONENT_OUTPUT_UPDATED"
+	ComponentErrorUpdated  ComponentEventType = "COMPONENT_ERROR_UPDATED"
 )
 
 func init() {
-	gob.Register(ComponentStatusEventData{})
-	gob.Register(ComponentInputEventData{})
-	gob.Register(ComponentOutputEventData{})
-	gob.Register(ComponentErrorEventData{})
-	gob.Register(PipelineStartedEventData{})
-	gob.Register(PipelineCompletedEventData{})
+	gob.Register(ComponentStatusUpdatedEventData{})
+	gob.Register(ComponentInputUpdatedEventData{})
+	gob.Register(ComponentOutputUpdatedEventData{})
+	gob.Register(ComponentErrorUpdatedEventData{})
+	gob.Register(MessageError{})
+	gob.Register(PipelineStatusUpdatedEventData{})
+	gob.Register(PipelineOutputUpdatedEventData{})
+	gob.Register(PipelineErrorUpdatedEventData{})
 }
 
 func NewMemoryStore(rc *redis.Client) MemoryStore {
@@ -309,56 +334,14 @@ func (wfm *workflowMemory) SetComponentData(ctx context.Context, batchIdx int, c
 	}
 	wfm.Data[batchIdx].(*data.Map).Fields[componentID].(*data.Map).Fields[string(t)] = value
 
-	if wfm.streaming {
-		// TODO: simplify struct conversion
-		s, err := value.ToStructValue()
-		if err != nil {
+	if t == ComponentDataInput {
+		if err := wfm.sendComponentEvent(ctx, batchIdx, componentID, ComponentInputUpdated); err != nil {
 			return err
 		}
-		b, err := protojson.Marshal(s)
-		if err != nil {
+	} else if t == ComponentDataOutput {
+		if err := wfm.sendComponentEvent(ctx, batchIdx, componentID, ComponentOutputUpdated); err != nil {
 			return err
 		}
-		var data map[string]any
-		err = json.Unmarshal(b, &data)
-		if err != nil {
-			return err
-		}
-
-		event := Event{}
-		if t == ComponentDataInput {
-			event.Event = ComponentInputUpdated
-			event.Data = ComponentInputEventData{
-				ComponentEventData: ComponentEventData{
-					UpdateTime:  time.Now(),
-					ComponentID: componentID,
-					BatchIndex:  batchIdx,
-				},
-				Input: data,
-			}
-		} else if t == ComponentDataOutput {
-			event.Event = ComponentOutputUpdated
-			event.Data = ComponentOutputEventData{
-				ComponentEventData: ComponentEventData{
-					UpdateTime:  time.Now(),
-					ComponentID: componentID,
-					BatchIndex:  batchIdx,
-				},
-				Output: data,
-			}
-		}
-		buf := bytes.Buffer{}
-		enc := gob.NewEncoder(&buf)
-		err = enc.Encode(event)
-		if err != nil {
-			return err
-		}
-
-		err = wfm.redisClient.Publish(ctx, wfm.ID, buf.Bytes()).Err()
-		if err != nil {
-			return err
-		}
-
 	}
 	return nil
 }
@@ -381,42 +364,11 @@ func (wfm *workflowMemory) SetComponentStatus(ctx context.Context, batchIdx int,
 	}
 	wfm.Data[batchIdx].(*data.Map).Fields[componentID].(*data.Map).Fields["status"].(*data.Map).Fields[string(t)] = data.NewBoolean(value)
 
-	if wfm.streaming {
-		// TODO: simplify struct conversion
-		st := wfm.Data[batchIdx].(*data.Map).Fields[componentID].(*data.Map).Fields["status"].(*data.Map)
-		started := st.Fields[string(ComponentStatusStarted)].(*data.Boolean).GetBoolean()
-		skipped := st.Fields[string(ComponentStatusSkipped)].(*data.Boolean).GetBoolean()
-		errored := st.Fields[string(ComponentStatusErrored)].(*data.Boolean).GetBoolean()
-		completed := st.Fields[string(ComponentStatusCompleted)].(*data.Boolean).GetBoolean()
-		event := Event{
-			Event: ComponentStatusUpdated,
-			Data: ComponentStatusEventData{
-				ComponentEventData: ComponentEventData{
-					UpdateTime:  time.Now(),
-					ComponentID: componentID,
-					BatchIndex:  batchIdx,
-				},
-				Status: map[ComponentStatusType]bool{
-					ComponentStatusStarted:   started,
-					ComponentStatusSkipped:   skipped,
-					ComponentStatusErrored:   errored,
-					ComponentStatusCompleted: completed,
-				},
-			},
-		}
-		buf := bytes.Buffer{}
-		enc := gob.NewEncoder(&buf)
-		err = enc.Encode(event)
-		if err != nil {
-			return err
-		}
-
-		err = wfm.redisClient.Publish(ctx, wfm.ID, buf.Bytes()).Err()
-		if err != nil {
-			return err
-		}
+	if err := wfm.sendComponentEvent(ctx, batchIdx, componentID, ComponentStatusUpdated); err != nil {
+		return err
 	}
-	return err
+
+	return nil
 }
 func (wfm *workflowMemory) SetComponentErrorMessage(ctx context.Context, batchIdx int, componentID string, msg string) (err error) {
 	wfm.mu.Lock()
@@ -427,30 +379,10 @@ func (wfm *workflowMemory) SetComponentErrorMessage(ctx context.Context, batchId
 	}
 	wfm.Data[batchIdx].(*data.Map).Fields[componentID].(*data.Map).Fields["error"].(*data.Map).Fields["message"] = data.NewString(msg)
 
-	if wfm.streaming {
-		event := Event{
-			Event: ComponentErrored,
-			Data: ComponentErrorEventData{
-				ComponentEventData: ComponentEventData{
-					UpdateTime:  time.Now(),
-					ComponentID: componentID,
-					BatchIndex:  batchIdx,
-				},
-				Message: msg,
-			},
-		}
-		buf := bytes.Buffer{}
-		enc := gob.NewEncoder(&buf)
-		err = enc.Encode(event)
-		if err != nil {
-			return err
-		}
-
-		err = wfm.redisClient.Publish(ctx, wfm.ID, buf.Bytes()).Err()
-		if err != nil {
-			return err
-		}
+	if err := wfm.sendComponentEvent(ctx, batchIdx, componentID, ComponentErrorUpdated); err != nil {
+		return err
 	}
+
 	return nil
 }
 func (wfm *workflowMemory) GetComponentStatus(ctx context.Context, batchIdx int, componentID string, t ComponentStatusType) (value bool, err error) {
@@ -486,10 +418,18 @@ func (wfm *workflowMemory) SetPipelineData(ctx context.Context, batchIdx int, t 
 		}
 		event := Event{}
 		if t == PipelineOutput {
-			event.Event = PipelineOutputUpdated
-			event.Data = PipelineCompletedEventData{
-				UpdateTime: time.Now(),
-				Output:     data,
+			event.Event = string(PipelineOutputUpdated)
+			event.Data = PipelineOutputUpdatedEventData{
+				PipelineEventData: PipelineEventData{
+					UpdateTime: time.Now(),
+					BatchIndex: batchIdx,
+					Status: map[PipelineStatusType]bool{
+						PipelineStatusStarted:   true,
+						PipelineStatusErrored:   false,
+						PipelineStatusCompleted: false,
+					},
+				},
+				Output: data,
 			}
 		}
 		buf := bytes.Buffer{}
@@ -578,4 +518,122 @@ func (wfm *workflowMemory) SetRecipe(r *datamodel.Recipe) {
 
 func (wfm *workflowMemory) GetRecipe() *datamodel.Recipe {
 	return wfm.Recipe
+}
+
+func (wfm *workflowMemory) getComponentEventData(_ context.Context, batchIdx int, componentID string) ComponentEventData {
+	// TODO: simplify struct conversion
+	st := wfm.Data[batchIdx].(*data.Map).Fields[componentID].(*data.Map).Fields["status"].(*data.Map)
+	started := st.Fields[string(ComponentStatusStarted)].(*data.Boolean).GetBoolean()
+	skipped := st.Fields[string(ComponentStatusSkipped)].(*data.Boolean).GetBoolean()
+	errored := st.Fields[string(ComponentStatusErrored)].(*data.Boolean).GetBoolean()
+	completed := st.Fields[string(ComponentStatusCompleted)].(*data.Boolean).GetBoolean()
+
+	return ComponentEventData{
+		UpdateTime:  time.Now(),
+		ComponentID: componentID,
+		BatchIndex:  batchIdx,
+		Status: map[ComponentStatusType]bool{
+			ComponentStatusStarted:   started,
+			ComponentStatusSkipped:   skipped,
+			ComponentStatusErrored:   errored,
+			ComponentStatusCompleted: completed,
+		},
+	}
+}
+
+func (wfm *workflowMemory) sendComponentEvent(ctx context.Context, batchIdx int, componentID string, t ComponentEventType) (err error) {
+
+	if wfm.streaming {
+		var event *Event
+		switch t {
+		case ComponentInputUpdated:
+			value := wfm.Data[batchIdx].(*data.Map).Fields[componentID].(*data.Map).Fields[string(ComponentDataInput)]
+
+			// TODO: simplify struct conversion
+			s, err := value.ToStructValue()
+			if err != nil {
+				return err
+			}
+			b, err := protojson.Marshal(s)
+			if err != nil {
+				return err
+			}
+			var data map[string]any
+			err = json.Unmarshal(b, &data)
+			if err != nil {
+				return err
+			}
+
+			event = &Event{
+				Event: string(ComponentInputUpdated),
+				Data: ComponentInputUpdatedEventData{
+					ComponentEventData: wfm.getComponentEventData(ctx, batchIdx, componentID),
+					Input:              data,
+				},
+			}
+
+		case ComponentOutputUpdated:
+
+			value := wfm.Data[batchIdx].(*data.Map).Fields[componentID].(*data.Map).Fields[string(ComponentDataOutput)]
+
+			// TODO: simplify struct conversion
+			s, err := value.ToStructValue()
+			if err != nil {
+				return err
+			}
+			b, err := protojson.Marshal(s)
+			if err != nil {
+				return err
+			}
+			var data map[string]any
+			err = json.Unmarshal(b, &data)
+			if err != nil {
+				return err
+			}
+
+			event = &Event{
+				Event: string(ComponentOutputUpdated),
+				Data: ComponentOutputUpdatedEventData{
+					ComponentEventData: wfm.getComponentEventData(ctx, batchIdx, componentID),
+					Output:             data,
+				},
+			}
+
+		case ComponentErrorUpdated:
+			message := wfm.Data[batchIdx].(*data.Map).Fields[componentID].(*data.Map).Fields["error"].(*data.Map).Fields["message"].(*data.String)
+			event = &Event{
+				Event: string(ComponentErrorUpdated),
+				Data: ComponentErrorUpdatedEventData{
+					ComponentEventData: wfm.getComponentEventData(ctx, batchIdx, componentID),
+					Error: MessageError{
+						Message: message.GetString(),
+					},
+				},
+			}
+
+		case ComponentStatusUpdated:
+			event = &Event{
+				Event: string(ComponentStatusUpdated),
+				Data: ComponentStatusUpdatedEventData{
+					ComponentEventData: wfm.getComponentEventData(ctx, batchIdx, componentID),
+				},
+			}
+		}
+
+		if event != nil {
+			buf := bytes.Buffer{}
+			enc := gob.NewEncoder(&buf)
+			err = enc.Encode(event)
+			if err != nil {
+				return err
+			}
+
+			err = wfm.redisClient.Publish(ctx, wfm.ID, buf.Bytes()).Err()
+			if err != nil {
+				return err
+			}
+		}
+
+	}
+	return nil
 }


### PR DESCRIPTION
Because

- The original events were not well-designed for frontend use.

This commit

- Refactors the event codebase.
- Returns component status in all component events.