### PR TITLE
feat(image): add basic operation tasks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 	github.com/mennanov/fieldmask-utils v1.0.0
 	github.com/minio/minio-go/v7 v7.0.71
 	github.com/nakagami/firebirdsql v0.9.10
+	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
 	github.com/openfga/api/proto v0.0.0-20240318145204-66b9e5cb403c
 	github.com/pkoukk/tiktoken-go v0.1.7
 	github.com/redis/go-redis/v9 v9.5.1

--- a/go.sum
+++ b/go.sum
@@ -1585,6 +1585,8 @@ github.com/nakagami/firebirdsql v0.9.10 h1:7Y73BiH3j/f8faIaryZvDZ3nEo0L7c6S5pg+q
 github.com/nakagami/firebirdsql v0.9.10/go.mod h1:ei91eXUYcMkWJOr4rK6Sta+BVmi3K+WvYR4yASlq/kY=
 github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
 github.com/neo4j/neo4j-go-driver v1.8.1-0.20200803113522-b626aa943eba/go.mod h1:ncO5VaFWh0Nrt+4KT4mOZboaczBZcLuHrG+/sUeP8gI=
+github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
+github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/npillmayer/nestext v0.1.3/go.mod h1:h2lrijH8jpicr25dFY+oAJLyzlya6jhnuG+zWp9L0Uk=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=

--- a/pkg/component/operator/image/v0/README.mdx
+++ b/pkg/component/operator/image/v0/README.mdx
@@ -7,6 +7,9 @@ description: "Learn about how to set up a VDP Image component https://github.com
 
 The Image component is an operator component that allows users to manipulate image files.
 It can carry out the following tasks:
