### PR TITLE
chore: add support for referencing array indices as strings

### DIFF
--- a/pkg/component/data/instillartifact/v0/artifact_operation.go
+++ b/pkg/component/data/instillartifact/v0/artifact_operation.go
@@ -63,8 +63,7 @@ func (e *execution) uploadFile(input *structpb.Struct) (*structpb.Struct, error)
 		return nil, fmt.Errorf("failed to convert input to struct: %w", err)
 	}
 
-	artifactClient, connection := e.client, e.connection
-	defer connection.Close()
+	artifactClient := e.client
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()

--- a/pkg/component/data/instillartifact/v0/main.go
+++ b/pkg/component/data/instillartifact/v0/main.go
@@ -94,5 +94,6 @@ func (c *component) CreateExecution(x base.ComponentExecution) (base.IExecution,
 }
 
 func (e *execution) Execute(ctx context.Context, jobs []*base.Job) error {
+	defer e.connection.Close()
 	return base.SequentialExecutor(ctx, jobs, e.execute)
 }

--- a/pkg/recipe/dag.go
+++ b/pkg/recipe/dag.go
@@ -219,6 +219,8 @@ func Render(ctx context.Context, template data.Value, batchIdx int, wfm memory.W
 			switch v := v.(type) {
 			case *data.String:
 				val += v.GetString()
+			case *data.Number:
+				val += strconv.FormatFloat(v.GetFloat(), 'f', -1, 64)
 			default:
 				b, err := json.Marshal(v)
 				if err != nil {

--- a/pkg/worker/utils.go
+++ b/pkg/worker/utils.go
@@ -28,9 +28,10 @@ func (w *worker) writeNewDataPoint(ctx context.Context, data utils.PipelineUsage
 }
 
 const (
-	rangeStart = "start"
-	rangeStop  = "stop"
-	rangeStep  = "step"
+	rangeStart             = "start"
+	rangeStop              = "stop"
+	rangeStep              = "step"
+	defaultRangeIdentifier = "i"
 )
 
 // setIteratorIndex converts the iterator index identifier into a numeric
@@ -38,7 +39,7 @@ const (
 // `${variable.array[0]}`.
 func setIteratorIndex(v data.Value, identifier string, index int) data.Value {
 	if identifier == "" {
-		identifier = "i"
+		identifier = defaultRangeIdentifier
 	}
 	switch v := v.(type) {
 	case *data.String:

--- a/pkg/worker/workflow.go
+++ b/pkg/worker/workflow.go
@@ -758,6 +758,17 @@ func (w *worker) PreIteratorActivity(ctx context.Context, param *PreIteratorActi
 					return nil, componentActivityError(ctx, wfm, err, preIteratorActivityErrorType, param.ID)
 				}
 			}
+		} else {
+			for e, rangeIndex := range indexes {
+				identifier := defaultRangeIdentifier
+				if param.Index != "" {
+					identifier = param.Index
+				}
+				err = childWFM.Set(ctx, e, identifier, data.NewNumberFromInteger(rangeIndex))
+				if err != nil {
+					return nil, componentActivityError(ctx, wfm, err, preIteratorActivityErrorType, param.ID)
+				}
+			}
 		}
 
 		for e, rangeIndex := range indexes {


### PR DESCRIPTION
Because

- We want to use the array index not only for bracket indexing but also as a variable.

This commit

- Adds support for referencing array indices as strings.
- Fixes instill-artifact client closing bug.