### PR TITLE
fix: the output schema is incorrect when there is an indeterministic instillFormat

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0
 	github.com/iancoleman/strcase v0.3.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/component v0.28.0-beta.0.20240926154519-34698241185f
+	github.com/instill-ai/component v0.28.0-beta.0.20240927125335-fa9eb174d67e
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240922180636-80bd4bf3bb56
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha

--- a/go.sum
+++ b/go.sum
@@ -1273,8 +1273,8 @@ github.com/influxdata/influxdb-client-go/v2 v2.12.3 h1:28nRlNMRIV4QbtIUvxhWqaxn0
 github.com/influxdata/influxdb-client-go/v2 v2.12.3/go.mod h1:IrrLUbCjjfkmRuaCiGQg4m2GbkaeJDcuWoxiWdQEbA0=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/instill-ai/component v0.28.0-beta.0.20240926154519-34698241185f h1:1lXCEHRD8kve03LPoU+k0C1lCGpydJK3bxmHaK8DuWg=
-github.com/instill-ai/component v0.28.0-beta.0.20240926154519-34698241185f/go.mod h1:8h/lD5G3Bclu4Wt46gTKaLfwM55aRvTnL8Onw8UKXNc=
+github.com/instill-ai/component v0.28.0-beta.0.20240927125335-fa9eb174d67e h1:UkZIRmWJ4xsPGSoeIPZiJlPY9N/iqL/qV4EXGjBL9/c=
+github.com/instill-ai/component v0.28.0-beta.0.20240927125335-fa9eb174d67e/go.mod h1:8h/lD5G3Bclu4Wt46gTKaLfwM55aRvTnL8Onw8UKXNc=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240922180636-80bd4bf3bb56 h1:CAvgheFIOS+Ryuor4kVv9BHh+ID9Wa1PCzkrr1xJkiI=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240922180636-80bd4bf3bb56/go.mod h1:rf0UY7VpEgpaLudYEcjx5rnbuwlBaaLyD4FQmWLtgAY=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=

--- a/pkg/service/convert.go
+++ b/pkg/service/convert.go
@@ -1012,12 +1012,17 @@ func (c *converter) GeneratePipelineDataSpec(variables map[string]*datamodel.Var
 
 				}
 				if walk.GetStructValue() != nil && walk.GetStructValue().Fields != nil {
+					// For fields without "instillFormat", we will fall back to using JSON format.
+					instillFormat := walk.GetStructValue().Fields["instillFormat"].GetStringValue()
+					if instillFormat == "" {
+						instillFormat = "json"
+					}
 					m, err = structpb.NewValue(map[string]interface{}{
 						"title":          v.Title,
 						"description":    v.Description,
 						"instillUIOrder": v.InstillUIOrder,
 						"type":           walk.GetStructValue().Fields["type"].GetStringValue(),
-						"instillFormat":  walk.GetStructValue().Fields["instillFormat"].GetStringValue(),
+						"instillFormat":  instillFormat,
 					})
 				}
 


### PR DESCRIPTION
Because:

- We generate the field schema in the output based on the component schema, but not all schemas have the `instillFormat`. Some schemas use JSON or other indeterministic formats.

This commit:

- Uses `JSON` as the fallback `instillFormat` for these indeterministic fields.