### PR TITLE
feat(integration): add identity to OAuth connections

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -26,7 +26,7 @@ database:
   host: pg-sql
   port: 5432
   name: pipeline
-  version: 29
+  version: 30
   timezone: Etc/UTC
   pool:
     idleconnections: 5

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/iFaceless/godub v0.0.0-20200728093528-a30bb4d1a0f1
 	github.com/iancoleman/strcase v0.3.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240922180636-80bd4bf3bb56
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241004133602-c424edaba4a3
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha.0.20241003075514-5ced228b7498
 	github.com/itchyny/gojq v0.12.14

--- a/go.sum
+++ b/go.sum
@@ -1275,8 +1275,8 @@ github.com/influxdata/influxdb-client-go/v2 v2.12.3 h1:28nRlNMRIV4QbtIUvxhWqaxn0
 github.com/influxdata/influxdb-client-go/v2 v2.12.3/go.mod h1:IrrLUbCjjfkmRuaCiGQg4m2GbkaeJDcuWoxiWdQEbA0=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240922180636-80bd4bf3bb56 h1:CAvgheFIOS+Ryuor4kVv9BHh+ID9Wa1PCzkrr1xJkiI=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240922180636-80bd4bf3bb56/go.mod h1:rf0UY7VpEgpaLudYEcjx5rnbuwlBaaLyD4FQmWLtgAY=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241004133602-c424edaba4a3 h1:Vk5CiAq09EcPBHam+Xv71ot3gkvJKuAqtxOaQxXO8Bc=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241004133602-c424edaba4a3/go.mod h1:rf0UY7VpEgpaLudYEcjx5rnbuwlBaaLyD4FQmWLtgAY=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a/go.mod h1:EpX3Yr661uWULtZf5UnJHfr5rw2PDyX8ku4Kx0UtYFw=
 github.com/instill-ai/x v0.4.0-alpha.0.20241003075514-5ced228b7498 h1:Wc6nbDoIQDiAZDipfog8xCu+BdEiLNK0MLaHxhjWubY=

