### PR TITLE
chore(usage): add missing id for org pipeline usage

### DIFF
--- a/pkg/usage/usage.go
+++ b/pkg/usage/usage.go
@@ -186,6 +186,7 @@ func (u *usage) RetrievePipelineUsageData() interface{} {
 					triggerDataList = append(
 						triggerDataList,
 						&usagePB.PipelineUsageData_UserUsageData_PipelineTriggerData{
+							PipelineId:         triggerData.PipelineID,
 							PipelineUid:        triggerData.PipelineUID,
 							PipelineReleaseId:  triggerData.PipelineReleaseID,
 							PipelineReleaseUid: triggerData.PipelineReleaseUID,


### PR DESCRIPTION
Because

- pipeline id is missing for organization pipeline usage records

This commit

- add missing id for organization pipeline usage records

resolves INS-6180