### PR TITLE
fix: the fallback mechanism for handling Instill Format with subtypes

### DIFF
--- a/pkg/service/convert.go
+++ b/pkg/service/convert.go
@@ -904,7 +904,7 @@ func checkInstillFormat(instillFormat string) string {
 		return "array:document"
 	}
 
-	// Remove wildcard *, for example, image/* -> image
+	// Remove subtype, for example, image/jpeg -> image
 	instillFormat, _, _ = strings.Cut(instillFormat, "/")
 	if slices.Contains(supportedInstillFormats, instillFormat) {
 		return instillFormat

--- a/pkg/service/convert.go
+++ b/pkg/service/convert.go
@@ -891,6 +891,7 @@ var supportedInstillFormats = []string{
 	"audio", "array:audio",
 	"video", "array:video",
 	"document", "array:document",
+	"file", "array:file",
 }
 
 // For fields without valid "instillFormat", we will fall back to using JSON format.

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -864,12 +864,12 @@ func (s *service) preTriggerPipeline(ctx context.Context, ns resource.Namespace,
 					}
 				}
 				variable.Fields[k] = array
-			case "document", "*/*":
+			case "document", "file", "*/*":
 				variable.Fields[k], err = data.NewDocumentFromURL(v.GetStringValue())
 				if err != nil {
 					return err
 				}
-			case "array:document", "array:*/*":
+			case "array:document", "array:file", "array:*/*":
 				array := data.NewArray(make([]data.Value, len(v.GetListValue().Values)))
 				for idx, val := range v.GetListValue().Values {
 					array.Values[idx], err = data.NewDocumentFromURL(val.GetStringValue())

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -197,6 +197,8 @@ func ConvertInstillFormat(f string) string {
 		return "video/*"
 	case "document":
 		return "*/*"
+	case "file":
+		return "*/*"
 	case "json":
 		return "semi-structured/json"
 	case "array:image":
@@ -206,6 +208,8 @@ func ConvertInstillFormat(f string) string {
 	case "array:video":
 		return "array:video/*"
 	case "array:document":
+		return "array:*/*"
+	case "array:file":
 		return "array:*/*"
 	case "array:json":
 		return "array:semi-structured/json"


### PR DESCRIPTION
Because

- The fallback mechanism failed when there was a subtype in the Instill Format. For example, when a component outputs `image/jpeg`, the Console could not successfully display the image.

This commit

- Fixes the fallback mechanism for handling Instill Format with subtypes.