### PR TITLE
fix: fix he pipeline output streaming was not functioning properly

### DIFF
--- a/pkg/worker/workflow.go
+++ b/pkg/worker/workflow.go
@@ -545,7 +545,7 @@ func (w *worker) ComponentActivity(ctx context.Context, param *ComponentActivity
 		for idx, originalIdx := range conditionMap {
 			jobs[idx] = &componentbase.Job{
 				Input:  NewInputReader(wfm, param.ID, originalIdx),
-				Output: NewOutputWriter(wfm, param.ID, originalIdx, param.Streaming),
+				Output: NewOutputWriter(wfm, param.ID, originalIdx, wfm.IsStreaming()),
 				Error:  NewErrorHandler(wfm, param.ID, originalIdx),
 			}
 		}


### PR DESCRIPTION
Because

- The pipeline output streaming was not functioning properly.

This commit

- Fixes the bug.