### PR TITLE
fix(integration): update GitHub scopes to read/write repository issues

### DIFF
--- a/pkg/component/application/github/v0/config/setup.json
+++ b/pkg/component/application/github/v0/config/setup.json
@@ -26,7 +26,7 @@
     "authUrl": "https://github.com/login/oauth/authorize",
     "accessUrl": "https://github.com/login/oauth/access_token",
     "scopes": [
-      "repo:status",
+      "repo",
       "write:repo_hook"
     ]
   },

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -1485,6 +1485,7 @@ func (r *repository) ListPipelineIDsByConnectionID(
 	queryBuilder := db.Table("pipeline").
 		Where(where, whereArgs...).
 		Where("recipe_yaml LIKE ?", reference).
+		Where("delete_time IS NULL").
 		Where("owner = ?", p.Owner.Permalink())
 
 	var count int64


### PR DESCRIPTION
Because

- GitHub component's `TASK_CREATE_ISSUE` didn't work with an OAuth connection.

This commit

- Updates the OAuth token scopes to allow issue creation / view.
- Additionally, updates the `ListPipelinesByConnectionID` endpoint to return only non-deleted pipelines.
