### PR TITLE
fix: the workflow timeout is using wrong value

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1271,8 +1271,6 @@ github.com/influxdata/influxdb-client-go/v2 v2.12.3 h1:28nRlNMRIV4QbtIUvxhWqaxn0
 github.com/influxdata/influxdb-client-go/v2 v2.12.3/go.mod h1:IrrLUbCjjfkmRuaCiGQg4m2GbkaeJDcuWoxiWdQEbA0=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/instill-ai/component v0.25.0-beta.0.20240826085103-da830bd57dcc h1:k/c9w3CK+MFjjGwklDn5CLLUDY30JtuUF921oxOIPwk=
-github.com/instill-ai/component v0.25.0-beta.0.20240826085103-da830bd57dcc/go.mod h1:6OW4uu948rEHhPGMDjjIff8RI9uElgm1ZUA10BRuGoU=
 github.com/instill-ai/component v0.25.0-beta.0.20240826165932-7e7891778000 h1:teRzu+b//9/RHMEbVbiv923IAb0yTV1w6L2xmgdUsTg=
 github.com/instill-ai/component v0.25.0-beta.0.20240826165932-7e7891778000/go.mod h1:6OW4uu948rEHhPGMDjjIff8RI9uElgm1ZUA10BRuGoU=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240823161910-354761b16f15 h1:4nFVI3TCq8Iu/lDz2YOAM/koNdjUktXUG16YEEpnXBo=

--- a/pkg/data/array.go
+++ b/pkg/data/array.go
@@ -1,6 +1,8 @@
 package data
 
 import (
+	"fmt"
+
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -31,6 +33,10 @@ func (a *Array) Get(path string) (v Value, err error) {
 	if err != nil {
 		return nil, err
 	}
+	if index >= len(a.Values) {
+		return nil, fmt.Errorf("path not found: %s", path)
+	}
+
 	return a.Values[index].Get(remainingPath)
 }
 func (a Array) ToStructValue() (v *structpb.Value, err error) {

--- a/pkg/data/map.go
+++ b/pkg/data/map.go
@@ -1,6 +1,8 @@
 package data
 
 import (
+	"fmt"
+
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -33,7 +35,11 @@ func (m *Map) Get(path string) (v Value, err error) {
 		return nil, err
 	}
 
-	return m.Fields[key].Get(remainingPath)
+	if v, ok := m.Fields[key]; !ok {
+		return nil, fmt.Errorf("path not found: %s", path)
+	} else {
+		return v.Get(remainingPath)
+	}
 }
 
 func (m Map) ToStructValue() (v *structpb.Value, err error) {

--- a/pkg/worker/workflow.go
+++ b/pkg/worker/workflow.go
@@ -194,8 +194,8 @@ func (w *worker) TriggerPipelineWorkflow(ctx workflow.Context, param *TriggerPip
 		ownerType = mgmtpb.OwnerType_OWNER_TYPE_UNSPECIFIED
 	}
 	sessionOptions := &workflow.SessionOptions{
-		CreationTimeout:  time.Minute,
-		ExecutionTimeout: time.Minute,
+		CreationTimeout:  time.Duration(config.Config.Server.Workflow.MaxWorkflowTimeout) * time.Second,
+		ExecutionTimeout: time.Duration(config.Config.Server.Workflow.MaxWorkflowTimeout) * time.Second,
 	}
 	ctx, _ = workflow.CreateSession(ctx, sessionOptions)
 	defer workflow.CompleteSession(ctx)
@@ -589,11 +589,11 @@ func (w *worker) OutputActivity(ctx context.Context, param *ComponentActivityPar
 	}
 
 	for idx := range wfm.GetBatchSize() {
-		output, err := wfm.Get(ctx, idx, string(memory.PipelineOutputTemplate))
+		outputTemplate, err := wfm.Get(ctx, idx, string(memory.PipelineOutputTemplate))
 		if err != nil {
 			return temporal.NewApplicationErrorWithCause("loading pipeline output", outputActivityErrorType, err)
 		}
-		output, err = recipe.Render(ctx, output, idx, wfm, true)
+		output, err := recipe.Render(ctx, outputTemplate, idx, wfm, true)
 		if err != nil {
 			return temporal.NewApplicationErrorWithCause("loading pipeline output", outputActivityErrorType, err)
 		}


### PR DESCRIPTION
Because

- The workflow timeout was set to the wrong value.
- The Map and Array didn’t handle errors properly.

This commit

- Fixes the bugs.