--- a/integration-test/pipeline/rest-integration.js
+++ b/integration-test/pipeline/rest-integration.js
@@ -45,7 +45,7 @@ export function CheckIntegrations() {
     var oAuthConfig = {
       authUrl: "https://slack.com/oauth/v2/authorize",
       accessUrl: "https://slack.com/api/oauth.v2.access",
-      scopes: ["channels:history", "groups:history", "chat:write"],
+      scopes: ["channels:history", "groups:history", "chat:write", "users:read", "users:read.email", "users.profile:read"],
     };
 
     // Basic view

--- a/integration-test/pipeline/rest-integration.js
+++ b/integration-test/pipeline/rest-integration.js
@@ -117,7 +117,9 @@ export function CheckConnections(data) {
       pipelinePublicHost + path,
       JSON.stringify({
         id: connectionID,
-        integrationId: integrationID,
+        // Needs to be an integration that doesn't support OAuth. Once it's
+        // supported, it's the only method allowed.
+        integrationId: "asana",
         method: "METHOD_DICTIONARY",
         setup: setup,
       }),

--- a/integration-test/pipeline/rest-integration.js
+++ b/integration-test/pipeline/rest-integration.js
@@ -106,6 +106,7 @@ export function CheckConnections(data) {
   var integrationID = "slack";
 
   var setup = {"token": "one2THREE"};
+  var identity = "identitti";
 
   group("Integration API: Create connection", () => {
     var path = collectionPath;
@@ -128,7 +129,7 @@ export function CheckConnections(data) {
       [`POST ${path} (dictionary) has a creation time`]: (r) => new Date(r.json().connection.createTime).getTime() > new Date().setTime(0),
     });
 
-    // Successful creation: dictionary
+    // Successful creation: OAuth
     var oAuthReq = http.request(
       "POST",
       pipelinePublicHost + path,
@@ -138,6 +139,7 @@ export function CheckConnections(data) {
         method: "METHOD_OAUTH",
         setup: setup,
         scopes: ["channels:history", "groups:history", "chat:write"],
+        identity: identity,
         oAuthAccessDetails: {
           ok: true,
           access_token: "xoxb-17653672481-19874698323-pdFZKVeTuE8sk7oOcBrzbqgy",
@@ -166,6 +168,7 @@ export function CheckConnections(data) {
     check(oAuthReq, {
       [`POST ${path} (OAuth) response status is 201`]: (r) => r.status === 201,
       [`POST ${path} (OAuth) has a UID`]: (r) => r.json().connection.uid.length > 0,
+      [`POST ${path} (OAuth) has an identity`]: (r) => r.json().connection.identity === identity,
       [`POST ${path} (OAuth) has a creation time`]: (r) => new Date(r.json().connection.createTime).getTime() > new Date().setTime(0),
     });
 
@@ -232,6 +235,7 @@ export function CheckConnections(data) {
       [`GET ${path} has setup hidden`]: (r) => r.json().connection.setup === null,
       [`GET ${path} has integration ID`]: (r) => r.json().connection.integrationId === integrationID,
       [`GET ${path} has integration title`]: (r) => r.json().connection.integrationTitle === "Slack",
+      [`GET ${path} has an identity`]: (r) => r.json().connection.identity === identity,
     });
 
     // Full view
@@ -386,6 +390,7 @@ component:
     ).json().connection;
 
     var newToken = "new-token";
+    var newIdentity = "nivedita";
     var newID = dbIDPrefix + "my-new-id";
     var newMethod = "METHOD_OAUTH";
     var scopes = ["foo"];
@@ -401,6 +406,7 @@ component:
         // Fields with an underlying structpb.Struct type (setup,
         // oAuthAccessDetails) will be updated in block.
         setup: {"token": newToken},
+        identity: newIdentity,
         oAuthAccessDetails: {
           token_type: "bot",
           enterprise: {
@@ -416,6 +422,7 @@ component:
       [`PATCH ${path} response status 200`]: (r) => r.status === 200,
       [`PATCH ${path} contains new ID`]: (r) => r.json().connection.id === newID,
       [`PATCH ${path} contains new method`]: (r) => r.json().connection.method === newMethod,
+      [`PATCH ${path} contains new identity`]: (r) => r.json().connection.identity === newIdentity,
       [`PATCH ${path} contains new setup`]: (r) => r.json().connection.setup.token === newToken,
       [`PATCH ${path} contains scopes`]: (r) => r.json().connection.scopes[0] === scopes[0],
       [`PATCH ${path} didn't modify UID`]: (r) => r.json().connection.uid === originalConn.uid,
@@ -428,6 +435,7 @@ component:
       [`GET ${path + "?view=VIEW_FULL"} response status is 200`]: (r) => r.status === 200,
       [`GET ${path + "?view=VIEW_FULL"} has new ID value`]: (r) => r.json().connection.id === newID,
       [`GET ${path + "?view=VIEW_FULL"} has new method`]: (r) => r.json().connection.method === newMethod,
+      [`GET ${path + "?view=VIEW_FULL"} has new identity`]: (r) => r.json().connection.identity === newIdentity,
       [`GET ${path + "?view=VIEW_FULL"} has scopes`]: (r) => r.json().connection.setup.token === newToken,
       [`GET ${path + "?view=VIEW_FULL"} has scopes`]: (r) =>
         r.json().connection.scopes[0] === scopes[0],

--- a/integration-test/proto/vdp/pipeline/v1beta/integration.proto
+++ b/integration-test/proto/vdp/pipeline/v1beta/integration.proto
@@ -8,8 +8,6 @@ import "google/api/field_behavior.proto";
 import "google/protobuf/field_mask.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
-// protoc-gen-validate message validators
-import "validate/validate.proto";
 // VDP definitions
 import "../../../vdp/pipeline/v1beta/common.proto";
 
@@ -28,10 +26,7 @@ message Connection {
     METHOD_OAUTH = 2;
   }
   // UUID-formatted unique identifier.
-  string uid = 1 [
-    (validate.rules).string.uuid = true,
-    (google.api.field_behavior) = OUTPUT_ONLY
-  ];
+  string uid = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
   // ID.
   string id = 2 [(google.api.field_behavior) = REQUIRED];
   // ID of the namespace owning the connection.
@@ -55,8 +50,24 @@ message Connection {
   // Connection details. This field is required on creation, optional on view.
   // When viewing the connection details, the setup values will be redacted.
   google.protobuf.Struct setup = 7 [(google.api.field_behavior) = REQUIRED];
-  // View defines how the integration is presented. The `setup` field is only
-  // showed in the FULL view.
+  // A list of scopes that identify the resources that the connection will be
+  // able to access on the user's behalf. This is typically passed on creation
+  // when the setup has been generated through an OAuth flow with a limited set
+  // of scopes.
+  repeated string scopes = 11 [(google.api.field_behavior) = OPTIONAL];
+  // When the connection method is METHOD_OAUTH, this field will hold the
+  // identity (e.g., email, username) with which the access token has been
+  // generated.
+  optional string identity = 13 [(google.api.field_behavior) = OPTIONAL];
+  // When the connection method is METHOD_OAUTH, the access token might come
+  // with some extra information that might vary across vendors. This
+  // information is passed as connection metadata.
+  optional google.protobuf.Struct o_auth_access_details = 12 [(google.api.field_behavior) = OPTIONAL];
+  // View defines how the connection is presented. The following fields are
+  // only shown in the FULL view:
+  // - setup
+  // - scopes
+  // - oAuthAccessDetails
   View view = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Creation timestamp.
   google.protobuf.Timestamp create_time = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
@@ -69,21 +80,18 @@ message Connection {
 message ListNamespaceConnectionsRequest {
   // Namespace ID.
   string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
-  // The maximum number of items to return. The default and cap values are 10
-  // and 100, respectively.
+  // The maximum number of items to return. The default and cap values are 10 and 100, respectively.
   optional int32 page_size = 2 [(google.api.field_behavior) = OPTIONAL];
   // Page token. By default, the first page will be returned.
   optional string page_token = 3 [(google.api.field_behavior) = OPTIONAL];
-  // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
-  // expression.
+  // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter expression.
   // The following filters are supported:
   // - `integrationId`
   // - `qConnection` (fuzzy search on connection ID, integration title or vendor)
-  // Examples:
-  // - List connections where app name, vendor or connection ID match `googl`:
-  // `q="googl"`.
-  // - List connections where the component type is `openai` (e.g. to setup a
-  // connector within a pipeline): `integration_id="openai"`.
+  //
+  // **Examples**:
+  // - List connections where app name, vendor or connection ID match `googl`: `q="googl"`.
+  // - List connections where the component type is `openai` (e.g. to setup a connector within a pipeline): `integrationId="openai"`.
   optional string filter = 4 [(google.api.field_behavior) = OPTIONAL];
 }
 
@@ -175,15 +183,6 @@ message TestNamespaceConnectionResponse {}
 // Integration contains the parameters to create a connection between
 // components and 3rd party apps.
 message Integration {
-  // SetupSchema defines the schema for a connection setup.
-  message SetupSchema {
-    // The connection method, which will define the fields in the schema.
-    Connection.Method method = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
-    // The connection setup field definitions. Each integration will require
-    // different data to connect to the 3rd party app.
-    google.protobuf.Struct schema = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
-  }
-
   // Link contains the information to display an reference to an external URL.
   message Link {
     // Text contains the message to display.
@@ -192,11 +191,22 @@ message Integration {
     string url = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
   }
 
+  // OAuthConfig contains the configuration parameters for fetching an access
+  // token via an OAuth 2.0 flow.
+  message OAuthConfig {
+    // The URL of the OAuth server to initiate the authentication and
+    // authorization process.
+    string auth_url = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+    // The URL of the OAuth server to exchange the authorization code for an
+    // access token.
+    string access_url = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+    // A list of scopes that identify the resources that the connection will be
+    // able to access on the user's behalf.
+    repeated string scopes = 11 [(google.api.field_behavior) = OUTPUT_ONLY];
+  }
+
   // UUID-formatted unique identifier. It references a component definition.
-  string uid = 1 [
-    (validate.rules).string.uuid = true,
-    (google.api.field_behavior) = OUTPUT_ONLY
-  ];
+  string uid = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Identifier of the integration, which references a component definition.
   // Components with that definition ID will be able to use the connections
   // produced by this integration.
@@ -214,12 +224,45 @@ message Integration {
   // information.
   string icon = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Reference to the vendor's documentation to expand the integration details.
-  optional string help_link = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Schemas defines the supported schemas for the connection setup.
-  repeated SetupSchema schemas = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // View defines how the integration is presented. The `spec` field is only
-  // showed in the FULL view.
+  optional Link help_link = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // The connection setup field definitions. Each integration will require
+  // different data to connect to the 3rd party app.
+  google.protobuf.Struct setup_schema = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Configuration parameters required for the OAuth setup flow. This field
+  // will be present only if the integration supports OAuth 2.0.
+  optional OAuthConfig o_auth_config = 11 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // View defines how the integration is presented. The following fields are
+  // only shown in the FULL view:
+  // - schemas
+  // - setupSchema
+  // - oAuthConfig
   View view = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // SetupSchema defines the schema for a connection setup.
+  // This message is deprecated.
+  message SetupSchema {
+    // The connection method, which will define the fields in the schema.
+    Connection.Method method = 1 [
+      deprecated = true,
+      (google.api.field_behavior) = OUTPUT_ONLY
+    ];
+    // The connection setup field definitions. Each integration will require
+    // different data to connect to the 3rd party app.
+    google.protobuf.Struct schema = 2 [
+      deprecated = true,
+      (google.api.field_behavior) = OUTPUT_ONLY
+    ];
+  }
+
+  // Schemas defines the supported schemas for the connection setup.
+  // We haven't found a case for a schema that changes on the connection method
+  // (components don't care about how the connection was built), so the schema
+  // will be provided in the setupSchema field and the OAuth support and
+  // configuration will be provided in oAuthConfig.
+  repeated SetupSchema schemas = 8 [
+    deprecated = true,
+    (google.api.field_behavior) = OUTPUT_ONLY
+  ];
 }
 
 // ListPipelineIDsByConnectionIDRequest represents a request to list the
@@ -229,13 +272,11 @@ message ListPipelineIDsByConnectionIDRequest {
   string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
   // Connection ID.
   string connection_id = 2 [(google.api.field_behavior) = REQUIRED];
-  // The maximum number of items to return. The default and cap values are 10
-  // and 100, respectively.
+  // The maximum number of items to return. The default and cap values are 10 and 100, respectively.
   optional int32 page_size = 3 [(google.api.field_behavior) = OPTIONAL];
   // Page token. By default, the first page will be returned.
   optional string page_token = 4 [(google.api.field_behavior) = OPTIONAL];
-  // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
-  // expression.
+  // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter expression.
   // The following filters are supported:
   // - `q` (fuzzy search on pipeline ID)
   optional string filter = 5 [(google.api.field_behavior) = OPTIONAL];
@@ -254,16 +295,15 @@ message ListPipelineIDsByConnectionIDResponse {
 // ListIntegrationsRequest represents a request to list the available
 // integrations.
 message ListIntegrationsRequest {
-  // The maximum number of items to return. The default and cap values are 10
-  // and 100, respectively.
+  // The maximum number of items to return. The default and cap values are 10 and 100, respectively.
   optional int32 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
   // Page token. By default, the first page will be returned.
   optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
-  // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
-  // expression.
+  // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter expression.
   // The following filters are supported:
   // - `qIntegration` (fuzzy search on title or vendor)
-  // Examples:
+  //
+  // **Examples**:
   // - List integrations where app name or vendor match `googl`: `q="googl"`.
   optional string filter = 3 [(google.api.field_behavior) = OPTIONAL];
 }

--- a/pkg/component/application/slack/v0/config/setup.json
+++ b/pkg/component/application/slack/v0/config/setup.json
@@ -28,7 +28,10 @@
     "scopes": [
       "channels:history",
       "groups:history",
-      "chat:write"
+      "chat:write",
+      "users:read",
+      "users:read.email",
+      "users.profile:read"
     ]
   },
   "title": "Slack Connection",

--- a/pkg/component/internal/mock/artifact_public_service_client_mock.gen.go
+++ b/pkg/component/internal/mock/artifact_public_service_client_mock.gen.go
@@ -60,6 +60,13 @@ type ArtifactPublicServiceClientMock struct {
 	beforeListCatalogFilesCounter uint64
 	ListCatalogFilesMock          mArtifactPublicServiceClientMockListCatalogFiles
 
+	funcListCatalogRuns          func(ctx context.Context, in *mm_artifactv1alpha.ListCatalogRunsRequest, opts ...grpc.CallOption) (lp1 *mm_artifactv1alpha.ListCatalogRunsResponse, err error)
+	funcListCatalogRunsOrigin    string
+	inspectFuncListCatalogRuns   func(ctx context.Context, in *mm_artifactv1alpha.ListCatalogRunsRequest, opts ...grpc.CallOption)
+	afterListCatalogRunsCounter  uint64
+	beforeListCatalogRunsCounter uint64
+	ListCatalogRunsMock          mArtifactPublicServiceClientMockListCatalogRuns
+
 	funcListCatalogs          func(ctx context.Context, in *mm_artifactv1alpha.ListCatalogsRequest, opts ...grpc.CallOption) (lp1 *mm_artifactv1alpha.ListCatalogsResponse, err error)
 	funcListCatalogsOrigin    string
 	inspectFuncListCatalogs   func(ctx context.Context, in *mm_artifactv1alpha.ListCatalogsRequest, opts ...grpc.CallOption)
@@ -156,6 +163,9 @@ func NewArtifactPublicServiceClientMock(t minimock.Tester) *ArtifactPublicServic
 
 	m.ListCatalogFilesMock = mArtifactPublicServiceClientMockListCatalogFiles{mock: m}
 	m.ListCatalogFilesMock.callArgs = []*ArtifactPublicServiceClientMockListCatalogFilesParams{}
+
+	m.ListCatalogRunsMock = mArtifactPublicServiceClientMockListCatalogRuns{mock: m}
+	m.ListCatalogRunsMock.callArgs = []*ArtifactPublicServiceClientMockListCatalogRunsParams{}
 
 	m.ListCatalogsMock = mArtifactPublicServiceClientMockListCatalogs{mock: m}
 	m.ListCatalogsMock.callArgs = []*ArtifactPublicServiceClientMockListCatalogsParams{}
@@ -2433,6 +2443,380 @@ func (m *ArtifactPublicServiceClientMock) MinimockListCatalogFilesInspect() {
 	if !m.ListCatalogFilesMock.invocationsDone() && afterListCatalogFilesCounter > 0 {
 		m.t.Errorf("Expected %d calls to ArtifactPublicServiceClientMock.ListCatalogFiles at\n%s but found %d calls",
 			mm_atomic.LoadUint64(&m.ListCatalogFilesMock.expectedInvocations), m.ListCatalogFilesMock.expectedInvocationsOrigin, afterListCatalogFilesCounter)
+	}
+}
+
+type mArtifactPublicServiceClientMockListCatalogRuns struct {
+	optional           bool
+	mock               *ArtifactPublicServiceClientMock
+	defaultExpectation *ArtifactPublicServiceClientMockListCatalogRunsExpectation
+	expectations       []*ArtifactPublicServiceClientMockListCatalogRunsExpectation
+
+	callArgs []*ArtifactPublicServiceClientMockListCatalogRunsParams
+	mutex    sync.RWMutex
+
+	expectedInvocations       uint64
+	expectedInvocationsOrigin string
+}
+
+// ArtifactPublicServiceClientMockListCatalogRunsExpectation specifies expectation struct of the ArtifactPublicServiceClient.ListCatalogRuns
+type ArtifactPublicServiceClientMockListCatalogRunsExpectation struct {
+	mock               *ArtifactPublicServiceClientMock
+	params             *ArtifactPublicServiceClientMockListCatalogRunsParams
+	paramPtrs          *ArtifactPublicServiceClientMockListCatalogRunsParamPtrs
+	expectationOrigins ArtifactPublicServiceClientMockListCatalogRunsExpectationOrigins
+	results            *ArtifactPublicServiceClientMockListCatalogRunsResults
+	returnOrigin       string
+	Counter            uint64
+}
+
+// ArtifactPublicServiceClientMockListCatalogRunsParams contains parameters of the ArtifactPublicServiceClient.ListCatalogRuns
+type ArtifactPublicServiceClientMockListCatalogRunsParams struct {
+	ctx  context.Context
+	in   *mm_artifactv1alpha.ListCatalogRunsRequest
+	opts []grpc.CallOption
+}
+
+// ArtifactPublicServiceClientMockListCatalogRunsParamPtrs contains pointers to parameters of the ArtifactPublicServiceClient.ListCatalogRuns
+type ArtifactPublicServiceClientMockListCatalogRunsParamPtrs struct {
+	ctx  *context.Context
+	in   **mm_artifactv1alpha.ListCatalogRunsRequest
+	opts *[]grpc.CallOption
+}
+
+// ArtifactPublicServiceClientMockListCatalogRunsResults contains results of the ArtifactPublicServiceClient.ListCatalogRuns
+type ArtifactPublicServiceClientMockListCatalogRunsResults struct {
+	lp1 *mm_artifactv1alpha.ListCatalogRunsResponse
+	err error
+}
+
+// ArtifactPublicServiceClientMockListCatalogRunsOrigins contains origins of expectations of the ArtifactPublicServiceClient.ListCatalogRuns
+type ArtifactPublicServiceClientMockListCatalogRunsExpectationOrigins struct {
+	origin     string
+	originCtx  string
+	originIn   string
+	originOpts string
+}
+
+// Marks this method to be optional. The default behavior of any method with Return() is '1 or more', meaning
+// the test will fail minimock's automatic final call check if the mocked method was not called at least once.
+// Optional() makes method check to work in '0 or more' mode.
+// It is NOT RECOMMENDED to use this option unless you really need it, as default behaviour helps to
+// catch the problems when the expected method call is totally skipped during test run.
+func (mmListCatalogRuns *mArtifactPublicServiceClientMockListCatalogRuns) Optional() *mArtifactPublicServiceClientMockListCatalogRuns {
+	mmListCatalogRuns.optional = true
+	return mmListCatalogRuns
+}
+
+// Expect sets up expected params for ArtifactPublicServiceClient.ListCatalogRuns
+func (mmListCatalogRuns *mArtifactPublicServiceClientMockListCatalogRuns) Expect(ctx context.Context, in *mm_artifactv1alpha.ListCatalogRunsRequest, opts ...grpc.CallOption) *mArtifactPublicServiceClientMockListCatalogRuns {
+	if mmListCatalogRuns.mock.funcListCatalogRuns != nil {
+		mmListCatalogRuns.mock.t.Fatalf("ArtifactPublicServiceClientMock.ListCatalogRuns mock is already set by Set")
+	}
+
+	if mmListCatalogRuns.defaultExpectation == nil {
+		mmListCatalogRuns.defaultExpectation = &ArtifactPublicServiceClientMockListCatalogRunsExpectation{}
+	}
+
+	if mmListCatalogRuns.defaultExpectation.paramPtrs != nil {
+		mmListCatalogRuns.mock.t.Fatalf("ArtifactPublicServiceClientMock.ListCatalogRuns mock is already set by ExpectParams functions")
+	}
+
+	mmListCatalogRuns.defaultExpectation.params = &ArtifactPublicServiceClientMockListCatalogRunsParams{ctx, in, opts}
+	mmListCatalogRuns.defaultExpectation.expectationOrigins.origin = minimock.CallerInfo(1)
+	for _, e := range mmListCatalogRuns.expectations {
+		if minimock.Equal(e.params, mmListCatalogRuns.defaultExpectation.params) {
+			mmListCatalogRuns.mock.t.Fatalf("Expectation set by When has same params: %#v", *mmListCatalogRuns.defaultExpectation.params)
+		}
+	}
+
+	return mmListCatalogRuns
+}
+
+// ExpectCtxParam1 sets up expected param ctx for ArtifactPublicServiceClient.ListCatalogRuns
+func (mmListCatalogRuns *mArtifactPublicServiceClientMockListCatalogRuns) ExpectCtxParam1(ctx context.Context) *mArtifactPublicServiceClientMockListCatalogRuns {
+	if mmListCatalogRuns.mock.funcListCatalogRuns != nil {
+		mmListCatalogRuns.mock.t.Fatalf("ArtifactPublicServiceClientMock.ListCatalogRuns mock is already set by Set")
+	}
+
+	if mmListCatalogRuns.defaultExpectation == nil {
+		mmListCatalogRuns.defaultExpectation = &ArtifactPublicServiceClientMockListCatalogRunsExpectation{}
+	}
+
+	if mmListCatalogRuns.defaultExpectation.params != nil {
+		mmListCatalogRuns.mock.t.Fatalf("ArtifactPublicServiceClientMock.ListCatalogRuns mock is already set by Expect")
+	}
+
+	if mmListCatalogRuns.defaultExpectation.paramPtrs == nil {
+		mmListCatalogRuns.defaultExpectation.paramPtrs = &ArtifactPublicServiceClientMockListCatalogRunsParamPtrs{}
+	}
+	mmListCatalogRuns.defaultExpectation.paramPtrs.ctx = &ctx
+	mmListCatalogRuns.defaultExpectation.expectationOrigins.originCtx = minimock.CallerInfo(1)
+
+	return mmListCatalogRuns
+}
+
+// ExpectInParam2 sets up expected param in for ArtifactPublicServiceClient.ListCatalogRuns
+func (mmListCatalogRuns *mArtifactPublicServiceClientMockListCatalogRuns) ExpectInParam2(in *mm_artifactv1alpha.ListCatalogRunsRequest) *mArtifactPublicServiceClientMockListCatalogRuns {
+	if mmListCatalogRuns.mock.funcListCatalogRuns != nil {
+		mmListCatalogRuns.mock.t.Fatalf("ArtifactPublicServiceClientMock.ListCatalogRuns mock is already set by Set")
+	}
+
+	if mmListCatalogRuns.defaultExpectation == nil {
+		mmListCatalogRuns.defaultExpectation = &ArtifactPublicServiceClientMockListCatalogRunsExpectation{}
+	}
+
+	if mmListCatalogRuns.defaultExpectation.params != nil {
+		mmListCatalogRuns.mock.t.Fatalf("ArtifactPublicServiceClientMock.ListCatalogRuns mock is already set by Expect")
+	}
+
+	if mmListCatalogRuns.defaultExpectation.paramPtrs == nil {
+		mmListCatalogRuns.defaultExpectation.paramPtrs = &ArtifactPublicServiceClientMockListCatalogRunsParamPtrs{}
+	}
+	mmListCatalogRuns.defaultExpectation.paramPtrs.in = &in
+	mmListCatalogRuns.defaultExpectation.expectationOrigins.originIn = minimock.CallerInfo(1)
+
+	return mmListCatalogRuns
+}
+
+// ExpectOptsParam3 sets up expected param opts for ArtifactPublicServiceClient.ListCatalogRuns
+func (mmListCatalogRuns *mArtifactPublicServiceClientMockListCatalogRuns) ExpectOptsParam3(opts ...grpc.CallOption) *mArtifactPublicServiceClientMockListCatalogRuns {
+	if mmListCatalogRuns.mock.funcListCatalogRuns != nil {
+		mmListCatalogRuns.mock.t.Fatalf("ArtifactPublicServiceClientMock.ListCatalogRuns mock is already set by Set")
+	}
+
+	if mmListCatalogRuns.defaultExpectation == nil {
+		mmListCatalogRuns.defaultExpectation = &ArtifactPublicServiceClientMockListCatalogRunsExpectation{}
+	}
+
+	if mmListCatalogRuns.defaultExpectation.params != nil {
+		mmListCatalogRuns.mock.t.Fatalf("ArtifactPublicServiceClientMock.ListCatalogRuns mock is already set by Expect")
+	}
+
+	if mmListCatalogRuns.defaultExpectation.paramPtrs == nil {
+		mmListCatalogRuns.defaultExpectation.paramPtrs = &ArtifactPublicServiceClientMockListCatalogRunsParamPtrs{}
+	}
+	mmListCatalogRuns.defaultExpectation.paramPtrs.opts = &opts
+	mmListCatalogRuns.defaultExpectation.expectationOrigins.originOpts = minimock.CallerInfo(1)
+
+	return mmListCatalogRuns
+}
+
+// Inspect accepts an inspector function that has same arguments as the ArtifactPublicServiceClient.ListCatalogRuns
+func (mmListCatalogRuns *mArtifactPublicServiceClientMockListCatalogRuns) Inspect(f func(ctx context.Context, in *mm_artifactv1alpha.ListCatalogRunsRequest, opts ...grpc.CallOption)) *mArtifactPublicServiceClientMockListCatalogRuns {
+	if mmListCatalogRuns.mock.inspectFuncListCatalogRuns != nil {
+		mmListCatalogRuns.mock.t.Fatalf("Inspect function is already set for ArtifactPublicServiceClientMock.ListCatalogRuns")
+	}
+
+	mmListCatalogRuns.mock.inspectFuncListCatalogRuns = f
+
+	return mmListCatalogRuns
+}
+
+// Return sets up results that will be returned by ArtifactPublicServiceClient.ListCatalogRuns
+func (mmListCatalogRuns *mArtifactPublicServiceClientMockListCatalogRuns) Return(lp1 *mm_artifactv1alpha.ListCatalogRunsResponse, err error) *ArtifactPublicServiceClientMock {
+	if mmListCatalogRuns.mock.funcListCatalogRuns != nil {
+		mmListCatalogRuns.mock.t.Fatalf("ArtifactPublicServiceClientMock.ListCatalogRuns mock is already set by Set")
+	}
+
+	if mmListCatalogRuns.defaultExpectation == nil {
+		mmListCatalogRuns.defaultExpectation = &ArtifactPublicServiceClientMockListCatalogRunsExpectation{mock: mmListCatalogRuns.mock}
+	}
+	mmListCatalogRuns.defaultExpectation.results = &ArtifactPublicServiceClientMockListCatalogRunsResults{lp1, err}
+	mmListCatalogRuns.defaultExpectation.returnOrigin = minimock.CallerInfo(1)
+	return mmListCatalogRuns.mock
+}
+
+// Set uses given function f to mock the ArtifactPublicServiceClient.ListCatalogRuns method
+func (mmListCatalogRuns *mArtifactPublicServiceClientMockListCatalogRuns) Set(f func(ctx context.Context, in *mm_artifactv1alpha.ListCatalogRunsRequest, opts ...grpc.CallOption) (lp1 *mm_artifactv1alpha.ListCatalogRunsResponse, err error)) *ArtifactPublicServiceClientMock {
+	if mmListCatalogRuns.defaultExpectation != nil {
+		mmListCatalogRuns.mock.t.Fatalf("Default expectation is already set for the ArtifactPublicServiceClient.ListCatalogRuns method")
+	}
+
+	if len(mmListCatalogRuns.expectations) > 0 {
+		mmListCatalogRuns.mock.t.Fatalf("Some expectations are already set for the ArtifactPublicServiceClient.ListCatalogRuns method")
+	}
+
+	mmListCatalogRuns.mock.funcListCatalogRuns = f
+	mmListCatalogRuns.mock.funcListCatalogRunsOrigin = minimock.CallerInfo(1)
+	return mmListCatalogRuns.mock
+}
+
+// When sets expectation for the ArtifactPublicServiceClient.ListCatalogRuns which will trigger the result defined by the following
+// Then helper
+func (mmListCatalogRuns *mArtifactPublicServiceClientMockListCatalogRuns) When(ctx context.Context, in *mm_artifactv1alpha.ListCatalogRunsRequest, opts ...grpc.CallOption) *ArtifactPublicServiceClientMockListCatalogRunsExpectation {
+	if mmListCatalogRuns.mock.funcListCatalogRuns != nil {
+		mmListCatalogRuns.mock.t.Fatalf("ArtifactPublicServiceClientMock.ListCatalogRuns mock is already set by Set")
+	}
+
+	expectation := &ArtifactPublicServiceClientMockListCatalogRunsExpectation{
+		mock:               mmListCatalogRuns.mock,
+		params:             &ArtifactPublicServiceClientMockListCatalogRunsParams{ctx, in, opts},
+		expectationOrigins: ArtifactPublicServiceClientMockListCatalogRunsExpectationOrigins{origin: minimock.CallerInfo(1)},
+	}
+	mmListCatalogRuns.expectations = append(mmListCatalogRuns.expectations, expectation)
+	return expectation
+}
+
+// Then sets up ArtifactPublicServiceClient.ListCatalogRuns return parameters for the expectation previously defined by the When method
+func (e *ArtifactPublicServiceClientMockListCatalogRunsExpectation) Then(lp1 *mm_artifactv1alpha.ListCatalogRunsResponse, err error) *ArtifactPublicServiceClientMock {
+	e.results = &ArtifactPublicServiceClientMockListCatalogRunsResults{lp1, err}
+	return e.mock
+}
+
+// Times sets number of times ArtifactPublicServiceClient.ListCatalogRuns should be invoked
+func (mmListCatalogRuns *mArtifactPublicServiceClientMockListCatalogRuns) Times(n uint64) *mArtifactPublicServiceClientMockListCatalogRuns {
+	if n == 0 {
+		mmListCatalogRuns.mock.t.Fatalf("Times of ArtifactPublicServiceClientMock.ListCatalogRuns mock can not be zero")
+	}
+	mm_atomic.StoreUint64(&mmListCatalogRuns.expectedInvocations, n)
+	mmListCatalogRuns.expectedInvocationsOrigin = minimock.CallerInfo(1)
+	return mmListCatalogRuns
+}
+
+func (mmListCatalogRuns *mArtifactPublicServiceClientMockListCatalogRuns) invocationsDone() bool {
+	if len(mmListCatalogRuns.expectations) == 0 && mmListCatalogRuns.defaultExpectation == nil && mmListCatalogRuns.mock.funcListCatalogRuns == nil {
+		return true
+	}
+
+	totalInvocations := mm_atomic.LoadUint64(&mmListCatalogRuns.mock.afterListCatalogRunsCounter)
+	expectedInvocations := mm_atomic.LoadUint64(&mmListCatalogRuns.expectedInvocations)
+
+	return totalInvocations > 0 && (expectedInvocations == 0 || expectedInvocations == totalInvocations)
+}
+
+// ListCatalogRuns implements mm_artifactv1alpha.ArtifactPublicServiceClient
+func (mmListCatalogRuns *ArtifactPublicServiceClientMock) ListCatalogRuns(ctx context.Context, in *mm_artifactv1alpha.ListCatalogRunsRequest, opts ...grpc.CallOption) (lp1 *mm_artifactv1alpha.ListCatalogRunsResponse, err error) {
+	mm_atomic.AddUint64(&mmListCatalogRuns.beforeListCatalogRunsCounter, 1)
+	defer mm_atomic.AddUint64(&mmListCatalogRuns.afterListCatalogRunsCounter, 1)
+
+	mmListCatalogRuns.t.Helper()
+
+	if mmListCatalogRuns.inspectFuncListCatalogRuns != nil {
+		mmListCatalogRuns.inspectFuncListCatalogRuns(ctx, in, opts...)
+	}
+
+	mm_params := ArtifactPublicServiceClientMockListCatalogRunsParams{ctx, in, opts}
+
+	// Record call args
+	mmListCatalogRuns.ListCatalogRunsMock.mutex.Lock()
+	mmListCatalogRuns.ListCatalogRunsMock.callArgs = append(mmListCatalogRuns.ListCatalogRunsMock.callArgs, &mm_params)
+	mmListCatalogRuns.ListCatalogRunsMock.mutex.Unlock()
+
+	for _, e := range mmListCatalogRuns.ListCatalogRunsMock.expectations {
+		if minimock.Equal(*e.params, mm_params) {
+			mm_atomic.AddUint64(&e.Counter, 1)
+			return e.results.lp1, e.results.err
+		}
+	}
+
+	if mmListCatalogRuns.ListCatalogRunsMock.defaultExpectation != nil {
+		mm_atomic.AddUint64(&mmListCatalogRuns.ListCatalogRunsMock.defaultExpectation.Counter, 1)
+		mm_want := mmListCatalogRuns.ListCatalogRunsMock.defaultExpectation.params
+		mm_want_ptrs := mmListCatalogRuns.ListCatalogRunsMock.defaultExpectation.paramPtrs
+
+		mm_got := ArtifactPublicServiceClientMockListCatalogRunsParams{ctx, in, opts}
+
+		if mm_want_ptrs != nil {
+
+			if mm_want_ptrs.ctx != nil && !minimock.Equal(*mm_want_ptrs.ctx, mm_got.ctx) {
+				mmListCatalogRuns.t.Errorf("ArtifactPublicServiceClientMock.ListCatalogRuns got unexpected parameter ctx, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmListCatalogRuns.ListCatalogRunsMock.defaultExpectation.expectationOrigins.originCtx, *mm_want_ptrs.ctx, mm_got.ctx, minimock.Diff(*mm_want_ptrs.ctx, mm_got.ctx))
+			}
+
+			if mm_want_ptrs.in != nil && !minimock.Equal(*mm_want_ptrs.in, mm_got.in) {
+				mmListCatalogRuns.t.Errorf("ArtifactPublicServiceClientMock.ListCatalogRuns got unexpected parameter in, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmListCatalogRuns.ListCatalogRunsMock.defaultExpectation.expectationOrigins.originIn, *mm_want_ptrs.in, mm_got.in, minimock.Diff(*mm_want_ptrs.in, mm_got.in))
+			}
+
+			if mm_want_ptrs.opts != nil && !minimock.Equal(*mm_want_ptrs.opts, mm_got.opts) {
+				mmListCatalogRuns.t.Errorf("ArtifactPublicServiceClientMock.ListCatalogRuns got unexpected parameter opts, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmListCatalogRuns.ListCatalogRunsMock.defaultExpectation.expectationOrigins.originOpts, *mm_want_ptrs.opts, mm_got.opts, minimock.Diff(*mm_want_ptrs.opts, mm_got.opts))
+			}
+
+		} else if mm_want != nil && !minimock.Equal(*mm_want, mm_got) {
+			mmListCatalogRuns.t.Errorf("ArtifactPublicServiceClientMock.ListCatalogRuns got unexpected parameters, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+				mmListCatalogRuns.ListCatalogRunsMock.defaultExpectation.expectationOrigins.origin, *mm_want, mm_got, minimock.Diff(*mm_want, mm_got))
+		}
+
+		mm_results := mmListCatalogRuns.ListCatalogRunsMock.defaultExpectation.results
+		if mm_results == nil {
+			mmListCatalogRuns.t.Fatal("No results are set for the ArtifactPublicServiceClientMock.ListCatalogRuns")
+		}
+		return (*mm_results).lp1, (*mm_results).err
+	}
+	if mmListCatalogRuns.funcListCatalogRuns != nil {
+		return mmListCatalogRuns.funcListCatalogRuns(ctx, in, opts...)
+	}
+	mmListCatalogRuns.t.Fatalf("Unexpected call to ArtifactPublicServiceClientMock.ListCatalogRuns. %v %v %v", ctx, in, opts)
+	return
+}
+
+// ListCatalogRunsAfterCounter returns a count of finished ArtifactPublicServiceClientMock.ListCatalogRuns invocations
+func (mmListCatalogRuns *ArtifactPublicServiceClientMock) ListCatalogRunsAfterCounter() uint64 {
+	return mm_atomic.LoadUint64(&mmListCatalogRuns.afterListCatalogRunsCounter)
+}
+
+// ListCatalogRunsBeforeCounter returns a count of ArtifactPublicServiceClientMock.ListCatalogRuns invocations
+func (mmListCatalogRuns *ArtifactPublicServiceClientMock) ListCatalogRunsBeforeCounter() uint64 {
+	return mm_atomic.LoadUint64(&mmListCatalogRuns.beforeListCatalogRunsCounter)
+}
+
+// Calls returns a list of arguments used in each call to ArtifactPublicServiceClientMock.ListCatalogRuns.
+// The list is in the same order as the calls were made (i.e. recent calls have a higher index)
+func (mmListCatalogRuns *mArtifactPublicServiceClientMockListCatalogRuns) Calls() []*ArtifactPublicServiceClientMockListCatalogRunsParams {
+	mmListCatalogRuns.mutex.RLock()
+
+	argCopy := make([]*ArtifactPublicServiceClientMockListCatalogRunsParams, len(mmListCatalogRuns.callArgs))
+	copy(argCopy, mmListCatalogRuns.callArgs)
+
+	mmListCatalogRuns.mutex.RUnlock()
+
+	return argCopy
+}
+
+// MinimockListCatalogRunsDone returns true if the count of the ListCatalogRuns invocations corresponds
+// the number of defined expectations
+func (m *ArtifactPublicServiceClientMock) MinimockListCatalogRunsDone() bool {
+	if m.ListCatalogRunsMock.optional {
+		// Optional methods provide '0 or more' call count restriction.
+		return true
+	}
+
+	for _, e := range m.ListCatalogRunsMock.expectations {
+		if mm_atomic.LoadUint64(&e.Counter) < 1 {
+			return false
+		}
+	}
+
+	return m.ListCatalogRunsMock.invocationsDone()
+}
+
+// MinimockListCatalogRunsInspect logs each unmet expectation
+func (m *ArtifactPublicServiceClientMock) MinimockListCatalogRunsInspect() {
+	for _, e := range m.ListCatalogRunsMock.expectations {
+		if mm_atomic.LoadUint64(&e.Counter) < 1 {
+			m.t.Errorf("Expected call to ArtifactPublicServiceClientMock.ListCatalogRuns at\n%s with params: %#v", e.expectationOrigins.origin, *e.params)
+		}
+	}
+
+	afterListCatalogRunsCounter := mm_atomic.LoadUint64(&m.afterListCatalogRunsCounter)
+	// if default expectation was set then invocations count should be greater than zero
+	if m.ListCatalogRunsMock.defaultExpectation != nil && afterListCatalogRunsCounter < 1 {
+		if m.ListCatalogRunsMock.defaultExpectation.params == nil {
+			m.t.Errorf("Expected call to ArtifactPublicServiceClientMock.ListCatalogRuns at\n%s", m.ListCatalogRunsMock.defaultExpectation.returnOrigin)
+		} else {
+			m.t.Errorf("Expected call to ArtifactPublicServiceClientMock.ListCatalogRuns at\n%s with params: %#v", m.ListCatalogRunsMock.defaultExpectation.expectationOrigins.origin, *m.ListCatalogRunsMock.defaultExpectation.params)
+		}
+	}
+	// if func was set then invocations count should be greater than zero
+	if m.funcListCatalogRuns != nil && afterListCatalogRunsCounter < 1 {
+		m.t.Errorf("Expected call to ArtifactPublicServiceClientMock.ListCatalogRuns at\n%s", m.funcListCatalogRunsOrigin)
+	}
+
+	if !m.ListCatalogRunsMock.invocationsDone() && afterListCatalogRunsCounter > 0 {
+		m.t.Errorf("Expected %d calls to ArtifactPublicServiceClientMock.ListCatalogRuns at\n%s but found %d calls",
+			mm_atomic.LoadUint64(&m.ListCatalogRunsMock.expectedInvocations), m.ListCatalogRunsMock.expectedInvocationsOrigin, afterListCatalogRunsCounter)
 	}
 }
 
@@ -6192,6 +6576,8 @@ func (m *ArtifactPublicServiceClientMock) MinimockFinish() {
 
 			m.MinimockListCatalogFilesInspect()
 
+			m.MinimockListCatalogRunsInspect()
+
 			m.MinimockListCatalogsInspect()
 
 			m.MinimockListChunksInspect()
@@ -6240,6 +6626,7 @@ func (m *ArtifactPublicServiceClientMock) minimockDone() bool {
 		m.MinimockGetFileCatalogDone() &&
 		m.MinimockGetSourceFileDone() &&
 		m.MinimockListCatalogFilesDone() &&
+		m.MinimockListCatalogRunsDone() &&
 		m.MinimockListCatalogsDone() &&
 		m.MinimockListChunksDone() &&
 		m.MinimockLivenessDone() &&

--- a/pkg/datamodel/datamodel.go
+++ b/pkg/datamodel/datamodel.go
@@ -619,6 +619,7 @@ type Connection struct {
 	NamespaceUID       uuid.UUID
 	IntegrationUID     uuid.UUID
 	Method             ConnectionMethod
+	Identity           sql.NullString
 	Setup              datatypes.JSON      `gorm:"type:jsonb"`
 	Scopes             pq.StringArray      `gorm:"type:text[]"`
 	OAuthAccessDetails datatypes.JSON      `gorm:"type:jsonb"`

--- a/pkg/db/migration/000030_connection_identity.down.sql
+++ b/pkg/db/migration/000030_connection_identity.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE connection DROP COLUMN IF EXISTS identity;
+
+COMMIT;

--- a/pkg/db/migration/000030_connection_identity.up.sql
+++ b/pkg/db/migration/000030_connection_identity.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE connection ADD COLUMN IF NOT EXISTS identity TEXT;
+
+COMMIT;

--- a/pkg/service/integration.go
+++ b/pkg/service/integration.go
@@ -194,6 +194,9 @@ func (s *service) validateConnection(conn *pb.Connection, integration *pb.Integr
 	switch conn.GetMethod() {
 	case pb.Connection_METHOD_DICTIONARY:
 		err := fmt.Errorf("%w: invalid payload in dictionary connection", errdomain.ErrInvalidArgument)
+		if integration.GetOAuthConfig() != nil {
+			return errmsg.AddMessage(err, integration.GetTitle()+" connection only accepts METHOD_OAUTH.")
+		}
 		if len(conn.GetScopes()) > 0 {
 			return errmsg.AddMessage(err, "Scopes only apply to OAuth connections.")
 		}

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -1885,7 +1885,7 @@ func (s *service) ListPipelineRuns(ctx context.Context, req *pipelinepb.ListPipe
 
 	return &pipelinepb.ListPipelineRunsResponse{
 		PipelineRuns: pbPipelineRuns,
-		TotalSize:    totalCount,
+		TotalSize:    int32(totalCount),
 		Page:         int32(page),
 		PageSize:     int32(pageSize),
 	}, nil
@@ -1985,7 +1985,7 @@ func (s *service) ListComponentRuns(ctx context.Context, req *pipelinepb.ListCom
 
 	return &pipelinepb.ListComponentRunsResponse{
 		ComponentRuns: pbComponentRuns,
-		TotalSize:     totalCount,
+		TotalSize:     int32(totalCount),
 		Page:          int32(page),
 		PageSize:      int32(pageSize),
 	}, nil

--- a/pkg/service/utils.go
+++ b/pkg/service/utils.go
@@ -114,23 +114,6 @@ func (s *service) convertPipelineRunToPB(run datamodel.PipelineRun) (*pipelinepb
 		result.CompleteTime = timestamppb.New(run.CompletedTime.Time)
 	}
 
-	for _, fileReference := range run.Inputs {
-		result.InputsReference = append(result.InputsReference, &pipelinepb.FileReference{
-			Name: fileReference.Name,
-			Type: fileReference.Type,
-			Size: fileReference.Size,
-			Url:  fileReference.URL,
-		})
-	}
-	for _, fileReference := range run.Outputs {
-		result.OutputsReference = append(result.OutputsReference, &pipelinepb.FileReference{
-			Name: fileReference.Name,
-			Type: fileReference.Type,
-			Size: fileReference.Size,
-			Url:  fileReference.URL,
-		})
-	}
-
 	return result, nil
 }
 


### PR DESCRIPTION
Because

- When a user authorizes an Instill component using OAuth, we want to
display the identity that they used.

This commit

- Adds identity information to OAuth connections.
- Makes OAuth method the only accepted one for connections if it's
  supported.
