### PR TITLE
feat: add `range` support for iterator implementation

### DIFF
--- a/pkg/datamodel/datamodel.go
+++ b/pkg/datamodel/datamodel.go
@@ -318,6 +318,8 @@ type Component struct {
 	Definition *Definition `json:"definition,omitempty" yaml:"-"`
 
 	// Fields for iterators
+	Range             []int                 `json:"range,omitempty" yaml:"range,omitempty"`
+	Index             string                `json:"index,omitempty" yaml:"index,omitempty"`
 	Component         ComponentMap          `json:"component,omitempty" yaml:"component,omitempty"`
 	OutputElements    map[string]string     `json:"outputElements,omitempty" yaml:"output-elements,omitempty"`
 	DataSpecification *pb.DataSpecification `json:"dataSpecification,omitempty" yaml:"-"`

--- a/pkg/recipe/dag.go
+++ b/pkg/recipe/dag.go
@@ -566,7 +566,9 @@ func GenerateDAG(componentMap datamodel.ComponentMap) (*dag, error) {
 			template, _ := json.Marshal(component.Input)
 			parents = append(parents, FindReferenceParent(string(template))...)
 		case datamodel.Iterator:
-			parents = append(parents, FindReferenceParent(component.Input.(string))...)
+			if component.Input != nil {
+				parents = append(parents, FindReferenceParent(component.Input.(string))...)
+			}
 			nestedComponentIDs := []string{id}
 			for nestedID := range component.Component {
 				nestedComponentIDs = append(nestedComponentIDs, nestedID)

--- a/pkg/worker/utils.go
+++ b/pkg/worker/utils.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/instill-ai/pipeline-backend/config"
+	"github.com/instill-ai/pipeline-backend/pkg/data"
 	"github.com/instill-ai/pipeline-backend/pkg/utils"
 )
 
@@ -23,4 +25,53 @@ func (w *worker) writeNewDataPoint(ctx context.Context, data utils.PipelineUsage
 	w.influxDBWriteClient.WritePoint(utils.DeprecatedNewPipelineDatapoint(data))
 
 	return nil
+}
+
+// setIteratorIndex converts the iterator index identifier into a numeric
+// index. For example, it converts `${variable.array[i]}` into
+// `${variable.array[0]}`.
+func setIteratorIndex(v data.Value, identifier string, index int) data.Value {
+	if identifier == "" {
+		identifier = "i"
+	}
+	switch v := v.(type) {
+	case *data.String:
+		s := v.GetString()
+		val := ""
+		for {
+			startIdx := strings.Index(s, "${")
+			if startIdx == -1 {
+				val += s
+				break
+			}
+			val += s[:startIdx]
+			s = s[startIdx:]
+			endIdx := strings.Index(s, "}")
+			if endIdx == -1 {
+				val += s
+				break
+			}
+
+			ref := strings.TrimSpace(s[2:endIdx])
+			ref = strings.ReplaceAll(ref, fmt.Sprintf("[%s]", identifier), fmt.Sprintf("[%d]", index))
+
+			val += fmt.Sprintf("${%s}", ref)
+			s = s[endIdx+1:]
+		}
+		return data.NewString(val)
+	case *data.Array:
+		m := data.NewArray(make([]data.Value, len(v.Values)))
+		for idx, item := range v.Values {
+			m.Values[idx] = setIteratorIndex(item, identifier, index)
+		}
+		return m
+	case *data.Map:
+		m := data.NewMap(make(map[string]data.Value))
+		for k, v := range v.Fields {
+			m.Fields[k] = setIteratorIndex(v, identifier, index)
+		}
+		return m
+	default:
+		return v
+	}
 }


### PR DESCRIPTION
Because

- Currently, our iterator only implements the `foreach` function, meaning we iterate over the iterator `input`. This approach is insufficient for some use cases, where users may want to control the iteration's start and end points.

This commit

- Adds `range` support to the iterator implementation. It introduces the syntax `range: [start, stop [,step]]` to allow users to configure the iteration parameters. Additionally, users can specify the iteration index using `index: i`, with `i` being the default identifier.