### PR TITLE
refactor: adopt new component Execute() interface

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0
 	github.com/iancoleman/strcase v0.3.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/component v0.26.0-beta.0.20240904150825-52b7d78110ce
+	github.com/instill-ai/component v0.26.0-beta.0.20240906062001-b647061f2c5f
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240905055017-a91e02faf276
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha

--- a/go.sum
+++ b/go.sum
@@ -1271,8 +1271,8 @@ github.com/influxdata/influxdb-client-go/v2 v2.12.3 h1:28nRlNMRIV4QbtIUvxhWqaxn0
 github.com/influxdata/influxdb-client-go/v2 v2.12.3/go.mod h1:IrrLUbCjjfkmRuaCiGQg4m2GbkaeJDcuWoxiWdQEbA0=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/instill-ai/component v0.26.0-beta.0.20240904150825-52b7d78110ce h1:XhMup+uEZolw2DuzH1SA2vBis8zQpeinFtsNQAfWyUc=
-github.com/instill-ai/component v0.26.0-beta.0.20240904150825-52b7d78110ce/go.mod h1:MUvttPlhGyqLtWD/iAf+BYSDtu4IuDZxT2DyzWsYMV0=
+github.com/instill-ai/component v0.26.0-beta.0.20240906062001-b647061f2c5f h1:ACT4ziXeWyQPyCFp6zBWTHnDBO+wv2iXDwsCAWyFBTM=
+github.com/instill-ai/component v0.26.0-beta.0.20240906062001-b647061f2c5f/go.mod h1:MUvttPlhGyqLtWD/iAf+BYSDtu4IuDZxT2DyzWsYMV0=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240905055017-a91e02faf276 h1:5Xom2Y9fxC0dAJCF+FM5g6XM9NjhsJ0VXjHPiqM3xjU=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240905055017-a91e02faf276/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=

