### PR TITLE
feat: support map representation for `range` in iterator

### DIFF
--- a/pkg/datamodel/datamodel.go
+++ b/pkg/datamodel/datamodel.go
@@ -318,7 +318,7 @@ type Component struct {
 	Definition *Definition `json:"definition,omitempty" yaml:"-"`
 
 	// Fields for iterators
-	Range             []int                 `json:"range,omitempty" yaml:"range,omitempty"`
+	Range             any                   `json:"range,omitempty" yaml:"range,omitempty"`
 	Index             string                `json:"index,omitempty" yaml:"index,omitempty"`
 	Component         ComponentMap          `json:"component,omitempty" yaml:"component,omitempty"`
 	OutputElements    map[string]string     `json:"outputElements,omitempty" yaml:"output-elements,omitempty"`

--- a/pkg/worker/utils.go
+++ b/pkg/worker/utils.go
@@ -27,6 +27,12 @@ func (w *worker) writeNewDataPoint(ctx context.Context, data utils.PipelineUsage
 	return nil
 }
 
+const (
+	rangeStart = "start"
+	rangeStop  = "stop"
+	rangeStep  = "step"
+)
+
 // setIteratorIndex converts the iterator index identifier into a numeric
 // index. For example, it converts `${variable.array[i]}` into
 // `${variable.array[0]}`.


### PR DESCRIPTION
Because

- Readability decreases when using array representation for `range` with variable references. For example:
    ```yaml
    range: [0, "${variable.top-k}", 1]
    ```

This commit

- Adds support for map representation, for example,
    ```yaml
    range:
      start: 0
      stop: ${variable.top-k}
      step: 1
    ```