### PR TITLE
feat(integration): load only connections present in the recipe and just once

### DIFF
--- a/integration-test/pipeline/rest-integration.js
+++ b/integration-test/pipeline/rest-integration.js
@@ -308,6 +308,10 @@ version: v1beta
 variable:
   recipients:
     instill-format: array:string
+output:
+  resp:
+    title: Response
+    value: \${email-0.output.result}
 component:
   email-0:
     type: email
@@ -318,12 +322,8 @@ component:
       subject: "Dummy email"
       message: "Hi I'm testing integrations"
     condition: null
-    setup: \${connection.${connectionID}}
     task: TASK_SEND_EMAIL
-output:
-  resp:
-    title: Response
-    value: \${email-0.output.result}
+    setup: \${connection.${connectionID}}
 `;
 
     const nPipelines = 30;

--- a/integration-test/pipeline/rest-trigger.js
+++ b/integration-test/pipeline/rest-trigger.js
@@ -5,12 +5,43 @@ import { randomString } from "https://jslib.k6.io/k6-utils/1.1.0/index.js";
 
 import { pipelinePublicHost } from "./const.js";
 
-import * as constant from "./const.js"
+import * as constant from "./const.js";
+
+const recipeWithoutSetup = `
+version: v1beta
+variable:
+  recipients:
+    instill-format: array:string
+output:
+  resp:
+    title: Response
+    value: \${email-0.output.result}
+component:
+  email-0:
+    type: email
+    input:
+      recipients: \${variable.recipients}
+      cc: null
+      bcc: null
+      subject: "Dummy email"
+      message: "Hi I'm testing integrations"
+    condition: null
+    task: TASK_SEND_EMAIL
+`;
+
 
 export function CheckTrigger(data) {
+  var collectionPath = `/v1beta/namespaces/${constant.defaultUsername}/pipelines`;
+
+  function resourcePath(id) {
+    return `${collectionPath}/${id}`;
+  }
+
+  function triggerPath(id) {
+    return resourcePath(id) + "/trigger";
+  }
 
   group("Pipelines API: Trigger a pipeline", () => {
-
     var reqHTTP = Object.assign(
       {
         id: randomString(10),
@@ -19,23 +50,20 @@ export function CheckTrigger(data) {
       constant.simplePipelineWithJSONRecipe
     );
 
-    check(http.request("POST", `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines`, JSON.stringify(reqHTTP), data.header), {
-      "POST /v1beta/${constant.namespace}/pipelines response status is 201 (HTTP pipeline)": (r) => r.status === 201,
+    check(http.request("POST", pipelinePublicHost + collectionPath, JSON.stringify(reqHTTP), data.header), {
+      [`POST ${collectionPath} (${reqHTTP.id}) response status is 201 (HTTP pipeline)`]: (r) => r.status === 201,
     });
 
-    check(http.request("POST", `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines/${reqHTTP.id}/trigger`, JSON.stringify(constant.simplePayload), data.header), {
-      [`POST /v1beta/${constant.namespace}/pipelines/${reqHTTP.id}/trigger response status is 200`]: (r) => r.status === 200,
+    check(http.request("POST", pipelinePublicHost + triggerPath(reqHTTP.id), JSON.stringify(constant.simplePayload), data.header), {
+      [`POST ${triggerPath(reqHTTP.id)} response status is 200`]: (r) => r.status === 200,
     });
 
-
-    check(http.request("DELETE", `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines/${reqHTTP.id}`, null, data.header), {
-      [`DELETE /v1beta/${constant.namespace}/pipelines/${reqHTTP.id} response status 204`]: (r) => r.status === 204,
+    check(http.request("DELETE", pipelinePublicHost + resourcePath(reqHTTP.id), null, data.header), {
+      [`DELETE ${resourcePath(reqHTTP.id)} response status 204`]: (r) => r.status === 204,
     });
-
   });
 
   group("Pipelines API: Trigger a pipeline with YAML recipe", () => {
-
     var reqHTTP = Object.assign(
       {
         id: randomString(10),
@@ -44,19 +72,70 @@ export function CheckTrigger(data) {
       constant.simplePipelineWithYAMLRecipe
     );
 
-    check(http.request("POST", `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines`, JSON.stringify(reqHTTP), data.header), {
-      "POST /v1beta/${constant.namespace}/pipelines response status is 201 (HTTP pipeline)": (r) => r.status === 201,
+    check(http.request("POST", pipelinePublicHost + collectionPath, JSON.stringify(reqHTTP), data.header), {
+      [`POST ${collectionPath} (${reqHTTP.id}) response status is 201 (HTTP pipeline)`]: (r) => r.status === 201,
     });
 
-    check(http.request("POST", `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines/${reqHTTP.id}/trigger`, JSON.stringify(constant.simplePayload), data.header), {
-      [`POST /v1beta/${constant.namespace}/pipelines/${reqHTTP.id}/trigger response status is 200`]: (r) => r.status === 200,
+    check(http.request("POST", pipelinePublicHost + triggerPath(reqHTTP.id), JSON.stringify(constant.simplePayload), data.header), {
+      [`POST ${triggerPath(reqHTTP.id)} response status is 200`]: (r) => r.status === 200,
     });
 
-
-    check(http.request("DELETE", `${pipelinePublicHost}/v1beta/${constant.namespace}/pipelines/${reqHTTP.id}`, null, data.header), {
-      [`DELETE /v1beta/${constant.namespace}/pipelines/${reqHTTP.id} response status 204`]: (r) => r.status === 204,
+    check(http.request("DELETE", pipelinePublicHost + resourcePath(reqHTTP.id), null, data.header), {
+      [`DELETE ${resourcePath(reqHTTP.id)} response status 204`]: (r) => r.status === 204,
     });
-
   });
 
+  group("Pipelines API: Validate pipeline on trigger", () => {
+    const payload = {
+      data: [{
+        variable: {recipients: ["a", "b"]},
+      }],
+    };
+
+    const missingConnRecipe = `${recipeWithoutSetup}
+    setup: \${connection.my-conn}`;
+
+    var reqMiss = {
+      id: constant.dbIDPrefix + `missing-conn`,
+      description: randomString(10),
+      rawRecipe: missingConnRecipe,
+    };
+
+    check(http.request("POST", pipelinePublicHost + collectionPath, JSON.stringify(reqMiss), data.header), {
+      [`POST ${collectionPath} (${reqMiss.id}) response status is 201`]: (r) => r.status === 201,
+    });
+
+    check(http.request("POST", pipelinePublicHost + triggerPath(reqMiss.id), JSON.stringify(payload), data.header), {
+      [`POST ${triggerPath(reqMiss.id)} response status is 400`]: (r) => r.status === 400,
+      [`POST ${triggerPath(reqMiss.id)} contains end-user message`]:
+        (r) => r.json().message === "Connection my-conn doesn't exist.",
+    });
+
+    check(http.request("DELETE", pipelinePublicHost + resourcePath(reqMiss.id), null, data.header), {
+      [`DELETE ${resourcePath(reqMiss.id)} response status 204`]: (r) => r.status === 204,
+    });
+
+    const invalidRefRecipe = `${recipeWithoutSetup}
+    setup: \${connnnnnection.my-conn}`;
+
+    var reqInvalid = {
+      id: constant.dbIDPrefix + `invalid-ref`,
+      description: randomString(10),
+      rawRecipe: invalidRefRecipe,
+    };
+
+    check(http.request("POST", pipelinePublicHost + collectionPath, JSON.stringify(reqInvalid), data.header), {
+      [`POST ${collectionPath} (${reqInvalid.id}) response status is 201`]: (r) => r.status === 201,
+    });
+
+    check(http.request("POST", pipelinePublicHost + triggerPath(reqInvalid.id), JSON.stringify(payload), data.header), {
+      [`POST ${triggerPath(reqInvalid.id)} response status is 400`]: (r) => r.status === 400,
+      [`POST ${triggerPath(reqInvalid.id)} contains end-user message`]: (r) =>
+        r.json().message === "String setup only supports connection references (${connection.<conn-id>}).",
+    });
+
+    check(http.request("DELETE", pipelinePublicHost + resourcePath(reqInvalid.id), null, data.header), {
+      [`DELETE ${resourcePath(reqInvalid.id)} response status 204`]: (r) => r.status === 204,
+    });
+  });
 }

--- a/pkg/recipe/connection.go
+++ b/pkg/recipe/connection.go
@@ -1,0 +1,74 @@
+package recipe
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/instill-ai/pipeline-backend/pkg/constant"
+	"github.com/instill-ai/pipeline-backend/pkg/datamodel"
+	"github.com/instill-ai/x/errmsg"
+
+	errdomain "github.com/instill-ai/pipeline-backend/pkg/errors"
+)
+
+var (
+	// ErrInvalidConnectionReference indicates a malformed or missing
+	// connection reference.
+	ErrInvalidConnectionReference = fmt.Errorf("%w: connection reference", errdomain.ErrInvalidArgument)
+
+	connRefPrefix, connRefSuffix   = fmt.Sprintf("${%s.", constant.SegConnection), "}"
+	lConnRefPrefix, lConnRefSuffix = len(connRefPrefix), len(connRefSuffix)
+)
+
+// ConnectionIDFromReference ...
+func ConnectionIDFromReference(ref string) (string, error) {
+	if !(strings.HasPrefix(ref, connRefPrefix) && strings.HasSuffix(ref, connRefSuffix)) {
+		return "", errmsg.AddMessage(
+			ErrInvalidConnectionReference,
+			"String setup only supports connection references (${connection.<conn-id>}).",
+		)
+	}
+
+	return ref[lConnRefPrefix : len(ref)-lConnRefSuffix], nil
+}
+
+// FetchReferencedSetup takes a connection reference, fetches that connection
+// from a repository and returns its setup.
+//
+// The connection fetcher method is passed as an argument. Ideally, this
+// should be defined as a method in service.Service but the current dependency
+// hierarchy prevents packages like worker to leverage it. Due to the
+// considerable refactor this would imply, this method was extracted to the
+// recipe package, avoiding a dependency cycle.
+func FetchReferencedSetup(
+	ctx context.Context,
+	ref string,
+	getNamespaceConnectionByID func(context.Context, string) (*datamodel.Connection, error),
+) (map[string]any, error) {
+	id, err := ConnectionIDFromReference(ref)
+	if err != nil {
+		return nil, err
+	}
+
+	conn, err := getNamespaceConnectionByID(ctx, id)
+	if err != nil {
+		if !errors.Is(err, errdomain.ErrNotFound) {
+			return nil, fmt.Errorf("fetching connection: %w", err)
+		}
+
+		return nil, errmsg.AddMessage(
+			ErrInvalidConnectionReference,
+			fmt.Sprintf("Connection %s doesn't exist.", id),
+		)
+	}
+
+	var setup map[string]any
+	if err := json.Unmarshal(conn.Setup, &setup); err != nil {
+		return nil, fmt.Errorf("unmarshalling setup: %w", err)
+	}
+
+	return setup, nil
+}

--- a/pkg/recipe/dag.go
+++ b/pkg/recipe/dag.go
@@ -12,12 +12,13 @@ import (
 	"go/ast"
 	"go/token"
 
+	"google.golang.org/protobuf/types/known/structpb"
+
 	"github.com/instill-ai/pipeline-backend/pkg/constant"
 	"github.com/instill-ai/pipeline-backend/pkg/data"
 	"github.com/instill-ai/pipeline-backend/pkg/datamodel"
 	"github.com/instill-ai/pipeline-backend/pkg/memory"
 	"github.com/instill-ai/x/errmsg"
-	"google.golang.org/protobuf/types/known/structpb"
 
 	componentbase "github.com/instill-ai/component/base"
 	pb "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"


### PR DESCRIPTION
Because

- In order to resolve the reference to a connection when triggering a pipeline, all the connections were loaded to memory.

This commit

- Inspects the setup of the components in the recipe and loads only the required connections.

## ⚠️  Warning

This will cause an error with a proper message when triggering a pipeline with an invalid reference:

```sh
$ curl -X POST 'http://localhost:8080/v1beta/namespaces/admin/pipelines/github-test/trigger' \
--header "Content-Type: application/json" \
--header "Authorization: Bearer instill_sk_KBcpJln4JfH0C0fVJm6ZLufaPzWnd8Fc" \
--data '{
        "inputs": [
                {
                        "prompt": "What are the pokemon types of Charizard? Answer with a comma-separated list of values that I can parse from a script. No formatting, no surrounding explanations, please."
                }
        ]
}' | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   276  100    64  100   212    262    870 --:--:-- --:--:-- --:--:--  1135
{
  "code": 3,
  "message": "component openai-0 not exist",
  "details": []
}
```

However, with a streaming request the request will stall, since only component activity errors are handled at the moment.

https://github.com/instill-ai/pipeline-backend/pull/672 addresses this, preventing the endpoint from stalling. It still doesn't return the error message in the response, but at least it prevents the experience from degrading after these changes.