+- [Concat](#concat)
+- [Crop](#crop)
+- [Resize](#resize)
 - [Draw Classification](#draw-classification)
 - [Draw Detection](#draw-detection)
 - [Draw Keypoint](#draw-keypoint)
@@ -26,6 +29,90 @@ The component definition and tasks are defined in the [definition.json](https://
 
 ## Supported Tasks
 
+### Concat
+
+Concatenate images horizontally or vertically. All images must have the same width and height. If `grid-width` and `grid-height` are not provided, the images will be concatenated to a square grid.
+
+<div class="markdown-col-no-wrap" data-col-1 data-col-2>
+
+| Input | ID | Type | Description |
+| :--- | :--- | :--- | :--- |
+| Task ID (required) | `task` | string | `TASK_CONCAT` |
+| Images (required) | `images` | array | Input images |
+| Grid Width | `grid-width` | integer | Grid width. If `grid-width` is provided, `grid-height` will be ignored. |
+| Grid Height | `grid-height` | integer | Grid height. If `grid-height` is provided, `grid-width` will be ignored. |
+| Padding | `padding` | integer | Padding between images. If `padding` is provided, it will be applied to all four sides of the image. |
+</div>
+
+
+
+
+
+
+<div class="markdown-col-no-wrap" data-col-1 data-col-2>
+
+| Output | ID | Type | Description |
+| :--- | :--- | :--- | :--- |
+| Image | `image` | string | Output image |
+</div>
+
+### Crop
+
+Crop image to the specified size.
+
+<div class="markdown-col-no-wrap" data-col-1 data-col-2>
+
+| Input | ID | Type | Description |
+| :--- | :--- | :--- | :--- |
+| Task ID (required) | `task` | string | `TASK_CROP` |
+| Image (required) | `image` | string | Input image |
+| Corner Radius | `corner-radius` | integer | Radius from the corner of the image to crop the image. If `corner-radius` is provided, `circle-radius` will be ignored. If the `corner-radius` is larger than half of min(width, height), the min(width, height) will be applied to `corner-radius` . |
+| Circle Radius | `circle-radius` | integer | Radius from the center of the circle to crop the image. If `circle-radius` is provided, `corner-radius` will be ignored. If the `circle-radius` is larger than half of min(width, height), the min(width, height) will be applied to `circle-radius`. |
+| Top Offset | `top-offset` | integer | Top offset of the crop |
+| Right Offset | `right-offset` | integer | Right offset of the crop |
+| Bottom Offset | `bottom-offset` | integer | Bottom offset of the crop |
+| Left Offset | `left-offset` | integer | Left offset of the crop |
+</div>
+
+
+
+
+
+
+<div class="markdown-col-no-wrap" data-col-1 data-col-2>
+
+| Output | ID | Type | Description |
+| :--- | :--- | :--- | :--- |
+| Image | `image` | string | Output image |
+</div>
+
+### Resize
+
+Resize image to the specified size.
+
+<div class="markdown-col-no-wrap" data-col-1 data-col-2>
+
+| Input | ID | Type | Description |
+| :--- | :--- | :--- | :--- |
+| Task ID (required) | `task` | string | `TASK_RESIZE` |
+| Image (required) | `image` | string | Input image |
+| Ratio | `ratio` | number | Resize ratio (e.g., 0.5 for half size, 2 for double size) to resize the image. If ratio is provided, width and height will be ignored. |
+| Width | `width` | integer | Width of the output image. |
+| Height | `height` | integer | Height of the output image. |
+</div>
+
+
+
+
+
+
+<div class="markdown-col-no-wrap" data-col-1 data-col-2>
+
+| Output | ID | Type | Description |
+| :--- | :--- | :--- | :--- |
+| Image | `image` | string | Output image |
+</div>
+
 ### Draw Classification
 
 Draw classification result on the image.
@@ -37,7 +124,7 @@ Draw classification result on the image.
 | Task ID (required) | `task` | string | `TASK_DRAW_CLASSIFICATION` |
 | Category (required) | `category` | string | The predicted category of the input. |
 | Image (required) | `image` | string | Input image |
-| Show Score | `showScore` | boolean | Show model confidence score on each instance |
+| Show Score | `show-score` | boolean | Show model confidence score on each instance |
 | Score (required) | `score` | number | The confidence score of the predicted category of the input. |
 </div>
 
@@ -64,7 +151,7 @@ Draw detection result on the image.
 | Task ID (required) | `task` | string | `TASK_DRAW_DETECTION` |
 | Image (required) | `image` | string | Input image |
 | [Objects](#draw-detection-objects) (required) | `objects` | array[object] | A list of detected objects. |
-| Show Score | `showScore` | boolean | Show model confidence score on each instance |
+| Show Score | `show-score` | boolean | Show model confidence score on each instance |
 </div>
 
 
@@ -118,7 +205,7 @@ Draw keypoint result on the image.
 | Task ID (required) | `task` | string | `TASK_DRAW_KEYPOINT` |
 | Image (required) | `image` | string | Input image |
 | [Objects](#draw-keypoint-objects) (required) | `objects` | array[object] | A list of keypoint objects, a keypoint object includes all the pre-defined keypoints of a detected object. |
-| Show Score | `showScore` | boolean | Show model confidence score on each instance |
+| Show Score | `show-score` | boolean | Show model confidence score on each instance |
 </div>
 
 
@@ -184,7 +271,7 @@ Draw OCR result on the image.
 | Task ID (required) | `task` | string | `TASK_DRAW_OCR` |
 | Image (required) | `image` | string | Input image |
 | [Objects](#draw-ocr-objects) (required) | `objects` | array[object] | A list of detected bounding boxes. |
-| Show Score | `showScore` | boolean | Show model confidence score on each instance |
+| Show Score | `show-score` | boolean | Show model confidence score on each instance |
 </div>
 
 
@@ -238,7 +325,7 @@ Draw instance segmentation result on the image.
 | Task ID (required) | `task` | string | `TASK_DRAW_INSTANCE_SEGMENTATION` |
 | Image (required) | `image` | string | Input image |
 | [Objects](#draw-instance-segmentation-objects) (required) | `objects` | array[object] | A list of detected instance bounding boxes. |
-| Show Score | `showScore` | boolean | Show model confidence score on each instance |
+| Show Score | `show-score` | boolean | Show model confidence score on each instance |
 </div>
 
 
@@ -292,7 +379,6 @@ Draw semantic segmentation result on the image.
 | :--- | :--- | :--- | :--- |
 | Task ID (required) | `task` | string | `TASK_DRAW_SEMANTIC_SEGMENTATION` |
 | Image (required) | `image` | string | Input image |
-| Show Score | `showScore` | boolean | Show model confidence score on each instance |
 | [Stuffs](#draw-semantic-segmentation-stuffs) (required) | `stuffs` | array[object] | A list of RLE binary masks. |
 </div>
 

--- a/pkg/component/operator/image/v0/config/definition.json
+++ b/pkg/component/operator/image/v0/config/definition.json
@@ -1,5 +1,8 @@
 {
   "availableTasks": [
+    "TASK_CONCAT",
+    "TASK_CROP",
+    "TASK_RESIZE",
     "TASK_DRAW_CLASSIFICATION",
     "TASK_DRAW_DETECTION",
     "TASK_DRAW_KEYPOINT",

--- a/pkg/component/operator/image/v0/config/tasks.json
+++ b/pkg/component/operator/image/v0/config/tasks.json
@@ -1,4 +1,289 @@
 {
+  "TASK_CONCAT": {
+    "instillShortDescription": "Concatenate images horizontally or vertically. All images must have the same width and height. If `grid-width` and `grid-height` are not provided, the images will be concatenated to a square grid.",
+    "input": {
+      "description": "Input",
+      "instillUIOrder": 0,
+      "properties": {
+        "images": {
+          "description": "Input images",
+          "instillAcceptFormats": [
+            "array:image/*"
+          ],
+          "instillUIOrder": 0,
+          "instillUpstreamTypes": [
+            "reference"
+          ],
+          "title": "Images",
+          "type": "array"
+        },
+        "grid-width": {
+          "description": "Grid width. If `grid-width` is provided, `grid-height` will be ignored.",
+          "instillAcceptFormats": [
+            "integer"
+          ],
+          "instillUIOrder": 1,
+          "instillUpstreamTypes": [
+            "value"
+          ],
+          "title": "Grid Width",
+          "type": "integer"
+        },
+        "grid-height": {
+          "description": "Grid height. If `grid-height` is provided, `grid-width` will be ignored.",
+          "instillAcceptFormats": [
+            "integer"
+          ],
+          "instillUIOrder": 2,
+          "instillUpstreamTypes": [
+            "value"
+          ],
+          "title": "Grid Height",
+          "type": "integer"
+        },
+        "padding": {
+          "description": "Padding between images. If `padding` is provided, it will be applied to all four sides of the image.",
+          "instillAcceptFormats": [
+            "integer"
+          ],
+          "instillUIOrder": 3,
+          "instillUpstreamTypes": [
+            "value"
+          ],
+          "title": "Padding",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "images"
+      ],
+      "title": "Input",
+      "type": "object"
+    },
+    "output": {
+      "description": "Output concatenated image",
+      "instillEditOnNodeFields": [
+        "image"
+      ],
+      "instillUIOrder": 0,
+      "properties": {
+        "image": {
+          "description": "Output image",
+          "instillFormat": "image/png",
+          "instillUIOrder": 0,
+          "title": "Image",
+          "type": "string"
+        }
+      },
+      "required": [
+        "image"
+      ],
+      "title": "Output",
+      "type": "object"
+    }
+  },
+  "TASK_CROP": {
+    "instillShortDescription": "Crop image to the specified size.",
+    "input": {
+      "description": "Input",
+      "instillUIOrder": 0,
+      "properties": {
+        "image": {
+          "description": "Input image",
+          "instillAcceptFormats": [
+            "image/*"
+          ],
+          "instillUIOrder": 0,
+          "instillUpstreamTypes": [
+            "reference"
+          ],
+          "title": "Image",
+          "type": "string"
+        },
+        "corner-radius": {
+          "description": "Radius from the corner of the image to crop the image. If `corner-radius` is provided, `circle-radius` will be ignored. If the `corner-radius` is larger than half of min(width, height), the min(width, height) will be applied to `corner-radius` .",
+          "instillAcceptFormats": [
+            "integer"
+          ],
+          "instillUIOrder": 1,
+          "instillUpstreamTypes": [
+            "value"
+          ],
+          "title": "Corner Radius",
+          "type": "integer"
+        },
+        "circle-radius": {
+          "description": "Radius from the center of the circle to crop the image. If `circle-radius` is provided, `corner-radius` will be ignored. If the `circle-radius` is larger than half of min(width, height), the min(width, height) will be applied to `circle-radius`.",
+          "instillAcceptFormats": [
+            "integer"
+          ],
+          "instillUIOrder": 2,
+          "instillUpstreamTypes": [
+            "value"
+          ],
+          "title": "Circle Radius",
+          "type": "integer"
+        },
+        "top-offset": {
+          "description": "Top offset of the crop",
+          "instillAcceptFormats": [
+            "integer"
+          ],
+          "instillUIOrder": 3,
+          "instillUpstreamTypes": [
+            "value"
+          ],
+          "title": "Top Offset",
+          "type": "integer"
+        },
+        "right-offset": {
+          "description": "Right offset of the crop",
+          "instillAcceptFormats": [
+            "integer"
+          ],
+          "instillUIOrder": 4,
+          "instillUpstreamTypes": [
+            "value"
+          ],
+          "title": "Right Offset",
+          "type": "integer"
+        },
+        "bottom-offset": {
+          "description": "Bottom offset of the crop",
+          "instillAcceptFormats": [
+            "integer"
+          ],
+          "instillUIOrder": 5,
+          "instillUpstreamTypes": [
+            "value"
+          ],
+          "title": "Bottom Offset",
+          "type": "integer"
+        },
+        "left-offset": {
+          "description": "Left offset of the crop",
+          "instillAcceptFormats": [
+            "integer"
+          ],
+          "instillUIOrder": 6,
+          "instillUpstreamTypes": [
+            "value"
+          ],
+          "title": "Left Offset",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "image"
+      ],
+      "title": "Input",
+      "type": "object"
+    },
+    "output": {
+      "description": "Output cropped image",
+      "instillEditOnNodeFields": [
+        "image"
+      ],
+      "instillUIOrder": 0,
+      "properties": {
+        "image": {
+          "description": "Output image",
+          "instillFormat": "image/png",
+          "instillUIOrder": 0,
+          "title": "Image",
+          "type": "string"
+        }
+      },
+      "required": [
+        "image"
+      ],
+      "title": "Output",
+      "type": "object"
+    }
+  },
+  "TASK_RESIZE": {
+    "instillShortDescription": "Resize image to the specified size.",
+    "input": {
+      "description": "Input",
+      "instillUIOrder": 0,
+      "properties": {
+        "image": {
+          "description": "Input image",
+          "instillAcceptFormats": [
+            "image/*"
+          ],
+          "instillUIOrder": 0,
+          "instillUpstreamTypes": [
+            "reference"
+          ],
+          "title": "Image",
+          "type": "string"
+        },
+        "ratio": {
+          "description": "Resize ratio (e.g., 0.5 for half size, 2 for double size) to resize the image. If ratio is provided, width and height will be ignored.",
+          "instillAcceptFormats": [
+            "number"
+          ],
+          "instillUIOrder": 1,
+          "instillUpstreamTypes": [
+            "value"
+          ],
+          "title": "Ratio",
+          "type": "number"
+        },
+        "width": {
+          "description": "Width of the output image.",
+          "instillAcceptFormats": [
+            "integer"
+          ],
+          "instillUIOrder": 2,
+          "instillUpstreamTypes": [
+            "value"
+          ],
+          "title": "Width",
+          "type": "integer"
+        },
+        "height": {
+          "description": "Height of the output image.",
+          "instillAcceptFormats": [
+            "integer"
+          ],
+          "instillUIOrder": 3,
+          "instillUpstreamTypes": [
+            "value"
+          ],
+          "title": "Height",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "image"
+      ],
+      "title": "Input",
+      "type": "object"
+    },
+    "output": {
+      "description": "Output resized image",
+      "instillEditOnNodeFields": [
+        "image"
+      ],
+      "instillUIOrder": 0,
+      "properties": {
+        "image": {
+          "description": "Output image",
+          "instillFormat": "image/png",
+          "instillUIOrder": 0,
+          "title": "Image",
+          "type": "string"
+        }
+      },
+      "required": [
+        "image"
+      ],
+      "title": "Output",
+      "type": "object"
+    }
+  },
   "TASK_DRAW_CLASSIFICATION": {
     "instillShortDescription": "Draw classification result on the image.",
     "input": {
@@ -39,7 +324,7 @@
             "reference"
           ]
         },
-        "showScore": {
+        "show-score": {
           "description": "Show model confidence score on each instance",
           "instillAcceptFormats": [
             "boolean"
@@ -70,7 +355,7 @@
       "properties": {
         "image": {
           "description": "Output image",
-          "instillFormat": "image/jpeg",
+          "instillFormat": "image/png",
           "instillUIOrder": 0,
           "title": "Image",
           "type": "string"
@@ -110,7 +395,7 @@
             "reference"
           ]
         },
-        "showScore": {
+        "show-score": {
           "description": "Show model confidence score on each instance",
           "instillAcceptFormats": [
             "boolean"
@@ -140,77 +425,7 @@
       "properties": {
         "image": {
           "description": "Output image",
-          "instillFormat": "image/jpeg",
-          "instillUIOrder": 0,
-          "title": "Image",
-          "type": "string"
-        }
-      },
-      "required": [
-        "image"
-      ],
-      "title": "Output",
-      "type": "object"
-    }
-  },
-  "TASK_DRAW_INSTANCE_SEGMENTATION": {
-    "instillShortDescription": "Draw instance segmentation result on the image.",
-    "input": {
-      "description": "Input",
-      "instillUIOrder": 0,
-      "properties": {
-        "image": {
-          "description": "Input image",
-          "instillAcceptFormats": [
-            "image/*"
-          ],
-          "instillUIOrder": 0,
-          "instillUpstreamTypes": [
-            "reference"
-          ],
-          "title": "Image",
-          "type": "string"
-        },
-        "objects": {
-          "$ref": "https://raw.githubusercontent.com/instill-ai/component/467caa4c05cf75d88e2036555529ecf6aa163b5c/resources/schemas/schema.json#/$defs/instill-types/instance-segmentation/properties/objects",
-          "instillAcceptFormats": [
-            "array:structured/instance-segmentation-object"
-          ],
-          "instillUpstreamTypes": [
-            "reference"
-          ]
-        },
-        "showScore": {
-          "description": "Show model confidence score on each instance",
-          "instillAcceptFormats": [
-            "boolean"
-          ],
-          "instillUIOrder": 0,
-          "instillUpstreamTypes": [
-            "value",
-            "reference"
-          ],
-          "title": "Show Score",
-          "type": "boolean"
-        }
-      },
-      "required": [
-        "image",
-        "objects"
-      ],
-      "title": "Input",
-      "type": "object"
-    },
-    "output": {
-      "description": "Output",
-      "instillEditOnNodeFields": [
-        "image"
-      ],
-      "instillUIOrder": 0,
-      "properties": {
-        "image": {
-          "description": "Output image",
-          "instillFormat": "image/jpeg",
+          "instillFormat": "image/png",
           "instillUIOrder": 0,
           "title": "Image",
           "type": "string"
@@ -250,7 +465,7 @@
             "reference"
           ]
         },
-        "showScore": {
+        "show-score": {
           "description": "Show model confidence score on each instance",
           "instillAcceptFormats": [
             "boolean"
@@ -280,7 +495,134 @@
       "properties": {
         "image": {
           "description": "Output image",
-          "instillFormat": "image/jpeg",
+          "instillFormat": "image/png",
+          "instillUIOrder": 0,
+          "title": "Image",
+          "type": "string"
+        }
+      },
+      "required": [
+        "image"
+      ],
+      "title": "Output",
+      "type": "object"
+    }
+  },
+  "TASK_DRAW_SEMANTIC_SEGMENTATION": {
+    "instillShortDescription": "Draw semantic segmentation result on the image.",
+    "input": {
+      "description": "Input",
+      "instillUIOrder": 0,
+      "properties": {
+        "image": {
+          "description": "Input image",
+          "instillAcceptFormats": [
+            "image/*"
+          ],
+          "instillUIOrder": 0,
+          "instillUpstreamTypes": [
+            "reference"
+          ],
+          "title": "Image",
+          "type": "string"
+        },
+        "stuffs": {
+          "$ref": "https://raw.githubusercontent.com/instill-ai/component/467caa4c05cf75d88e2036555529ecf6aa163b5c/resources/schemas/schema.json#/$defs/instill-types/semantic-segmentation/properties/stuffs",
+          "instillAcceptFormats": [
+            "array:structured/semantic-segmentation-stuff"
+          ],
+          "instillUpstreamTypes": [
+            "reference"
+          ]
+        }
+      },
+      "required": [
+        "image",
+        "stuffs"
+      ],
+      "title": "Input",
+      "type": "object"
+    },
+    "output": {
+      "description": "Output",
+      "instillEditOnNodeFields": [
+        "image"
+      ],
+      "instillUIOrder": 0,
+      "properties": {
+        "image": {
+          "description": "Output image",
+          "instillFormat": "image/png",
+          "instillUIOrder": 0,
+          "title": "Image",
+          "type": "string"
+        }
+      },
+      "required": [
+        "image"
+      ],
+      "title": "Output",
+      "type": "object"
+    }
+  },
+  "TASK_DRAW_INSTANCE_SEGMENTATION": {
+    "instillShortDescription": "Draw instance segmentation result on the image.",
+    "input": {
+      "description": "Input",
+      "instillUIOrder": 0,
+      "properties": {
+        "image": {
+          "description": "Input image",
+          "instillAcceptFormats": [
+            "image/*"
+          ],
+          "instillUIOrder": 0,
+          "instillUpstreamTypes": [
+            "reference"
+          ],
+          "title": "Image",
+          "type": "string"
+        },
+        "objects": {
+          "$ref": "https://raw.githubusercontent.com/instill-ai/component/467caa4c05cf75d88e2036555529ecf6aa163b5c/resources/schemas/schema.json#/$defs/instill-types/instance-segmentation/properties/objects",
+          "instillAcceptFormats": [
+            "array:structured/instance-segmentation-object"
+          ],
+          "instillUpstreamTypes": [
+            "reference"
+          ]
+        },
+        "show-score": {
+          "description": "Show model confidence score on each instance",
+          "instillAcceptFormats": [
+            "boolean"
+          ],
+          "instillUIOrder": 0,
+          "instillUpstreamTypes": [
+            "value",
+            "reference"
+          ],
+          "title": "Show Score",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "image",
+        "objects"
+      ],
+      "title": "Input",
+      "type": "object"
+    },
+    "output": {
+      "description": "Output",
+      "instillEditOnNodeFields": [
+        "image"
+      ],
+      "instillUIOrder": 0,
+      "properties": {
+        "image": {
+          "description": "Output image",
+          "instillFormat": "image/png",
           "instillUIOrder": 0,
           "title": "Image",
           "type": "string"
@@ -320,7 +662,7 @@
             "reference"
           ]
         },
-        "showScore": {
+        "show-score": {
           "description": "Show model confidence score on each instance",
           "instillAcceptFormats": [
             "boolean"
@@ -350,77 +692,7 @@
       "properties": {
         "image": {
           "description": "Output image",
-          "instillFormat": "image/jpeg",
-          "instillUIOrder": 0,
-          "title": "Image",
-          "type": "string"
-        }
-      },
-      "required": [
-        "image"
-      ],
-      "title": "Output",
-      "type": "object"
-    }
-  },
-  "TASK_DRAW_SEMANTIC_SEGMENTATION": {
-    "instillShortDescription": "Draw semantic segmentation result on the image.",
-    "input": {
-      "description": "Input",
-      "instillUIOrder": 0,
-      "properties": {
-        "image": {
-          "description": "Input image",
-          "instillAcceptFormats": [
-            "image/*"
-          ],
-          "instillUIOrder": 0,
-          "instillUpstreamTypes": [
-            "reference"
-          ],
-          "title": "Image",
-          "type": "string"
-        },
-        "showScore": {
-          "description": "Show model confidence score on each instance",
-          "instillAcceptFormats": [
-            "boolean"
-          ],
-          "instillUIOrder": 0,
-          "instillUpstreamTypes": [
-            "value",
-            "reference"
-          ],
-          "title": "Show Score",
-          "type": "boolean"
-        },
-        "stuffs": {
-          "$ref": "https://raw.githubusercontent.com/instill-ai/component/467caa4c05cf75d88e2036555529ecf6aa163b5c/resources/schemas/schema.json#/$defs/instill-types/semantic-segmentation/properties/stuffs",
-          "instillAcceptFormats": [
-            "array:structured/semantic-segmentation-stuff"
-          ],
-          "instillUpstreamTypes": [
-            "reference"
-          ]
-        }
-      },
-      "required": [
-        "image",
-        "stuffs"
-      ],
-      "title": "Input",
-      "type": "object"
-    },
-    "output": {
-      "description": "Output",
-      "instillEditOnNodeFields": [
-        "image"
-      ],
-      "instillUIOrder": 0,
-      "properties": {
-        "image": {
-          "description": "Output image",
-          "instillFormat": "image/jpeg",
+          "instillFormat": "image/png",
           "instillUIOrder": 0,
           "title": "Image",
           "type": "string"

--- a/pkg/component/operator/image/v0/draw.go
+++ b/pkg/component/operator/image/v0/draw.go
@@ -1,57 +1,24 @@
 package image
 
 import (
-	"bytes"
-	"encoding/base64"
-	"fmt"
 	"image"
 	"image/color"
-	"image/jpeg"
 	"math/rand"
-	"sort"
-	"strconv"
-	"strings"
 
 	"github.com/fogleman/gg"
 	"golang.org/x/image/font/opentype"
-	"google.golang.org/protobuf/types/known/structpb"
 )
 
-// BoundingBox holds the coordinates of a bounding box.
-type BoundingBox struct {
-	Top    int
-	Left   int
-	Width  int
-	Height int
+type boundingBox struct {
+	Top    int `json:"top"`
+	Left   int `json:"left"`
+	Width  int `json:"width"`
+	Height int `json:"height"`
 }
 
 // Size returns the area of the bounding box.
-func (b *BoundingBox) Size() int {
+func (b *boundingBox) Size() int {
 	return b.Width * b.Height
-}
-
-func structpbToBoundingBox(s *structpb.Struct) *BoundingBox {
-	return &BoundingBox{
-		Top:    int(s.Fields["top"].GetNumberValue()),
-		Left:   int(s.Fields["left"].GetNumberValue()),
-		Width:  int(s.Fields["width"].GetNumberValue()),
-		Height: int(s.Fields["height"].GetNumberValue()),
-	}
-}
-
-// Keypoint holds the coordinates of a keypoint.
-type Keypoint struct {
-	x float64
-	y float64
-	v float64
-}
-
-func structpbToKeypoint(s *structpb.Struct) *Keypoint {
-	return &Keypoint{
-		x: s.Fields["x"].GetNumberValue(),
-		y: s.Fields["y"].GetNumberValue(),
-		v: s.Fields["v"].GetNumberValue(),
-	}
 }
 
 // Use the same color palette defined in yolov7: https://github.com/WongKinYiu/yolov7/blob/main/utils/plots.py#L449-L462
@@ -78,42 +45,13 @@ var palette = []color.RGBA{
 	{255, 255, 255, 255},
 }
 
-var skeleton = [][]int{{16, 14}, {14, 12}, {17, 15}, {15, 13}, {12, 13}, {6, 12},
-	{7, 13}, {6, 7}, {6, 8}, {7, 9}, {8, 10}, {9, 11}, {2, 3}, {1, 2}, {1, 3}, {2, 4}, {3, 5}, {4, 6}, {5, 7},
-}
-
-var keypointLimbColorIdx = []int{9, 9, 9, 9, 7, 7, 7, 0, 0, 0, 0, 0, 16, 16, 16, 16, 16, 16, 16}
-var keypointColorIdx = []int{16, 16, 16, 16, 16, 0, 0, 0, 0, 0, 0, 9, 9, 9, 9, 9, 9}
-
-func convertToBase64(img image.Image) ([]byte, error) {
-	var buf bytes.Buffer
-	err := jpeg.Encode(&buf, img, &jpeg.Options{Quality: 100})
-	if err != nil {
-		return nil, err
-	}
-	base64Str := base64.StdEncoding.EncodeToString(buf.Bytes())
-	base64Bytes := []byte(base64Str)
-	return base64Bytes, nil
-}
-
-func convertToRGBA(img image.Image) *image.RGBA {
-	bounds := img.Bounds()
-	rgba := image.NewRGBA(bounds)
-	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
-		for x := bounds.Min.X; x < bounds.Max.X; x++ {
-			originalColor := img.At(x, y)
-			rgba.Set(x, y, color.RGBAModel.Convert(originalColor))
-		}
-	}
-	return rgba
-}
-
-func indexUniqueCategories(objs []*structpb.Value) map[string]int {
+func indexUniqueCategories(objs []*detectionObject) map[string]int {
 	catIdx := make(map[string]int)
 	for _, obj := range objs {
-		_, exist := catIdx[obj.GetStructValue().Fields["category"].GetStringValue()]
+		_, exist := catIdx[obj.Category]
 		if !exist {
-			catIdx[obj.GetStructValue().Fields["category"].GetStringValue()] = len(catIdx)
+			catIdx[obj.Category] = len(catIdx)
+
 		}
 	}
 	return catIdx
@@ -207,175 +145,7 @@ func rleDecode(rle []int, width, height int) [][]bool {
 	return mask
 }
 
-func drawSemanticMask(img *image.RGBA, rle string, colorSeed int) error {
-	// Split the string by commas to get the individual number strings.
-	numberStrings := strings.Split(rle, ",")
-
-	// Allocate an array of integers with the same length as the number of numberStrings.
-	rleInts := make([]int, len(numberStrings))
-
-	// Convert each number string to an integer.
-	for i, s := range numberStrings {
-		n, err := strconv.Atoi(strings.TrimSpace(s))
-		if err != nil {
-			return fmt.Errorf("failed to convert RLE string to int: %s, error: %v", s, err)
-		}
-		rleInts[i] = n
-	}
-
-	bound := img.Bounds()
-
-	// Decode the RLE mask for the full image size.
-	mask := rleDecode(rleInts, bound.Dx(), bound.Dy())
-
-	// Iterate over the bounding box and draw the mask onto the image.
-	for y := 0; y < bound.Dy(); y++ {
-		for x := 0; x < bound.Dx(); x++ {
-			if mask[y][x] {
-				// The mask is present for this pixel, so draw it on the image.
-				// Here you could set a specific color or just use the mask value.
-				// For example, let's paint the mask as a red semi-transparent overlay:
-				originalColor := img.At(x, y).(color.RGBA)
-				// Blend the original color with the mask color.
-				blendedColor := blendColors(originalColor, randomColor(colorSeed, 128))
-				img.Set(x, y, blendedColor)
-			}
-		}
-	}
-
-	dc := gg.NewContextForRGBA(img)
-	dc.SetColor(color.RGBA{255, 255, 255, 255})
-
-	// Find contour points
-	contourPoints := findContour(mask)
-
-	// Draw the contour
-	for _, pt := range contourPoints {
-		// Scale points as needed for your canvas size
-		dc.DrawPoint(float64(pt.X), float64(pt.Y), 0.5)
-		dc.Fill()
-	}
-
-	return nil
-}
-
-func drawInstanceMask(img *image.RGBA, bbox *BoundingBox, rle string, colorSeed int) error {
-
-	// Split the string by commas to get the individual number strings.
-	numberStrings := strings.Split(rle, ",")
-
-	// Allocate an array of integers with the same length as the number of numberStrings.
-	rleInts := make([]int, len(numberStrings))
-
-	// Convert each number string to an integer.
-	for i, s := range numberStrings {
-		n, err := strconv.Atoi(strings.TrimSpace(s))
-		if err != nil {
-			return fmt.Errorf("failed to convert RLE string to int: %s, error: %v", s, err)
-		}
-		rleInts[i] = n
-	}
-
-	// Decode the RLE mask for the full image size.
-	mask := rleDecode(rleInts, bbox.Width, bbox.Height)
-
-	// Iterate over the bounding box and draw the mask onto the image.
-	for y := 0; y < bbox.Height; y++ {
-		for x := 0; x < bbox.Width; x++ {
-			if mask[y][x] {
-				// The mask is present for this pixel, so draw it on the image.
-				// Here you could set a specific color or just use the mask value.
-				// For example, let's paint the mask as a red semi-transparent overlay:
-				originalColor := img.At(x+bbox.Left, y+bbox.Top).(color.RGBA)
-				// Blend the original color with the mask color.
-				blendedColor := blendColors(originalColor, randomColor(colorSeed, 156))
-				img.Set(x+bbox.Left, y+bbox.Top, blendedColor)
-			}
-		}
-	}
-
-	dc := gg.NewContextForRGBA(img)
-	dc.SetColor(randomColor(colorSeed, 255))
-	contourPoints := findContour(mask)
-	for _, pt := range contourPoints {
-		dc.DrawPoint(float64(pt.X+bbox.Left), float64(pt.Y+bbox.Top), 0.5)
-		dc.Fill()
-	}
-
-	return nil
-}
-
-func drawBoundingBox(img *image.RGBA, bbox *BoundingBox, colorSeed int) error {
-	dc := gg.NewContextForRGBA(img)
-	originalColor := img.At(bbox.Left, bbox.Top).(color.RGBA)
-	blendedColor := blendColors(originalColor, randomColor(colorSeed, 255))
-	dc.SetColor(blendedColor)
-	dc.SetLineWidth(3)
-	dc.DrawRoundedRectangle(float64(bbox.Left), float64(bbox.Top), float64(bbox.Width), float64(bbox.Height), 4)
-	dc.Stroke()
-	return nil
-}
-
-func drawSkeleton(img *image.RGBA, kpts []*Keypoint) error {
-	dc := gg.NewContextForRGBA(img)
-	for idx, kpt := range kpts {
-		if kpt.v > 0.5 {
-			dc.SetColor(palette[keypointColorIdx[idx]])
-			dc.DrawPoint(kpt.x, kpt.y, 2)
-			dc.Fill()
-		}
-	}
-	for idx, sk := range skeleton {
-		if kpts[sk[0]-1].v > 0.5 && kpts[sk[1]-1].v > 0.5 {
-			dc.SetColor(palette[keypointLimbColorIdx[idx]])
-			dc.SetLineWidth(2)
-			dc.DrawLine(kpts[sk[0]-1].x, kpts[sk[0]-1].y, kpts[sk[1]-1].x, kpts[sk[1]-1].y)
-			dc.Stroke()
-		}
-	}
-	return nil
-}
-
-func drawImageLabel(img *image.RGBA, category string, score float64) error {
-
-	dc := gg.NewContextForRGBA(img)
-
-	// Parse the font
-	font, err := opentype.Parse(IBMPlexSansRegular)
-	if err != nil {
-		return err
-	}
-
-	// Create a font face
-	face, err := opentype.NewFace(font, &opentype.FaceOptions{
-		Size: 20,
-		DPI:  72,
-	})
-	if err != nil {
-		return err
-	}
-
-	// Set the font face
-	dc.SetFontFace(face)
-
-	w, h := dc.MeasureString(category)
-
-	// Set the rectangle padding
-	padding := 2.0
-
-	x := padding
-	y := padding
-	w += 6 * padding
-	h += padding
-	dc.SetRGB(0, 0, 0)
-	dc.DrawRoundedRectangle(x, y, w, h, 4)
-	dc.Fill()
-	dc.SetColor(color.RGBA{255, 255, 255, 255})
-	dc.DrawString(category, 4*padding, 11*padding)
-	return nil
-}
-
-func drawObjectLabel(img *image.RGBA, bbox *BoundingBox, category string, maskAdjustment bool, colorSeed int) error {
+func drawObjectLabel(img *image.RGBA, bbox *boundingBox, category string, maskAdjustment bool, colorSeed int) error {
 
 	dc := gg.NewContextForRGBA(img)
 
@@ -433,169 +203,4 @@ func drawObjectLabel(img *image.RGBA, bbox *BoundingBox, category string, maskAd
 	}
 
 	return nil
-}
-
-func draOCRLabel(img *image.RGBA, bbox *BoundingBox, text string) error {
-
-	dc := gg.NewContextForRGBA(img)
-
-	// Parse the font
-	font, err := opentype.Parse(IBMPlexSansRegular)
-	if err != nil {
-		return err
-	}
-
-	// Create a font face
-	face, err := opentype.NewFace(font, &opentype.FaceOptions{
-		Size: 20,
-		DPI:  72,
-	})
-	if err != nil {
-		return err
-	}
-
-	// Set the font face
-	dc.SetFontFace(face)
-
-	w, h := dc.MeasureString(text)
-
-	// Set the rectangle padding
-	padding := 2.0
-
-	x := float64(bbox.Left)
-	y := float64(bbox.Top)
-	w += 4 * padding
-	h += padding
-	dc.SetRGBA(0, 0, 0, 128)
-	dc.DrawRoundedRectangle(x, y, w, h, 4)
-	dc.Fill()
-	dc.SetColor(color.RGBA{255, 255, 255, 255})
-	dc.DrawString(text, float64(bbox.Left)+2*padding, float64(bbox.Top)+h-4*padding)
-
-	return nil
-}
-
-func drawClassification(srcImg image.Image, category string, score float64) ([]byte, error) {
-	img := convertToRGBA(srcImg)
-
-	if err := drawImageLabel(img, category, score); err != nil {
-		return nil, err
-	}
-
-	base64Img, err := convertToBase64(img)
-	if err != nil {
-		return nil, err
-	}
-	return base64Img, nil
-}
-
-func drawDetection(srcImg image.Image, objs []*structpb.Value) ([]byte, error) {
-	img := convertToRGBA(srcImg)
-
-	catIdx := indexUniqueCategories(objs)
-
-	for _, obj := range objs {
-		bbox := structpbToBoundingBox(obj.GetStructValue().Fields["bounding-box"].GetStructValue())
-		if err := drawBoundingBox(img, bbox, catIdx[obj.GetStructValue().Fields["category"].GetStringValue()]); err != nil {
-			return nil, err
-		}
-	}
-
-	for _, obj := range objs {
-		bbox := structpbToBoundingBox(obj.GetStructValue().Fields["bounding-box"].GetStructValue())
-		if err := drawObjectLabel(img, bbox, obj.GetStructValue().Fields["category"].GetStringValue(), false, catIdx[obj.GetStructValue().Fields["category"].GetStringValue()]); err != nil {
-			return nil, err
-		}
-	}
-
-	base64Img, err := convertToBase64(img)
-	if err != nil {
-		return nil, err
-	}
-	return base64Img, nil
-}
-
-func drawKeypoint(srcImg image.Image, objs []*structpb.Value) ([]byte, error) {
-	img := convertToRGBA(srcImg)
-	for _, obj := range objs {
-		kpts := make([]*Keypoint, len(obj.GetStructValue().Fields["keypoints"].GetListValue().Values))
-		for idx, kpt := range obj.GetStructValue().Fields["keypoints"].GetListValue().Values {
-			kpts[idx] = structpbToKeypoint(kpt.GetStructValue())
-		}
-		if err := drawSkeleton(img, kpts); err != nil {
-			return nil, err
-		}
-	}
-
-	base64Img, err := convertToBase64(img)
-	if err != nil {
-		return nil, err
-	}
-	return base64Img, nil
-}
-
-func drawOCR(srcImg image.Image, objs []*structpb.Value) ([]byte, error) {
-	img := convertToRGBA(srcImg)
-
-	for _, obj := range objs {
-		bbox := structpbToBoundingBox(obj.GetStructValue().Fields["bounding-box"].GetStructValue())
-		if err := draOCRLabel(img, bbox, obj.GetStructValue().Fields["text"].GetStringValue()); err != nil {
-			return nil, err
-		}
-	}
-
-	base64Img, err := convertToBase64(img)
-	if err != nil {
-		return nil, err
-	}
-	return base64Img, nil
-}
-
-func drawInstanceSegmentation(srcImg image.Image, objs []*structpb.Value) ([]byte, error) {
-
-	img := convertToRGBA(srcImg)
-
-	// Sort the objects by size.
-	sort.Slice(objs, func(i, j int) bool {
-		bbox1 := structpbToBoundingBox(objs[i].GetStructValue().Fields["bounding-box"].GetStructValue())
-		bbox2 := structpbToBoundingBox(objs[j].GetStructValue().Fields["bounding-box"].GetStructValue())
-		return bbox1.Size() > bbox2.Size()
-	})
-
-	for instIdx, obj := range objs {
-		bbox := structpbToBoundingBox(obj.GetStructValue().Fields["bounding-box"].GetStructValue())
-		if err := drawInstanceMask(img, bbox, obj.GetStructValue().Fields["rle"].GetStringValue(), instIdx); err != nil {
-			return nil, err
-		}
-	}
-
-	for instIdx, obj := range objs {
-		bbox := structpbToBoundingBox(obj.GetStructValue().Fields["bounding-box"].GetStructValue())
-		text := obj.GetStructValue().Fields["category"].GetStringValue()
-		if err := drawObjectLabel(img, bbox, text, true, instIdx); err != nil {
-			return nil, err
-		}
-	}
-
-	base64Img, err := convertToBase64(img)
-	if err != nil {
-		return nil, err
-	}
-	return base64Img, nil
-}
-
-func drawSemanticSegmentation(srcImg image.Image, stuffs []*structpb.Value) ([]byte, error) {
-	img := convertToRGBA(srcImg)
-
-	for idx, stuff := range stuffs {
-		if err := drawSemanticMask(img, stuff.GetStructValue().Fields["rle"].GetStringValue(), idx); err != nil {
-			return nil, err
-		}
-	}
-
-	base64Img, err := convertToBase64(img)
-	if err != nil {
-		return nil, err
-	}
-	return base64Img, nil
 }

--- a/pkg/component/operator/image/v0/draw_test.go
+++ b/pkg/component/operator/image/v0/draw_test.go
@@ -3,19 +3,20 @@ package image
 import (
 	"image"
 	"image/color"
-	"reflect"
 	"testing"
+
+	"github.com/frankban/quicktest"
 )
 
 func TestBoundingBoxSize(t *testing.T) {
+	c := quicktest.New(t)
 	bbox := &boundingBox{Top: 10, Left: 20, Width: 100, Height: 50}
 	expected := 5000
-	if size := bbox.Size(); size != expected {
-		t.Errorf("Expected size %d, but got %d", expected, size)
-	}
+	c.Assert(bbox.Size(), quicktest.Equals, expected)
 }
 
 func TestIndexUniqueCategories(t *testing.T) {
+	c := quicktest.New(t)
 	objs := []*detectionObject{
 		{Category: "cat"},
 		{Category: "dog"},
@@ -24,35 +25,30 @@ func TestIndexUniqueCategories(t *testing.T) {
 	}
 	expected := map[string]int{"cat": 0, "dog": 1, "bird": 2}
 	result := indexUniqueCategories(objs)
-	if !reflect.DeepEqual(result, expected) {
-		t.Errorf("Expected %v, but got %v", expected, result)
-	}
+	c.Assert(result, quicktest.DeepEquals, expected)
 }
 
 func TestRandomColor(t *testing.T) {
+	c := quicktest.New(t)
 	color1 := randomColor(1, 255)
 	color2 := randomColor(1, 255)
-	if color1 != color2 {
-		t.Errorf("Expected same colors for same seed, but got %v and %v", color1, color2)
-	}
+	c.Assert(color1, quicktest.Equals, color2)
 
 	color3 := randomColor(2, 255)
-	if color1 == color3 {
-		t.Errorf("Expected different colors for different seeds, but got %v and %v", color1, color3)
-	}
+	c.Assert(color1, quicktest.Not(quicktest.Equals), color3)
 }
 
 func TestBlendColors(t *testing.T) {
+	c := quicktest.New(t)
 	c1 := color.RGBA{R: 255, G: 0, B: 0, A: 255}
 	c2 := color.RGBA{R: 0, G: 255, B: 0, A: 128}
 	expected := color.RGBA{R: 127, G: 128, B: 0, A: 255}
 	result := blendColors(c1, c2)
-	if result != expected {
-		t.Errorf("Expected %v, but got %v", expected, result)
-	}
+	c.Assert(result, quicktest.Equals, expected)
 }
 
 func TestHasFalseNeighbor(t *testing.T) {
+	c := quicktest.New(t)
 	mask := [][]bool{
 		{true, true, false},
 		{true, true, true},
@@ -69,13 +65,12 @@ func TestHasFalseNeighbor(t *testing.T) {
 	}
 	for _, tt := range tests {
 		result := hasFalseNeighbor(mask, tt.x, tt.y)
-		if result != tt.expected {
-			t.Errorf("For (%d, %d), expected %v, but got %v", tt.x, tt.y, tt.expected, result)
-		}
+		c.Assert(result, quicktest.Equals, tt.expected)
 	}
 }
 
 func TestFindContour(t *testing.T) {
+	c := quicktest.New(t)
 	mask := [][]bool{
 		{false, true, false},
 		{true, true, true},
@@ -89,12 +84,11 @@ func TestFindContour(t *testing.T) {
 		{X: 1, Y: 2},
 	}
 	result := findContour(mask)
-	if !reflect.DeepEqual(result, expected) {
-		t.Errorf("Expected %v, but got %v", expected, result)
-	}
+	c.Assert(result, quicktest.DeepEquals, expected)
 }
 
 func TestRleDecode(t *testing.T) {
+	c := quicktest.New(t)
 	rle := []int{3, 2, 1}
 	width, height := 3, 2
 	expected := [][]bool{
@@ -102,7 +96,5 @@ func TestRleDecode(t *testing.T) {
 		{false, true, false},
 	}
 	result := rleDecode(rle, width, height)
-	if !reflect.DeepEqual(result, expected) {
-		t.Errorf("Expected %v, but got %v", expected, result)
-	}
+	c.Assert(result, quicktest.DeepEquals, expected)
 }

--- a/pkg/component/operator/image/v0/image.go
+++ b/pkg/component/operator/image/v0/image.go
@@ -1,0 +1,53 @@
+package image
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"image"
+	"image/color"
+	"image/png"
+
+	"github.com/instill-ai/pipeline-backend/pkg/component/base"
+)
+
+// base64Image is a base64 encoded image
+type base64Image string
+
+func decodeBase64Image(base64Img string) (image.Image, error) {
+	imgBytes, err := base64.StdEncoding.DecodeString(base.TrimBase64Mime(base64Img))
+	if err != nil {
+		return nil, fmt.Errorf("error decoding base64 image: %v", err)
+	}
+
+	img, _, err := image.Decode(bytes.NewReader(imgBytes))
+	if err != nil {
+		return nil, fmt.Errorf("error decoding image: %v", err)
+	}
+
+	return img, nil
+}
+
+func encodeBase64Image(img image.Image) (string, error) {
+	buf := new(bytes.Buffer)
+	err := png.Encode(buf, img)
+	if err != nil {
+		return "", fmt.Errorf("error encoding image: %v", err)
+	}
+
+	base64ByteImg := base64.StdEncoding.EncodeToString(buf.Bytes())
+
+	return base64ByteImg, nil
+}
+
+func convertToRGBA(img image.Image) *image.RGBA {
+	bounds := img.Bounds()
+	rgba := image.NewRGBA(bounds)
+	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
+		for x := bounds.Min.X; x < bounds.Max.X; x++ {
+			originalColor := img.At(x, y)
+			rgba.Set(x, y, color.RGBAModel.Convert(originalColor))
+		}
+	}
+	return rgba
+}

--- a/pkg/component/operator/image/v0/main.go
+++ b/pkg/component/operator/image/v0/main.go
@@ -2,16 +2,12 @@
 package image
 
 import (
-	"bytes"
 	"context"
-	"encoding/base64"
 	"fmt"
-	"image"
 	"sync"
 
 	_ "embed"
 	_ "image/gif"
-	_ "image/jpeg"
 	_ "image/png"
 
 	"google.golang.org/protobuf/types/known/structpb"
@@ -28,17 +24,15 @@ var (
 	comp      *component
 )
 
-// Operator is the derived operator
 type component struct {
 	base.Component
 }
 
-// Execution is the derived execution
 type execution struct {
 	base.ComponentExecution
+	execute func(*structpb.Struct, *base.Job, context.Context) (*structpb.Struct, error)
 }
 
-// Init initializes the operator
 func Init(bc base.Component) *component {
 	once.Do(func() {
 		comp = &component{Component: bc}
@@ -50,89 +44,39 @@ func Init(bc base.Component) *component {
 	return comp
 }
 
+// TODO: pinglin change the comment from connector to component
 // CreateExecution initializes a connector executor that can be used in a
 // pipeline trigger.
 func (c *component) CreateExecution(x base.ComponentExecution) (base.IExecution, error) {
-	return &execution{ComponentExecution: x}, nil
+	e := &execution{ComponentExecution: x}
+
+	switch x.Task {
+	case "TASK_CONCAT":
+		e.execute = concat
+	case "TASK_CROP":
+		e.execute = crop
+	case "TASK_RESIZE":
+		e.execute = resize
+	case "TASK_DRAW_CLASSIFICATION":
+		e.execute = drawClassification
+	case "TASK_DRAW_DETECTION":
+		e.execute = drawDetection
+	case "TASK_DRAW_KEYPOINT":
+		e.execute = drawKeypoint
+	case "TASK_DRAW_SEMANTIC_SEGMENTATION":
+		e.execute = drawSemanticSegmentation
+	case "TASK_DRAW_INSTANCE_SEGMENTATION":
+		e.execute = drawInstanceSegmentation
+	case "TASK_DRAW_OCR":
+		e.execute = drawOCR
+	default:
+		return nil, fmt.Errorf("not supported task: %s", x.Task)
+	}
+
+	return e, nil
 }
 
 // Execute executes the derived execution
 func (e *execution) Execute(ctx context.Context, jobs []*base.Job) error {
-
-	var base64ByteImg []byte
-	for _, job := range jobs {
-
-		input, err := job.Input.Read(ctx)
-		if err != nil {
-			job.Error.Error(ctx, err)
-			continue
-		}
-		b, err := base64.StdEncoding.DecodeString(base.TrimBase64Mime(input.Fields["image"].GetStringValue()))
-		if err != nil {
-			job.Error.Error(ctx, err)
-			continue
-		}
-
-		img, _, err := image.Decode(bytes.NewReader(b))
-		if err != nil {
-			job.Error.Error(ctx, err)
-			continue
-		}
-
-		switch e.Task {
-		case "TASK_DRAW_CLASSIFICATION":
-			base64ByteImg, err = drawClassification(img, input.Fields["category"].GetStringValue(), input.Fields["score"].GetNumberValue())
-			if err != nil {
-				job.Error.Error(ctx, err)
-				continue
-			}
-		case "TASK_DRAW_DETECTION":
-			base64ByteImg, err = drawDetection(img, input.Fields["objects"].GetListValue().Values)
-			if err != nil {
-				job.Error.Error(ctx, err)
-				continue
-			}
-		case "TASK_DRAW_KEYPOINT":
-			base64ByteImg, err = drawKeypoint(img, input.Fields["objects"].GetListValue().Values)
-			if err != nil {
-				job.Error.Error(ctx, err)
-				continue
-			}
-		case "TASK_DRAW_OCR":
-			base64ByteImg, err = drawOCR(img, input.Fields["objects"].GetListValue().Values)
-			if err != nil {
-				job.Error.Error(ctx, err)
-				continue
-			}
-		case "TASK_DRAW_INSTANCE_SEGMENTATION":
-			base64ByteImg, err = drawInstanceSegmentation(img, input.Fields["objects"].GetListValue().Values)
-			if err != nil {
-				job.Error.Error(ctx, err)
-				continue
-			}
-		case "TASK_DRAW_SEMANTIC_SEGMENTATION":
-			base64ByteImg, err = drawSemanticSegmentation(img, input.Fields["stuffs"].GetListValue().Values)
-			if err != nil {
-				job.Error.Error(ctx, err)
-				continue
-			}
-		default:
-			job.Error.Error(ctx, fmt.Errorf("not supported task: %s", e.Task))
-			continue
-		}
-
-		output := &structpb.Struct{Fields: make(map[string]*structpb.Value)}
-
-		output.Fields["image"] = &structpb.Value{
-			Kind: &structpb.Value_StringValue{
-				StringValue: fmt.Sprintf("data:image/jpeg;base64,%s", string(base64ByteImg)),
-			},
-		}
-
-		err = job.Output.Write(ctx, output)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+	return base.ConcurrentExecutor(ctx, jobs, e.execute)
 }

--- a/pkg/component/operator/image/v0/main.go
+++ b/pkg/component/operator/image/v0/main.go
@@ -44,8 +44,7 @@ func Init(bc base.Component) *component {
 	return comp
 }
 
-// TODO: pinglin change the comment from connector to component
-// CreateExecution initializes a connector executor that can be used in a
+// CreateExecution initializes a component execution that can be used in a
 // pipeline trigger.
 func (c *component) CreateExecution(x base.ComponentExecution) (base.IExecution, error) {
 	e := &execution{ComponentExecution: x}

--- a/pkg/component/operator/image/v0/task_concat.go
+++ b/pkg/component/operator/image/v0/task_concat.go
@@ -1,0 +1,94 @@
+package image
+
+import (
+	"context"
+	"fmt"
+	"image"
+	"image/draw"
+	"math"
+
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/instill-ai/pipeline-backend/pkg/component/base"
+)
+
+type ConcatInput struct {
+	Images     []base64Image `json:"images"`
+	GridWidth  int           `json:"grid-width"`
+	GridHeight int           `json:"grid-height"`
+	Padding    int           `json:"padding"`
+}
+
+type ConcatOutput struct {
+	Image base64Image `json:"image"`
+}
+
+func concat(input *structpb.Struct, job *base.Job, ctx context.Context) (*structpb.Struct, error) {
+	// Parse input
+	var inputStruct ConcatInput
+	if err := base.ConvertFromStructpb(input, &inputStruct); err != nil {
+		return nil, fmt.Errorf("error converting input: %v", err)
+	}
+
+	// Check if images are provided
+	if len(inputStruct.Images) == 0 {
+		return nil, fmt.Errorf("no images provided")
+	}
+
+	// Decode images
+	images := make([]image.Image, len(inputStruct.Images))
+	for i, base64Img := range inputStruct.Images {
+		img, err := decodeBase64Image(string(base64Img))
+		if err != nil {
+			return nil, fmt.Errorf("error decoding image %d: %v", i, err)
+		}
+		images[i] = img
+	}
+
+	// Determine grid dimensions
+	gridWidth, gridHeight := determineGridDimensions(len(images), inputStruct.GridWidth, inputStruct.GridHeight)
+
+	// Calculate output image dimensions
+	sampleImg := images[0]
+	imgWidth, imgHeight := sampleImg.Bounds().Dx(), sampleImg.Bounds().Dy()
+	padding := inputStruct.Padding
+	outputWidth := gridWidth*imgWidth + (gridWidth-1)*padding
+	outputHeight := gridHeight*imgHeight + (gridHeight-1)*padding
+
+	// Create output image
+	output := image.NewRGBA(image.Rect(0, 0, outputWidth, outputHeight))
+
+	// Place images in grid
+	for i, img := range images {
+		row := i / gridWidth
+		col := i % gridWidth
+		x := col * (imgWidth + padding)
+		y := row * (imgHeight + padding)
+		draw.Draw(output, image.Rect(x, y, x+imgWidth, y+imgHeight), img, image.Point{}, draw.Over)
+	}
+
+	// Encode output image
+	base64Output, err := encodeBase64Image(output)
+	if err != nil {
+		return nil, fmt.Errorf("error encoding output image: %v", err)
+	}
+
+	// Prepare output
+	outputStruct := ConcatOutput{
+		Image: base64Image(fmt.Sprintf("data:image/png;base64,%s", base64Output)),
+	}
+
+	return base.ConvertToStructpb(outputStruct)
+}
+
+func determineGridDimensions(imageCount, gridWidth, gridHeight int) (int, int) {
+	if gridWidth > 0 {
+		return gridWidth, int(math.Ceil(float64(imageCount) / float64(gridWidth)))
+	}
+	if gridHeight > 0 {
+		return int(math.Ceil(float64(imageCount) / float64(gridHeight))), gridHeight
+	}
+	// Default to square grid
+	side := int(math.Ceil(math.Sqrt(float64(imageCount))))
+	return side, side
+}

--- a/pkg/component/operator/image/v0/task_concat_test.go
+++ b/pkg/component/operator/image/v0/task_concat_test.go
@@ -6,12 +6,14 @@ import (
 	"image/color"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/frankban/quicktest"
 
 	"github.com/instill-ai/pipeline-backend/pkg/component/base"
 )
 
 func TestConcat(t *testing.T) {
+	c := quicktest.New(t)
+
 	// Create sample images
 	img1 := createTestImage(50, 50, color.RGBA{255, 0, 0, 255})   // Red
 	img2 := createTestImage(50, 50, color.RGBA{0, 255, 0, 255})   // Green
@@ -82,29 +84,28 @@ func TestConcat(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
+		c.Run(tc.name, func(c *quicktest.C) {
 			inputStruct, err := base.ConvertToStructpb(tc.input)
-			assert.NoError(t, err)
+			c.Assert(err, quicktest.IsNil)
 
 			output, err := concat(inputStruct, nil, context.Background())
 
 			if tc.expectedError != "" {
-				assert.Error(t, err)
-				assert.Contains(t, err.Error(), tc.expectedError)
+				c.Assert(err, quicktest.ErrorMatches, tc.expectedError)
 			} else {
-				assert.NoError(t, err)
+				c.Assert(err, quicktest.IsNil)
 
 				var concatOutput ConcatOutput
 				err = base.ConvertFromStructpb(output, &concatOutput)
-				assert.NoError(t, err)
+				c.Assert(err, quicktest.IsNil)
 
 				// Decode the output image
 				decodedImg, err := decodeBase64Image(string(concatOutput.Image)[22:]) // Remove "data:image/png;base64," prefix
-				assert.NoError(t, err)
+				c.Assert(err, quicktest.IsNil)
 
 				// Check if the output image dimensions match the expected dimensions
-				assert.Equal(t, tc.expectedWidth, decodedImg.Bounds().Dx())
-				assert.Equal(t, tc.expectedHeight, decodedImg.Bounds().Dy())
+				c.Assert(decodedImg.Bounds().Dx(), quicktest.Equals, tc.expectedWidth)
+				c.Assert(decodedImg.Bounds().Dy(), quicktest.Equals, tc.expectedHeight)
 
 				// Additional checks can be added here, such as verifying the colors of specific pixels
 			}

--- a/pkg/component/operator/image/v0/task_concat_test.go
+++ b/pkg/component/operator/image/v0/task_concat_test.go
@@ -1,0 +1,124 @@
+package image
+
+import (
+	"context"
+	"image"
+	"image/color"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/instill-ai/pipeline-backend/pkg/component/base"
+)
+
+func TestConcat(t *testing.T) {
+	// Create sample images
+	img1 := createTestImage(50, 50, color.RGBA{255, 0, 0, 255})   // Red
+	img2 := createTestImage(50, 50, color.RGBA{0, 255, 0, 255})   // Green
+	img3 := createTestImage(50, 50, color.RGBA{0, 0, 255, 255})   // Blue
+	img4 := createTestImage(50, 50, color.RGBA{255, 255, 0, 255}) // Yellow
+
+	base64Img1, _ := encodeBase64Image(img1)
+	base64Img2, _ := encodeBase64Image(img2)
+	base64Img3, _ := encodeBase64Image(img3)
+	base64Img4, _ := encodeBase64Image(img4)
+
+	testCases := []struct {
+		name           string
+		input          ConcatInput
+		expectedWidth  int
+		expectedHeight int
+		expectedError  string
+	}{
+		{
+			name: "2x2 grid with padding",
+			input: ConcatInput{
+				Images: []base64Image{
+					base64Image(base64Img1),
+					base64Image(base64Img2),
+					base64Image(base64Img3),
+					base64Image(base64Img4),
+				},
+				GridWidth: 2,
+				Padding:   10,
+			},
+			expectedWidth:  110,
+			expectedHeight: 110,
+		},
+		{
+			name: "1x4 grid without padding",
+			input: ConcatInput{
+				Images: []base64Image{
+					base64Image(base64Img1),
+					base64Image(base64Img2),
+					base64Image(base64Img3),
+					base64Image(base64Img4),
+				},
+				GridHeight: 1,
+			},
+			expectedWidth:  200,
+			expectedHeight: 50,
+		},
+		{
+			name: "Default square grid",
+			input: ConcatInput{
+				Images: []base64Image{
+					base64Image(base64Img1),
+					base64Image(base64Img2),
+					base64Image(base64Img3),
+					base64Image(base64Img4),
+				},
+			},
+			expectedWidth:  100,
+			expectedHeight: 100,
+		},
+		{
+			name: "Invalid input (no images)",
+			input: ConcatInput{
+				Images: []base64Image{},
+			},
+			expectedError: "no images provided",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			inputStruct, err := base.ConvertToStructpb(tc.input)
+			assert.NoError(t, err)
+
+			output, err := concat(inputStruct, nil, context.Background())
+
+			if tc.expectedError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectedError)
+			} else {
+				assert.NoError(t, err)
+
+				var concatOutput ConcatOutput
+				err = base.ConvertFromStructpb(output, &concatOutput)
+				assert.NoError(t, err)
+
+				// Decode the output image
+				decodedImg, err := decodeBase64Image(string(concatOutput.Image)[22:]) // Remove "data:image/png;base64," prefix
+				assert.NoError(t, err)
+
+				// Check if the output image dimensions match the expected dimensions
+				assert.Equal(t, tc.expectedWidth, decodedImg.Bounds().Dx())
+				assert.Equal(t, tc.expectedHeight, decodedImg.Bounds().Dy())
+
+				// Additional checks can be added here, such as verifying the colors of specific pixels
+			}
+		})
+	}
+}
+
+// Helper function to create a test image with a solid color
+func createTestImage(width, height int, c color.Color) image.Image {
+	img := image.NewRGBA(image.Rect(0, 0, width, height))
+	for y := 0; y < height; y++ {
+		for x := 0; x < width; x++ {
+			img.Set(x, y, c)
+		}
+	}
+	return img
+}

--- a/pkg/component/operator/image/v0/task_crop.go
+++ b/pkg/component/operator/image/v0/task_crop.go
@@ -1,0 +1,159 @@
+package image
+
+import (
+	"context"
+	"fmt"
+	"image"
+	"image/color"
+	"math"
+
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/instill-ai/pipeline-backend/pkg/component/base"
+)
+
+type cropInput struct {
+	Image        base64Image `json:"image"`
+	CornerRadius int         `json:"corner-radius"`
+	CircleRadius int         `json:"circle-radius"`
+	TopOffset    int         `json:"top-offset"`
+	RightOffset  int         `json:"right-offset"`
+	BottomOffset int         `json:"bottom-offset"`
+	LeftOffset   int         `json:"left-offset"`
+}
+
+type cropOutput struct {
+	Image base64Image `json:"image"`
+}
+
+func cropCornerRadius(img image.Image, radius int) image.Image {
+	bounds := img.Bounds()
+	width, height := bounds.Dx(), bounds.Dy()
+	result := image.NewRGBA(bounds)
+
+	radiusSquared := radius * radius
+
+	for y := 0; y < height; y++ {
+		for x := 0; x < width; x++ {
+			if isInsideRoundedCorner(x, y, width, height, radius, radiusSquared) {
+				result.Set(x, y, img.At(x, y))
+			} else {
+				result.Set(x, y, color.Transparent)
+			}
+		}
+	}
+
+	return result
+}
+
+func isInsideRoundedCorner(x, y, width, height, radius int, radiusSquared int) bool {
+	dx, dy := 0, 0
+	switch {
+	case x < radius && y < radius: // Top-left corner
+		dx, dy = radius-x-1, radius-y-1
+	case x >= width-radius && y < radius: // Top-right corner
+		dx, dy = x-(width-radius), radius-y-1
+	case x < radius && y >= height-radius: // Bottom-left corner
+		dx, dy = radius-x-1, y-(height-radius)
+	case x >= width-radius && y >= height-radius: // Bottom-right corner
+		dx, dy = x-(width-radius), y-(height-radius)
+	default:
+		return true
+	}
+	return dx*dx+dy*dy < radiusSquared
+}
+
+func cropCircle(img image.Image, centerX, centerY, radius int) image.Image {
+	bounds := img.Bounds()
+	result := image.NewRGBA(bounds)
+	radiusSquared := radius * radius
+
+	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
+		for x := bounds.Min.X; x < bounds.Max.X; x++ {
+			dx, dy := x-centerX, y-centerY
+			if dx*dx+dy*dy <= radiusSquared {
+				result.Set(x, y, img.At(x, y))
+			} else {
+				result.Set(x, y, color.Transparent)
+			}
+		}
+	}
+
+	return result
+}
+
+func crop(input *structpb.Struct, job *base.Job, ctx context.Context) (*structpb.Struct, error) {
+	inputStruct := cropInput{}
+
+	err := base.ConvertFromStructpb(input, &inputStruct)
+	if err != nil {
+		return nil, fmt.Errorf("error converting input to struct: %v", err)
+	}
+
+	img, err := decodeBase64Image(string(inputStruct.Image))
+	if err != nil {
+		return nil, fmt.Errorf("error decoding image: %v", err)
+	}
+
+	bounds := img.Bounds()
+	width := bounds.Dx()
+	height := bounds.Dy()
+
+	// Always perform rectangular crop first
+	x1 := inputStruct.LeftOffset
+	y1 := inputStruct.TopOffset
+	x2 := width - inputStruct.RightOffset
+	y2 := height - inputStruct.BottomOffset
+
+	if x1 < 0 || y1 < 0 || x2 > width || y2 > height || x1 >= x2 || y1 >= y2 {
+		return nil, fmt.Errorf("invalid crop dimensions")
+	}
+
+	// Create a new image with the cropped dimensions
+	croppedImg := image.NewRGBA(image.Rect(0, 0, x2-x1, y2-y1))
+
+	// Copy the pixels from the original image to the new cropped image
+	for y := y1; y < y2; y++ {
+		for x := x1; x < x2; x++ {
+			croppedImg.Set(x-x1, y-y1, img.At(x, y))
+		}
+	}
+
+	// Apply corner radius or circle crop if specified
+	if inputStruct.CircleRadius > 0 {
+		bounds := croppedImg.Bounds()
+		width, height := bounds.Dx(), bounds.Dy()
+		centerX, centerY := width/2, height/2
+		radius := inputStruct.CircleRadius
+
+		// Limit radius to half of the smaller dimension
+		maxRadius := width
+		if height < width {
+			maxRadius = height
+		}
+		if radius > maxRadius/2 {
+			radius = maxRadius / 2
+		}
+
+		croppedImg = cropCircle(croppedImg, centerX, centerY, radius).(*image.RGBA)
+	} else if inputStruct.CornerRadius > 0 {
+		bounds := croppedImg.Bounds()
+		width, height := bounds.Dx(), bounds.Dy()
+
+		// Limit corner radius to half of the smaller dimension
+		maxRadius := math.Min(float64(width), float64(height)) / 2
+		radius := int(math.Min(float64(inputStruct.CornerRadius), maxRadius))
+		croppedImg = cropCornerRadius(croppedImg, radius).(*image.RGBA)
+	}
+
+	base64Img, err := encodeBase64Image(croppedImg)
+	if err != nil {
+		return nil, err
+	}
+
+	output := cropOutput{
+		Image: base64Image(fmt.Sprintf("data:image/png;base64,%s", base64Img)),
+	}
+
+	return base.ConvertToStructpb(output)
+}

--- a/pkg/component/operator/image/v0/task_crop_test.go
+++ b/pkg/component/operator/image/v0/task_crop_test.go
@@ -1,0 +1,132 @@
+package image
+
+import (
+	"context"
+	"image"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/instill-ai/pipeline-backend/pkg/component/base"
+)
+
+func TestCrop(t *testing.T) {
+	// Create a sample 100x100 image
+	img := image.NewRGBA(image.Rect(0, 0, 100, 100))
+	for y := 0; y < 100; y++ {
+		for x := 0; x < 100; x++ {
+			img.Set(x, y, image.White)
+		}
+	}
+	base64Img, err := encodeBase64Image(img)
+	assert.NoError(t, err)
+
+	testCases := []struct {
+		name           string
+		input          cropInput
+		expectedWidth  int
+		expectedHeight int
+		expectedError  string
+		checkCorners   bool
+	}{
+		{
+			name: "Rectangular crop",
+			input: cropInput{
+				Image:        base64Image("data:image/png;base64," + base64Img),
+				TopOffset:    10,
+				RightOffset:  20,
+				BottomOffset: 30,
+				LeftOffset:   40,
+			},
+			expectedWidth:  40,
+			expectedHeight: 60,
+		},
+		{
+			name: "Circular crop",
+			input: cropInput{
+				Image:        base64Image("data:image/png;base64," + base64Img),
+				CircleRadius: 25,
+			},
+			expectedWidth:  100,
+			expectedHeight: 100,
+			checkCorners:   true,
+		},
+		{
+			name: "Corner radius crop",
+			input: cropInput{
+				Image:        base64Image("data:image/png;base64," + base64Img),
+				CornerRadius: 20,
+			},
+			expectedWidth:  100,
+			expectedHeight: 100,
+			checkCorners:   true,
+		},
+		{
+			name: "No crop (all offsets 0)",
+			input: cropInput{
+				Image: base64Image("data:image/png;base64," + base64Img),
+			},
+			expectedWidth:  100,
+			expectedHeight: 100,
+		},
+		{
+			name: "Invalid crop dimensions",
+			input: cropInput{
+				Image:        base64Image("data:image/png;base64," + base64Img),
+				TopOffset:    50,
+				RightOffset:  50,
+				BottomOffset: 51,
+				LeftOffset:   50,
+			},
+			expectedError: "invalid crop dimensions",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			inputStruct, err := base.ConvertToStructpb(tc.input)
+			assert.NoError(t, err)
+
+			output, err := crop(inputStruct, nil, context.Background())
+
+			if tc.expectedError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectedError)
+			} else {
+				assert.NoError(t, err)
+
+				var croppedOutput cropOutput
+				err = base.ConvertFromStructpb(output, &croppedOutput)
+				assert.NoError(t, err)
+
+				// Decode the output image as PNG
+				decodedImg, err := decodeBase64Image(string(croppedOutput.Image)[22:]) // Remove "data:image/png;base64," prefix
+				assert.NoError(t, err)
+
+				// Check if the output image dimensions match the expected dimensions
+				assert.Equal(t, tc.expectedWidth, decodedImg.Bounds().Dx())
+				assert.Equal(t, tc.expectedHeight, decodedImg.Bounds().Dy())
+
+				// For circular and corner radius crop, check if corners are transparent
+				if tc.checkCorners {
+					checkCornerTransparency(t, decodedImg)
+				}
+			}
+		})
+	}
+}
+
+func checkCornerTransparency(t *testing.T, img image.Image) {
+	bounds := img.Bounds()
+	corners := []image.Point{
+		{X: bounds.Min.X, Y: bounds.Min.Y},
+		{X: bounds.Max.X - 1, Y: bounds.Min.Y},
+		{X: bounds.Min.X, Y: bounds.Max.Y - 1},
+		{X: bounds.Max.X - 1, Y: bounds.Max.Y - 1},
+	}
+
+	for _, corner := range corners {
+		_, _, _, a := img.At(corner.X, corner.Y).RGBA()
+		assert.Equal(t, uint32(0), a, "Corner at (%d, %d) should be transparent", corner.X, corner.Y)
+	}
+}

--- a/pkg/component/operator/image/v0/task_draw_classification.go
+++ b/pkg/component/operator/image/v0/task_draw_classification.go
@@ -1,0 +1,98 @@
+package image
+
+import (
+	"context"
+	"fmt"
+	"image"
+	"image/color"
+
+	"github.com/fogleman/gg"
+	"golang.org/x/image/font/opentype"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/instill-ai/pipeline-backend/pkg/component/base"
+)
+
+type drawClassificationInput struct {
+	Image     base64Image `json:"image"`
+	Category  string      `json:"category"`
+	Score     float64     `json:"score"`
+	ShowScore bool        `json:"show-score"`
+}
+
+type drawClassificationOutput struct {
+	Image base64Image `json:"image"`
+}
+
+func drawImageLabel(img *image.RGBA, category string) error {
+
+	dc := gg.NewContextForRGBA(img)
+
+	// Parse the font
+	font, err := opentype.Parse(IBMPlexSansRegular)
+	if err != nil {
+		return err
+	}
+
+	// Create a font face
+	face, err := opentype.NewFace(font, &opentype.FaceOptions{
+		Size: 20,
+		DPI:  72,
+	})
+	if err != nil {
+		return err
+	}
+
+	// Set the font face
+	dc.SetFontFace(face)
+
+	w, h := dc.MeasureString(category)
+
+	// Set the rectangle padding
+	padding := 2.0
+
+	x := padding
+	y := padding
+	w += 6 * padding
+	h += padding
+	dc.SetRGB(0, 0, 0)
+	dc.DrawRoundedRectangle(x, y, w, h, 4)
+	dc.Fill()
+	dc.SetColor(color.RGBA{255, 255, 255, 255})
+	dc.DrawString(category, 4*padding, 11*padding)
+	return nil
+}
+
+func drawClassification(input *structpb.Struct, job *base.Job, ctx context.Context) (*structpb.Struct, error) {
+
+	inputStruct := drawClassificationInput{}
+
+	err := base.ConvertFromStructpb(input, &inputStruct)
+	if err != nil {
+		return nil, fmt.Errorf("error converting input to struct: %v", err)
+	}
+
+	category := inputStruct.Category
+
+	img, err := decodeBase64Image(string(inputStruct.Image))
+	if err != nil {
+		return nil, fmt.Errorf("error decoding image: %v", err)
+	}
+
+	imgRGBA := convertToRGBA(img)
+
+	if err := drawImageLabel(imgRGBA, category); err != nil {
+		return nil, err
+	}
+
+	base64Img, err := encodeBase64Image(imgRGBA)
+	if err != nil {
+		return nil, err
+	}
+
+	output := drawClassificationOutput{
+		Image: base64Image(fmt.Sprintf("data:image/png;base64,%s", base64Img)),
+	}
+
+	return base.ConvertToStructpb(output)
+}

--- a/pkg/component/operator/image/v0/task_draw_classification_test.go
+++ b/pkg/component/operator/image/v0/task_draw_classification_test.go
@@ -1,0 +1,62 @@
+package image
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	_ "embed"
+
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/instill-ai/pipeline-backend/pkg/component/base"
+)
+
+//go:embed testdata/cls-dog.json
+var clsDogJSON []byte
+
+// TestDrawClassification tests the drawClassification function
+func TestDrawClassification(t *testing.T) {
+	testCases := []struct {
+		name      string
+		inputJSON []byte
+	}{
+		{
+			name:      "Classification Dog",
+			inputJSON: clsDogJSON,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			inputData := &structpb.Struct{}
+			if err := json.Unmarshal(tc.inputJSON, inputData); err != nil {
+				t.Fatalf("Failed to unmarshal test data: %v", err)
+			}
+
+			bc := base.Component{}
+			component := Init(bc)
+
+			e, err := component.CreateExecution(base.ComponentExecution{
+				Component: component,
+				Task:      "TASK_DRAW_CLASSIFICATION",
+			})
+
+			if err != nil {
+				t.Fatalf("drawClassification create execution returned an error: %v", err)
+			}
+
+			ir, ow, eh, job := base.GenerateMockJob(t)
+			ir.ReadMock.Expect(context.Background()).Return(inputData, nil)
+			ow.WriteMock.Times(1).Return(nil)
+
+			if err := e.Execute(context.Background(), []*base.Job{job}); err != nil {
+				t.Fatalf("drawClassification returned an error: %v", err)
+			}
+
+			ir.MinimockFinish()
+			ow.MinimockFinish()
+			eh.MinimockFinish()
+		})
+	}
+}

--- a/pkg/component/operator/image/v0/task_draw_classification_test.go
+++ b/pkg/component/operator/image/v0/task_draw_classification_test.go
@@ -7,6 +7,7 @@ import (
 
 	_ "embed"
 
+	"github.com/frankban/quicktest"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/instill-ai/pipeline-backend/pkg/component/base"
@@ -17,6 +18,8 @@ var clsDogJSON []byte
 
 // TestDrawClassification tests the drawClassification function
 func TestDrawClassification(t *testing.T) {
+	c := quicktest.New(t)
+
 	testCases := []struct {
 		name      string
 		inputJSON []byte
@@ -28,31 +31,27 @@ func TestDrawClassification(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
+		c.Run(tc.name, func(c *quicktest.C) {
 			inputData := &structpb.Struct{}
-			if err := json.Unmarshal(tc.inputJSON, inputData); err != nil {
-				t.Fatalf("Failed to unmarshal test data: %v", err)
-			}
+			err := json.Unmarshal(tc.inputJSON, inputData)
+			c.Assert(err, quicktest.IsNil, quicktest.Commentf("Failed to unmarshal test data"))
 
 			bc := base.Component{}
 			component := Init(bc)
 
 			e, err := component.CreateExecution(base.ComponentExecution{
-				Component: component,
-				Task:      "TASK_DRAW_CLASSIFICATION",
-			})
+					Component: component,
+					Task:      "TASK_DRAW_CLASSIFICATION",
+				})
 
-			if err != nil {
-				t.Fatalf("drawClassification create execution returned an error: %v", err)
-			}
+			c.Assert(err, quicktest.IsNil, quicktest.Commentf("drawClassification create execution returned an error"))
 
-			ir, ow, eh, job := base.GenerateMockJob(t)
+			ir, ow, eh, job := base.GenerateMockJob(c)
 			ir.ReadMock.Expect(context.Background()).Return(inputData, nil)
 			ow.WriteMock.Times(1).Return(nil)
 
-			if err := e.Execute(context.Background(), []*base.Job{job}); err != nil {
-				t.Fatalf("drawClassification returned an error: %v", err)
-			}
+			err = e.Execute(context.Background(), []*base.Job{job})
+			c.Assert(err, quicktest.IsNil, quicktest.Commentf("drawClassification returned an error"))
 
 			ir.MinimockFinish()
 			ow.MinimockFinish()

--- a/pkg/component/operator/image/v0/task_draw_detection.go
+++ b/pkg/component/operator/image/v0/task_draw_detection.go
@@ -1,0 +1,82 @@
+package image
+
+import (
+	"context"
+	"fmt"
+	"image"
+	"image/color"
+
+	"github.com/fogleman/gg"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/instill-ai/pipeline-backend/pkg/component/base"
+)
+
+type detectionObject struct {
+	BoundingBox *boundingBox `json:"bounding-box"`
+	Category    string       `json:"category"`
+	Score       float64      `json:"score"`
+}
+
+type drawDetectionInput struct {
+	Image     base64Image        `json:"image"`
+	Objects   []*detectionObject `json:"objects"`
+	ShowScore bool               `json:"show-score"`
+}
+
+type drawDetectionOutput struct {
+	Image base64Image `json:"image"`
+}
+
+func drawBoundingBox(img *image.RGBA, bbox *boundingBox, colorSeed int) error {
+	dc := gg.NewContextForRGBA(img)
+	originalColor := img.At(bbox.Left, bbox.Top).(color.RGBA)
+	blendedColor := blendColors(originalColor, randomColor(colorSeed, 255))
+	dc.SetColor(blendedColor)
+	dc.SetLineWidth(3)
+	dc.DrawRoundedRectangle(float64(bbox.Left), float64(bbox.Top), float64(bbox.Width), float64(bbox.Height), 4)
+	dc.Stroke()
+	return nil
+}
+
+func drawDetection(input *structpb.Struct, job *base.Job, ctx context.Context) (*structpb.Struct, error) {
+
+	inputStruct := drawDetectionInput{}
+
+	err := base.ConvertFromStructpb(input, &inputStruct)
+	if err != nil {
+		return nil, fmt.Errorf("error converting input to struct: %v", err)
+	}
+
+	catIdx := indexUniqueCategories(inputStruct.Objects)
+
+	img, err := decodeBase64Image(string(inputStruct.Image))
+	if err != nil {
+		return nil, fmt.Errorf("error decoding image: %v", err)
+	}
+
+	imgRGBA := convertToRGBA(img)
+
+	for _, obj := range inputStruct.Objects {
+		if err := drawBoundingBox(imgRGBA, obj.BoundingBox, catIdx[obj.Category]); err != nil {
+			return nil, err
+		}
+	}
+
+	for _, obj := range inputStruct.Objects {
+		if err := drawObjectLabel(imgRGBA, obj.BoundingBox, obj.Category, false, catIdx[obj.Category]); err != nil {
+			return nil, err
+		}
+	}
+
+	base64Img, err := encodeBase64Image(imgRGBA)
+	if err != nil {
+		return nil, err
+	}
+
+	output := drawDetectionOutput{
+		Image: base64Image(fmt.Sprintf("data:image/png;base64,%s", base64Img)),
+	}
+
+	return base.ConvertToStructpb(output)
+}

--- a/pkg/component/operator/image/v0/task_draw_detection_test.go
+++ b/pkg/component/operator/image/v0/task_draw_detection_test.go
@@ -1,0 +1,69 @@
+package image
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	_ "embed"
+
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/instill-ai/pipeline-backend/pkg/component/base"
+)
+
+//go:embed testdata/det-coco-1.json
+var detCOCO1JSON []byte
+
+//go:embed testdata/det-coco-2.json
+var detCOCO2JSON []byte
+
+// TestDrawDetection tests the drawDetection function
+func TestDrawDetection(t *testing.T) {
+	testCases := []struct {
+		name      string
+		inputJSON []byte
+	}{
+		{
+			name:      "COCO Detection 1",
+			inputJSON: detCOCO1JSON,
+		},
+		{
+			name:      "COCO Detection 2",
+			inputJSON: detCOCO2JSON,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			inputData := &structpb.Struct{}
+			if err := json.Unmarshal(tc.inputJSON, inputData); err != nil {
+				t.Fatalf("Failed to unmarshal test data: %v", err)
+			}
+
+			bc := base.Component{}
+			component := Init(bc)
+
+			e, err := component.CreateExecution(base.ComponentExecution{
+				Component: component,
+				Task:      "TASK_DRAW_DETECTION",
+			})
+
+			if err != nil {
+				t.Fatalf("drawDetection create execution returned an error: %v", err)
+			}
+
+			ir, ow, eh, job := base.GenerateMockJob(t)
+			ir.ReadMock.Expect(context.Background()).Return(inputData, nil)
+			ow.WriteMock.Times(1).Return(nil)
+
+			if err := e.Execute(context.Background(), []*base.Job{job}); err != nil {
+				t.Fatalf("drawDetection returned an error: %v", err)
+			}
+
+			ir.MinimockFinish()
+			ow.MinimockFinish()
+			eh.MinimockFinish()
+		})
+	}
+}

--- a/pkg/component/operator/image/v0/task_draw_detection_test.go
+++ b/pkg/component/operator/image/v0/task_draw_detection_test.go
@@ -7,6 +7,7 @@ import (
 
 	_ "embed"
 
+	"github.com/frankban/quicktest"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/instill-ai/pipeline-backend/pkg/component/base"
@@ -20,26 +21,27 @@ var detCOCO2JSON []byte
 
 // TestDrawDetection tests the drawDetection function
 func TestDrawDetection(t *testing.T) {
+	c := quicktest.New(t)
+
 	testCases := []struct {
 		name      string
 		inputJSON []byte
 	}{
 		{
-			name:      "COCO Detection 1",
+			name:      "Detection COCO 1",
 			inputJSON: detCOCO1JSON,
 		},
 		{
-			name:      "COCO Detection 2",
+			name:      "Detection COCO 2",
 			inputJSON: detCOCO2JSON,
 		},
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
+		c.Run(tc.name, func(c *quicktest.C) {
 			inputData := &structpb.Struct{}
-			if err := json.Unmarshal(tc.inputJSON, inputData); err != nil {
-				t.Fatalf("Failed to unmarshal test data: %v", err)
-			}
+			err := json.Unmarshal(tc.inputJSON, inputData)
+			c.Assert(err, quicktest.IsNil, quicktest.Commentf("Failed to unmarshal test data"))
 
 			bc := base.Component{}
 			component := Init(bc)
@@ -49,17 +51,14 @@ func TestDrawDetection(t *testing.T) {
 				Task:      "TASK_DRAW_DETECTION",
 			})
 
-			if err != nil {
-				t.Fatalf("drawDetection create execution returned an error: %v", err)
-			}
+			c.Assert(err, quicktest.IsNil, quicktest.Commentf("drawDetection create execution returned an error"))
 
-			ir, ow, eh, job := base.GenerateMockJob(t)
+			ir, ow, eh, job := base.GenerateMockJob(c)
 			ir.ReadMock.Expect(context.Background()).Return(inputData, nil)
 			ow.WriteMock.Times(1).Return(nil)
 
-			if err := e.Execute(context.Background(), []*base.Job{job}); err != nil {
-				t.Fatalf("drawDetection returned an error: %v", err)
-			}
+			err = e.Execute(context.Background(), []*base.Job{job})
+			c.Assert(err, quicktest.IsNil, quicktest.Commentf("drawDetection returned an error"))
 
 			ir.MinimockFinish()
 			ow.MinimockFinish()

--- a/pkg/component/operator/image/v0/task_draw_instance_segmentation.go
+++ b/pkg/component/operator/image/v0/task_draw_instance_segmentation.go
@@ -1,0 +1,129 @@
+package image
+
+import (
+	"context"
+	"fmt"
+	"image"
+	"image/color"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/fogleman/gg"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/instill-ai/pipeline-backend/pkg/component/base"
+)
+
+type instanceSegmentationObject struct {
+	BoundingBox *boundingBox `json:"bounding-box"`
+	Category    string       `json:"category"`
+	RLE         string       `json:"rle"`
+	Score       float64      `json:"score"`
+}
+
+type drawInstanceSegmentationInput struct {
+	Image     base64Image                   `json:"image"`
+	Objects   []*instanceSegmentationObject `json:"objects"`
+	ShowScore bool                          `json:"show-score"`
+}
+
+type drawInstanceSegmentationOutput struct {
+	Image base64Image `json:"image"`
+}
+
+func drawInstanceMask(img *image.RGBA, bbox *boundingBox, rle string, colorSeed int) error {
+
+	// Split the string by commas to get the individual number strings.
+	numberStrings := strings.Split(rle, ",")
+
+	// Allocate an array of integers with the same length as the number of numberStrings.
+	rleInts := make([]int, len(numberStrings))
+
+	// Convert each number string to an integer.
+	for i, s := range numberStrings {
+		n, err := strconv.Atoi(strings.TrimSpace(s))
+		if err != nil {
+			return fmt.Errorf("failed to convert RLE string to int: %s, error: %v", s, err)
+		}
+		rleInts[i] = n
+	}
+
+	// Decode the RLE mask for the full image size.
+	mask := rleDecode(rleInts, bbox.Width, bbox.Height)
+
+	// Iterate over the bounding box and draw the mask onto the image.
+	for y := 0; y < bbox.Height; y++ {
+		for x := 0; x < bbox.Width; x++ {
+			if mask[y][x] {
+				// The mask is present for this pixel, so draw it on the image.
+				// Here you could set a specific color or just use the mask value.
+				// For example, let's paint the mask as a red semi-transparent overlay:
+				originalColor := img.At(x+bbox.Left, y+bbox.Top).(color.RGBA)
+				// Blend the original color with the mask color.
+				blendedColor := blendColors(originalColor, randomColor(colorSeed, 156))
+				img.Set(x+bbox.Left, y+bbox.Top, blendedColor)
+			}
+		}
+	}
+
+	dc := gg.NewContextForRGBA(img)
+	dc.SetColor(randomColor(colorSeed, 255))
+	contourPoints := findContour(mask)
+	for _, pt := range contourPoints {
+		dc.DrawPoint(float64(pt.X+bbox.Left), float64(pt.Y+bbox.Top), 0.5)
+		dc.Fill()
+	}
+
+	return nil
+}
+
+func drawInstanceSegmentation(input *structpb.Struct, job *base.Job, ctx context.Context) (*structpb.Struct, error) {
+
+	inputStruct := drawInstanceSegmentationInput{}
+
+	err := base.ConvertFromStructpb(input, &inputStruct)
+	if err != nil {
+		return nil, fmt.Errorf("error converting input to struct: %v", err)
+	}
+
+	img, err := decodeBase64Image(string(inputStruct.Image))
+	if err != nil {
+		return nil, fmt.Errorf("error decoding image: %v", err)
+	}
+
+	imgRGBA := convertToRGBA(img)
+
+	// Sort the objects by size.
+	sort.Slice(inputStruct.Objects, func(i, j int) bool {
+		bbox1 := inputStruct.Objects[i].BoundingBox
+		bbox2 := inputStruct.Objects[j].BoundingBox
+		return bbox1.Size() > bbox2.Size()
+	})
+
+	for instIdx, obj := range inputStruct.Objects {
+		bbox := obj.BoundingBox
+		if err := drawInstanceMask(imgRGBA, bbox, obj.RLE, instIdx); err != nil {
+			return nil, err
+		}
+	}
+
+	for instIdx, obj := range inputStruct.Objects {
+		bbox := obj.BoundingBox
+		text := obj.Category
+		if err := drawObjectLabel(imgRGBA, bbox, text, true, instIdx); err != nil {
+			return nil, err
+		}
+	}
+
+	base64Img, err := encodeBase64Image(imgRGBA)
+	if err != nil {
+		return nil, err
+	}
+
+	output := drawInstanceSegmentationOutput{
+		Image: base64Image(fmt.Sprintf("data:image/png;base64,%s", base64Img)),
+	}
+
+	return base.ConvertToStructpb(output)
+}

--- a/pkg/component/operator/image/v0/task_draw_instance_segmentation_test.go
+++ b/pkg/component/operator/image/v0/task_draw_instance_segmentation_test.go
@@ -7,6 +7,7 @@ import (
 
 	_ "embed"
 
+	"github.com/frankban/quicktest"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/instill-ai/pipeline-backend/pkg/component/base"
@@ -23,30 +24,31 @@ var instSegStomataJSON []byte
 
 // TestDrawInstanceSegmentation tests the drawInstanceSegmentation function
 func TestDrawInstanceSegmentation(t *testing.T) {
+	c := quicktest.New(t)
+
 	testCases := []struct {
 		name      string
 		inputJSON []byte
 	}{
 		{
-			name:      "COCO Instance Segmentation 1",
+			name:      "Instance Segmentation COCO 1",
 			inputJSON: instSegCOCO1JSON,
 		},
 		{
-			name:      "COCO Instance Segmentation 2",
+			name:      "Instance Segmentation COCO 2",
 			inputJSON: instSegCOCO2JSON,
 		},
 		{
-			name:      "Stomata Instance Segmentation",
+			name:      "Instance Segmentation Stomata",
 			inputJSON: instSegStomataJSON,
 		},
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
+		c.Run(tc.name, func(c *quicktest.C) {
 			inputData := &structpb.Struct{}
-			if err := json.Unmarshal(tc.inputJSON, inputData); err != nil {
-				t.Fatalf("Failed to unmarshal test data: %v", err)
-			}
+			err := json.Unmarshal(tc.inputJSON, inputData)
+			c.Assert(err, quicktest.IsNil, quicktest.Commentf("Failed to unmarshal test data"))
 
 			bc := base.Component{}
 			component := Init(bc)
@@ -56,17 +58,14 @@ func TestDrawInstanceSegmentation(t *testing.T) {
 				Task:      "TASK_DRAW_INSTANCE_SEGMENTATION",
 			})
 
-			if err != nil {
-				t.Fatalf("drawInstanceSegmentation create execution returned an error: %v", err)
-			}
+			c.Assert(err, quicktest.IsNil, quicktest.Commentf("drawInstanceSegmentation create execution returned an error"))
 
-			ir, ow, eh, job := base.GenerateMockJob(t)
+			ir, ow, eh, job := base.GenerateMockJob(c)
 			ir.ReadMock.Expect(context.Background()).Return(inputData, nil)
 			ow.WriteMock.Times(1).Return(nil)
 
-			if err := e.Execute(context.Background(), []*base.Job{job}); err != nil {
-				t.Fatalf("drawInstanceSegmentation returned an error: %v", err)
-			}
+			err = e.Execute(context.Background(), []*base.Job{job})
+			c.Assert(err, quicktest.IsNil, quicktest.Commentf("drawInstanceSegmentation returned an error"))
 
 			ir.MinimockFinish()
 			ow.MinimockFinish()

--- a/pkg/component/operator/image/v0/task_draw_instance_segmentation_test.go
+++ b/pkg/component/operator/image/v0/task_draw_instance_segmentation_test.go
@@ -1,0 +1,76 @@
+package image
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	_ "embed"
+
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/instill-ai/pipeline-backend/pkg/component/base"
+)
+
+//go:embed testdata/inst-seg-coco-1.json
+var instSegCOCO1JSON []byte
+
+//go:embed testdata/inst-seg-coco-2.json
+var instSegCOCO2JSON []byte
+
+//go:embed testdata/inst-seg-stomata.json
+var instSegStomataJSON []byte
+
+// TestDrawInstanceSegmentation tests the drawInstanceSegmentation function
+func TestDrawInstanceSegmentation(t *testing.T) {
+	testCases := []struct {
+		name      string
+		inputJSON []byte
+	}{
+		{
+			name:      "COCO Instance Segmentation 1",
+			inputJSON: instSegCOCO1JSON,
+		},
+		{
+			name:      "COCO Instance Segmentation 2",
+			inputJSON: instSegCOCO2JSON,
+		},
+		{
+			name:      "Stomata Instance Segmentation",
+			inputJSON: instSegStomataJSON,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			inputData := &structpb.Struct{}
+			if err := json.Unmarshal(tc.inputJSON, inputData); err != nil {
+				t.Fatalf("Failed to unmarshal test data: %v", err)
+			}
+
+			bc := base.Component{}
+			component := Init(bc)
+
+			e, err := component.CreateExecution(base.ComponentExecution{
+				Component: component,
+				Task:      "TASK_DRAW_INSTANCE_SEGMENTATION",
+			})
+
+			if err != nil {
+				t.Fatalf("drawInstanceSegmentation create execution returned an error: %v", err)
+			}
+
+			ir, ow, eh, job := base.GenerateMockJob(t)
+			ir.ReadMock.Expect(context.Background()).Return(inputData, nil)
+			ow.WriteMock.Times(1).Return(nil)
+
+			if err := e.Execute(context.Background(), []*base.Job{job}); err != nil {
+				t.Fatalf("drawInstanceSegmentation returned an error: %v", err)
+			}
+
+			ir.MinimockFinish()
+			ow.MinimockFinish()
+			eh.MinimockFinish()
+		})
+	}
+}

--- a/pkg/component/operator/image/v0/task_draw_keypoint.go
+++ b/pkg/component/operator/image/v0/task_draw_keypoint.go
@@ -1,0 +1,95 @@
+package image
+
+import (
+	"context"
+	"fmt"
+	"image"
+
+	"github.com/fogleman/gg"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/instill-ai/pipeline-backend/pkg/component/base"
+)
+
+type keypoint struct {
+	X float64 `json:"x"`
+	Y float64 `json:"y"`
+	V float64 `json:"v"`
+}
+
+type keypointObject struct {
+	BoundingBox *boundingBox `json:"bounding-box"`
+	Keypoints   []*keypoint  `json:"keypoints"`
+	Score       float64      `json:"score"`
+}
+
+type drawKeypointInput struct {
+	Image     base64Image       `json:"image"`
+	Objects   []*keypointObject `json:"objects"`
+	ShowScore bool              `json:"show-score"`
+}
+
+type drawKeypointOutput struct {
+	Image base64Image `json:"image"`
+}
+
+var skeleton = [][]int{{16, 14}, {14, 12}, {17, 15}, {15, 13}, {12, 13}, {6, 12},
+	{7, 13}, {6, 7}, {6, 8}, {7, 9}, {8, 10}, {9, 11}, {2, 3}, {1, 2}, {1, 3}, {2, 4}, {3, 5}, {4, 6}, {5, 7},
+}
+
+var keypointLimbColorIdx = []int{9, 9, 9, 9, 7, 7, 7, 0, 0, 0, 0, 0, 16, 16, 16, 16, 16, 16, 16}
+var keypointColorIdx = []int{16, 16, 16, 16, 16, 0, 0, 0, 0, 0, 0, 9, 9, 9, 9, 9, 9}
+
+func drawSkeleton(img *image.RGBA, kpts []*keypoint) error {
+	dc := gg.NewContextForRGBA(img)
+	for idx, kpt := range kpts {
+		if kpt.V > 0.5 {
+			dc.SetColor(palette[keypointColorIdx[idx]])
+			dc.DrawPoint(kpt.X, kpt.Y, 2)
+			dc.Fill()
+		}
+	}
+	for idx, sk := range skeleton {
+		if kpts[sk[0]-1].V > 0.5 && kpts[sk[1]-1].V > 0.5 {
+			dc.SetColor(palette[keypointLimbColorIdx[idx]])
+			dc.SetLineWidth(2)
+			dc.DrawLine(kpts[sk[0]-1].X, kpts[sk[0]-1].Y, kpts[sk[1]-1].X, kpts[sk[1]-1].Y)
+			dc.Stroke()
+		}
+	}
+	return nil
+}
+
+func drawKeypoint(input *structpb.Struct, job *base.Job, ctx context.Context) (*structpb.Struct, error) {
+
+	inputStruct := drawKeypointInput{}
+
+	err := base.ConvertFromStructpb(input, &inputStruct)
+	if err != nil {
+		return nil, fmt.Errorf("error converting input to struct: %v", err)
+	}
+
+	img, err := decodeBase64Image(string(inputStruct.Image))
+	if err != nil {
+		return nil, fmt.Errorf("error decoding image: %v", err)
+	}
+
+	imgRGBA := convertToRGBA(img)
+
+	for _, obj := range inputStruct.Objects {
+		if err := drawSkeleton(imgRGBA, obj.Keypoints); err != nil {
+			return nil, err
+		}
+	}
+
+	base64Img, err := encodeBase64Image(imgRGBA)
+	if err != nil {
+		return nil, err
+	}
+
+	output := drawKeypointOutput{
+		Image: base64Image(fmt.Sprintf("data:image/png;base64,%s", base64Img)),
+	}
+
+	return base.ConvertToStructpb(output)
+}

--- a/pkg/component/operator/image/v0/task_draw_keypoint_test.go
+++ b/pkg/component/operator/image/v0/task_draw_keypoint_test.go
@@ -1,0 +1,69 @@
+package image
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	_ "embed"
+
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/instill-ai/pipeline-backend/pkg/component/base"
+)
+
+//go:embed testdata/kp-coco-1.json
+var kpCOCO1JSON []byte
+
+//go:embed testdata/kp-coco-2.json
+var kpCOCO2JSON []byte
+
+// TestDrawKeypoint tests the drawKeypoint function
+func TestDrawKeypoint(t *testing.T) {
+	testCases := []struct {
+		name      string
+		inputJSON []byte
+	}{
+		{
+			name:      "COCO Keypoint 1",
+			inputJSON: kpCOCO1JSON,
+		},
+		{
+			name:      "COCO Keypoint 2",
+			inputJSON: kpCOCO2JSON,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			inputData := &structpb.Struct{}
+			if err := json.Unmarshal(tc.inputJSON, inputData); err != nil {
+				t.Fatalf("Failed to unmarshal test data: %v", err)
+			}
+
+			bc := base.Component{}
+			component := Init(bc)
+
+			e, err := component.CreateExecution(base.ComponentExecution{
+				Component: component,
+				Task:      "TASK_DRAW_KEYPOINT",
+			})
+
+			if err != nil {
+				t.Fatalf("drawKeypoint create execution returned an error: %v", err)
+			}
+
+			ir, ow, eh, job := base.GenerateMockJob(t)
+			ir.ReadMock.Expect(context.Background()).Return(inputData, nil)
+			ow.WriteMock.Times(1).Return(nil)
+
+			if err := e.Execute(context.Background(), []*base.Job{job}); err != nil {
+				t.Fatalf("drawKeypoint returned an error: %v", err)
+			}
+
+			ir.MinimockFinish()
+			ow.MinimockFinish()
+			eh.MinimockFinish()
+		})
+	}
+}

--- a/pkg/component/operator/image/v0/task_draw_ocr.go
+++ b/pkg/component/operator/image/v0/task_draw_ocr.go
@@ -1,0 +1,105 @@
+package image
+
+import (
+	"context"
+	"fmt"
+	"image"
+	"image/color"
+
+	"github.com/fogleman/gg"
+	"golang.org/x/image/font/opentype"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/instill-ai/pipeline-backend/pkg/component/base"
+)
+
+type ocrObject struct {
+	BoundingBox *boundingBox `json:"bounding-box"`
+	Text        string       `json:"text"`
+	Score       float64      `json:"score"`
+}
+
+type drawOCRInput struct {
+	Image     base64Image  `json:"image"`
+	Objects   []*ocrObject `json:"objects"`
+	ShowScore bool         `json:"show-score"`
+}
+
+type drawOCROutput struct {
+	Image base64Image `json:"image"`
+}
+
+func draOCRLabel(img *image.RGBA, bbox *boundingBox, text string) error {
+
+	dc := gg.NewContextForRGBA(img)
+
+	// Parse the font
+	font, err := opentype.Parse(IBMPlexSansRegular)
+	if err != nil {
+		return err
+	}
+
+	// Create a font face
+	face, err := opentype.NewFace(font, &opentype.FaceOptions{
+		Size: 20,
+		DPI:  72,
+	})
+	if err != nil {
+		return err
+	}
+
+	// Set the font face
+	dc.SetFontFace(face)
+
+	w, h := dc.MeasureString(text)
+
+	// Set the rectangle padding
+	padding := 2.0
+
+	x := float64(bbox.Left)
+	y := float64(bbox.Top)
+	w += 4 * padding
+	h += padding
+	dc.SetRGBA(0, 0, 0, 128)
+	dc.DrawRoundedRectangle(x, y, w, h, 4)
+	dc.Fill()
+	dc.SetColor(color.RGBA{255, 255, 255, 255})
+	dc.DrawString(text, float64(bbox.Left)+2*padding, float64(bbox.Top)+h-4*padding)
+
+	return nil
+}
+
+func drawOCR(input *structpb.Struct, job *base.Job, ctx context.Context) (*structpb.Struct, error) {
+
+	inputStruct := drawOCRInput{}
+
+	err := base.ConvertFromStructpb(input, &inputStruct)
+	if err != nil {
+		return nil, fmt.Errorf("error converting input to struct: %v", err)
+	}
+
+	img, err := decodeBase64Image(string(inputStruct.Image))
+	if err != nil {
+		return nil, fmt.Errorf("error decoding image: %v", err)
+	}
+
+	imgRGBA := convertToRGBA(img)
+
+	for _, obj := range inputStruct.Objects {
+		bbox := obj.BoundingBox
+		if err := draOCRLabel(imgRGBA, bbox, obj.Text); err != nil {
+			return nil, err
+		}
+	}
+
+	base64Img, err := encodeBase64Image(imgRGBA)
+	if err != nil {
+		return nil, err
+	}
+
+	output := drawOCROutput{
+		Image: base64Image(fmt.Sprintf("data:image/png;base64,%s", base64Img)),
+	}
+
+	return base.ConvertToStructpb(output)
+}

--- a/pkg/component/operator/image/v0/task_draw_ocr_test.go
+++ b/pkg/component/operator/image/v0/task_draw_ocr_test.go
@@ -1,0 +1,62 @@
+package image
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	_ "embed"
+
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/instill-ai/pipeline-backend/pkg/component/base"
+)
+
+//go:embed testdata/ocr-mm.json
+var ocrMMJSON []byte
+
+// TestDrawOCR tests the drawOCR function
+func TestDrawOCR(t *testing.T) {
+	testCases := []struct {
+		name      string
+		inputJSON []byte
+	}{
+		{
+			name:      "OCR MM",
+			inputJSON: ocrMMJSON,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			inputData := &structpb.Struct{}
+			if err := json.Unmarshal(tc.inputJSON, inputData); err != nil {
+				t.Fatalf("Failed to unmarshal test data: %v", err)
+			}
+
+			bc := base.Component{}
+			component := Init(bc)
+
+			e, err := component.CreateExecution(base.ComponentExecution{
+				Component: component,
+				Task:      "TASK_DRAW_OCR",
+			})
+
+			if err != nil {
+				t.Fatalf("drawOCR create execution returned an error: %v", err)
+			}
+
+			ir, ow, eh, job := base.GenerateMockJob(t)
+			ir.ReadMock.Expect(context.Background()).Return(inputData, nil)
+			ow.WriteMock.Times(1).Return(nil)
+
+			if err := e.Execute(context.Background(), []*base.Job{job}); err != nil {
+				t.Fatalf("drawOCR returned an error: %v", err)
+			}
+
+			ir.MinimockFinish()
+			ow.MinimockFinish()
+			eh.MinimockFinish()
+		})
+	}
+}

--- a/pkg/component/operator/image/v0/task_draw_semantic_segmentation.go
+++ b/pkg/component/operator/image/v0/task_draw_semantic_segmentation.go
@@ -1,0 +1,115 @@
+package image
+
+import (
+	"context"
+	"fmt"
+	"image"
+	"image/color"
+	"strconv"
+	"strings"
+
+	"github.com/fogleman/gg"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/instill-ai/pipeline-backend/pkg/component/base"
+)
+
+type semanticSegmentationStuff struct {
+	Category string `json:"category"`
+	RLE      string `json:"rle"`
+}
+
+type drawSemanticSegmentationInput struct {
+	Image  base64Image                  `json:"image"`
+	Stuffs []*semanticSegmentationStuff `json:"stuffs"`
+}
+
+type drawSemanticSegmentationOutput struct {
+	Image base64Image `json:"image"`
+}
+
+func drawSemanticMask(img *image.RGBA, rle string, colorSeed int) error {
+	// Split the string by commas to get the individual number strings.
+	numberStrings := strings.Split(rle, ",")
+
+	// Allocate an array of integers with the same length as the number of numberStrings.
+	rleInts := make([]int, len(numberStrings))
+
+	// Convert each number string to an integer.
+	for i, s := range numberStrings {
+		n, err := strconv.Atoi(strings.TrimSpace(s))
+		if err != nil {
+			return fmt.Errorf("failed to convert RLE string to int: %s, error: %v", s, err)
+		}
+		rleInts[i] = n
+	}
+
+	bound := img.Bounds()
+
+	// Decode the RLE mask for the full image size.
+	mask := rleDecode(rleInts, bound.Dx(), bound.Dy())
+
+	// Iterate over the bounding box and draw the mask onto the image.
+	for y := 0; y < bound.Dy(); y++ {
+		for x := 0; x < bound.Dx(); x++ {
+			if mask[y][x] {
+				// The mask is present for this pixel, so draw it on the image.
+				// Here you could set a specific color or just use the mask value.
+				// For example, let's paint the mask as a red semi-transparent overlay:
+				originalColor := img.At(x, y).(color.RGBA)
+				// Blend the original color with the mask color.
+				blendedColor := blendColors(originalColor, randomColor(colorSeed, 128))
+				img.Set(x, y, blendedColor)
+			}
+		}
+	}
+
+	dc := gg.NewContextForRGBA(img)
+	dc.SetColor(color.RGBA{255, 255, 255, 255})
+
+	// Find contour points
+	contourPoints := findContour(mask)
+
+	// Draw the contour
+	for _, pt := range contourPoints {
+		// Scale points as needed for your canvas size
+		dc.DrawPoint(float64(pt.X), float64(pt.Y), 0.5)
+		dc.Fill()
+	}
+
+	return nil
+}
+
+func drawSemanticSegmentation(input *structpb.Struct, job *base.Job, ctx context.Context) (*structpb.Struct, error) {
+
+	inputStruct := drawSemanticSegmentationInput{}
+
+	err := base.ConvertFromStructpb(input, &inputStruct)
+	if err != nil {
+		return nil, fmt.Errorf("error converting input to struct: %v", err)
+	}
+
+	img, err := decodeBase64Image(string(inputStruct.Image))
+	if err != nil {
+		return nil, fmt.Errorf("error decoding image: %v", err)
+	}
+
+	imgRGBA := convertToRGBA(img)
+
+	for idx, stuff := range inputStruct.Stuffs {
+		if err := drawSemanticMask(imgRGBA, stuff.RLE, idx); err != nil {
+			return nil, err
+		}
+	}
+
+	base64Img, err := encodeBase64Image(imgRGBA)
+	if err != nil {
+		return nil, err
+	}
+
+	output := drawSemanticSegmentationOutput{
+		Image: base64Image(fmt.Sprintf("data:image/png;base64,%s", base64Img)),
+	}
+
+	return base.ConvertToStructpb(output)
+}

--- a/pkg/component/operator/image/v0/task_draw_semantic_segmentation_test.go
+++ b/pkg/component/operator/image/v0/task_draw_semantic_segmentation_test.go
@@ -1,0 +1,62 @@
+package image
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	_ "embed"
+
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/instill-ai/pipeline-backend/pkg/component/base"
+)
+
+//go:embed testdata/sem-seg-cityscape.json
+var semSegCityscapeJSON []byte
+
+// TestDrawSemanticSegmentation tests the drawSemanticSegmentation function
+func TestDrawSemanticSegmentation(t *testing.T) {
+	testCases := []struct {
+		name      string
+		inputJSON []byte
+	}{
+		{
+			name:      "Cityscape Semantic Segmentation",
+			inputJSON: semSegCityscapeJSON,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			inputData := &structpb.Struct{}
+			if err := json.Unmarshal(tc.inputJSON, inputData); err != nil {
+				t.Fatalf("Failed to unmarshal test data: %v", err)
+			}
+
+			bc := base.Component{}
+			component := Init(bc)
+
+			e, err := component.CreateExecution(base.ComponentExecution{
+				Component: component,
+				Task:      "TASK_DRAW_SEMANTIC_SEGMENTATION",
+			})
+
+			if err != nil {
+				t.Fatalf("drawSemanticSegmentation create execution returned an error: %v", err)
+			}
+
+			ir, ow, eh, job := base.GenerateMockJob(t)
+			ir.ReadMock.Expect(context.Background()).Return(inputData, nil)
+			ow.WriteMock.Times(1).Return(nil)
+
+			if err := e.Execute(context.Background(), []*base.Job{job}); err != nil {
+				t.Fatalf("drawSemanticSegmentation returned an error: %v", err)
+			}
+
+			ir.MinimockFinish()
+			ow.MinimockFinish()
+			eh.MinimockFinish()
+		})
+	}
+}

--- a/pkg/component/operator/image/v0/task_resize.go
+++ b/pkg/component/operator/image/v0/task_resize.go
@@ -1,0 +1,94 @@
+package image
+
+import (
+	"context"
+	"fmt"
+	"image"
+
+	"google.golang.org/protobuf/types/known/structpb"
+
+	nr "github.com/nfnt/resize"
+
+	"github.com/instill-ai/pipeline-backend/pkg/component/base"
+)
+
+type resizeInput struct {
+	Image  base64Image `json:"image"`
+	Width  int         `json:"width"`
+	Height int         `json:"height"`
+	Ratio  float64     `json:"ratio"`
+}
+
+type resizeOutput struct {
+	Image base64Image `json:"image"`
+}
+
+func resize(input *structpb.Struct, job *base.Job, ctx context.Context) (*structpb.Struct, error) {
+	var inputStruct resizeInput
+	if err := base.ConvertFromStructpb(input, &inputStruct); err != nil {
+		return nil, fmt.Errorf("error converting input to struct: %w", err)
+	}
+
+	// Validate input parameters
+	if err := validateInputParams(inputStruct); err != nil {
+		return nil, err
+	}
+
+	img, err := decodeBase64Image(string(inputStruct.Image))
+	if err != nil {
+		return nil, fmt.Errorf("error decoding image: %w", err)
+	}
+
+	// Determine new dimensions
+	width, height := calculateNewDimensions(inputStruct, img.Bounds())
+
+	// Check if resizing is needed
+	if width == img.Bounds().Dx() && height == img.Bounds().Dy() {
+		return createOutput(img)
+	}
+
+	// Resize the image
+	resizedImg := nr.Resize(uint(width), uint(height), img, nr.Lanczos3)
+	return createOutput(resizedImg)
+}
+
+func validateInputParams(input resizeInput) error {
+	if input.Ratio < 0 || input.Ratio > 1 {
+		return fmt.Errorf("ratio must be between 0 and 1")
+	}
+	if input.Width < 0 || input.Height < 0 {
+		return fmt.Errorf("width and height must be greater than or equal to 0")
+	}
+	return nil
+}
+
+func calculateNewDimensions(input resizeInput, bounds image.Rectangle) (int, int) {
+	if input.Ratio > 0 {
+		return int(float64(bounds.Dx()) * input.Ratio),
+			int(float64(bounds.Dy()) * input.Ratio)
+	}
+
+	aspectRatio := float64(bounds.Dx()) / float64(bounds.Dy())
+
+	switch {
+	case input.Width > 0 && input.Height > 0:
+		return input.Width, input.Height
+	case input.Width > 0:
+		return input.Width, int(float64(input.Width) / aspectRatio)
+	case input.Height > 0:
+		return int(float64(input.Height) * aspectRatio), input.Height
+	default:
+		return bounds.Dx(), bounds.Dy()
+	}
+}
+
+func createOutput(img image.Image) (*structpb.Struct, error) {
+	base64Img, err := encodeBase64Image(img)
+	if err != nil {
+		return nil, err
+	}
+	output := resizeOutput{
+		Image: base64Image(fmt.Sprintf("data:image/png;base64,%s", base64Img)),
+	}
+	return base.ConvertToStructpb(output)
+}

--- a/pkg/component/operator/image/v0/task_resize_test.go
+++ b/pkg/component/operator/image/v0/task_resize_test.go
@@ -1,0 +1,129 @@
+package image
+
+import (
+	"context"
+	"image"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/instill-ai/pipeline-backend/pkg/component/base"
+)
+
+func TestResize(t *testing.T) {
+	// Create a sample 100x100 image
+	img := image.NewRGBA(image.Rect(0, 0, 100, 100))
+	base64Img, err := encodeBase64Image(img)
+	assert.NoError(t, err)
+
+	testCases := []struct {
+		name           string
+		input          resizeInput
+		expectedWidth  int
+		expectedHeight int
+		expectedError  string
+	}{
+		{
+			name: "Resize by width and height",
+			input: resizeInput{
+				Image:  base64Image("data:image/png;base64," + base64Img),
+				Width:  80,
+				Height: 20,
+			},
+			expectedWidth:  80,
+			expectedHeight: 20,
+		},
+		{
+			name: "Resize by ratio",
+			input: resizeInput{
+				Image: base64Image("data:image/png;base64," + base64Img),
+				Ratio: 0.2,
+			},
+			expectedWidth:  20,
+			expectedHeight: 20,
+		},
+		{
+			name: "Resize by ratio 0",
+			input: resizeInput{
+				Image: base64Image("data:image/png;base64," + base64Img),
+				Ratio: 0,
+			},
+			expectedWidth:  100,
+			expectedHeight: 100,
+		},
+		{
+			name: "Resize by width and height 0",
+			input: resizeInput{
+				Image:  base64Image("data:image/png;base64," + base64Img),
+				Width:  0,
+				Height: 0,
+			},
+			expectedWidth:  100,
+			expectedHeight: 100,
+		},
+		{
+			name: "Resize by width 0",
+			input: resizeInput{
+				Image:  base64Image("data:image/png;base64," + base64Img),
+				Width:  0,
+				Height: 100,
+			},
+			expectedWidth:  100,
+			expectedHeight: 100,
+		},
+		{
+			name: "Negative ratio",
+			input: resizeInput{
+				Image: base64Image("data:image/png;base64," + base64Img),
+				Ratio: -0.5,
+			},
+			expectedError: "ratio must be between 0 and 1",
+		},
+		{
+			name: "Negative width",
+			input: resizeInput{
+				Image:  base64Image("data:image/png;base64," + base64Img),
+				Width:  -100,
+				Height: 100,
+			},
+			expectedError: "width and height must be greater than or equal to 0",
+		},
+		{
+			name: "Negative height",
+			input: resizeInput{
+				Image:  base64Image("data:image/png;base64," + base64Img),
+				Width:  100,
+				Height: -100,
+			},
+			expectedError: "width and height must be greater than or equal to 0",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			inputStruct, err := base.ConvertToStructpb(tc.input)
+			assert.NoError(t, err)
+
+			output, err := resize(inputStruct, nil, context.Background())
+
+			if tc.expectedError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectedError)
+			} else {
+				assert.NoError(t, err)
+
+				var resizedOutput resizeOutput
+				err = base.ConvertFromStructpb(output, &resizedOutput)
+				assert.NoError(t, err)
+
+				// Decode the output image
+				decodedImg, err := decodeBase64Image(string(resizedOutput.Image)[22:]) // Remove "data:image/png;base64," prefix
+				assert.NoError(t, err)
+
+				// Check if the output image dimensions match the expected dimensions
+				assert.Equal(t, tc.expectedWidth, decodedImg.Bounds().Dx())
+				assert.Equal(t, tc.expectedHeight, decodedImg.Bounds().Dy())
+			}
+		})
+	}
+}


### PR DESCRIPTION
This is a port of https://github.com/instill-ai/component/pull/380

Because

- the Image operator requires `crop`, `resize`, and `concat` function

This commit

- implement the functions
- refactor the code and adopt the latest `concurrentExecutor`