### PR TITLE
chore: fix nil value render bug

### DIFF
--- a/pkg/recipe/dag.go
+++ b/pkg/recipe/dag.go
@@ -248,8 +248,6 @@ func Render(ctx context.Context, template data.Value, batchIdx int, wfm memory.W
 			}
 		}
 		return arr, nil
-	case *data.Null:
-		return nil, nil
 	default:
 		return input, nil
 	}


### PR DESCRIPTION
Because

- The `Render()` function should return `data.Null` instead of `nil`.

This commit

- Fixes this bug.