### PR TITLE
fix: fix event for iterator input updates was not being sent

### DIFF
--- a/pkg/memory/memory.go
+++ b/pkg/memory/memory.go
@@ -473,7 +473,7 @@ func (wfm *workflowMemory) sendComponentEvent(ctx context.Context, batchIdx int,
 			if err != nil {
 				return err
 			}
-			var data map[string]any
+			var data any
 			err = json.Unmarshal(b, &data)
 			if err != nil {
 				return err


### PR DESCRIPTION
Because

- The event for iterator input updates was not being sent.

This commit

- Fixes the bug.