### PR TITLE
chore: ensure Temporal Activities are completed before Workflow completed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,18 +20,8 @@ dev:							## Run dev container
 	@docker inspect --type container ${SERVICE_NAME} >/dev/null 2>&1 && echo "A container named ${SERVICE_NAME} is already running." || \
 		echo "Run dev container ${SERVICE_NAME}. To stop it, run \"make stop\"."
 	@docker run -d --rm \
+		-v $(PWD):/${SERVICE_NAME} \
 		-p ${SERVICE_PORT}:${SERVICE_PORT} \
-		-v $(PWD)/../go.work:/go.work \
-		-v $(PWD)/../go.work.sum:/go.work.sum \
-		-v $(PWD)/../mgmt-backend:/mgmt-backend \
-		-v $(PWD)/../model-backend:/model-backend \
-		-v $(PWD)/../pipeline-backend:/pipeline-backend \
-		-v $(PWD)/../artifact-backend:/artifact-backend \
-		-v $(PWD)/../mgmt-backend-cloud:/mgmt-backend-cloud \
-		-v $(PWD)/../model-backend-cloud:/model-backend-cloud \
-		-v $(PWD)/../pipeline-backend-cloud:/pipeline-backend-cloud \
-		-v $(PWD)/../protogengo:/protogengo \
-		-v $(PWD)/../component:/component \
 		--network instill-network \
 		--name ${SERVICE_NAME} \
 		instill/${SERVICE_NAME}:dev >/dev/null 2>&1
@@ -56,6 +46,7 @@ top:							## Display all running service processes
 build:							## Build dev docker image
 	@docker build \
 		--build-arg SERVICE_NAME=${SERVICE_NAME} \
+		--build-arg GOLANG_VERSION=${GOLANG_VERSION} \
 		--build-arg K6_VERSION=${K6_VERSION} \
 		-f Dockerfile.dev  -t instill/${SERVICE_NAME}:dev .
 
@@ -109,6 +100,11 @@ integration-test:				## Run integration test
 	@TEST_FOLDER_ABS_PATH=${PWD} k6 run \
 		-e API_GATEWAY_PROTOCOL=${API_GATEWAY_PROTOCOL} -e API_GATEWAY_URL=${API_GATEWAY_URL} \
 		integration-test/pipeline/rest.js --no-usage-report --quiet
+
+.PHONY: gen-mock
+gen-mock:
+	@go install github.com/gojuno/minimock/v3/cmd/minimock@v3.3.13
+	@go generate -run minimock ./...
 
 .PHONY: help
 help:       	 				## Show this help

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0
 	github.com/iancoleman/strcase v0.3.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/component v0.25.0-beta.0.20240826165932-7e7891778000
+	github.com/instill-ai/component v0.25.0-beta.0.20240827093527-0f9a7b2d29c3
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240823161910-354761b16f15
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0
 	github.com/iancoleman/strcase v0.3.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/component v0.25.0-beta.0.20240827093527-0f9a7b2d29c3
+	github.com/instill-ai/component v0.25.0-beta.0.20240827093852-a48c211f8b0b
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240823161910-354761b16f15
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha

--- a/go.sum
+++ b/go.sum
@@ -1273,6 +1273,8 @@ github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
 github.com/instill-ai/component v0.25.0-beta.0.20240827093527-0f9a7b2d29c3 h1:wMAwtKBp0kWIpwx/+L45+o4urmSHtN3W3oyQLVEvrac=
 github.com/instill-ai/component v0.25.0-beta.0.20240827093527-0f9a7b2d29c3/go.mod h1:6OW4uu948rEHhPGMDjjIff8RI9uElgm1ZUA10BRuGoU=
+github.com/instill-ai/component v0.25.0-beta.0.20240827093852-a48c211f8b0b h1:P+xAZVPwZo39TSTvkbrwLeqQOh6uSWPiMdS/Z5va9QM=
+github.com/instill-ai/component v0.25.0-beta.0.20240827093852-a48c211f8b0b/go.mod h1:6OW4uu948rEHhPGMDjjIff8RI9uElgm1ZUA10BRuGoU=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240823161910-354761b16f15 h1:4nFVI3TCq8Iu/lDz2YOAM/koNdjUktXUG16YEEpnXBo=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240823161910-354761b16f15/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=

--- a/go.sum
+++ b/go.sum
@@ -1271,8 +1271,8 @@ github.com/influxdata/influxdb-client-go/v2 v2.12.3 h1:28nRlNMRIV4QbtIUvxhWqaxn0
 github.com/influxdata/influxdb-client-go/v2 v2.12.3/go.mod h1:IrrLUbCjjfkmRuaCiGQg4m2GbkaeJDcuWoxiWdQEbA0=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/instill-ai/component v0.25.0-beta.0.20240826165932-7e7891778000 h1:teRzu+b//9/RHMEbVbiv923IAb0yTV1w6L2xmgdUsTg=
-github.com/instill-ai/component v0.25.0-beta.0.20240826165932-7e7891778000/go.mod h1:6OW4uu948rEHhPGMDjjIff8RI9uElgm1ZUA10BRuGoU=
+github.com/instill-ai/component v0.25.0-beta.0.20240827093527-0f9a7b2d29c3 h1:wMAwtKBp0kWIpwx/+L45+o4urmSHtN3W3oyQLVEvrac=
+github.com/instill-ai/component v0.25.0-beta.0.20240827093527-0f9a7b2d29c3/go.mod h1:6OW4uu948rEHhPGMDjjIff8RI9uElgm1ZUA10BRuGoU=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240823161910-354761b16f15 h1:4nFVI3TCq8Iu/lDz2YOAM/koNdjUktXUG16YEEpnXBo=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240823161910-354761b16f15/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=

--- a/pkg/handler/pipeline.go
+++ b/pkg/handler/pipeline.go
@@ -576,6 +576,7 @@ func (h *PublicHandler) UpdateNamespacePipeline(ctx context.Context, req *pb.Upd
 	}
 
 	pbPipelineToUpdate := getResp.GetPipeline()
+	pbPipelineToUpdate.Recipe = nil
 
 	// Return error if IMMUTABLE fields are intentionally changed
 	if err := checkfield.CheckUpdateImmutableFields(pbPipelineReq, pbPipelineToUpdate, immutablePipelineFields); err != nil {


### PR DESCRIPTION
Because

- Temporal Activities will result in errors if they aren't finished before the Workflow is completed

This commit

- Ensures Temporal Activities are completed before the Workflow is marked as completed
- Fixes a pipeline recipe update bug.
- Reverts wrong Makefile commit.