### PR TITLE
chore(integration): temporarily remove Slack OAuth integration

### DIFF
--- a/pkg/component/application/slack/v0/config/setup.json
+++ b/pkg/component/application/slack/v0/config/setup.json
@@ -22,18 +22,6 @@
   "instillEditOnNodeFields": [
     "token"
   ],
-  "instillOAuthConfig": {
-    "authUrl": "https://slack.com/oauth/v2/authorize",
-    "accessUrl": "https://slack.com/api/oauth.v2.access",
-    "scopes": [
-      "channels:history",
-      "groups:history",
-      "chat:write",
-      "users:read",
-      "users:read.email",
-      "users.profile:read"
-    ]
-  },
   "title": "Slack Connection",
   "type": "object"
 }


### PR DESCRIPTION
Because

- We're going to need 2 OAuth tokens for Slack, one for the Instill App bot
  and another for the user.

This commit

- Temporarily removes the OAuth integration for Slack.
