### PR TITLE
chore(component): fix contribution guidelines and make command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ gen-mock:
 	@go generate -run minimock ./...
 
 .PHONY: gen-component-doc
-gen-doc:					## Generate component docs
+gen-component-doc:				## Generate component docs
 	@rm -f $$(find ./pkg/component -name README.mdx | paste -d ' ' -s -)
 	@cd ./pkg/component/tools/compogen && go install .
 	@go generate -run compogen ./pkg/component/...

--- a/pkg/component/CONTRIBUTING.md
+++ b/pkg/component/CONTRIBUTING.md
@@ -77,6 +77,7 @@ component.
   "id": "hello",
   "uid": "e05d3d71-779c-45f8-904d-e90a050ca3b2",
   "title": "Hello",
+  "type": "COMPONENT_TYPE_OPERATOR",
   "description": "'Hello, world' operator used as a template for adding components",
   "spec": {},
   "availableTasks": [


### PR DESCRIPTION
Because

- The component definition in the guideline lacks a type, which makes it not
  show up in the console.
- Make command referenced in guidelines is different than the one in `Makefile`.

This commit

- Renames make command.
- Fixes definition in guidelines.