--- a/pkg/recipe/dag.go
+++ b/pkg/recipe/dag.go
@@ -180,7 +180,7 @@ func Render(ctx context.Context, template data.Value, batchIdx int, wfm memory.W
 			val, err := resolveReference(ctx, wfm, batchIdx, s)
 			if err != nil {
 				if allowUnresolved {
-					return data.NewString(input.GetString()), nil
+					return data.NewNull(), nil
 				}
 				return nil, err
 			}
@@ -206,7 +206,7 @@ func Render(ctx context.Context, template data.Value, batchIdx int, wfm memory.W
 			v, err := resolveReference(ctx, wfm, batchIdx, ref)
 			if err != nil {
 				if allowUnresolved {
-					return data.NewString(input.GetString()), nil
+					return data.NewNull(), nil
 				}
 				return nil, err
 			}

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -784,6 +784,9 @@ func (s *service) preTriggerPipeline(ctx context.Context, ns resource.Namespace,
 		// TODO: refactor array parser
 		variable := data.NewMap(nil)
 		for k, v := range d.Variable.Fields {
+			if _, ok := instillFormatMap[k]; !ok {
+				continue
+			}
 			switch instillFormatMap[k] {
 			case "string":
 				variable.Fields[k] = data.NewString(v.GetStringValue())

--- a/pkg/worker/io.go
+++ b/pkg/worker/io.go
@@ -44,90 +44,103 @@ func (i *setupReader) Read(ctx context.Context) (setups []*structpb.Struct, err 
 }
 
 type inputReader struct {
-	compID       string
-	wfm          memory.WorkflowMemory
-	conditionMap map[int]int
+	compID      string
+	wfm         memory.WorkflowMemory
+	originalIdx int
 }
 
-func NewInputReader(wfm memory.WorkflowMemory, compID string, conditionMap map[int]int) *inputReader {
+func NewInputReader(wfm memory.WorkflowMemory, compID string, originalIdx int) *inputReader {
 	return &inputReader{
-		compID:       compID,
-		wfm:          wfm,
-		conditionMap: conditionMap,
+		compID:      compID,
+		wfm:         wfm,
+		originalIdx: originalIdx,
 	}
 }
 
-func (i *inputReader) Read(ctx context.Context) (inputs []*structpb.Struct, err error) {
+func (i *inputReader) Read(ctx context.Context) (inputStruct *structpb.Struct, err error) {
 
-	for idx := range len(i.conditionMap) {
-		inputTemplate, err := i.wfm.GetComponentData(ctx, i.conditionMap[idx], i.compID, memory.ComponentDataInput)
-		if err != nil {
-			return nil, err
-		}
-
-		inputVal, err := recipe.Render(ctx, inputTemplate, i.conditionMap[idx], i.wfm, false)
-		if err != nil {
-			return nil, err
-		}
-
-		if err = i.wfm.SetComponentData(ctx, i.conditionMap[idx], i.compID, memory.ComponentDataInput, inputVal); err != nil {
-			return nil, err
-		}
-
-		input, err := inputVal.ToStructValue()
-		if err != nil {
-			return nil, err
-		}
-		inputs = append(inputs, input.GetStructValue())
-
+	inputTemplate, err := i.wfm.GetComponentData(ctx, i.originalIdx, i.compID, memory.ComponentDataInput)
+	if err != nil {
+		return nil, err
 	}
-	return inputs, nil
+
+	inputVal, err := recipe.Render(ctx, inputTemplate, i.originalIdx, i.wfm, false)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = i.wfm.SetComponentData(ctx, i.originalIdx, i.compID, memory.ComponentDataInput, inputVal); err != nil {
+		return nil, err
+	}
+
+	input, err := inputVal.ToStructValue()
+	if err != nil {
+		return nil, err
+	}
+
+	return input.GetStructValue(), nil
 }
 
 type outputWriter struct {
-	compID       string
-	wfm          memory.WorkflowMemory
-	conditionMap map[int]int
-	streaming    bool
+	compID      string
+	wfm         memory.WorkflowMemory
+	originalIdx int
+	streaming   bool
 }
 
-func NewOutputWriter(wfm memory.WorkflowMemory, compID string, conditionMap map[int]int, streaming bool) *outputWriter {
+func NewOutputWriter(wfm memory.WorkflowMemory, compID string, originalIdx int, streaming bool) *outputWriter {
 	return &outputWriter{
-		compID:       compID,
-		wfm:          wfm,
-		conditionMap: conditionMap,
-		streaming:    streaming,
+		compID:      compID,
+		wfm:         wfm,
+		originalIdx: originalIdx,
+		streaming:   streaming,
 	}
 }
 
-func (o *outputWriter) Write(ctx context.Context, outputs []*structpb.Struct) (err error) {
+func (o *outputWriter) Write(ctx context.Context, output *structpb.Struct) (err error) {
 
-	for idx, output := range outputs {
-		val, err := data.NewValueFromStruct(structpb.NewStructValue(output))
+	val, err := data.NewValueFromStruct(structpb.NewStructValue(output))
+	if err != nil {
+		return err
+	}
+	if err := o.wfm.SetComponentData(ctx, o.originalIdx, o.compID, memory.ComponentDataOutput, val); err != nil {
+		return err
+	}
+
+	if o.streaming {
+		outputTemplate, err := o.wfm.Get(ctx, o.originalIdx, string(memory.PipelineOutputTemplate))
 		if err != nil {
 			return err
 		}
-		if err := o.wfm.SetComponentData(ctx, o.conditionMap[idx], o.compID, memory.ComponentDataOutput, val); err != nil {
+
+		output, err := recipe.Render(ctx, outputTemplate, o.originalIdx, o.wfm, true)
+		if err != nil {
 			return err
 		}
-
-		if o.streaming {
-			outputTemplate, err := o.wfm.Get(ctx, idx, string(memory.PipelineOutputTemplate))
-			if err != nil {
-				return err
-			}
-
-			output, err := recipe.Render(ctx, outputTemplate, idx, o.wfm, true)
-			if err != nil {
-				return err
-			}
-			err = o.wfm.SetPipelineData(ctx, idx, memory.PipelineOutput, output)
-			if err != nil {
-				return err
-			}
+		err = o.wfm.SetPipelineData(ctx, o.originalIdx, memory.PipelineOutput, output)
+		if err != nil {
+			return err
 		}
-
 	}
 
 	return nil
+}
+
+type errorHandler struct {
+	compID      string
+	wfm         memory.WorkflowMemory
+	originalIdx int
+}
+
+func NewErrorHandler(wfm memory.WorkflowMemory, compID string, originalIdx int) *errorHandler {
+	return &errorHandler{
+		compID:      compID,
+		wfm:         wfm,
+		originalIdx: originalIdx,
+	}
+}
+
+func (e *errorHandler) Error(ctx context.Context, err error) {
+	_ = e.wfm.SetComponentStatus(ctx, e.originalIdx, e.compID, memory.ComponentStatusErrored, true)
+	_ = e.wfm.SetComponentErrorMessage(ctx, e.originalIdx, e.compID, err.Error())
 }


### PR DESCRIPTION
Because

- Previously, our component `Execute` interface did not handle batch processing well, particularly with error handling. If one data item encountered an error, the entire batch would fail. This is not ideal since each data item in the batch should be executed independently.
- When a component encounters an error, downstream components should be skipped.

This commit

- Adopts the new `Execute()` interface for more fine-grained error logging.
- Skips a component if its upstream components contain errors.