### PR TITLE
feat: add supports for Data properties

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,18 @@ dev:							## Run dev container
 	@docker inspect --type container ${SERVICE_NAME} >/dev/null 2>&1 && echo "A container named ${SERVICE_NAME} is already running." || \
 		echo "Run dev container ${SERVICE_NAME}. To stop it, run \"make stop\"."
 	@docker run -d --rm \
-		-v $(PWD):/${SERVICE_NAME} \
 		-p ${SERVICE_PORT}:${SERVICE_PORT} \
+		-v $(PWD)/../go.work:/go.work \
+		-v $(PWD)/../go.work.sum:/go.work.sum \
+		-v $(PWD)/../mgmt-backend:/mgmt-backend \
+		-v $(PWD)/../model-backend:/model-backend \
+		-v $(PWD)/../pipeline-backend:/pipeline-backend \
+		-v $(PWD)/../artifact-backend:/artifact-backend \
+		-v $(PWD)/../mgmt-backend-cloud:/mgmt-backend-cloud \
+		-v $(PWD)/../model-backend-cloud:/model-backend-cloud \
+		-v $(PWD)/../pipeline-backend-cloud:/pipeline-backend-cloud \
+		-v $(PWD)/../protogengo:/protogengo \
+		-v $(PWD)/../component:/component \
 		--network instill-network \
 		--name ${SERVICE_NAME} \
 		instill/${SERVICE_NAME}:dev >/dev/null 2>&1
@@ -46,7 +56,6 @@ top:							## Display all running service processes
 build:							## Build dev docker image
 	@docker build \
 		--build-arg SERVICE_NAME=${SERVICE_NAME} \
-		--build-arg GOLANG_VERSION=${GOLANG_VERSION} \
 		--build-arg K6_VERSION=${K6_VERSION} \
 		-f Dockerfile.dev  -t instill/${SERVICE_NAME}:dev .
 
@@ -100,11 +109,6 @@ integration-test:				## Run integration test
 	@TEST_FOLDER_ABS_PATH=${PWD} k6 run \
 		-e API_GATEWAY_PROTOCOL=${API_GATEWAY_PROTOCOL} -e API_GATEWAY_URL=${API_GATEWAY_URL} \
 		integration-test/pipeline/rest.js --no-usage-report --quiet
-
-.PHONY: gen-mock
-gen-mock:
-	@go install github.com/gojuno/minimock/v3/cmd/minimock@v3.3.13
-	@go generate -run minimock ./...
 
 .PHONY: help
 help:       	 				## Show this help

