### PR TITLE
feat: use explicit parameter for target namespace when cloning pipeline

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/iFaceless/godub v0.0.0-20200728093528-a30bb4d1a0f1
 	github.com/iancoleman/strcase v0.3.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241004133602-c424edaba4a3
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241007141417-545e5d187408
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.4.0-alpha.0.20241003075514-5ced228b7498
 	github.com/itchyny/gojq v0.12.14

--- a/go.sum
+++ b/go.sum
@@ -1275,8 +1275,8 @@ github.com/influxdata/influxdb-client-go/v2 v2.12.3 h1:28nRlNMRIV4QbtIUvxhWqaxn0
 github.com/influxdata/influxdb-client-go/v2 v2.12.3/go.mod h1:IrrLUbCjjfkmRuaCiGQg4m2GbkaeJDcuWoxiWdQEbA0=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241004133602-c424edaba4a3 h1:Vk5CiAq09EcPBHam+Xv71ot3gkvJKuAqtxOaQxXO8Bc=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241004133602-c424edaba4a3/go.mod h1:rf0UY7VpEgpaLudYEcjx5rnbuwlBaaLyD4FQmWLtgAY=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241007141417-545e5d187408 h1:GTx0g6dXxd7WUm4bvJK1N+j8zuxIaSoXD5AZ2Vl+FXI=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241007141417-545e5d187408/go.mod h1:rf0UY7VpEgpaLudYEcjx5rnbuwlBaaLyD4FQmWLtgAY=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a/go.mod h1:EpX3Yr661uWULtZf5UnJHfr5rw2PDyX8ku4Kx0UtYFw=
 github.com/instill-ai/x v0.4.0-alpha.0.20241003075514-5ced228b7498 h1:Wc6nbDoIQDiAZDipfog8xCu+BdEiLNK0MLaHxhjWubY=

--- a/pkg/handler/pipeline.go
+++ b/pkg/handler/pipeline.go
@@ -851,32 +851,6 @@ func (h *PublicHandler) RenameNamespacePipeline(ctx context.Context, req *pb.Ren
 	return &pb.RenameNamespacePipelineResponse{Pipeline: pbPipeline}, nil
 }
 
-func (h *PublicHandler) CloneUserPipeline(ctx context.Context, req *pb.CloneUserPipelineRequest) (resp *pb.CloneUserPipelineResponse, err error) {
-	_, err = h.CloneNamespacePipeline(ctx, &pb.CloneNamespacePipelineRequest{
-		NamespaceId: strings.Split(req.Name, "/")[1],
-		PipelineId:  strings.Split(req.Name, "/")[3],
-		Target:      req.Target,
-		Description: req.Description,
-	})
-	if err != nil {
-		return nil, err
-	}
-	return &pb.CloneUserPipelineResponse{}, nil
-}
-
-func (h *PublicHandler) CloneOrganizationPipeline(ctx context.Context, req *pb.CloneOrganizationPipelineRequest) (resp *pb.CloneOrganizationPipelineResponse, err error) {
-	_, err = h.CloneNamespacePipeline(ctx, &pb.CloneNamespacePipelineRequest{
-		NamespaceId: strings.Split(req.Name, "/")[1],
-		PipelineId:  strings.Split(req.Name, "/")[3],
-		Target:      req.Target,
-		Description: req.Description,
-	})
-	if err != nil {
-		return nil, err
-	}
-	return &pb.CloneOrganizationPipelineResponse{}, nil
-}
-
 func (h *PublicHandler) CloneNamespacePipeline(ctx context.Context, req *pb.CloneNamespacePipelineRequest) (*pb.CloneNamespacePipelineResponse, error) {
 
 	eventName := "CloneNamespacePipeline"
@@ -899,7 +873,15 @@ func (h *PublicHandler) CloneNamespacePipeline(ctx context.Context, req *pb.Clon
 		return nil, err
 	}
 
-	pbPipeline, err := h.service.CloneNamespacePipeline(ctx, ns, req.PipelineId, req.GetTarget(), req.GetDescription(), req.GetSharing())
+	pbPipeline, err := h.service.CloneNamespacePipeline(
+		ctx,
+		ns,
+		req.PipelineId,
+		req.GetTargetNamespaceId(),
+		req.GetTargetPipelineId(),
+		req.GetDescription(),
+		req.GetSharing(),
+	)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err
@@ -913,34 +895,6 @@ func (h *PublicHandler) CloneNamespacePipeline(ctx context.Context, req *pb.Clon
 		customotel.SetEventResource(pbPipeline),
 	)))
 	return &pb.CloneNamespacePipelineResponse{}, nil
