### PR TITLE
feat: Add assignees and labels support for create issue task in GitHub component

### DIFF
--- a/pkg/component/application/github/v0/README.mdx
+++ b/pkg/component/application/github/v0/README.mdx
@@ -509,6 +509,8 @@ Create an issue
 | Repository (required) | `repository` | string | Repository name |
 | Issue title (required) | `title` | string | Title of the issue |
 | Issue body (required) | `body` | string | Body of the issue |
+| Assignees | `assignees` | array[string] | Assignees of the issue |
+| Labels | `labels` | array[string] | Labels of the issue |
 </div>
 
 

--- a/pkg/component/application/github/v0/config/tasks.json
+++ b/pkg/component/application/github/v0/config/tasks.json
@@ -1241,6 +1241,38 @@
             "template"
           ],
           "instillUIOrder": 4
+        },
+        "assignees": {
+          "$ref": "#/$defs/issue/properties/assignees",
+          "instillAcceptFormats": [
+            "array:string"
+          ],
+          "instillUpstreamTypes": [
+            "value",
+            "reference"
+          ],
+          "items": {
+            "instillUIMultiline": false,
+            "type": "string"
+          },
+          "title": "Assignees",
+          "instillUIOrder": 5
+        },
+        "labels": {
+          "$ref": "#/$defs/issue/properties/labels",
+          "instillAcceptFormats": [
+            "array:string"
+          ],
+          "instillUpstreamTypes": [
+            "value",
+            "reference"
+          ],
+          "items": {
+            "instillUIMultiline": false,
+            "type": "string"
+          },
+          "title": "Labels",
+          "instillUIOrder": 6
         }
       },
       "required": [

--- a/pkg/component/application/github/v0/issues.go
+++ b/pkg/component/application/github/v0/issues.go
@@ -177,8 +177,10 @@ func (githubClient *Client) getIssueTask(ctx context.Context, props *structpb.St
 
 type CreateIssueInput struct {
 	RepoInfo
-	Title string `json:"title"`
-	Body  string `json:"body"`
+	Title     string   `json:"title"`
+	Body      string   `json:"body"`
+	Assignees []string `json:"assignees"`
+	Labels    []string `json:"labels"`
 }
 
 type CreateIssueResp struct {
@@ -196,8 +198,10 @@ func (githubClient *Client) createIssueTask(ctx context.Context, props *structpb
 		return nil, err
 	}
 	issueRequest := &github.IssueRequest{
-		Title: &inputStruct.Title,
-		Body:  &inputStruct.Body,
+		Title:     &inputStruct.Title,
+		Body:      &inputStruct.Body,
+		Assignees: &inputStruct.Assignees,
+		Labels:    &inputStruct.Labels,
 	}
 	issue, _, err := githubClient.Issues.Create(ctx, owner, repository, issueRequest)
 	if err != nil {


### PR DESCRIPTION
Because

- When creating issue using Github Component, Labels and Assignees field can be populated by providing github username and labels in input of component, which can be generated by AI components. Resolves instill-ai/instill-core#1095

This commit

- Add `Labels` and `Assignees` field in input for Create Issue Task.