--- a/pkg/data/array.go
+++ b/pkg/data/array.go
@@ -19,6 +19,20 @@ func NewArray(v []Value) (arr *Array) {
 
 func (Array) isValue() {}
 
+func (a *Array) Get(path string) (v Value, err error) {
+	if path == "" {
+		return a, nil
+	}
+	path, err = standardizePath(path)
+	if err != nil {
+		return nil, err
+	}
+	index, remainingPath, err := trimFirstIndexFromPath(path)
+	if err != nil {
+		return nil, err
+	}
+	return a.Values[index].Get(remainingPath)
+}
 func (a Array) ToStructValue() (v *structpb.Value, err error) {
 	arr := &structpb.ListValue{Values: make([]*structpb.Value, len(a.Values))}
 	for idx, v := range a.Values {

--- a/pkg/data/audio.go
+++ b/pkg/data/audio.go
@@ -7,7 +7,7 @@ type Audio struct {
 func (Audio) isValue() {}
 
 func NewAudioFromBytes(b []byte, contentType, fileName string) (audio *Audio, err error) {
-	f, err := NewFileFromBytes(b, contentType, fileName, nil)
+	f, err := NewFileFromBytes(b, contentType, fileName)
 	if err != nil {
 		return
 	}
@@ -15,7 +15,7 @@ func NewAudioFromBytes(b []byte, contentType, fileName string) (audio *Audio, er
 }
 
 func NewAudioFromURL(url string) (audio *Audio, err error) {
-	f, err := NewFileFromURL(url, nil)
+	f, err := NewFileFromURL(url)
 	if err != nil {
 		return
 	}

--- a/pkg/data/boolean.go
+++ b/pkg/data/boolean.go
@@ -1,6 +1,10 @@
 package data
 
-import "google.golang.org/protobuf/types/known/structpb"
+import (
+	"fmt"
+
+	"google.golang.org/protobuf/types/known/structpb"
+)
 
 type Boolean struct {
 	Raw bool
@@ -14,6 +18,13 @@ func (Boolean) isValue() {}
 
 func (b *Boolean) GetBoolean() bool {
 	return b.Raw
+}
+
+func (b *Boolean) Get(path string) (v Value, err error) {
+	if path == "" {
+		return b, nil
+	}
+	return nil, fmt.Errorf("wrong path %s for Boolean", path)
 }
 
 func (b Boolean) ToStructValue() (v *structpb.Value, err error) {

--- a/pkg/data/bytearray.go
+++ b/pkg/data/bytearray.go
@@ -2,6 +2,7 @@ package data
 
 import (
 	"encoding/base64"
+	"fmt"
 
 	"google.golang.org/protobuf/types/known/structpb"
 )
@@ -18,6 +19,13 @@ func (ByteArray) isValue() {}
 
 func (b *ByteArray) GetByteArray() []byte {
 	return b.Raw
+}
+
+func (b *ByteArray) Get(path string) (v Value, err error) {
+	if path == "" {
+		return b, nil
+	}
+	return nil, fmt.Errorf("wrong path %s for ByteArray", path)
 }
 
 func (b ByteArray) ToStructValue() (v *structpb.Value, err error) {

--- a/pkg/data/convert.go
+++ b/pkg/data/convert.go
@@ -1,0 +1,49 @@
+package data
+
+import (
+	"bytes"
+	"fmt"
+	"image"
+	"image/gif"
+	"image/jpeg"
+	"image/png"
+)
+
+func convertFile(raw []byte, sourceContentType, targetContentType string) (b []byte, err error) {
+	var img image.Image
+	switch sourceContentType {
+	case PNG:
+		if img, err = png.Decode(bytes.NewReader(raw)); err != nil {
+			return
+		}
+	case JPEG:
+		if img, err = jpeg.Decode(bytes.NewReader(raw)); err != nil {
+			return
+		}
+	case GIF:
+		if img, err = gif.Decode(bytes.NewReader(raw)); err != nil {
+			return
+		}
+	default:
+		return nil, fmt.Errorf("conversion error")
+	}
+
+	buf := new(bytes.Buffer)
+	switch targetContentType {
+	case PNG:
+		if err = png.Encode(buf, img); err != nil {
+			return
+		}
+	case JPEG:
+		if err = jpeg.Encode(buf, img, nil); err != nil {
+			return
+		}
+	case GIF:
+		if err = gif.Encode(buf, img, nil); err != nil {
+			return
+		}
+	default:
+		return nil, fmt.Errorf("conversion error")
+	}
+	return buf.Bytes(), nil
+}

--- a/pkg/data/data.go
+++ b/pkg/data/data.go
@@ -11,6 +11,7 @@ type Data map[string]Value
 type Value interface {
 	isValue()
 	ToStructValue() (v *structpb.Value, err error)
+	Get(path string) (v Value, err error)
 }
 
 func NewValue(in any) (val Value, err error) {

--- a/pkg/data/document.go
+++ b/pkg/data/document.go
@@ -2,7 +2,6 @@ package data
 
 import (
 	"fmt"
-	"strings"
 )
 
 type Document struct {
@@ -19,7 +18,7 @@ const PDF = "application/pdf"
 func (Document) isValue() {}
 
 func NewDocumentFromBytes(b []byte, contentType, fileName string) (doc *Document, err error) {
-	f, err := NewFileFromBytes(b, contentType, fileName, nil)
+	f, err := NewFileFromBytes(b, contentType, fileName)
 	if err != nil {
 		return
 	}
@@ -27,7 +26,7 @@ func NewDocumentFromBytes(b []byte, contentType, fileName string) (doc *Document
 }
 
 func NewDocumentFromURL(url string) (doc *Document, err error) {
-	f, err := NewFileFromURL(url, nil)
+	f, err := NewFileFromURL(url)
 	if err != nil {
 		return
 	}
@@ -50,16 +49,16 @@ func (d *Document) Get(path string) (v Value, err error) {
 		return
 	}
 	switch {
-	case path == "":
+	case comparePath(path, ""):
 		// TODO: we use data-url for now
 		return d.GetDataURL(d.ContentType)
-	case path == ".text":
+	case comparePath(path, ".text"):
 		return d.GetText(), nil
-	case strings.HasPrefix(path, ".base64"):
+	case comparePath(path, ".base64"):
 		return d.GetBase64(d.ContentType)
-	case strings.HasPrefix(path, ".data-url"):
+	case comparePath(path, ".data-url"):
 		return d.GetDataURL(d.ContentType)
-	case strings.HasPrefix(path, ".byte-array"):
+	case comparePath(path, ".byte-array"):
 		return d.GetByteArray(d.ContentType)
 	}
 	return nil, fmt.Errorf("wrong path")

--- a/pkg/data/document.go
+++ b/pkg/data/document.go
@@ -2,6 +2,10 @@ package data
 
 import (
 	"fmt"
+	"strings"
+
+	"github.com/instill-ai/component/operator/document/v0"
+	//  "github.com/instill-ai/component/store"
 )
 
 type Document struct {
@@ -39,8 +43,106 @@ func newDocument(f *File) (doc *Document, err error) {
 	}, nil
 }
 
-func (d *Document) GetText() *String {
-	return NewString("test")
+func (d *Document) GetText() (val *String, err error) {
+
+	dataURL, err := d.GetDataURL(d.ContentType)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := document.ConvertToText(document.ConvertToTextInput{
+		Document: dataURL.GetString(),
+		Filename: d.FileName,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return NewString(res.Body), nil
+}
+
+func (d *Document) GetMarkdown() (val *String, err error) {
+
+	dataURL, err := d.GetDataURL(d.ContentType)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := document.ConvertDocumentToMarkdown(
+		&document.ConvertDocumentToMarkdownInput{
+			Document: dataURL.GetString(),
+			Filename: d.FileName,
+		}, document.GetMarkdownTransformer)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewString(res.Body), nil
+}
+
+func (d *Document) GetPDF() (val *Document, err error) {
+
+	dataURL, err := d.GetDataURL(d.ContentType)
+	if err != nil {
+		return nil, err
+	}
+
+	ext := ""
+	switch d.ContentType {
+	case DOC:
+		ext = "doc"
+	case DOCX:
+		ext = "docx"
+	case PPT:
+		ext = "ppt"
+	case PPTX:
+		ext = "pptx"
+	case HTML:
+		ext = "html"
+	case PDF:
+		return d, nil
+	}
+
+	s, err := document.ConvertToPDF(dataURL.GetString(), ext)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewDocumentFromURL(fmt.Sprintf("data:application/pdf;base64,%s", s))
+}
+
+func (d *Document) GetImages() (mp *Array, err error) {
+
+	pdf, err := d.GetPDF()
+	if err != nil {
+		return nil, err
+	}
+	fmt.Println(d.FileName)
+
+	dataURL, err := pdf.GetDataURL("application/pdf")
+	if err != nil {
+		return nil, err
+	}
+	fmt.Println("cccc", dataURL.GetString()[:40])
+	res, err := document.ConvertPDFToImage(&document.ConvertPDFToImagesInput{
+		PDF:      dataURL.GetString(),
+		Filename: d.FileName,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	images := NewArray(make([]Value, len(res.Images)))
+
+	for idx := range res.Images {
+
+		img := strings.Split(res.Images[idx], ",")[1]
+		images.Values[idx], err = NewImageFromURL(fmt.Sprintf("data:image/jpeg;filename=%s;base64,%s", res.Filenames[idx], img))
+		if err != nil {
+			return nil, fmt.Errorf("NewImageFromBytes: %w", err)
+		}
+	}
+	return images, nil
 }
 
 func (d *Document) Get(path string) (v Value, err error) {
@@ -53,7 +155,25 @@ func (d *Document) Get(path string) (v Value, err error) {
 		// TODO: we use data-url for now
 		return d.GetDataURL(d.ContentType)
 	case comparePath(path, ".text"):
-		return d.GetText(), nil
+		return d.GetText()
+	case comparePath(path, ".markdown"):
+		return d.GetMarkdown()
+	case comparePath(path, ".pdf"):
+		return d.GetPDF()
+	case comparePath(path, ".images"):
+		return d.GetImages()
+	case matchPathPrefix(path, ".images"):
+		// TODO: we should only convert the required pages.
+		images, err := d.GetImages()
+		if err != nil {
+			return nil, err
+		}
+		_, path, err = trimFirstKeyFromPath(path)
+		if err != nil {
+			return nil, err
+		}
+		return images.Get(path)
+
 	case comparePath(path, ".base64"):
 		return d.GetBase64(d.ContentType)
 	case comparePath(path, ".data-url"):

--- a/pkg/data/file.go
+++ b/pkg/data/file.go
@@ -92,7 +92,7 @@ func (f *File) GetDataURL(contentType string) (url *String, err error) {
 	if err != nil {
 		return
 	}
-	s, err := encodeDataURL(ba.GetByteArray(), contentType)
+	s, err := encodeDataURL(ba.GetByteArray(), contentType, f.FileName)
 	if err != nil {
 		return
 	}
@@ -128,7 +128,7 @@ func (f *File) Get(path string) (v Value, err error) {
 	switch {
 	case comparePath(path, ".source-url"):
 		return f.GetSourceURL(), nil
-	case comparePath(path, ".file-name"):
+	case comparePath(path, ".filename"):
 		return f.GetFileName(), nil
 	case comparePath(path, ".file-size"):
 		return f.GetFileSize(), nil

--- a/pkg/data/map.go
+++ b/pkg/data/map.go
@@ -34,7 +34,6 @@ func (m *Map) Get(path string) (v Value, err error) {
 	}
 
 	return m.Fields[key].Get(remainingPath)
-
 }
 
 func (m Map) ToStructValue() (v *structpb.Value, err error) {

--- a/pkg/data/map.go
+++ b/pkg/data/map.go
@@ -19,12 +19,30 @@ func NewMap(m map[string]Value) (mp *Map) {
 
 func (Map) isValue() {}
 
+func (m *Map) Get(path string) (v Value, err error) {
+
+	if path == "" {
+		return m, nil
+	}
+	path, err = standardizePath(path)
+	if err != nil {
+		return nil, err
+	}
+	key, remainingPath, err := trimFirstKeyFromPath(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return m.Fields[key].Get(remainingPath)
+
+}
+
 func (m Map) ToStructValue() (v *structpb.Value, err error) {
 	mp := &structpb.Struct{Fields: make(map[string]*structpb.Value)}
 	for k, v := range m.Fields {
 		if v != nil {
 			switch v := v.(type) {
-			case Null:
+			case *Null:
 			default:
 				mp.Fields[k], err = v.ToStructValue()
 				if err != nil {

--- a/pkg/data/null.go
+++ b/pkg/data/null.go
@@ -1,6 +1,10 @@
 package data
 
-import "google.golang.org/protobuf/types/known/structpb"
+import (
+	"fmt"
+
+	"google.golang.org/protobuf/types/known/structpb"
+)
 
 type Null struct {
 }
@@ -10,6 +14,13 @@ func NewNull() *Null {
 }
 
 func (Null) isValue() {}
+
+func (n *Null) Get(path string) (v Value, err error) {
+	if path == "" {
+		return n, nil
+	}
+	return nil, fmt.Errorf("wrong path %s for Null", path)
+}
 
 func (n Null) ToStructValue() (v *structpb.Value, err error) {
 	return structpb.NewNullValue(), nil

--- a/pkg/data/number.go
+++ b/pkg/data/number.go
@@ -1,6 +1,10 @@
 package data
 
-import "google.golang.org/protobuf/types/known/structpb"
+import (
+	"fmt"
+
+	"google.golang.org/protobuf/types/known/structpb"
+)
 
 type Number struct {
 	Raw float64
@@ -22,6 +26,13 @@ func (n *Number) GetInteger() int {
 
 func (n *Number) GetFloat() float64 {
 	return n.Raw
+}
+
+func (n *Number) Get(path string) (v Value, err error) {
+	if path == "" {
+		return n, nil
+	}
+	return nil, fmt.Errorf("wrong path %s for Number", path)
 }
 
 func (n Number) ToStructValue() (v *structpb.Value, err error) {

--- a/pkg/data/string.go
+++ b/pkg/data/string.go
@@ -1,6 +1,10 @@
 package data
 
-import "google.golang.org/protobuf/types/known/structpb"
+import (
+	"fmt"
+
+	"google.golang.org/protobuf/types/known/structpb"
+)
 
 type String struct {
 	Raw string
@@ -14,6 +18,13 @@ func NewString(t string) *String {
 
 func (s *String) GetString() string {
 	return s.Raw
+}
+
+func (s *String) Get(path string) (v Value, err error) {
+	if path == "" {
+		return s, nil
+	}
+	return nil, fmt.Errorf("wrong path %s for String", path)
 }
 
 func (s String) ToStructValue() (v *structpb.Value, err error) {

--- a/pkg/data/utils.go
+++ b/pkg/data/utils.go
@@ -3,6 +3,7 @@ package data
 import (
 	"encoding/base64"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/gabriel-vasile/mimetype"
@@ -31,4 +32,53 @@ func decodeDataURL(s string) (b []byte, contentType string, fileName string, err
 func encodeDataURL(b []byte, contentType string) (s string, err error) {
 	s = fmt.Sprintf("data:%s;base64,%s", contentType, base64.StdEncoding.EncodeToString(b))
 	return
+}
+
+func standardizePath(path string) (newPath string, err error) {
+	splits := strings.FieldsFunc(path, func(s rune) bool {
+		return s == '.' || s == '['
+	})
+	for _, split := range splits {
+		if strings.HasSuffix(split, "]") {
+			// Array Index
+			newPath += fmt.Sprintf("[%s", split)
+		} else {
+			// Map Key
+			newPath += fmt.Sprintf("[\"%s\"]", split)
+		}
+	}
+	return newPath, err
+}
+
+func trimFirstKeyFromPath(path string) (key, remainingPath string, err error) {
+	key, remainingPath, _ = strings.Cut(path, "]")
+	if strings.HasPrefix(key, "[\"") && strings.HasSuffix(key, "\"") {
+		return key[2 : len(key)-1], remainingPath, nil
+	}
+	return "", "", fmt.Errorf("can not parse key from path: %s", path)
+}
+
+func trimFirstIndexFromPath(path string) (index int, remainingPath string, err error) {
+	key, remainingPath, _ := strings.Cut(path, "]")
+	if strings.HasPrefix(key, "[") {
+		index, err := strconv.Atoi(key[1:])
+		if err == nil {
+			return index, remainingPath, nil
+		}
+
+	}
+	return 0, "", fmt.Errorf("can not parse index from path: %s", path)
+}
+
+func comparePath(path1, path2 string) bool {
+	var err error
+	path1, err = standardizePath(path1)
+	if err != nil {
+		return false
+	}
+	path2, err = standardizePath(path2)
+	if err != nil {
+		return false
+	}
+	return path1 == path2
 }

--- a/pkg/data/utils.go
+++ b/pkg/data/utils.go
@@ -19,18 +19,21 @@ func decodeDataURL(s string) (b []byte, contentType string, fileName string, err
 		tags := ""
 		contentType, tags, _ = strings.Cut(mime[1], ";")
 		b, err = base64.StdEncoding.DecodeString(slices[1])
-		for _, tag := range strings.Split(tags, ",") {
+		for _, tag := range strings.Split(tags, ";") {
+
 			key, value, _ := strings.Cut(tag, "=")
 			if key == "filename" || key == "fileName" || key == "file-name" {
 				fileName = value
 			}
 		}
+		fmt.Println("contentType", s[:30], contentType, "tags", tags, fileName)
 	}
+
 	return
 }
 
-func encodeDataURL(b []byte, contentType string) (s string, err error) {
-	s = fmt.Sprintf("data:%s;base64,%s", contentType, base64.StdEncoding.EncodeToString(b))
+func encodeDataURL(b []byte, contentType, fileName string) (s string, err error) {
+	s = fmt.Sprintf("data:%s;filename=%s;base64,%s", contentType, fileName, base64.StdEncoding.EncodeToString(b))
 	return
 }
 
@@ -81,4 +84,17 @@ func comparePath(path1, path2 string) bool {
 		return false
 	}
 	return path1 == path2
+}
+
+func matchPathPrefix(path, prefix string) bool {
+	var err error
+	path, err = standardizePath(path)
+	if err != nil {
+		return false
+	}
+	prefix, err = standardizePath(prefix)
+	if err != nil {
+		return false
+	}
+	return strings.HasPrefix(path, prefix)
 }

--- a/pkg/data/video.go
+++ b/pkg/data/video.go
@@ -7,7 +7,7 @@ type Video struct {
 func (Video) isValue() {}
 
 func NewVideoFromBytes(b []byte, contentType, fileName string) (video *Video, err error) {
-	f, err := NewFileFromBytes(b, contentType, fileName, nil)
+	f, err := NewFileFromBytes(b, contentType, fileName)
 	if err != nil {
 		return
 	}
@@ -15,7 +15,7 @@ func NewVideoFromBytes(b []byte, contentType, fileName string) (video *Video, er
 }
 
 func NewVideoFromURL(url string) (video *Video, err error) {
-	f, err := NewFileFromURL(url, nil)
+	f, err := NewFileFromURL(url)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Because

- We introduced data structures for unstructured data, and we want users to easily access the data and perform format conversions.

This commit

- Refactors the reference system.
- Adds support for data properties and format conversions. For example, users can get the image width via `${some-component.image.width}` or convert a PDF to markdown via `${variable.document.markdown}`.