### PR TITLE
chore: move logPipelineRunStart logic to service after querying pipel…

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -19,12 +19,13 @@ import (
 	"github.com/instill-ai/pipeline-backend/pkg/logger"
 	"github.com/instill-ai/pipeline-backend/pkg/minio"
 	"github.com/instill-ai/pipeline-backend/pkg/repository"
-	"github.com/instill-ai/x/temporal"
-	"github.com/instill-ai/x/zapadapter"
 
 	database "github.com/instill-ai/pipeline-backend/pkg/db"
 	customotel "github.com/instill-ai/pipeline-backend/pkg/logger/otel"
 	pipelineworker "github.com/instill-ai/pipeline-backend/pkg/worker"
+
+	"github.com/instill-ai/x/temporal"
+	"github.com/instill-ai/x/zapadapter"
 )
 
 func initTemporalNamespace(ctx context.Context, client client.Client) {
@@ -175,10 +176,8 @@ func main() {
 	w.RegisterActivity(cw.LoadDAGDataActivity)
 	w.RegisterActivity(cw.PostTriggerActivity)
 	w.RegisterActivity(cw.IncreasePipelineTriggerCountActivity)
-	w.RegisterActivity(cw.UpsertPipelineRunActivity)
 	w.RegisterActivity(cw.UpdatePipelineRunActivity)
 	w.RegisterActivity(cw.UpsertComponentRunActivity)
-	w.RegisterActivity(cw.UploadToMinioActivity)
 	w.RegisterActivity(cw.UploadInputsToMinioActivity)
 	w.RegisterActivity(cw.UploadOutputsToMinioActivity)
 	w.RegisterActivity(cw.UploadRecipeToMinioActivity)

--- a/pkg/handler/pipeline.go
+++ b/pkg/handler/pipeline.go
@@ -22,17 +22,17 @@ import (
 
 	fieldmask_utils "github.com/mennanov/fieldmask-utils"
 
-	"github.com/instill-ai/x/checkfield"
-
 	"github.com/instill-ai/pipeline-backend/pkg/constant"
 	"github.com/instill-ai/pipeline-backend/pkg/logger"
 	"github.com/instill-ai/pipeline-backend/pkg/resource"
 	"github.com/instill-ai/pipeline-backend/pkg/service"
 
-	pb "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
-
 	errdomain "github.com/instill-ai/pipeline-backend/pkg/errors"
 	customotel "github.com/instill-ai/pipeline-backend/pkg/logger/otel"
+
+	"github.com/instill-ai/x/checkfield"
+
+	pb "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
 
 func (h *PrivateHandler) ListPipelinesAdmin(ctx context.Context, req *pb.ListPipelinesAdminRequest) (*pb.ListPipelinesAdminResponse, error) {

--- a/pkg/recipe/variable.go
+++ b/pkg/recipe/variable.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/instill-ai/pipeline-backend/config"
 	"github.com/instill-ai/pipeline-backend/pkg/constant"
-	"github.com/instill-ai/pipeline-backend/pkg/datamodel"
 	"github.com/instill-ai/pipeline-backend/pkg/resource"
 )
 
@@ -22,7 +21,6 @@ type SystemVariables struct {
 	PipelineReleaseUID uuid.UUID              `json:"__PIPELINE_RELEASE_UID"`
 	PipelineOwnerType  resource.NamespaceType `json:"__PIPELINE_OWNER_TYPE"`
 	PipelineOwnerUID   uuid.UUID              `json:"__PIPELINE_OWNER_UID"`
-	PipelineRunSource  datamodel.RunSource    `json:"__PIPELINE_RUN_SOURCE"`
 
 	// PipelineUserUID is the authenticated user executing a pipeline.
 	PipelineUserUID uuid.UUID `json:"__PIPELINE_USER_UID"`

--- a/pkg/service/main.go
+++ b/pkg/service/main.go
@@ -9,6 +9,7 @@ import (
 	"go.einride.tech/aip/filtering"
 	"go.einride.tech/aip/ordering"
 	"go.temporal.io/sdk/client"
+	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/instill-ai/pipeline-backend/pkg/acl"
@@ -100,6 +101,7 @@ type service struct {
 	converter                Converter
 	minioClient              minio.MinioI
 	memory                   memory.MemoryStore
+	log                      *zap.Logger
 }
 
 // NewService initiates a service instance
@@ -112,17 +114,18 @@ func NewService(
 	m mgmtpb.MgmtPrivateServiceClient,
 	minioClient minio.MinioI,
 ) Service {
-	logger, _ := logger.GetZapLogger(context.Background())
+	zapLogger, _ := logger.GetZapLogger(context.Background())
 
 	return &service{
 		repository:               r,
 		redisClient:              rc,
 		temporalClient:           t,
 		mgmtPrivateServiceClient: m,
-		component:                componentstore.Init(logger, nil, nil),
+		component:                componentstore.Init(zapLogger, nil, nil),
 		aclClient:                acl,
 		converter:                c,
 		minioClient:              minioClient,
 		memory:                   memory.NewMemoryStore(rc),
+		log:                      zapLogger,
 	}
 }

--- a/pkg/service/pipelinerun.go
+++ b/pkg/service/pipelinerun.go
@@ -1,0 +1,58 @@
+package service
+
+import (
+	"context"
+	"time"
+
+	"github.com/gofrs/uuid"
+	"go.uber.org/zap"
+	"gopkg.in/guregu/null.v4"
+
+	"github.com/instill-ai/pipeline-backend/pkg/constant"
+	"github.com/instill-ai/pipeline-backend/pkg/datamodel"
+	"github.com/instill-ai/pipeline-backend/pkg/resource"
+	"github.com/instill-ai/pipeline-backend/pkg/utils"
+
+	runpb "github.com/instill-ai/protogen-go/common/run/v1alpha"
+)
+
+const defaultPipelineReleaseID = "latest"
+
+func (s *service) logPipelineRunStart(ctx context.Context, pipelineTriggerID string, pipelineUID uuid.UUID, pipelineReleaseID string) *datamodel.PipelineRun {
+	runSource := datamodel.RunSource(runpb.RunSource_RUN_SOURCE_API)
+	userAgentValue, ok := runpb.RunSource_value[resource.GetRequestSingleHeader(ctx, constant.HeaderUserAgentKey)]
+	if ok {
+		runSource = datamodel.RunSource(userAgentValue)
+	}
+
+	requesterUID := utils.GetUserUID(ctx)
+
+	pipelineRun := &datamodel.PipelineRun{
+		PipelineTriggerUID: uuid.FromStringOrNil(pipelineTriggerID),
+		PipelineUID:        pipelineUID,
+		PipelineVersion:    pipelineReleaseID,
+		Status:             datamodel.RunStatus(runpb.RunStatus_RUN_STATUS_PROCESSING),
+		Source:             runSource,
+		TriggeredBy:        requesterUID,
+		StartedTime:        time.Now(),
+	}
+
+	if err := s.repository.UpsertPipelineRun(ctx, pipelineRun); err != nil {
+		s.log.Error("failed to log pipeline run", zap.String("pipelineTriggerID", pipelineTriggerID), zap.Error(err))
+	}
+	return pipelineRun
+}
+
+func (s *service) logPipelineRunError(ctx context.Context, pipelineTriggerID string, err error, startedTime time.Time) {
+	now := time.Now()
+	pipelineRunUpdates := &datamodel.PipelineRun{
+		Error:         null.StringFrom(err.Error()),
+		Status:        datamodel.RunStatus(runpb.RunStatus_RUN_STATUS_FAILED),
+		TotalDuration: null.IntFrom(now.Sub(startedTime).Milliseconds()),
+		CompletedTime: null.TimeFrom(now),
+	}
+
+	if err = s.repository.UpdatePipelineRun(ctx, pipelineTriggerID, pipelineRunUpdates); err != nil {
+		s.log.Error("failed to log pipeline run error", zap.String("pipelineTriggerID", pipelineTriggerID), zap.Error(err))
+	}
+}

--- a/pkg/worker/main.go
+++ b/pkg/worker/main.go
@@ -35,10 +35,8 @@ type Worker interface {
 	PostTriggerActivity(ctx context.Context, param *PostTriggerActivityParam) error
 	IncreasePipelineTriggerCountActivity(context.Context, recipe.SystemVariables) error
 
-	UpsertPipelineRunActivity(ctx context.Context, param *UpsertPipelineRunActivityParam) error
 	UpdatePipelineRunActivity(ctx context.Context, param *UpdatePipelineRunActivityParam) error
 	UpsertComponentRunActivity(ctx context.Context, param *UpsertComponentRunActivityParam) error
-	UploadToMinioActivity(ctx context.Context, param *UploadToMinioActivityParam) (string, error)
 	UploadInputsToMinioActivity(ctx context.Context, param *UploadInputsToMinioActivityParam) error
 	UploadOutputsToMinioActivity(ctx context.Context, param *UploadOutputsToMinioActivityParam) error
 	UploadRecipeToMinioActivity(ctx context.Context, param *UploadRecipeToMinioActivityParam) error

--- a/pkg/worker/minioactivity.go
+++ b/pkg/worker/minioactivity.go
@@ -10,24 +10,11 @@ import (
 
 	"github.com/instill-ai/pipeline-backend/pkg/constant"
 	"github.com/instill-ai/pipeline-backend/pkg/datamodel"
-	"github.com/instill-ai/pipeline-backend/pkg/logger"
 	"github.com/instill-ai/pipeline-backend/pkg/memory"
 )
 
-const (
-	UploadOutputsWorkflow = "UploadOutputsToMinioWorkflow"
-)
-
-func (w *worker) UploadToMinioActivity(ctx context.Context, param *UploadToMinioActivityParam) (string, error) {
-	url, _, err := w.minioClient.UploadFileBytes(ctx, param.ObjectName, param.Data, param.ContentType)
-	if err != nil {
-		return "", err
-	}
-	return url, nil
-}
-
 func (w *worker) UploadInputsToMinioActivity(ctx context.Context, param *UploadInputsToMinioActivityParam) error {
-	log, _ := logger.GetZapLogger(ctx)
+	log := w.log.With(zap.String("PipelineTriggerID", param.PipelineTriggerID))
 	log.Info("UploadInputsToMinioActivity started")
 
 	wfm, err := w.memoryStore.GetWorkflowMemory(ctx, param.PipelineTriggerID)
@@ -69,12 +56,14 @@ func (w *worker) UploadInputsToMinioActivity(ctx context.Context, param *UploadI
 		log.Error("failed to save pipeline run input data", zap.Error(err))
 		return err
 	}
+
+	log.Info("UploadInputsToMinioActivity finished")
 	return nil
 }
 
 func (w *worker) UploadRecipeToMinioActivity(ctx context.Context, param *UploadRecipeToMinioActivityParam) error {
-	log, _ := logger.GetZapLogger(ctx)
-	log.Info("UploadReceiptToMinioActivity started", zap.String("PipelineTriggerID", param.PipelineTriggerID))
+	log := w.log.With(zap.String("PipelineTriggerUID", param.PipelineTriggerID))
+	log.Info("UploadReceiptToMinioActivity started")
 
 	wfm, err := w.memoryStore.GetWorkflowMemory(ctx, param.PipelineTriggerID)
 	if err != nil {
@@ -100,7 +89,7 @@ func (w *worker) UploadRecipeToMinioActivity(ctx context.Context, param *UploadR
 		constant.ContentTypeJSON,
 	)
 	if err != nil {
-		w.log.Error("failed to upload pipeline run inputs to minio", zap.Error(err))
+		log.Error("failed to upload pipeline run inputs to minio", zap.Error(err))
 		return err
 	}
 
@@ -111,15 +100,18 @@ func (w *worker) UploadRecipeToMinioActivity(ctx context.Context, param *UploadR
 		URL:  url,
 	}}})
 	if err != nil {
-		w.log.Error("failed to log pipeline run with recipe snapshot", zap.Error(err))
+		log.Error("failed to log pipeline run with recipe snapshot", zap.Error(err))
 		return err
 	}
+
+	log.Info("UploadReceiptToMinioActivity finished")
 	return nil
 }
 
 func (w *worker) UploadOutputsToMinioActivity(ctx context.Context, param *UploadOutputsToMinioActivityParam) error {
 	eventName := "UploadOutputsToMinioActivity"
-	w.log.Info(fmt.Sprintf("%s started", eventName), zap.String("PipelineTriggerID", param.PipelineTriggerID))
+	log := w.log.With(zap.String("PipelineTriggerUID", param.PipelineTriggerID))
+	log.Info(fmt.Sprintf("%s started", eventName))
 
 	objectName := fmt.Sprintf("pipeline-runs/output/%s.json", param.PipelineTriggerID)
 
@@ -146,7 +138,7 @@ func (w *worker) UploadOutputsToMinioActivity(ctx context.Context, param *Upload
 
 	url, objectInfo, err := w.minioClient.UploadFile(ctx, objectName, outputStructs, constant.ContentTypeJSON)
 	if err != nil {
-		w.log.Error("failed to upload pipeline run inputs to minio", zap.Error(err))
+		log.Error("failed to upload pipeline run inputs to minio", zap.Error(err))
 		return err
 	}
 
@@ -159,17 +151,19 @@ func (w *worker) UploadOutputsToMinioActivity(ctx context.Context, param *Upload
 
 	err = w.repository.UpdatePipelineRun(ctx, param.PipelineTriggerID, &datamodel.PipelineRun{Outputs: outputs})
 	if err != nil {
-		w.log.Error("failed to save pipeline run output data", zap.Error(err))
+		log.Error("failed to save pipeline run output data", zap.Error(err))
 		return err
 	}
 
-	w.log.Info(fmt.Sprintf("%s finished", eventName), zap.String("PipelineTriggerID", param.PipelineTriggerID))
+	log.Info(fmt.Sprintf("%s finished", eventName))
 	return nil
 }
 
 func (w *worker) UploadComponentInputsActivity(ctx context.Context, param *ComponentActivityParam) error {
 	pipelineTriggerID := param.SystemVariables.PipelineTriggerID
-	w.log.Info("UploadComponentInputsActivity started", zap.String("PipelineTriggerID", pipelineTriggerID))
+	log := w.log.With(zap.String("PipelineTriggerUID", pipelineTriggerID), zap.String("ComponentID", param.ID))
+
+	log.Info("UploadComponentInputsActivity started")
 
 	wfm, err := w.memoryStore.GetWorkflowMemory(ctx, param.WorkflowID)
 	if err != nil {
@@ -194,7 +188,7 @@ func (w *worker) UploadComponentInputsActivity(ctx context.Context, param *Compo
 
 	url, objectInfo, err := w.minioClient.UploadFile(ctx, objectName, compInputs, constant.ContentTypeJSON)
 	if err != nil {
-		w.log.Error("failed to upload component run inputs to minio", zap.Error(err))
+		log.Error("failed to upload component run inputs to minio", zap.Error(err))
 		return err
 	}
 
@@ -207,7 +201,7 @@ func (w *worker) UploadComponentInputsActivity(ctx context.Context, param *Compo
 
 	err = w.repository.UpdateComponentRun(ctx, pipelineTriggerID, param.ID, &datamodel.ComponentRun{Inputs: inputs})
 	if err != nil {
-		w.log.Error("failed to save pipeline run input data", zap.Error(err))
+		log.Error("failed to save pipeline run input data", zap.Error(err))
 		return err
 	}
 	return nil
@@ -215,7 +209,9 @@ func (w *worker) UploadComponentInputsActivity(ctx context.Context, param *Compo
 
 func (w *worker) UploadComponentOutputsActivity(ctx context.Context, param *ComponentActivityParam) error {
 	pipelineTriggerID := param.SystemVariables.PipelineTriggerID
-	w.log.Info("UploadComponentOutputsActivity started", zap.String("PipelineTriggerID", pipelineTriggerID))
+	log := w.log.With(zap.String("PipelineTriggerUID", pipelineTriggerID), zap.String("ComponentID", param.ID))
+
+	log.Info("UploadComponentOutputsActivity started")
 
 	objectName := fmt.Sprintf("component-runs/%s/output/%s.json", pipelineTriggerID, param.ID)
 
@@ -240,7 +236,7 @@ func (w *worker) UploadComponentOutputsActivity(ctx context.Context, param *Comp
 
 	url, objectInfo, err := w.minioClient.UploadFile(ctx, objectName, compOutputs, constant.ContentTypeJSON)
 	if err != nil {
-		w.log.Error("failed to upload component run outputs to minio", zap.Error(err))
+		log.Error("failed to upload component run outputs to minio", zap.Error(err))
 		return err
 	}
 
@@ -253,8 +249,9 @@ func (w *worker) UploadComponentOutputsActivity(ctx context.Context, param *Comp
 
 	err = w.repository.UpdateComponentRun(ctx, pipelineTriggerID, param.ID, &datamodel.ComponentRun{Outputs: outputs})
 	if err != nil {
-		w.log.Error("failed to save pipeline run output data", zap.Error(err))
+		log.Error("failed to save pipeline run output data", zap.Error(err))
 		return err
 	}
+
 	return nil
 }


### PR DESCRIPTION
…ine from DB

Because

- The run logging should record errors from both before and after entering temporal workflow.

This commit

- move logPipelineRunStart logic to service layer