-}
-
-func (h *PublicHandler) CloneUserPipelineRelease(ctx context.Context, req *pb.CloneUserPipelineReleaseRequest) (resp *pb.CloneUserPipelineReleaseResponse, err error) {
-	_, err = h.CloneNamespacePipelineRelease(ctx, &pb.CloneNamespacePipelineReleaseRequest{
-		NamespaceId: strings.Split(req.Name, "/")[1],
-		PipelineId:  strings.Split(req.Name, "/")[3],
-		ReleaseId:   strings.Split(req.Name, "/")[5],
-		Target:      req.Target,
-		Description: req.Description,
-	})
-	if err != nil {
-		return nil, err
-	}
-	return &pb.CloneUserPipelineReleaseResponse{}, nil
-}
-
-func (h *PublicHandler) CloneOrganizationPipelineRelease(ctx context.Context, req *pb.CloneOrganizationPipelineReleaseRequest) (resp *pb.CloneOrganizationPipelineReleaseResponse, err error) {
-	_, err = h.CloneNamespacePipelineRelease(ctx, &pb.CloneNamespacePipelineReleaseRequest{
-		NamespaceId: strings.Split(req.Name, "/")[1],
-		PipelineId:  strings.Split(req.Name, "/")[3],
-		ReleaseId:   strings.Split(req.Name, "/")[5],
-		Target:      req.Target,
-		Description: req.Description,
-	})
-	if err != nil {
-		return nil, err
-	}
-	return &pb.CloneOrganizationPipelineReleaseResponse{}, nil
 }
 
 func (h *PublicHandler) CloneNamespacePipelineRelease(ctx context.Context, req *pb.CloneNamespacePipelineReleaseRequest) (*pb.CloneNamespacePipelineReleaseResponse, error) {
@@ -968,7 +922,16 @@ func (h *PublicHandler) CloneNamespacePipelineRelease(ctx context.Context, req *
 		return nil, err
 	}
 
-	pbPipeline, err := h.service.CloneNamespacePipelineRelease(ctx, ns, uuid.FromStringOrNil(pipeline.Uid), req.ReleaseId, req.GetTarget(), req.GetDescription(), req.GetSharing())
+	pbPipeline, err := h.service.CloneNamespacePipelineRelease(
+		ctx,
+		ns,
+		uuid.FromStringOrNil(pipeline.Uid),
+		req.ReleaseId,
+		req.GetTargetNamespaceId(),
+		req.GetTargetPipelineId(),
+		req.GetDescription(),
+		req.GetSharing(),
+	)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return nil, err

--- a/pkg/service/main.go
+++ b/pkg/service/main.go
@@ -37,7 +37,7 @@ type Service interface {
 	DeleteNamespacePipelineByID(ctx context.Context, ns resource.Namespace, id string) error
 	ValidateNamespacePipelineByID(ctx context.Context, ns resource.Namespace, id string) ([]*pb.ErrPipelineValidation, error)
 	GetNamespacePipelineLatestReleaseUID(ctx context.Context, ns resource.Namespace, id string) (uuid.UUID, error)
-	CloneNamespacePipeline(ctx context.Context, ns resource.Namespace, id string, target string, description string, sharing *pb.Sharing) (*pb.Pipeline, error)
+	CloneNamespacePipeline(ctx context.Context, ns resource.Namespace, id, targetNamespaceID, targetPipelineID, description string, sharing *pb.Sharing) (*pb.Pipeline, error)
 
 	ListPipelinesAdmin(ctx context.Context, pageSize int32, pageToken string, view pb.Pipeline_View, filter filtering.Filter, showDeleted bool) ([]*pb.Pipeline, int32, string, error)
 	GetPipelineByUIDAdmin(ctx context.Context, uid uuid.UUID, view pb.Pipeline_View) (*pb.Pipeline, error)
@@ -49,7 +49,7 @@ type Service interface {
 	DeleteNamespacePipelineReleaseByID(ctx context.Context, ns resource.Namespace, pipelineUID uuid.UUID, id string) error
 	RestoreNamespacePipelineReleaseByID(ctx context.Context, ns resource.Namespace, pipelineUID uuid.UUID, id string) error
 	UpdateNamespacePipelineReleaseIDByID(ctx context.Context, ns resource.Namespace, pipelineUID uuid.UUID, id string, newID string) (*pb.PipelineRelease, error)
-	CloneNamespacePipelineRelease(ctx context.Context, ns resource.Namespace, pipelineUID uuid.UUID, id string, target string, description string, sharing *pb.Sharing) (*pb.Pipeline, error)
+	CloneNamespacePipelineRelease(ctx context.Context, ns resource.Namespace, pipelineUID uuid.UUID, id, targetNamespaceID, targetPipelineID, description string, sharing *pb.Sharing) (*pb.Pipeline, error)
 
 	CreateNamespaceSecret(ctx context.Context, ns resource.Namespace, secret *pb.Secret) (*pb.Secret, error)
 	ListNamespaceSecrets(ctx context.Context, ns resource.Namespace, pageSize int32, pageToken string, filter filtering.Filter) ([]*pb.Secret, int32, string, error)


### PR DESCRIPTION
Because

- Users should explicitly set the target namespace and pipeline ID when cloning a pipeline.

This commit

- Refactors parameters in the Clone API to support this functionality.