### PR TITLE
chore: add `UpsertPipelineRunActivity` for pipeline run logging

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -174,6 +174,7 @@ func main() {
 	w.RegisterActivity(cw.PreTriggerActivity)
 	w.RegisterActivity(cw.PostTriggerActivity)
 	w.RegisterActivity(cw.IncreasePipelineTriggerCountActivity)
+	w.RegisterActivity(cw.UpsertPipelineRunActivity)
 	w.RegisterActivity(cw.UpdatePipelineRunActivity)
 	w.RegisterActivity(cw.UpsertComponentRunActivity)
 	w.RegisterActivity(cw.UploadToMinioActivity)

--- a/pkg/worker/main.go
+++ b/pkg/worker/main.go
@@ -34,6 +34,7 @@ type Worker interface {
 	PostTriggerActivity(ctx context.Context, param *PostTriggerActivityParam) error
 	IncreasePipelineTriggerCountActivity(context.Context, recipe.SystemVariables) error
 
+	UpsertPipelineRunActivity(ctx context.Context, param *UpsertPipelineRunActivityParam) error
 	UpdatePipelineRunActivity(ctx context.Context, param *UpdatePipelineRunActivityParam) error
 	UpsertComponentRunActivity(ctx context.Context, param *UpsertComponentRunActivityParam) error
 	UploadToMinioActivity(ctx context.Context, param *UploadToMinioActivityParam) (string, error)


### PR DESCRIPTION
Because

- We cannot put time-consuming database operations directly in the Temporal workflow.

This commit

- Adds the missing `UpsertPipelineRunActivity`