### PR TITLE
chore(json): document pitfall in JQ filter

### DIFF
--- a/pkg/component/operator/json/v0/.compogen/extra-jq.mdx
+++ b/pkg/component/operator/json/v0/.compogen/extra-jq.mdx
@@ -13,3 +13,11 @@ Here are some examples on how the `jq` syntax works.
 | `[{"id":1},{"id":2},{"id":3}]` | `.[] \| .id` | `[1, 2, 3]` |
 | `{"a":1,"b":2}` | `.a += 1 \| .b *= 2` | `[{ "a": 2, "b": 4 }]` |
 | `{"a":1} [2] 3` | `. as {$a} ?// [$a] ?// $a \| $a` | `[1, 2, 3]` |
+
+There's a common pitfall in `jq`, which doesn't support the dash (`-`)
+character in dictionary key names and interprets them as a subtraction. The way
+to access such fields in a `jq` filter is by wrapping the key in double quotes:
+
+| Input JSON | `jq` filter | Output |
+| :--- | :--- | :--- |
+| `[{"key-a": "value1"}, {"key-a": "value2"}]` | `.[] \| ."key-a"` | `["value1", "value2"]` |

--- a/pkg/component/operator/json/v0/README.mdx
+++ b/pkg/component/operator/json/v0/README.mdx
@@ -110,6 +110,14 @@ Here are some examples on how the `jq` syntax works.
 | `[{"id":1},{"id":2},{"id":3}]` | `.[] \| .id` | `[1, 2, 3]` |
 | `{"a":1,"b":2}` | `.a += 1 \| .b *= 2` | `[{ "a": 2, "b": 4 }]` |
 | `{"a":1} [2] 3` | `. as {$a} ?// [$a] ?// $a \| $a` | `[1, 2, 3]` |
+
+There's a common pitfall in `jq`, which doesn't support the dash (`-`)
+character in dictionary key names and interprets them as a subtraction. The way
+to access such fields in a `jq` filter is by wrapping the key in double quotes:
+
+| Input JSON | `jq` filter | Output |
+| :--- | :--- | :--- |
+| `[{"key-a": "value1"}, {"key-a": "value2"}]` | `.[] \| ."key-a"` | `["value1", "value2"]` |
 ## Example Recipes
 
 Recipe for the [Resume Screening](https://instill.tech/instill-ai/pipelines/structured-resume-screening/playground) pipeline.


### PR DESCRIPTION
Because

- JQ doesn't support slashes in dictionary key names, which has caused some confusion.

This commit

- Document this pitfall and its workaround.
