### PR TITLE
chore: fix wrong user-uid and requester-uid for webhook request

### DIFF
--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -1477,6 +1477,15 @@ func (s *service) HandleNamespacePipelineEventByID(ctx context.Context, ns resou
 		return nil, errdomain.ErrNotFound
 	}
 
+	// TODO: In the webhook event, the request is sent by a system user, not an
+	// end user. It doesn't include the user UID or requester UID. For now,
+	// we'll use the namespace as the user ID and requester UID.
+	// A proper authentication mechanism for system users needs to be designed.
+	md, _ := metadata.FromIncomingContext(ctx)
+	md.Set(constant.HeaderUserUIDKey, ns.NsUID.String())
+	md.Set(constant.HeaderRequesterUIDKey, ns.NsUID.String())
+	ctx = metadata.NewIncomingContext(ctx, md)
+
 	pipelineRun := s.logPipelineRunStart(ctx, pipelineTriggerID, dbPipeline.UID, defaultPipelineReleaseID)
 	defer func() {
 		if err != nil {
@@ -1490,8 +1499,6 @@ func (s *service) HandleNamespacePipelineEventByID(ctx context.Context, ns resou
 	} else {
 		return nil, fmt.Errorf("eventID not correct")
 	}
-
-	md, _ := metadata.FromIncomingContext(ctx)
 
 	isVerificationEvent, out, err := s.component.HandleVerificationEvent(targetType, md, data, nil)
 	if err != nil {

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -1526,8 +1526,11 @@ func (s *service) HandleNamespacePipelineEventByID(ctx context.Context, ns resou
 		for _, l := range v.Listen {
 			l := l[2 : len(l)-1]
 			s := strings.Split(l, ".")
-			if eventID == s[1] {
-				path := strings.Join(s[3:], ".")
+			if s[0] != "on" || s[1] != "event" {
+				return nil, fmt.Errorf("cannot listen to data outside of `on.event`")
+			}
+			if eventID == s[2] {
+				path := strings.Join(s[4:], ".")
 				res, err := jsonpath.Get(fmt.Sprintf("$.%s", path), jsonInput)
 				if err != nil {
 					return nil, err


### PR DESCRIPTION
Because

- Some headers were missing in the webhook request.

This commit

- Fixes the incorrect `user-uid` and `requester-uid` in the webhook request.
- Updates the reference syntax for event messages. Users now need to use `${on.event.xxx}` instead of `${event.xxx}`.