### PR TITLE
refactor: move all workflow memory operations into Temporal Activities

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -172,6 +172,7 @@ func main() {
 	w.RegisterActivity(cw.PreIteratorActivity)
 	w.RegisterActivity(cw.PostIteratorActivity)
 	w.RegisterActivity(cw.PreTriggerActivity)
+	w.RegisterActivity(cw.LoadDAGDataActivity)
 	w.RegisterActivity(cw.PostTriggerActivity)
 	w.RegisterActivity(cw.IncreasePipelineTriggerCountActivity)
 	w.RegisterActivity(cw.UpsertPipelineRunActivity)

--- a/pkg/handler/pipeline.go
+++ b/pkg/handler/pipeline.go
@@ -1862,7 +1862,7 @@ func (h *PublicHandler) TriggerNamespacePipelineRelease(ctx context.Context, req
 
 	logger, _ := logger.GetZapLogger(ctx)
 
-	ns, releaseID, pbPipeline, pbPipelineRelease, returnTraces, err := h.preTriggerNamespacePipelineRelease(ctx, req)
+	ns, releaseID, pbPipeline, _, returnTraces, err := h.preTriggerNamespacePipelineRelease(ctx, req)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
@@ -1879,7 +1879,6 @@ func (h *PublicHandler) TriggerNamespacePipelineRelease(ctx context.Context, req
 		span,
 		logUUID.String(),
 		eventName,
-		customotel.SetEventResource(pbPipelineRelease),
 	)))
 
 	return &pb.TriggerNamespacePipelineReleaseResponse{Outputs: outputs, Metadata: metadata}, nil

--- a/pkg/service/convert.go
+++ b/pkg/service/convert.go
@@ -139,13 +139,17 @@ func (c *converter) processSetup(ctx context.Context, ownerPermalink string, set
 				// Remove the prefix and suffix
 				secretKey := v[9 : len(v)-1]
 
-				// Since we allow unfinished pipeline recipes, the secret
-				// reference target might not exist. We ignore the error here.
-				s, err := c.repository.GetNamespaceSecretByID(ctx, ownerPermalink, secretKey)
-				if err == nil {
-					rendered[k] = *s.Value
-				} else {
+				if secretKey == "INSTILL_SECRET" {
 					rendered[k] = v
+				} else {
+					// Since we allow unfinished pipeline recipes, the secret
+					// reference target might not exist. We ignore the error here.
+					s, err := c.repository.GetNamespaceSecretByID(ctx, ownerPermalink, secretKey)
+					if err == nil {
+						rendered[k] = *s.Value
+					} else {
+						rendered[k] = v
+					}
 				}
 			} else {
 				rendered[k] = v

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -1813,7 +1813,9 @@ func (s *service) ListPipelineRuns(ctx context.Context, req *pipelinepb.ListPipe
 
 				pbRun.DataSpecification, err = s.converter.GeneratePipelineDataSpec(dbRecipe.Variable, dbRecipe.Output, dbRecipe.Component)
 				if err != nil {
-					return nil, err
+					// Some recipes cannot generate a DataSpecification, so we
+					// can skip them.
+					pbRun.DataSpecification = nil
 				}
 
 			}

--- a/pkg/worker/main.go
+++ b/pkg/worker/main.go
@@ -29,6 +29,7 @@ type Worker interface {
 	ComponentActivity(ctx context.Context, param *ComponentActivityParam) error
 	OutputActivity(ctx context.Context, param *ComponentActivityParam) error
 	PreIteratorActivity(ctx context.Context, param *PreIteratorActivityParam) (*PreIteratorActivityResult, error)
+	LoadDAGDataActivity(ctx context.Context, param *LoadDAGDataActivityParam) (*LoadDAGDataActivityResult, error)
 	PostIteratorActivity(ctx context.Context, param *PostIteratorActivityParam) error
 	PreTriggerActivity(ctx context.Context, param *PreTriggerActivityParam) error
 	PostTriggerActivity(ctx context.Context, param *PostTriggerActivityParam) error


### PR DESCRIPTION
Because

- Temporal Sessions only work for Activities, and we can't ensure that Temporal Workflow and Activities run in the same worker.

This commit

- Moves all workflow memory operations into Temporal Activities.
- Allows `nil` DataSpecification for pipeline runs, as some recipes may not be valid and can't produce a DataSpecification.
- Removes unnecessary logs and warnings.