### PR TITLE
chore: purge pipeline workflow memory in Redis after the trigger is completed

### DIFF
--- a/pkg/memory/memory.go
+++ b/pkg/memory/memory.go
@@ -57,6 +57,7 @@ type MemoryStore interface {
 	NewWorkflowMemory(ctx context.Context, workflowID string, recipe *datamodel.Recipe, batchSize int) (workflow WorkflowMemory, err error)
 	GetWorkflowMemory(ctx context.Context, workflowID string) (workflow WorkflowMemory, err error)
 	PurgeWorkflowMemory(ctx context.Context, workflowID string) (err error)
+	PurgeWorkflowMemoryFromRedis(ctx context.Context, workflowID string) (err error)
 
 	WriteWorkflowMemoryToRedis(ctx context.Context, workflowID string) (err error)
 	LoadWorkflowMemoryFromRedis(ctx context.Context, workflowID string) (workflow WorkflowMemory, err error)
@@ -232,6 +233,13 @@ func (ms *memoryStore) GetWorkflowMemory(ctx context.Context, workflowID string)
 
 func (ms *memoryStore) PurgeWorkflowMemory(ctx context.Context, workflowID string) (err error) {
 	ms.workflows.Delete(workflowID)
+	return nil
+}
+func (ms *memoryStore) PurgeWorkflowMemoryFromRedis(ctx context.Context, workflowID string) (err error) {
+	cmd := ms.redisClient.Del(ctx, fmt.Sprintf("pipeline_trigger:%s", workflowID))
+	if cmd.Err() != nil {
+		return cmd.Err()
+	}
 	return nil
 }
 

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -1262,6 +1262,7 @@ func (s *service) triggerAsyncPipeline(
 
 	defer func() {
 		_ = s.memory.PurgeWorkflowMemory(ctx, pipelineTriggerID)
+		_ = s.memory.PurgeWorkflowMemoryFromRedis(ctx, pipelineTriggerID)
 	}()
 	err := s.preTriggerPipeline(ctx, ns, r, pipelineTriggerID, pipelineData)
 	if err != nil {


### PR DESCRIPTION
Because

- We can directly remove the workflow memory in Redis after the trigger is completed.

This commit

- Purges the pipeline workflow memory in Redis after the trigger is completed.