### PR TITLE
feat(slack): allow posting messages as user or bot

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -26,7 +26,7 @@ database:
   host: pg-sql
   port: 5432
   name: pipeline
-  version: 30
+  version: 31
   timezone: Etc/UTC
   pool:
     idleconnections: 5

--- a/pkg/component/application/slack/v0/.compogen/extra-setup.mdx
+++ b/pkg/component/application/slack/v0/.compogen/extra-setup.mdx
@@ -1,0 +1,13 @@
+### Connecting through a Slack App
+
+The Slack component connects with your workspace via a [Slack
+App](https://api.slack.com/docs/apps). In order to read / write messages from / to Slack, you'll need to:
+
+- [Add the
+  app](https://slack.com/intl/en-gb/help/articles/202035138-Add-apps-to-your-Slack-workspace)
+  to your workspace.
+- Add the app to the channels you want to interact with.
+
+On **Instill Cloud**, the `instill-ai` app will be used fo connect with Slack.
+On **Instill Core**, you can provide the client ID and client secret of your
+app in order to connect with your workspace.

--- a/pkg/component/application/slack/v0/README.mdx
+++ b/pkg/component/application/slack/v0/README.mdx
@@ -32,10 +32,24 @@ ${connection.<my-connection-id>}`.
 
 | Field | Field ID | Type | Note |
 | :--- | :--- | :--- | :--- |
-| Token (required) | `token` | string | Fill in your Slack app access token. For more information about how to access to create app tokens, please refer to the Slack API documentation.  |
+| Bot OAuth Token (required) | `bot-token` | string | Token associated to the application bot  |
+| User OAuth Token | `user-token` | string | Token to act on behalf of a Slack user  |
 
 </div>
 
+### Connecting through a Slack App
+
+The Slack component connects with your workspace via a [Slack
+App](https://api.slack.com/docs/apps). In order to read / write messages from / to Slack, you'll need to:
+
+- [Add the
+  app](https://slack.com/intl/en-gb/help/articles/202035138-Add-apps-to-your-Slack-workspace)
+  to your workspace.
+- Add the app to the channels you want to interact with.
+
+On **Instill Cloud**, the `instill-ai` app will be used fo connect with Slack.
+On **Instill Core**, you can provide the client ID and client secret of your
+app in order to connect with your workspace.
 
 
 
@@ -50,8 +64,8 @@ Get the latest message since specific date
 | Input | ID | Type | Description |
 | :--- | :--- | :--- | :--- |
 | Task ID (required) | `task` | string | `TASK_READ_MESSAGE` |
-| Channel Name (required) | `channel-name` | string | A channel name display in Slack |
-| Start to read date | `start-to-read-date` | string | earliest date in all read messages |
+| Channel Name (required) | `channel-name` | string | Channel name, as displayed on Slack |
+| Start to read date | `start-to-read-date` | string | Date (in <code>YYYY-MM-DD<code> format) from which messages will start to be fetched |
 </div>
 
 
@@ -105,8 +119,9 @@ send message to a specific channel
 | Input | ID | Type | Description |
 | :--- | :--- | :--- | :--- |
 | Task ID (required) | `task` | string | `TASK_WRITE_MESSAGE` |
-| Channel Name (required) | `channel-name` | string | A channel name display in Slack |
-| Message (required) | `message` | string | message to be sent to the target channel |
+| Channel Name (required) | `channel-name` | string | Channel name, as displayed on Slack |
+| Message (required) | `message` | string | The message to be sent to the target channel |
+| Send As User | `as-user` | boolean | Send the message on behalf of the user identified by the <code>setup.user-token</code> field |
 </div>
 
 
@@ -118,5 +133,5 @@ send message to a specific channel
 
 | Output | ID | Type | Description |
 | :--- | :--- | :--- | :--- |
-| Result | `result` | string | result for sending message |
+| Result | `result` | string | Result of the message delivery |
 </div>

--- a/pkg/component/application/slack/v0/api_functions.go
+++ b/pkg/component/application/slack/v0/api_functions.go
@@ -102,12 +102,12 @@ func setAPIRespToReadTaskResp(apiResp []slack.Message, readTaskResp *ReadTaskRes
 			return err
 		}
 
-		startReadDate, err := time.Parse("2006-01-02", startReadDateString)
+		startReadDate, err := time.Parse(time.DateOnly, startReadDateString)
 		if err != nil {
 			return err
 		}
 
-		formatedDate, err := time.Parse("2006-01-02", formatedDateString)
+		formatedDate, err := time.Parse(time.DateOnly, formatedDateString)
 		if err != nil {
 			return err
 		}
@@ -132,7 +132,7 @@ func setAPIRespToReadTaskResp(apiResp []slack.Message, readTaskResp *ReadTaskRes
 
 func setRepliedToConversation(resp *ReadTaskResp, replies []slack.Message, idx int) error {
 	c := resp.Conversations[idx]
-	lastDay, err := time.Parse("2006-01-02", c.LastDate)
+	lastDay, err := time.Parse(time.DateOnly, c.LastDate)
 	if err != nil {
 		return err
 	}
@@ -157,13 +157,13 @@ func setRepliedToConversation(resp *ReadTaskResp, replies []slack.Message, idx i
 			return err
 		}
 
-		replyDate, err := time.Parse("2006-01-02", foramtedDate)
+		replyDate, err := time.Parse(time.DateOnly, foramtedDate)
 		if err != nil {
 			return err
 		}
 
 		if replyDate.After(lastDay) {
-			replyDateString := replyDate.Format("2006-01-02")
+			replyDateString := replyDate.Format(time.DateOnly)
 			resp.Conversations[idx].LastDate = replyDateString
 		}
 		resp.Conversations[idx].ThreadReplyMessage = append(resp.Conversations[idx].ThreadReplyMessage, reply)

--- a/pkg/component/application/slack/v0/api_functions.go
+++ b/pkg/component/application/slack/v0/api_functions.go
@@ -11,14 +11,14 @@ import (
 
 var types = []string{"private_channel", "public_channel"}
 
-func loopChannelListAPI(e *execution, channelName string) (string, error) {
+func loopChannelListAPI(client SlackClient, channelName string) (string, error) {
 	var apiParams slack.GetConversationsParameters
 	apiParams.Types = types
 
 	var targetChannelID string
 	for {
 
-		slackChannels, nextCur, err := e.client.GetConversations(&apiParams)
+		slackChannels, nextCur, err := client.GetConversations(&apiParams)
 		if err != nil {
 			return "", err
 		}
@@ -50,13 +50,13 @@ func getChannelID(channelName string, channels []slack.Channel) (channelID strin
 	return ""
 }
 
-func getConversationHistory(e *execution, channelID string, nextCur string) (*slack.GetConversationHistoryResponse, error) {
+func getConversationHistory(client SlackClient, channelID string, nextCur string) (*slack.GetConversationHistoryResponse, error) {
 	apiHistoryParams := slack.GetConversationHistoryParameters{
 		ChannelID: channelID,
 		Cursor:    nextCur,
 	}
 
-	historiesResp, err := e.client.GetConversationHistory(&apiHistoryParams)
+	historiesResp, err := client.GetConversationHistory(&apiHistoryParams)
 	if err != nil {
 		return nil, err
 	}
@@ -68,12 +68,12 @@ func getConversationHistory(e *execution, channelID string, nextCur string) (*sl
 	return historiesResp, nil
 }
 
-func getConversationReply(e *execution, channelID string, ts string) ([]slack.Message, error) {
+func getConversationReply(client SlackClient, channelID string, ts string) ([]slack.Message, error) {
 	apiParams := slack.GetConversationRepliesParameters{
 		ChannelID: channelID,
 		Timestamp: ts,
 	}
-	msgs, _, nextCur, err := e.client.GetConversationReplies(&apiParams)
+	msgs, _, nextCur, err := client.GetConversationReplies(&apiParams)
 
 	if err != nil {
 		return nil, err
@@ -87,7 +87,7 @@ func getConversationReply(e *execution, channelID string, ts string) ([]slack.Me
 
 	for nextCur != "" {
 		apiParams.Cursor = nextCur
-		msgs, _, nextCur, err = e.client.GetConversationReplies(&apiParams)
+		msgs, _, nextCur, err = client.GetConversationReplies(&apiParams)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/component/application/slack/v0/api_functions.go
+++ b/pkg/component/application/slack/v0/api_functions.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/instill-ai/x/errmsg"
 	"github.com/slack-go/slack"
 )
 
@@ -29,8 +30,10 @@ func loopChannelListAPI(e *execution, channelName string) (string, error) {
 		}
 
 		if targetChannelID == "" && nextCur == "" {
-			err := fmt.Errorf("there is no match name in slack channel [%v]", channelName)
-			return "", err
+			return "", errmsg.AddMessage(
+				fmt.Errorf("couldn't find channel by name"),
+				fmt.Sprintf("Couldn't find channel [%s].", channelName),
+			)
 		}
 
 		apiParams.Cursor = nextCur

--- a/pkg/component/application/slack/v0/client.go
+++ b/pkg/component/application/slack/v0/client.go
@@ -2,14 +2,8 @@ package slack
 
 import (
 	"github.com/slack-go/slack"
-	"google.golang.org/protobuf/types/known/structpb"
 )
 
-func newClient(setup *structpb.Struct) *slack.Client {
-	return slack.New(getToken(setup))
-}
-
-// Need to confirm where the map is
-func getToken(setup *structpb.Struct) string {
-	return setup.GetFields()["token"].GetStringValue()
+func newClient(token string) *slack.Client {
+	return slack.New(token)
 }

--- a/pkg/component/application/slack/v0/component_test.go
+++ b/pkg/component/application/slack/v0/component_test.go
@@ -212,14 +212,14 @@ func TestComponent_ExecuteReadTask(t *testing.T) {
 	mockDateTime, _ := transformTSToDate("1715159449.399879", time.RFC3339)
 	testcases := []struct {
 		name       string
-		input      UserInputReadTask
+		input      userInputReadTask
 		wantResp   ReadTaskResp
 		wantErr    string
 		wantErrMsg string
 	}{
 		{
 			name: "ok to read",
-			input: UserInputReadTask{
+			input: userInputReadTask{
 				ChannelName:     "test_channel",
 				StartToReadDate: "2024-05-05",
 			},
@@ -247,7 +247,7 @@ func TestComponent_ExecuteReadTask(t *testing.T) {
 		},
 		{
 			name: "fail to read",
-			input: UserInputReadTask{
+			input: userInputReadTask{
 				ChannelName: "test_channel_1",
 			},
 			wantErr:    `fetching channel ID: couldn't find channel by name`,

--- a/pkg/component/application/slack/v0/config/definition.json
+++ b/pkg/component/application/slack/v0/config/definition.json
@@ -16,7 +16,7 @@
   "uid": "1e9f469e-da5e-46eb-8a89-23466627e3b5",
   "vendor": "Slack",
   "vendorAttributes": {},
-  "version": "0.1.0",
+  "version": "0.2.0",
   "sourceUrl": "https://github.com/instill-ai/pipeline-backend/blob/main/pkg/component/application/slack/v0",
   "releaseStage": "RELEASE_STAGE_ALPHA"
 }

--- a/pkg/component/application/slack/v0/config/setup.json
+++ b/pkg/component/application/slack/v0/config/setup.json
@@ -2,8 +2,8 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
-    "token": {
-      "description": "Fill in your Slack app access token. For more information about how to access to create app tokens, please refer to the Slack API documentation.",
+    "bot-token": {
+      "description": "Token associated to the application bot",
       "instillUpstreamTypes": [
         "reference"
       ],
@@ -12,12 +12,25 @@
       ],
       "instillSecret": true,
       "instillUIOrder": 0,
-      "title": "Token",
+      "title": "Bot OAuth Token",
+      "type": "string"
+    },
+    "user-token": {
+      "description": "Token to act on behalf of a Slack user",
+      "instillUpstreamTypes": [
+        "reference"
+      ],
+      "instillAcceptFormats": [
+        "string"
+      ],
+      "instillSecret": true,
+      "instillUIOrder": 1,
+      "title": "User OAuth Token",
       "type": "string"
     }
   },
   "required": [
-    "token"
+    "bot-token"
   ],
   "instillEditOnNodeFields": [
     "token"

--- a/pkg/component/application/slack/v0/config/tasks.json
+++ b/pkg/component/application/slack/v0/config/tasks.json
@@ -22,7 +22,7 @@
       "instillUIOrder": 0,
       "properties": {
         "channel-name": {
-          "description": "A channel name display in Slack",
+          "description": "Channel name, as displayed on Slack",
           "instillAcceptFormats": [
             "string"
           ],
@@ -37,7 +37,7 @@
           "type": "string"
         },
         "start-to-read-date": {
-          "description": "earliest date in all read messages",
+          "description": "Date (in <code>YYYY-MM-DD<code> format) from which messages will start to be fetched",
           "instillAcceptFormats": [
             "string"
           ],
@@ -162,7 +162,7 @@
       "instillUIOrder": 0,
       "properties": {
         "channel-name": {
-          "description": "A channel name display in Slack",
+          "description": "Channel name, as displayed on Slack",
           "instillAcceptFormats": [
             "string"
           ],
@@ -177,7 +177,7 @@
           "type": "string"
         },
         "message": {
-          "description": "message to be sent to the target channel",
+          "description": "The message to be sent to the target channel",
           "instillAcceptFormats": [
             "string"
           ],
@@ -190,6 +190,16 @@
           ],
           "title": "Message",
           "type": "string"
+        },
+        "as-user": {
+          "default": false,
+          "description": "Send the message on behalf of the user identified by the <code>setup.user-token</code> field",
+          "instillUIOrder": 2,
+          "title": "Send As User",
+          "instillFormat": "boolean",
+          "instillAcceptFormats": ["boolean"],
+          "instillUpstreamTypes": ["value"],
+          "type": "boolean"
         }
       },
       "required": [
@@ -204,7 +214,7 @@
       "instillUIOrder": 0,
       "properties": {
         "result": {
-          "description": "result for sending message",
+          "description": "Result of the message delivery",
           "instillEditOnNodeFields": [],
           "instillUIOrder": 0,
           "required": [],

--- a/pkg/component/application/slack/v0/main.go
+++ b/pkg/component/application/slack/v0/main.go
@@ -1,4 +1,4 @@
-//go:generate compogen readme ./config ./README.mdx
+//go:generate compogen readme ./config ./README.mdx --extraContents setup=.compogen/extra-setup.mdx
 package slack
 
 import (

--- a/pkg/component/application/slack/v0/main.go
+++ b/pkg/component/application/slack/v0/main.go
@@ -32,6 +32,18 @@ var (
 	comp *component
 )
 
+// SlackClient implements the methods we'll need to interact with Slack.
+// TODO jvallesm: instead of using an interface and mocking it in the tests,
+// create a client with the Slack SDK and use OptionAPIURL to test the
+// component.
+type SlackClient interface {
+	GetConversations(params *slack.GetConversationsParameters) ([]slack.Channel, string, error)
+	PostMessage(channelID string, options ...slack.MsgOption) (string, string, error)
+	GetConversationHistory(params *slack.GetConversationHistoryParameters) (*slack.GetConversationHistoryResponse, error)
+	GetConversationReplies(params *slack.GetConversationRepliesParameters) ([]slack.Message, bool, string, error)
+	GetUsersInfo(users ...string) (*[]slack.User, error)
+}
+
 type component struct {
 	base.Component
 }
@@ -39,16 +51,17 @@ type component struct {
 type execution struct {
 	base.ComponentExecution
 
-	execute func(*structpb.Struct) (*structpb.Struct, error)
-	client  SlackClient
+	botClient  SlackClient
+	userClient SlackClient
+	execute    func(*structpb.Struct) (*structpb.Struct, error)
 }
 
-type SlackClient interface {
-	GetConversations(params *slack.GetConversationsParameters) ([]slack.Channel, string, error)
-	PostMessage(channelID string, options ...slack.MsgOption) (string, string, error)
-	GetConversationHistory(params *slack.GetConversationHistoryParameters) (*slack.GetConversationHistoryResponse, error)
-	GetConversationReplies(params *slack.GetConversationRepliesParameters) ([]slack.Message, bool, string, error)
-	GetUsersInfo(users ...string) (*[]slack.User, error)
+func (e *execution) botToken() string {
+	return e.Setup.GetFields()["bot-token"].GetStringValue()
+}
+
+func (e *execution) userToken() string {
+	return e.Setup.GetFields()["user-token"].GetStringValue()
 }
 
 // Init returns an implementation of IComponent that interacts with Slack.
@@ -65,9 +78,21 @@ func Init(bc base.Component) *component {
 }
 
 func (c *component) CreateExecution(x base.ComponentExecution) (base.IExecution, error) {
-	e := &execution{
-		ComponentExecution: x,
-		client:             newClient(x.Setup),
+	e := &execution{ComponentExecution: x}
+
+	// TODO jvallesm: this should be replaced by a validation at the recipe
+	// level. The recipe and the setup schema have enough information so the
+	// trigger can be aborted earlier.
+	if e.botToken() == "" {
+		return nil, errmsg.AddMessage(
+			fmt.Errorf("missing bot token"),
+			"Bot token is a required setup field.",
+		)
+	}
+
+	e.botClient = newClient(e.botToken())
+	if e.userToken() != "" {
+		e.userClient = newClient(e.userToken())
 	}
 
 	switch x.Task {

--- a/pkg/component/application/slack/v0/task_functions.go
+++ b/pkg/component/application/slack/v0/task_functions.go
@@ -70,7 +70,7 @@ func (e *execution) readMessage(in *structpb.Struct) (*structpb.Struct, error) {
 	if params.StartToReadDate == "" {
 		currentTime := time.Now()
 		sevenDaysAgo := currentTime.AddDate(0, 0, -7)
-		sevenDaysAgoString := sevenDaysAgo.Format("2006-01-02")
+		sevenDaysAgoString := sevenDaysAgo.Format(time.DateOnly)
 		params.StartToReadDate = sevenDaysAgoString
 	}
 

--- a/pkg/component/application/slack/v0/task_functions.go
+++ b/pkg/component/application/slack/v0/task_functions.go
@@ -13,7 +13,7 @@ import (
 	"github.com/instill-ai/x/errmsg"
 )
 
-type UserInputReadTask struct {
+type userInputReadTask struct {
 	ChannelName     string `json:"channel-name"`
 	StartToReadDate string `json:"start-to-read-date"`
 }
@@ -53,7 +53,7 @@ type WriteTaskResp struct {
 func (e *execution) readMessage(in *structpb.Struct) (*structpb.Struct, error) {
 	client := e.botClient
 
-	params := UserInputReadTask{}
+	params := userInputReadTask{}
 	if err := base.ConvertFromStructpb(in, &params); err != nil {
 		return nil, fmt.Errorf("converting task input: %w", err)
 	}

--- a/pkg/db/migration/convert/convert000019/convert.go
+++ b/pkg/db/migration/convert/convert000019/convert.go
@@ -8,6 +8,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/instill-ai/pipeline-backend/pkg/datamodel"
+	"github.com/instill-ai/pipeline-backend/pkg/db/migration/convert"
 )
 
 const batchSize = 100
@@ -15,8 +16,7 @@ const batchSize = 100
 // JQInputToKebabCaseConverter executes code along with the 19th database
 // schema revision.
 type JQInputToKebabCaseConverter struct {
-	DB     *gorm.DB
-	Logger *zap.Logger
+	convert.Basic
 }
 
 // Migrate updates the `TASK_JQ` input in the JSON operator to kebab-case.

--- a/pkg/db/migration/convert/convert000020/convert.go
+++ b/pkg/db/migration/convert/convert000020/convert.go
@@ -9,6 +9,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/instill-ai/pipeline-backend/pkg/datamodel"
+	"github.com/instill-ai/pipeline-backend/pkg/db/migration/convert"
 
 	mgmtpb "github.com/instill-ai/protogen-go/core/mgmt/v1beta"
 )
@@ -18,8 +19,7 @@ const batchSize = 100
 // NamespaceIDMigrator migrate the existing owner field to new namespace_id and
 // namespace_type field.
 type NamespaceIDMigrator struct {
-	DB         *gorm.DB
-	Logger     *zap.Logger
+	convert.Basic
 	MgmtClient mgmtpb.MgmtPrivateServiceClient
 }
 

--- a/pkg/db/migration/convert/convert000021/convert.go
+++ b/pkg/db/migration/convert/convert000021/convert.go
@@ -8,6 +8,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/instill-ai/pipeline-backend/pkg/datamodel"
+	"github.com/instill-ai/pipeline-backend/pkg/db/migration/convert"
 )
 
 const batchSize = 100
@@ -15,8 +16,7 @@ const batchSize = 100
 // ConvertToTextTaskConverter executes code along with the 21st database
 // schema revision.
 type ConvertToTextTaskConverter struct {
-	DB     *gorm.DB
-	Logger *zap.Logger
+	convert.Basic
 }
 
 // Migrate `TASK_CONVERT_TO_TEXT` from the Text operator to the Document operator

--- a/pkg/db/migration/convert/convert000022/convert.go
+++ b/pkg/db/migration/convert/convert000022/convert.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/instill-ai/pipeline-backend/pkg/datamodel"
+	"github.com/instill-ai/pipeline-backend/pkg/db/migration/convert"
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
 	"gorm.io/gorm"
@@ -12,8 +13,7 @@ import (
 const batchSize = 100
 
 type ConvertWebsiteToWebConverter struct {
-	DB     *gorm.DB
-	Logger *zap.Logger
+	convert.Basic
 }
 
 func (c *ConvertWebsiteToWebConverter) Migrate() error {

--- a/pkg/db/migration/convert/convert000024/convert.go
+++ b/pkg/db/migration/convert/convert000024/convert.go
@@ -8,13 +8,13 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/instill-ai/pipeline-backend/pkg/datamodel"
+	"github.com/instill-ai/pipeline-backend/pkg/db/migration/convert"
 )
 
 const batchSize = 100
 
 type ConvertToTextTaskConverter struct {
-	DB     *gorm.DB
-	Logger *zap.Logger
+	convert.Basic
 }
 
 func (c *ConvertToTextTaskConverter) Migrate() error {

--- a/pkg/db/migration/convert/convert000029/convert.go
+++ b/pkg/db/migration/convert/convert000029/convert.go
@@ -8,13 +8,13 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/instill-ai/pipeline-backend/pkg/datamodel"
+	"github.com/instill-ai/pipeline-backend/pkg/db/migration/convert"
 )
 
 const batchSize = 100
 
 type ConvertToArtifactType struct {
-	DB     *gorm.DB
-	Logger *zap.Logger
+	convert.Basic
 }
 
 func (c *ConvertToArtifactType) Migrate() error {

--- a/pkg/db/migration/convert/convert000031/convert.go
+++ b/pkg/db/migration/convert/convert000031/convert.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/instill-ai/pipeline-backend/pkg/datamodel"
 	"github.com/instill-ai/pipeline-backend/pkg/db/migration/convert"
+
+	componentstore "github.com/instill-ai/pipeline-backend/pkg/component/store"
 )
 
 const batchSize = 100
@@ -40,13 +42,14 @@ func (c *SlackSetupConverter) Migrate() error {
 
 func (c *SlackSetupConverter) migrateConnection() error {
 	// fetch slack component ID
-	cd := new(datamodel.ComponentDefinition)
-	if err := c.DB.Model(cd).Where("id = ?", "slack").First(cd).Error; err != nil {
+	cds := componentstore.Init(c.Logger, nil, nil)
+	cd, err := cds.GetDefinitionByID("slack", nil, nil)
+	if err != nil {
 		return fmt.Errorf("fetching slack component UID")
 	}
 
 	q := c.DB.Select("uid", "setup").
-		Where("integration_uid = ?", cd.UID.String()).
+		Where("integration_uid = ?", cd.Uid).
 		Where("delete_time IS NULL")
 
 	connections := make([]*datamodel.Connection, 0, batchSize)

--- a/pkg/db/migration/convert/convert000031/convert.go
+++ b/pkg/db/migration/convert/convert000031/convert.go
@@ -1,0 +1,206 @@
+package convert000031
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"go.uber.org/zap"
+	"gopkg.in/yaml.v3"
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
+
+	"github.com/instill-ai/pipeline-backend/pkg/datamodel"
+	"github.com/instill-ai/pipeline-backend/pkg/db/migration/convert"
+)
+
+const batchSize = 100
+
+// SlackSetupConverter executes code along with the 19th database
+// schema revision.
+type SlackSetupConverter struct {
+	convert.Basic
+}
+
+// Migrate updates the `TASK_JQ` input in the JSON operator to kebab-case.
+func (c *SlackSetupConverter) Migrate() error {
+	if err := c.migrateConnection(); err != nil {
+		return fmt.Errorf("migrating connections: %w", err)
+	}
+
+	if err := c.migratePipeline(); err != nil {
+		return fmt.Errorf("migrating pipelines: %w", err)
+	}
+
+	if err := c.migratePipelineRelease(); err != nil {
+		return fmt.Errorf("migrating pipeline releases: %w", err)
+	}
+
+	return nil
+}
+
+func (c *SlackSetupConverter) migrateConnection() error {
+	// fetch slack component ID
+	cd := new(datamodel.ComponentDefinition)
+	if err := c.DB.Model(cd).Where("id = ?", "slack").First(cd).Error; err != nil {
+		return fmt.Errorf("fetching slack component UID")
+	}
+
+	q := c.DB.Select("uid", "setup").
+		Where("integration_uid = ?", cd.UID.String()).
+		Where("delete_time IS NULL")
+
+	connections := make([]*datamodel.Connection, 0, batchSize)
+	return q.FindInBatches(&connections, batchSize, func(tx *gorm.DB, _ int) error {
+		for _, conn := range connections {
+			l := c.Logger.With(zap.String("connectionUID", conn.UID.String()))
+
+			var setup map[string]any
+			if err := json.Unmarshal(conn.Setup, &setup); err != nil {
+				return fmt.Errorf("unmarshalling setup: %w", err)
+			}
+
+			updated := c.updateToken(setup)
+			if !updated {
+				continue
+			}
+
+			j, err := json.Marshal(setup)
+			if err != nil {
+				return fmt.Errorf("marshalling setup: %w", err)
+			}
+
+			result := tx.Model(conn).Where("uid = ?", conn.UID).Update("setup", datatypes.JSON(j))
+			if result.Error != nil {
+				l.Error("Failed to update connection setup.")
+				return fmt.Errorf("updating connection setup: %w", result.Error)
+			}
+		}
+
+		return nil
+	}).Error
+}
+
+func (c *SlackSetupConverter) migratePipeline() error {
+	q := c.DB.Select("uid", "recipe_yaml", "recipe").
+		Where("recipe_yaml LIKE ?", "%%type: slack%%").
+		Where("delete_time IS NULL")
+
+	pipelines := make([]*datamodel.Pipeline, 0, batchSize)
+	return q.FindInBatches(&pipelines, batchSize, func(tx *gorm.DB, _ int) error {
+		for _, p := range pipelines {
+			isRecipeUpdated := false
+			l := c.Logger.With(zap.String("pipelineUID", p.UID.String()))
+
+			for id, comp := range p.Recipe.Component {
+				isComponentUpdated, err := c.updateSlackSetup(comp)
+				if err != nil {
+					l.With(zap.String("componentID", id), zap.Error(err)).
+						Error("Failed to update pipeline.")
+
+					return fmt.Errorf("updating pipeline component: %w", err)
+				}
+
+				isRecipeUpdated = isComponentUpdated || isRecipeUpdated
+			}
+
+			if isRecipeUpdated {
+				recipeYAML, err := yaml.Marshal(p.Recipe)
+				if err != nil {
+					return fmt.Errorf("marshalling recipe: %w", err)
+				}
+				result := tx.Model(p).Where("uid = ?", p.UID).Update("recipe_yaml", string(recipeYAML))
+				if result.Error != nil {
+					l.Error("Failed to update pipeline recipe.")
+					return fmt.Errorf("updating pipeline recipe: %w", result.Error)
+				}
+			}
+		}
+
+		return nil
+	}).Error
+}
+
+func (c *SlackSetupConverter) migratePipelineRelease() error {
+	q := c.DB.Select("uid", "recipe_yaml", "recipe").
+		Where("recipe_yaml LIKE ?", "%%type: slack%%").
+		Where("delete_time IS NULL")
+
+	pipelineReleases := make([]*datamodel.PipelineRelease, 0, batchSize)
+	return q.FindInBatches(&pipelineReleases, batchSize, func(tx *gorm.DB, _ int) error {
+		for _, pr := range pipelineReleases {
+			isRecipeUpdated := false
+			l := c.Logger.With(zap.String("pipelineReleaseUID", pr.UID.String()))
+
+			for id, comp := range pr.Recipe.Component {
+				isComponentUpdated, err := c.updateSlackSetup(comp)
+				if err != nil {
+					l.With(zap.String("componentID", id), zap.Error(err)).
+						Error("Failed to update pipeline release.")
+
+					return fmt.Errorf("updating pipeline release component: %w", err)
+				}
+
+				isRecipeUpdated = isComponentUpdated || isRecipeUpdated
+			}
+
+			if isRecipeUpdated {
+				recipeYAML, err := yaml.Marshal(pr.Recipe)
+				if err != nil {
+					return fmt.Errorf("marshalling recipe: %w", err)
+				}
+
+				result := tx.Model(pr).Where("uid = ?", pr.UID).Update("recipe_yaml", string(recipeYAML))
+				if result.Error != nil {
+					l.Error("Failed to update pipeline release.")
+					return fmt.Errorf("updating pipeline release recipe: %w", result.Error)
+				}
+			}
+		}
+
+		return nil
+	}).Error
+}
+
+func (c *SlackSetupConverter) updateSlackSetup(comp *datamodel.Component) (bool, error) {
+	if comp.Type == "iterator" {
+		isComponentUpdated := false
+		for _, comp := range comp.Component {
+			isSubComponentUpdated, err := c.updateSlackSetup(comp)
+			if err != nil {
+				return false, fmt.Errorf("updating iterator component: %w", err)
+			}
+
+			isComponentUpdated = isSubComponentUpdated || isComponentUpdated
+		}
+
+		return isComponentUpdated, nil
+	}
+
+	if comp.Type != "slack" {
+		return false, nil
+	}
+
+	setup, isMap := comp.Setup.(map[string]any)
+	if !isMap {
+		// Component setup references a connection.
+		return false, nil
+	}
+
+	if updated := c.updateToken(setup); !updated {
+		return false, nil
+	}
+
+	comp.Setup = setup
+	return true, nil
+}
+
+func (c *SlackSetupConverter) updateToken(setup map[string]any) (updated bool) {
+	if _, hasToken := setup["token"]; !hasToken {
+		return false
+	}
+
+	setup["bot-token"] = setup["token"]
+	delete(setup, "token")
+
+	return true
+}

--- a/pkg/db/migration/convert/converter.go
+++ b/pkg/db/migration/convert/converter.go
@@ -1,0 +1,12 @@
+package convert
+
+import (
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+)
+
+// Basic contains the basic elements to execute a conversion migration.
+type Basic struct {
+	DB     *gorm.DB
+	Logger *zap.Logger
+}

--- a/pkg/db/migration/migration.go
+++ b/pkg/db/migration/migration.go
@@ -3,6 +3,7 @@ package migration
 import (
 	"context"
 
+	"github.com/instill-ai/pipeline-backend/pkg/db/migration/convert"
 	"github.com/instill-ai/pipeline-backend/pkg/db/migration/convert/convert000013"
 	"github.com/instill-ai/pipeline-backend/pkg/db/migration/convert/convert000015"
 	"github.com/instill-ai/pipeline-backend/pkg/db/migration/convert/convert000016"
@@ -12,6 +13,7 @@ import (
 	"github.com/instill-ai/pipeline-backend/pkg/db/migration/convert/convert000022"
 	"github.com/instill-ai/pipeline-backend/pkg/db/migration/convert/convert000024"
 	"github.com/instill-ai/pipeline-backend/pkg/db/migration/convert/convert000029"
+	"github.com/instill-ai/pipeline-backend/pkg/db/migration/convert/convert000031"
 	"github.com/instill-ai/pipeline-backend/pkg/external"
 	"github.com/instill-ai/pipeline-backend/pkg/logger"
 
@@ -36,9 +38,10 @@ func Migrate(version uint) error {
 
 	db := database.GetConnection().WithContext(ctx)
 	defer database.Close(db)
-	mgmtPrivateServiceClient, mgmtPrivateServiceClientConn := external.InitMgmtPrivateServiceClient(ctx)
-	if mgmtPrivateServiceClientConn != nil {
-		defer mgmtPrivateServiceClientConn.Close()
+
+	bc := convert.Basic{
+		DB:     db,
+		Logger: l,
 	}
 
 	switch version {
@@ -49,36 +52,27 @@ func Migrate(version uint) error {
 	case 16:
 		m = new(convert000016.Migration)
 	case 19:
-		m = &convert000019.JQInputToKebabCaseConverter{
-			DB:     db,
-			Logger: l,
-		}
+		m = &convert000019.JQInputToKebabCaseConverter{Basic: bc}
 	case 20:
+		mgmtPrivateServiceClient, mgmtPrivateServiceClientConn := external.InitMgmtPrivateServiceClient(ctx)
+		if mgmtPrivateServiceClientConn != nil {
+			defer mgmtPrivateServiceClientConn.Close()
+		}
+
 		m = &convert000020.NamespaceIDMigrator{
-			DB:         db,
-			Logger:     l,
+			Basic:      bc,
 			MgmtClient: mgmtPrivateServiceClient,
 		}
 	case 21:
-		m = &convert000021.ConvertToTextTaskConverter{
-			DB:     db,
-			Logger: l,
-		}
+		m = &convert000021.ConvertToTextTaskConverter{Basic: bc}
 	case 22:
-		m = &convert000022.ConvertWebsiteToWebConverter{
-			DB:     db,
-			Logger: l,
-		}
+		m = &convert000022.ConvertWebsiteToWebConverter{Basic: bc}
 	case 24:
-		m = &convert000024.ConvertToTextTaskConverter{
-			DB:     db,
-			Logger: l,
-		}
+		m = &convert000024.ConvertToTextTaskConverter{Basic: bc}
 	case 29:
-		m = &convert000029.ConvertToArtifactType{
-			DB:     db,
-			Logger: l,
-		}
+		m = &convert000029.ConvertToArtifactType{Basic: bc}
+	case 31:
+		m = &convert000031.SlackSetupConverter{Basic: bc}
 	default:
 		return nil
 	}


### PR DESCRIPTION
Because

- Slack integration can send messages as either a user or a bot.

This commit

- Updates the component `setup` to hold both tokens.
