### PR TITLE
fix(streaming): close connection and purge workflow memory at the end of the trigger workflow

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -175,6 +175,7 @@ func main() {
 	w.RegisterActivity(cw.PreTriggerActivity)
 	w.RegisterActivity(cw.LoadDAGDataActivity)
 	w.RegisterActivity(cw.PostTriggerActivity)
+	w.RegisterActivity(cw.ClosePipelineActivity)
 	w.RegisterActivity(cw.IncreasePipelineTriggerCountActivity)
 	w.RegisterActivity(cw.UpdatePipelineRunActivity)
 	w.RegisterActivity(cw.UpsertComponentRunActivity)

--- a/pkg/worker/main.go
+++ b/pkg/worker/main.go
@@ -33,6 +33,7 @@ type Worker interface {
 	PostIteratorActivity(ctx context.Context, param *PostIteratorActivityParam) error
 	PreTriggerActivity(ctx context.Context, param *PreTriggerActivityParam) error
 	PostTriggerActivity(ctx context.Context, param *PostTriggerActivityParam) error
+	ClosePipelineActivity(ctx context.Context, workflowID string, isStreaming bool) error
 	IncreasePipelineTriggerCountActivity(context.Context, recipe.SystemVariables) error
 
 	UpdatePipelineRunActivity(ctx context.Context, param *UpdatePipelineRunActivityParam) error


### PR DESCRIPTION
Because

- Errors outside of `ComponentActivity` don't close the SSE connection, leaving the request hanging.

This commit

- Defers the `PipelineClosed` event and the workflow memory purge at the end of the trigger workflow.
  - This effectively handles both error and success scenarios.
- Wraps `PreTriggerActivity` errors in a handler that sends a pipeline update event.
  - In order to return the error in the response, we'll need to implement the `PipelineErrorUpdated` event.
