### PR TITLE
fix(document): fix bugs about image to text

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,12 @@ RUN apk add --no-cache \
     && /opt/venv/bin/pip install pdfplumber tokenizers \
     && rm -rf /var/cache/apk/* /var/cache/fontconfig/*
 
+# Download tesseract data
+RUN curl -L https://github.com/tesseract-ocr/tessdata_best/raw/main/eng.traineddata \
+    -o /usr/share/tessdata/eng.traineddata \
+    && curl -L https://github.com/tesseract-ocr/tessdata_best/raw/main/osd.traineddata \
+    -o /usr/share/tessdata/osd.traineddata
+
 ARG TARGETARCH
 ARG BUILDARCH
 RUN apk add unrtf --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,9 +46,7 @@ RUN apk add --no-cache \
 
 # Download tesseract data
 RUN curl -L https://github.com/tesseract-ocr/tessdata_best/raw/main/eng.traineddata \
-    -o /usr/share/tessdata/eng.traineddata \
-    && curl -L https://github.com/tesseract-ocr/tessdata_best/raw/main/osd.traineddata \
-    -o /usr/share/tessdata/osd.traineddata
+    -o /usr/share/tessdata/eng.traineddata
 
 ARG TARGETARCH
 ARG BUILDARCH


### PR DESCRIPTION
Because

- there is no tessdata when we install tesseract-ocr

This commit

- curl traineddata to get data for English version
