### PR TITLE
chore: fix preset downloader

### DIFF
--- a/cmd/init/presetdownloader/downloader.go
+++ b/cmd/init/presetdownloader/downloader.go
@@ -126,7 +126,7 @@ func DownloadPresetPipelines(ctx context.Context, repo repository.Repository) er
 	for {
 		//nolint:staticcheck
 		resp, err := cloudPipelineClient.ListOrganizationPipelines(ctx, &pipelinepb.ListOrganizationPipelinesRequest{
-			Parent:    fmt.Sprintf("organizations/%s", constant.PresetNamespaceUID),
+			Parent:    fmt.Sprintf("organizations/%s", constant.PresetNamespaceID),
 			View:      pipelinepb.Pipeline_VIEW_RECIPE.Enum(),
 			PageToken: &pageToken,
 		})
@@ -183,7 +183,7 @@ func DownloadPresetPipelines(ctx context.Context, repo repository.Repository) er
 			for {
 				//nolint:staticcheck
 				releaseResp, err := cloudPipelineClient.ListOrganizationPipelineReleases(ctx, &pipelinepb.ListOrganizationPipelineReleasesRequest{
-					Parent:    fmt.Sprintf("organizations/%s/pipelines/%s", constant.PresetNamespaceUID, dbPipeline.ID),
+					Parent:    fmt.Sprintf("organizations/%s/pipelines/%s", constant.PresetNamespaceID, dbPipeline.ID),
 					View:      pipelinepb.Pipeline_VIEW_RECIPE.Enum(),
 					PageToken: &releasePageToken,
 				})


### PR DESCRIPTION
Because

- The organization ID was incorrect when downloading the preset downloader.

This commit

- Fixes the bug.