### PR TITLE
fix: make the pipeline share-code immutable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,12 +20,21 @@ dev:							## Run dev container
 	@docker inspect --type container ${SERVICE_NAME} >/dev/null 2>&1 && echo "A container named ${SERVICE_NAME} is already running." || \
 		echo "Run dev container ${SERVICE_NAME}. To stop it, run \"make stop\"."
 	@docker run -d --rm \
-		-v $(PWD):/${SERVICE_NAME} \
 		-p ${PUBLIC_SERVICE_PORT}:${PUBLIC_SERVICE_PORT} \
-		-p ${PRIVATE_SERVICE_PORT}:${PRIVATE_SERVICE_PORT} \
+		-v $(PWD)/../go.work:/go.work \
+		-v $(PWD)/../go.work.sum:/go.work.sum \
+		-v $(PWD)/../mgmt-backend:/mgmt-backend \
+		-v $(PWD)/../model-backend:/model-backend \
+		-v $(PWD)/../pipeline-backend:/pipeline-backend \
+		-v $(PWD)/../artifact-backend:/artifact-backend \
+		-v $(PWD)/../mgmt-backend-cloud:/mgmt-backend-cloud \
+		-v $(PWD)/../model-backend-cloud:/model-backend-cloud \
+		-v $(PWD)/../pipeline-backend-cloud:/pipeline-backend-cloud \
+		-v $(PWD)/../protogengo:/protogengo \
+		-v $(PWD)/../component:/component \
 		--network instill-network \
 		--name ${SERVICE_NAME} \
-		instill/${SERVICE_NAME}:dev >/dev/null 2>&1
+		instill/${SERVICE_NAME}:dev
 
 .PHONY: logs
 logs:							## Tail container logs with -n 10
@@ -111,7 +120,7 @@ integration-test:				## Run integration test
 
 .PHONY: gen-mock
 gen-mock:
-	@go install github.com/gojuno/minimock/v3/cmd/minimock@v3.4.0
+	@go install github.com/gojuno/minimock/v3/cmd/minimock@v3.3.13
 	@go generate -run minimock ./...
 
 .PHONY: help

--- a/pkg/data/data.go
+++ b/pkg/data/data.go
@@ -79,6 +79,8 @@ func NewJSONValue(in any) (val Value, err error) {
 			}
 		}
 		return mp, nil
+	case nil:
+		return NewNull(), nil
 	}
 
 	return nil, fmt.Errorf("NewJSONValue error")

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -381,7 +381,10 @@ func (s *service) UpdateNamespacePipelineByID(ctx context.Context, ns resource.N
 		return nil, err
 	}
 
-	dbPipeline.ShareCode = generateShareCode()
+	if existingPipeline.ShareCode == "" {
+		dbPipeline.ShareCode = generateShareCode()
+	}
+
 	if err := s.setSchedulePipeline(ctx, ns, dbPipeline.ID, "", dbPipeline.UID, uuid.Nil, dbPipeline.Recipe); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Because

- The pipeline share-code changes every time the pipeline is saved.

This commit

- Makes the pipeline share-code immutable
