### PR TITLE
chore: bump component package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0
 	github.com/iancoleman/strcase v0.3.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/component v0.26.0-beta.0.20240909235612-a32aff5c8bcb
+	github.com/instill-ai/component v0.27.0-beta
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240905055017-a91e02faf276
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha

--- a/go.sum
+++ b/go.sum
@@ -1271,8 +1271,8 @@ github.com/influxdata/influxdb-client-go/v2 v2.12.3 h1:28nRlNMRIV4QbtIUvxhWqaxn0
 github.com/influxdata/influxdb-client-go/v2 v2.12.3/go.mod h1:IrrLUbCjjfkmRuaCiGQg4m2GbkaeJDcuWoxiWdQEbA0=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/instill-ai/component v0.26.0-beta.0.20240909235612-a32aff5c8bcb h1:XBCnY6WC4Oq2Y0SGWb8pzAHaUSAvmJVJL9W/l8MM+T0=
-github.com/instill-ai/component v0.26.0-beta.0.20240909235612-a32aff5c8bcb/go.mod h1:n6B5jgGzO21jJYoynNWo4yj6P14Ms6Ywvy6Dggu6Tws=
+github.com/instill-ai/component v0.27.0-beta h1:KCxuYWKOvGVUX3SuuYFvoCXG0lmfJ04huY1Bg2/HLz4=
+github.com/instill-ai/component v0.27.0-beta/go.mod h1:n6B5jgGzO21jJYoynNWo4yj6P14Ms6Ywvy6Dggu6Tws=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240905055017-a91e02faf276 h1:5Xom2Y9fxC0dAJCF+FM5g6XM9NjhsJ0VXjHPiqM3xjU=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240905055017-a91e02faf276/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=


### PR DESCRIPTION
Because

- A new version of component has been released

This commit

- Updates `component` to v0.27.0-beta
