### PR TITLE
chore: hide preset pipelines in `GET /pipelines` requests

### DIFF
--- a/cmd/init/presetdownloader/downloader.go
+++ b/cmd/init/presetdownloader/downloader.go
@@ -31,11 +31,6 @@ import (
 	pipelinepb "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
 
-// The ID and UID within the preset namespace must consistently match between
-// mgmt and pipeline-backend.
-const PresetNamespaceID = "preset"
-const PresetNamespaceUID = "63196cec-1c95-49e8-9bf6-9f9497a15f72"
-
 func DownloadPresetPipelines(ctx context.Context, repo repository.Repository) error {
 	// In Instill Cloud, we have a special organization called `preset`, which
 	// stores all the preset pipelines that users can use or clone. We also want
@@ -124,14 +119,14 @@ func DownloadPresetPipelines(ctx context.Context, repo repository.Repository) er
 
 	ns := resource.Namespace{
 		NsType: resource.Organization,
-		NsID:   PresetNamespaceID,
-		NsUID:  uuid.FromStringOrNil(PresetNamespaceUID),
+		NsID:   constant.PresetNamespaceID,
+		NsUID:  uuid.FromStringOrNil(constant.PresetNamespaceUID),
 	}
 	pageToken := ""
 	for {
 		//nolint:staticcheck
 		resp, err := cloudPipelineClient.ListOrganizationPipelines(ctx, &pipelinepb.ListOrganizationPipelinesRequest{
-			Parent:    fmt.Sprintf("organizations/%s", PresetNamespaceID),
+			Parent:    fmt.Sprintf("organizations/%s", constant.PresetNamespaceUID),
 			View:      pipelinepb.Pipeline_VIEW_RECIPE.Enum(),
 			PageToken: &pageToken,
 		})
@@ -188,7 +183,7 @@ func DownloadPresetPipelines(ctx context.Context, repo repository.Repository) er
 			for {
 				//nolint:staticcheck
 				releaseResp, err := cloudPipelineClient.ListOrganizationPipelineReleases(ctx, &pipelinepb.ListOrganizationPipelineReleasesRequest{
-					Parent:    fmt.Sprintf("organizations/%s/pipelines/%s", PresetNamespaceID, dbPipeline.ID),
+					Parent:    fmt.Sprintf("organizations/%s/pipelines/%s", constant.PresetNamespaceUID, dbPipeline.ID),
 					View:      pipelinepb.Pipeline_VIEW_RECIPE.Enum(),
 					PageToken: &releasePageToken,
 				})

--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -55,3 +55,10 @@ const ContentTypeJSON = "application/json"
 // Given this configuration, a component will override the value of a parameter
 // with its global secret when it finds this keyword.
 const GlobalSecretKey = "INSTILL_SECRET"
+
+// The ID and UID within the preset namespace must consistently match between
+// mgmt and pipeline-backend.
+const (
+	PresetNamespaceID  = "preset"
+	PresetNamespaceUID = "63196cec-1c95-49e8-9bf6-9f9497a15f72"
+)

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -398,9 +398,12 @@ func (r *repository) listPipelines(ctx context.Context, where string, whereArgs 
 }
 
 func (r *repository) ListPipelines(ctx context.Context, pageSize int64, pageToken string, isBasicView bool, filter filtering.Filter, uidAllowList []uuid.UUID, showDeleted bool, embedReleases bool, order ordering.OrderBy) ([]*datamodel.Pipeline, int64, string, error) {
+	// Note: Preset pipelines are ignored in `GET /pipelines` requests. These
+	// pipelines are used by the artifact backend and should not be directly
+	// exposed to users.
 	return r.listPipelines(ctx,
-		"",
-		[]interface{}{},
+		"(owner != ?)",
+		[]interface{}{fmt.Sprintf("organizations/%s", constant.PresetNamespaceUID)},
 		pageSize, pageToken, isBasicView, filter, uidAllowList, showDeleted, embedReleases, order)
 }
 func (r *repository) ListNamespacePipelines(ctx context.Context, ownerPermalink string, pageSize int64, pageToken string, isBasicView bool, filter filtering.Filter, uidAllowList []uuid.UUID, showDeleted bool, embedReleases bool, order ordering.OrderBy) ([]*datamodel.Pipeline, int64, string, error) {


### PR DESCRIPTION
Because

- Preset pipelines should be hided in `GET /pipelines` requests. These pipelines are used by the artifact backend and should not be directly exposed to users.

This commit

- hides preset pipelines in `GET /pipelines` requests
