### PR TITLE
chore(component): increase OpenAI request timeout

### DIFF
--- a/pkg/component/ai/openai/v0/main.go
+++ b/pkg/component/ai/openai/v0/main.go
@@ -141,6 +141,7 @@ func (e *execution) worker(ctx context.Context, client *httpclient.Client, job *
 
 	switch e.Task {
 	case TextGenerationTask:
+		client.SetTimeout(30 * time.Minute)
 		inputStruct := TextCompletionInput{}
 		err := base.ConvertFromStructpb(input, &inputStruct)
 		if err != nil {


### PR DESCRIPTION
Because

- The OpenAI request timeout is too short for handling text generation effectively.

This commit

- Increases the OpenAI request timeout duration.