### PR TITLE
chore: fix wrong recipe parsing in pipeline release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0
 	github.com/iancoleman/strcase v0.3.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/component v0.25.0-beta.0.20240828105657-cfc907630fb3
+	github.com/instill-ai/component v0.25.0-beta.0.20240828161517-b58909f36591
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240823161910-354761b16f15
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha

--- a/go.sum
+++ b/go.sum
@@ -1271,8 +1271,8 @@ github.com/influxdata/influxdb-client-go/v2 v2.12.3 h1:28nRlNMRIV4QbtIUvxhWqaxn0
 github.com/influxdata/influxdb-client-go/v2 v2.12.3/go.mod h1:IrrLUbCjjfkmRuaCiGQg4m2GbkaeJDcuWoxiWdQEbA0=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/instill-ai/component v0.25.0-beta.0.20240828105657-cfc907630fb3 h1:XQK8NIO2vpQSA9yAZW96JcNCnYmZD47q+xX4Bl74amM=
-github.com/instill-ai/component v0.25.0-beta.0.20240828105657-cfc907630fb3/go.mod h1:6OW4uu948rEHhPGMDjjIff8RI9uElgm1ZUA10BRuGoU=
+github.com/instill-ai/component v0.25.0-beta.0.20240828161517-b58909f36591 h1:b8w3wOINu1GlZWjvq/i4SPvgmArVu2Dx56AtH9g37Kw=
+github.com/instill-ai/component v0.25.0-beta.0.20240828161517-b58909f36591/go.mod h1:6OW4uu948rEHhPGMDjjIff8RI9uElgm1ZUA10BRuGoU=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240823161910-354761b16f15 h1:4nFVI3TCq8Iu/lDz2YOAM/koNdjUktXUG16YEEpnXBo=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240823161910-354761b16f15/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=

--- a/pkg/service/convert.go
+++ b/pkg/service/convert.go
@@ -655,7 +655,7 @@ func (c *converter) ConvertPipelineReleaseToDB(ctx context.Context, pipelineUID 
 
 	var recipe *datamodel.Recipe
 	if pbPipelineRelease.Recipe != nil {
-		recipe := &datamodel.Recipe{}
+		recipe = &datamodel.Recipe{}
 		b, err := protojson.Marshal(pbPipelineRelease.Recipe)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Because

- The recipe parsing in the pipeline release was incorrect

This commit

- Fixes the bug
- Updates the component package.