### PR TITLE
feat(run): run logging data list by requester API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/iFaceless/godub v0.0.0-20200728093528-a30bb4d1a0f1
 	github.com/iancoleman/strcase v0.3.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241007141417-545e5d187408
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241012090311-e872dc0b511d
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.5.0-alpha
 	github.com/itchyny/gojq v0.12.14

--- a/go.sum
+++ b/go.sum
@@ -1275,8 +1275,8 @@ github.com/influxdata/influxdb-client-go/v2 v2.12.3 h1:28nRlNMRIV4QbtIUvxhWqaxn0
 github.com/influxdata/influxdb-client-go/v2 v2.12.3/go.mod h1:IrrLUbCjjfkmRuaCiGQg4m2GbkaeJDcuWoxiWdQEbA0=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241007141417-545e5d187408 h1:GTx0g6dXxd7WUm4bvJK1N+j8zuxIaSoXD5AZ2Vl+FXI=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241007141417-545e5d187408/go.mod h1:rf0UY7VpEgpaLudYEcjx5rnbuwlBaaLyD4FQmWLtgAY=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241012090311-e872dc0b511d h1:jf2RQtRFNxnPMkjTD0AAqXDXO8lHYOrWU3Hrr+yGEzY=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241012090311-e872dc0b511d/go.mod h1:rf0UY7VpEgpaLudYEcjx5rnbuwlBaaLyD4FQmWLtgAY=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a/go.mod h1:EpX3Yr661uWULtZf5UnJHfr5rw2PDyX8ku4Kx0UtYFw=
 github.com/instill-ai/x v0.5.0-alpha h1:xIeIvrLzwJYOBmZwOePVFVkKGEcMDqtHmn1cfVVNlIE=

--- a/pkg/datamodel/runlogging.go
+++ b/pkg/datamodel/runlogging.go
@@ -67,6 +67,7 @@ func (j *JSONB) Scan(value interface{}) error {
 type PipelineRun struct {
 	PipelineTriggerUID uuid.UUID      `gorm:"primaryKey" json:"pipeline-trigger-uid"`                                        // Unique identifier for each run
 	PipelineUID        uuid.UUID      `gorm:"type:uuid;index" json:"pipeline-uid"`                                           // Pipeline unique ID used in the run
+	Pipeline           Pipeline       `gorm:"foreignKey:PipelineUID;references:UID"`                                         // Pipeline instance referenced in the run
 	PipelineVersion    string         `gorm:"type:varchar(255)" json:"pipeline-version"`                                     // Pipeline version used in the run
 	Status             RunStatus      `gorm:"type:valid_trigger_status;index" json:"status"`                                 // Current status of the run (e.g., Running, Completed, Failed)
 	Source             RunSource      `gorm:"type:valid_trigger_source" json:"source"`                                       // Origin of the run (e.g., Web click, API)

--- a/pkg/handler/pipeline.go
+++ b/pkg/handler/pipeline.go
@@ -1995,36 +1995,19 @@ func (h *PublicHandler) ListComponentRuns(ctx context.Context, req *pb.ListCompo
 	return resp, nil
 }
 
+// todo: rename function to ListPipelineRunsByRequester in protobuf and update message names here
 func (h *PublicHandler) ListPipelineRunsByCreditOwner(ctx context.Context, req *pb.ListPipelineRunsByCreditOwnerRequest) (*pb.ListPipelineRunsByCreditOwnerResponse, error) {
 	logger, _ := logger.GetZapLogger(ctx)
 	logUUID, _ := uuid.NewV4()
-	logger.Info("ListPipelineRunsByCreditOwner starts", zap.String("logUUID", logUUID.String()))
+	logger.Info("ListPipelineRunsByRequester starts", zap.String("logUUID", logUUID.String()))
 
-	if req.GetStart().IsValid() && req.GetStop().IsValid() && req.GetStart().AsTime().After(req.GetStop().AsTime()) {
-		return nil, fmt.Errorf("input stop time earlier than start time")
-	}
-
-	declarations, err := filtering.NewDeclarations([]filtering.DeclarationOption{
-		filtering.DeclareStandardFunctions(),
-		filtering.DeclareIdent("status", filtering.TypeString),
-		filtering.DeclareIdent("source", filtering.TypeString),
-	}...)
+	resp, err := h.service.ListPipelineRunsByRequester(ctx, req)
 	if err != nil {
-		return nil, err
-	}
-
-	filter, err := filtering.ParseFilter(req, declarations)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := h.service.ListPipelineRunsByCreditOwner(ctx, req, filter)
-	if err != nil {
-		logger.Error("failed in ListPipelineRunsByCreditOwner", zap.String("logUUID", logUUID.String()), zap.Error(err))
+		logger.Error("failed in ListPipelineRunsByRequester", zap.String("logUUID", logUUID.String()), zap.Error(err))
 		return nil, status.Error(codes.Internal, "Failed to list pipeline runs")
 	}
 
-	logger.Info("ListPipelineRunsByCreditOwner finished", zap.String("logUUID", logUUID.String()))
+	logger.Info("ListPipelineRunsByRequester finished", zap.String("logUUID", logUUID.String()))
 
 	return resp, nil
 }

--- a/pkg/mock/acl_client_interface_mock.gen.go
+++ b/pkg/mock/acl_client_interface_mock.gen.go
@@ -5,11 +5,13 @@ package mock
 import (
 	"context"
 	"sync"
+
 	mm_atomic "sync/atomic"
 	mm_time "time"
 
 	"github.com/gofrs/uuid"
 	"github.com/gojuno/minimock/v3"
+
 	"github.com/instill-ai/pipeline-backend/pkg/datamodel"
 )
 

--- a/pkg/mock/converter_mock.gen.go
+++ b/pkg/mock/converter_mock.gen.go
@@ -5,13 +5,16 @@ package mock
 import (
 	"context"
 	"sync"
+
 	mm_atomic "sync/atomic"
 	mm_time "time"
 
 	"github.com/gofrs/uuid"
 	"github.com/gojuno/minimock/v3"
+
 	"github.com/instill-ai/pipeline-backend/pkg/datamodel"
 	"github.com/instill-ai/pipeline-backend/pkg/resource"
+
 	pb "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
 

--- a/pkg/mock/mgmt_private_service_client_mock.gen.go
+++ b/pkg/mock/mgmt_private_service_client_mock.gen.go
@@ -3,14 +3,17 @@
 package mock
 
 import (
-	context "context"
 	"sync"
+
+	context "context"
 	mm_atomic "sync/atomic"
 	mm_time "time"
 
 	"github.com/gojuno/minimock/v3"
-	mm_mgmtv1beta "github.com/instill-ai/protogen-go/core/mgmt/v1beta"
+
 	grpc "google.golang.org/grpc"
+
+	mm_mgmtv1beta "github.com/instill-ai/protogen-go/core/mgmt/v1beta"
 )
 
 // MgmtPrivateServiceClientMock implements mm_mgmtv1beta.MgmtPrivateServiceClient

--- a/pkg/mock/minio_i_mock.gen.go
+++ b/pkg/mock/minio_i_mock.gen.go
@@ -5,12 +5,15 @@ package mock
 import (
 	"context"
 	"sync"
+
 	mm_atomic "sync/atomic"
 	mm_time "time"
 
 	"github.com/gojuno/minimock/v3"
-	mm_minio "github.com/instill-ai/pipeline-backend/pkg/minio"
+
 	minio "github.com/minio/minio-go/v7"
+
+	mm_minio "github.com/instill-ai/pipeline-backend/pkg/minio"
 )
 
 // MinioIMock implements mm_minio.MinioI

--- a/pkg/mock/repository_mock.gen.go
+++ b/pkg/mock/repository_mock.gen.go
@@ -5,7 +5,6 @@ package mock
 import (
 	"context"
 	"sync"
-	"time"
 
 	mm_atomic "sync/atomic"
 	mm_time "time"
@@ -175,9 +174,9 @@ type RepositoryMock struct {
 	beforeGetPaginatedComponentRunsByPipelineRunIDWithPermissionsCounter uint64
 	GetPaginatedComponentRunsByPipelineRunIDWithPermissionsMock          mRepositoryMockGetPaginatedComponentRunsByPipelineRunIDWithPermissions
 
-	funcGetPaginatedPipelineRunsByRequester          func(ctx context.Context, requesterUID string, startTime time.Time, endTime time.Time, page int, pageSize int, filter filtering.Filter, order ordering.OrderBy) (pa1 []datamodel.PipelineRun, i1 int64, err error)
+	funcGetPaginatedPipelineRunsByRequester          func(ctx context.Context, params mm_repository.GetPipelineRunsByRequesterParams) (pa1 []datamodel.PipelineRun, i1 int64, err error)
 	funcGetPaginatedPipelineRunsByRequesterOrigin    string
-	inspectFuncGetPaginatedPipelineRunsByRequester   func(ctx context.Context, requesterUID string, startTime time.Time, endTime time.Time, page int, pageSize int, filter filtering.Filter, order ordering.OrderBy)
+	inspectFuncGetPaginatedPipelineRunsByRequester   func(ctx context.Context, params mm_repository.GetPipelineRunsByRequesterParams)
 	afterGetPaginatedPipelineRunsByRequesterCounter  uint64
 	beforeGetPaginatedPipelineRunsByRequesterCounter uint64
 	GetPaginatedPipelineRunsByRequesterMock          mRepositoryMockGetPaginatedPipelineRunsByRequester
@@ -8514,26 +8513,14 @@ type RepositoryMockGetPaginatedPipelineRunsByRequesterExpectation struct {
 
 // RepositoryMockGetPaginatedPipelineRunsByRequesterParams contains parameters of the Repository.GetPaginatedPipelineRunsByRequester
 type RepositoryMockGetPaginatedPipelineRunsByRequesterParams struct {
-	ctx          context.Context
-	requesterUID string
-	startTime    time.Time
-	endTime      time.Time
-	page         int
-	pageSize     int
-	filter       filtering.Filter
-	order        ordering.OrderBy
+	ctx    context.Context
+	params mm_repository.GetPipelineRunsByRequesterParams
 }
 
 // RepositoryMockGetPaginatedPipelineRunsByRequesterParamPtrs contains pointers to parameters of the Repository.GetPaginatedPipelineRunsByRequester
 type RepositoryMockGetPaginatedPipelineRunsByRequesterParamPtrs struct {
-	ctx          *context.Context
-	requesterUID *string
-	startTime    *time.Time
-	endTime      *time.Time
-	page         *int
-	pageSize     *int
-	filter       *filtering.Filter
-	order        *ordering.OrderBy
+	ctx    *context.Context
+	params *mm_repository.GetPipelineRunsByRequesterParams
 }
 
 // RepositoryMockGetPaginatedPipelineRunsByRequesterResults contains results of the Repository.GetPaginatedPipelineRunsByRequester
@@ -8545,15 +8532,9 @@ type RepositoryMockGetPaginatedPipelineRunsByRequesterResults struct {
 
 // RepositoryMockGetPaginatedPipelineRunsByRequesterOrigins contains origins of expectations of the Repository.GetPaginatedPipelineRunsByRequester
 type RepositoryMockGetPaginatedPipelineRunsByRequesterExpectationOrigins struct {
-	origin             string
-	originCtx          string
-	originRequesterUID string
-	originStartTime    string
-	originEndTime      string
-	originPage         string
-	originPageSize     string
-	originFilter       string
-	originOrder        string
+	origin       string
+	originCtx    string
+	originParams string
 }
 
 // Marks this method to be optional. The default behavior of any method with Return() is '1 or more', meaning
@@ -8567,7 +8548,7 @@ func (mmGetPaginatedPipelineRunsByRequester *mRepositoryMockGetPaginatedPipeline
 }
 
 // Expect sets up expected params for Repository.GetPaginatedPipelineRunsByRequester
-func (mmGetPaginatedPipelineRunsByRequester *mRepositoryMockGetPaginatedPipelineRunsByRequester) Expect(ctx context.Context, requesterUID string, startTime time.Time, endTime time.Time, page int, pageSize int, filter filtering.Filter, order ordering.OrderBy) *mRepositoryMockGetPaginatedPipelineRunsByRequester {
+func (mmGetPaginatedPipelineRunsByRequester *mRepositoryMockGetPaginatedPipelineRunsByRequester) Expect(ctx context.Context, params mm_repository.GetPipelineRunsByRequesterParams) *mRepositoryMockGetPaginatedPipelineRunsByRequester {
 	if mmGetPaginatedPipelineRunsByRequester.mock.funcGetPaginatedPipelineRunsByRequester != nil {
 		mmGetPaginatedPipelineRunsByRequester.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByRequester mock is already set by Set")
 	}
@@ -8580,7 +8561,7 @@ func (mmGetPaginatedPipelineRunsByRequester *mRepositoryMockGetPaginatedPipeline
 		mmGetPaginatedPipelineRunsByRequester.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByRequester mock is already set by ExpectParams functions")
 	}
 
-	mmGetPaginatedPipelineRunsByRequester.defaultExpectation.params = &RepositoryMockGetPaginatedPipelineRunsByRequesterParams{ctx, requesterUID, startTime, endTime, page, pageSize, filter, order}
+	mmGetPaginatedPipelineRunsByRequester.defaultExpectation.params = &RepositoryMockGetPaginatedPipelineRunsByRequesterParams{ctx, params}
 	mmGetPaginatedPipelineRunsByRequester.defaultExpectation.expectationOrigins.origin = minimock.CallerInfo(1)
 	for _, e := range mmGetPaginatedPipelineRunsByRequester.expectations {
 		if minimock.Equal(e.params, mmGetPaginatedPipelineRunsByRequester.defaultExpectation.params) {
@@ -8614,8 +8595,8 @@ func (mmGetPaginatedPipelineRunsByRequester *mRepositoryMockGetPaginatedPipeline
 	return mmGetPaginatedPipelineRunsByRequester
 }
 
-// ExpectRequesterUIDParam2 sets up expected param requesterUID for Repository.GetPaginatedPipelineRunsByRequester
-func (mmGetPaginatedPipelineRunsByRequester *mRepositoryMockGetPaginatedPipelineRunsByRequester) ExpectRequesterUIDParam2(requesterUID string) *mRepositoryMockGetPaginatedPipelineRunsByRequester {
+// ExpectParamsParam2 sets up expected param params for Repository.GetPaginatedPipelineRunsByRequester
+func (mmGetPaginatedPipelineRunsByRequester *mRepositoryMockGetPaginatedPipelineRunsByRequester) ExpectParamsParam2(params mm_repository.GetPipelineRunsByRequesterParams) *mRepositoryMockGetPaginatedPipelineRunsByRequester {
 	if mmGetPaginatedPipelineRunsByRequester.mock.funcGetPaginatedPipelineRunsByRequester != nil {
 		mmGetPaginatedPipelineRunsByRequester.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByRequester mock is already set by Set")
 	}
@@ -8631,152 +8612,14 @@ func (mmGetPaginatedPipelineRunsByRequester *mRepositoryMockGetPaginatedPipeline
 	if mmGetPaginatedPipelineRunsByRequester.defaultExpectation.paramPtrs == nil {
 		mmGetPaginatedPipelineRunsByRequester.defaultExpectation.paramPtrs = &RepositoryMockGetPaginatedPipelineRunsByRequesterParamPtrs{}
 	}
-	mmGetPaginatedPipelineRunsByRequester.defaultExpectation.paramPtrs.requesterUID = &requesterUID
-	mmGetPaginatedPipelineRunsByRequester.defaultExpectation.expectationOrigins.originRequesterUID = minimock.CallerInfo(1)
-
-	return mmGetPaginatedPipelineRunsByRequester
-}
-
-// ExpectStartTimeParam3 sets up expected param startTime for Repository.GetPaginatedPipelineRunsByRequester
-func (mmGetPaginatedPipelineRunsByRequester *mRepositoryMockGetPaginatedPipelineRunsByRequester) ExpectStartTimeParam3(startTime time.Time) *mRepositoryMockGetPaginatedPipelineRunsByRequester {
-	if mmGetPaginatedPipelineRunsByRequester.mock.funcGetPaginatedPipelineRunsByRequester != nil {
-		mmGetPaginatedPipelineRunsByRequester.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByRequester mock is already set by Set")
-	}
-
-	if mmGetPaginatedPipelineRunsByRequester.defaultExpectation == nil {
-		mmGetPaginatedPipelineRunsByRequester.defaultExpectation = &RepositoryMockGetPaginatedPipelineRunsByRequesterExpectation{}
-	}
-
-	if mmGetPaginatedPipelineRunsByRequester.defaultExpectation.params != nil {
-		mmGetPaginatedPipelineRunsByRequester.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByRequester mock is already set by Expect")
-	}
-
-	if mmGetPaginatedPipelineRunsByRequester.defaultExpectation.paramPtrs == nil {
-		mmGetPaginatedPipelineRunsByRequester.defaultExpectation.paramPtrs = &RepositoryMockGetPaginatedPipelineRunsByRequesterParamPtrs{}
-	}
-	mmGetPaginatedPipelineRunsByRequester.defaultExpectation.paramPtrs.startTime = &startTime
-	mmGetPaginatedPipelineRunsByRequester.defaultExpectation.expectationOrigins.originStartTime = minimock.CallerInfo(1)
-
-	return mmGetPaginatedPipelineRunsByRequester
-}
-
-// ExpectEndTimeParam4 sets up expected param endTime for Repository.GetPaginatedPipelineRunsByRequester
-func (mmGetPaginatedPipelineRunsByRequester *mRepositoryMockGetPaginatedPipelineRunsByRequester) ExpectEndTimeParam4(endTime time.Time) *mRepositoryMockGetPaginatedPipelineRunsByRequester {
-	if mmGetPaginatedPipelineRunsByRequester.mock.funcGetPaginatedPipelineRunsByRequester != nil {
-		mmGetPaginatedPipelineRunsByRequester.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByRequester mock is already set by Set")
-	}
-
-	if mmGetPaginatedPipelineRunsByRequester.defaultExpectation == nil {
-		mmGetPaginatedPipelineRunsByRequester.defaultExpectation = &RepositoryMockGetPaginatedPipelineRunsByRequesterExpectation{}
-	}
-
-	if mmGetPaginatedPipelineRunsByRequester.defaultExpectation.params != nil {
-		mmGetPaginatedPipelineRunsByRequester.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByRequester mock is already set by Expect")
-	}
-
-	if mmGetPaginatedPipelineRunsByRequester.defaultExpectation.paramPtrs == nil {
-		mmGetPaginatedPipelineRunsByRequester.defaultExpectation.paramPtrs = &RepositoryMockGetPaginatedPipelineRunsByRequesterParamPtrs{}
-	}
-	mmGetPaginatedPipelineRunsByRequester.defaultExpectation.paramPtrs.endTime = &endTime
-	mmGetPaginatedPipelineRunsByRequester.defaultExpectation.expectationOrigins.originEndTime = minimock.CallerInfo(1)
-
-	return mmGetPaginatedPipelineRunsByRequester
-}
-
-// ExpectPageParam5 sets up expected param page for Repository.GetPaginatedPipelineRunsByRequester
-func (mmGetPaginatedPipelineRunsByRequester *mRepositoryMockGetPaginatedPipelineRunsByRequester) ExpectPageParam5(page int) *mRepositoryMockGetPaginatedPipelineRunsByRequester {
-	if mmGetPaginatedPipelineRunsByRequester.mock.funcGetPaginatedPipelineRunsByRequester != nil {
-		mmGetPaginatedPipelineRunsByRequester.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByRequester mock is already set by Set")
-	}
-
-	if mmGetPaginatedPipelineRunsByRequester.defaultExpectation == nil {
-		mmGetPaginatedPipelineRunsByRequester.defaultExpectation = &RepositoryMockGetPaginatedPipelineRunsByRequesterExpectation{}
-	}
-
-	if mmGetPaginatedPipelineRunsByRequester.defaultExpectation.params != nil {
-		mmGetPaginatedPipelineRunsByRequester.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByRequester mock is already set by Expect")
-	}
-
-	if mmGetPaginatedPipelineRunsByRequester.defaultExpectation.paramPtrs == nil {
-		mmGetPaginatedPipelineRunsByRequester.defaultExpectation.paramPtrs = &RepositoryMockGetPaginatedPipelineRunsByRequesterParamPtrs{}
-	}
-	mmGetPaginatedPipelineRunsByRequester.defaultExpectation.paramPtrs.page = &page
-	mmGetPaginatedPipelineRunsByRequester.defaultExpectation.expectationOrigins.originPage = minimock.CallerInfo(1)
-
-	return mmGetPaginatedPipelineRunsByRequester
-}
-
-// ExpectPageSizeParam6 sets up expected param pageSize for Repository.GetPaginatedPipelineRunsByRequester
-func (mmGetPaginatedPipelineRunsByRequester *mRepositoryMockGetPaginatedPipelineRunsByRequester) ExpectPageSizeParam6(pageSize int) *mRepositoryMockGetPaginatedPipelineRunsByRequester {
-	if mmGetPaginatedPipelineRunsByRequester.mock.funcGetPaginatedPipelineRunsByRequester != nil {
-		mmGetPaginatedPipelineRunsByRequester.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByRequester mock is already set by Set")
-	}
-
-	if mmGetPaginatedPipelineRunsByRequester.defaultExpectation == nil {
-		mmGetPaginatedPipelineRunsByRequester.defaultExpectation = &RepositoryMockGetPaginatedPipelineRunsByRequesterExpectation{}
-	}
-
-	if mmGetPaginatedPipelineRunsByRequester.defaultExpectation.params != nil {
-		mmGetPaginatedPipelineRunsByRequester.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByRequester mock is already set by Expect")
-	}
-
-	if mmGetPaginatedPipelineRunsByRequester.defaultExpectation.paramPtrs == nil {
-		mmGetPaginatedPipelineRunsByRequester.defaultExpectation.paramPtrs = &RepositoryMockGetPaginatedPipelineRunsByRequesterParamPtrs{}
-	}
-	mmGetPaginatedPipelineRunsByRequester.defaultExpectation.paramPtrs.pageSize = &pageSize
-	mmGetPaginatedPipelineRunsByRequester.defaultExpectation.expectationOrigins.originPageSize = minimock.CallerInfo(1)
-
-	return mmGetPaginatedPipelineRunsByRequester
-}
-
-// ExpectFilterParam7 sets up expected param filter for Repository.GetPaginatedPipelineRunsByRequester
-func (mmGetPaginatedPipelineRunsByRequester *mRepositoryMockGetPaginatedPipelineRunsByRequester) ExpectFilterParam7(filter filtering.Filter) *mRepositoryMockGetPaginatedPipelineRunsByRequester {
-	if mmGetPaginatedPipelineRunsByRequester.mock.funcGetPaginatedPipelineRunsByRequester != nil {
-		mmGetPaginatedPipelineRunsByRequester.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByRequester mock is already set by Set")
-	}
-
-	if mmGetPaginatedPipelineRunsByRequester.defaultExpectation == nil {
-		mmGetPaginatedPipelineRunsByRequester.defaultExpectation = &RepositoryMockGetPaginatedPipelineRunsByRequesterExpectation{}
-	}
-
-	if mmGetPaginatedPipelineRunsByRequester.defaultExpectation.params != nil {
-		mmGetPaginatedPipelineRunsByRequester.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByRequester mock is already set by Expect")
-	}
-
-	if mmGetPaginatedPipelineRunsByRequester.defaultExpectation.paramPtrs == nil {
-		mmGetPaginatedPipelineRunsByRequester.defaultExpectation.paramPtrs = &RepositoryMockGetPaginatedPipelineRunsByRequesterParamPtrs{}
-	}
-	mmGetPaginatedPipelineRunsByRequester.defaultExpectation.paramPtrs.filter = &filter
-	mmGetPaginatedPipelineRunsByRequester.defaultExpectation.expectationOrigins.originFilter = minimock.CallerInfo(1)
-
-	return mmGetPaginatedPipelineRunsByRequester
-}
-
-// ExpectOrderParam8 sets up expected param order for Repository.GetPaginatedPipelineRunsByRequester
-func (mmGetPaginatedPipelineRunsByRequester *mRepositoryMockGetPaginatedPipelineRunsByRequester) ExpectOrderParam8(order ordering.OrderBy) *mRepositoryMockGetPaginatedPipelineRunsByRequester {
-	if mmGetPaginatedPipelineRunsByRequester.mock.funcGetPaginatedPipelineRunsByRequester != nil {
-		mmGetPaginatedPipelineRunsByRequester.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByRequester mock is already set by Set")
-	}
-
-	if mmGetPaginatedPipelineRunsByRequester.defaultExpectation == nil {
-		mmGetPaginatedPipelineRunsByRequester.defaultExpectation = &RepositoryMockGetPaginatedPipelineRunsByRequesterExpectation{}
-	}
-
-	if mmGetPaginatedPipelineRunsByRequester.defaultExpectation.params != nil {
-		mmGetPaginatedPipelineRunsByRequester.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByRequester mock is already set by Expect")
-	}
-
-	if mmGetPaginatedPipelineRunsByRequester.defaultExpectation.paramPtrs == nil {
-		mmGetPaginatedPipelineRunsByRequester.defaultExpectation.paramPtrs = &RepositoryMockGetPaginatedPipelineRunsByRequesterParamPtrs{}
-	}
-	mmGetPaginatedPipelineRunsByRequester.defaultExpectation.paramPtrs.order = &order
-	mmGetPaginatedPipelineRunsByRequester.defaultExpectation.expectationOrigins.originOrder = minimock.CallerInfo(1)
+	mmGetPaginatedPipelineRunsByRequester.defaultExpectation.paramPtrs.params = &params
+	mmGetPaginatedPipelineRunsByRequester.defaultExpectation.expectationOrigins.originParams = minimock.CallerInfo(1)
 
 	return mmGetPaginatedPipelineRunsByRequester
 }
 
 // Inspect accepts an inspector function that has same arguments as the Repository.GetPaginatedPipelineRunsByRequester
-func (mmGetPaginatedPipelineRunsByRequester *mRepositoryMockGetPaginatedPipelineRunsByRequester) Inspect(f func(ctx context.Context, requesterUID string, startTime time.Time, endTime time.Time, page int, pageSize int, filter filtering.Filter, order ordering.OrderBy)) *mRepositoryMockGetPaginatedPipelineRunsByRequester {
+func (mmGetPaginatedPipelineRunsByRequester *mRepositoryMockGetPaginatedPipelineRunsByRequester) Inspect(f func(ctx context.Context, params mm_repository.GetPipelineRunsByRequesterParams)) *mRepositoryMockGetPaginatedPipelineRunsByRequester {
 	if mmGetPaginatedPipelineRunsByRequester.mock.inspectFuncGetPaginatedPipelineRunsByRequester != nil {
 		mmGetPaginatedPipelineRunsByRequester.mock.t.Fatalf("Inspect function is already set for RepositoryMock.GetPaginatedPipelineRunsByRequester")
 	}
@@ -8801,7 +8644,7 @@ func (mmGetPaginatedPipelineRunsByRequester *mRepositoryMockGetPaginatedPipeline
 }
 
 // Set uses given function f to mock the Repository.GetPaginatedPipelineRunsByRequester method
-func (mmGetPaginatedPipelineRunsByRequester *mRepositoryMockGetPaginatedPipelineRunsByRequester) Set(f func(ctx context.Context, requesterUID string, startTime time.Time, endTime time.Time, page int, pageSize int, filter filtering.Filter, order ordering.OrderBy) (pa1 []datamodel.PipelineRun, i1 int64, err error)) *RepositoryMock {
+func (mmGetPaginatedPipelineRunsByRequester *mRepositoryMockGetPaginatedPipelineRunsByRequester) Set(f func(ctx context.Context, params mm_repository.GetPipelineRunsByRequesterParams) (pa1 []datamodel.PipelineRun, i1 int64, err error)) *RepositoryMock {
 	if mmGetPaginatedPipelineRunsByRequester.defaultExpectation != nil {
 		mmGetPaginatedPipelineRunsByRequester.mock.t.Fatalf("Default expectation is already set for the Repository.GetPaginatedPipelineRunsByRequester method")
 	}
@@ -8817,14 +8660,14 @@ func (mmGetPaginatedPipelineRunsByRequester *mRepositoryMockGetPaginatedPipeline
 
 // When sets expectation for the Repository.GetPaginatedPipelineRunsByRequester which will trigger the result defined by the following
 // Then helper
-func (mmGetPaginatedPipelineRunsByRequester *mRepositoryMockGetPaginatedPipelineRunsByRequester) When(ctx context.Context, requesterUID string, startTime time.Time, endTime time.Time, page int, pageSize int, filter filtering.Filter, order ordering.OrderBy) *RepositoryMockGetPaginatedPipelineRunsByRequesterExpectation {
+func (mmGetPaginatedPipelineRunsByRequester *mRepositoryMockGetPaginatedPipelineRunsByRequester) When(ctx context.Context, params mm_repository.GetPipelineRunsByRequesterParams) *RepositoryMockGetPaginatedPipelineRunsByRequesterExpectation {
 	if mmGetPaginatedPipelineRunsByRequester.mock.funcGetPaginatedPipelineRunsByRequester != nil {
 		mmGetPaginatedPipelineRunsByRequester.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByRequester mock is already set by Set")
 	}
 
 	expectation := &RepositoryMockGetPaginatedPipelineRunsByRequesterExpectation{
 		mock:               mmGetPaginatedPipelineRunsByRequester.mock,
-		params:             &RepositoryMockGetPaginatedPipelineRunsByRequesterParams{ctx, requesterUID, startTime, endTime, page, pageSize, filter, order},
+		params:             &RepositoryMockGetPaginatedPipelineRunsByRequesterParams{ctx, params},
 		expectationOrigins: RepositoryMockGetPaginatedPipelineRunsByRequesterExpectationOrigins{origin: minimock.CallerInfo(1)},
 	}
 	mmGetPaginatedPipelineRunsByRequester.expectations = append(mmGetPaginatedPipelineRunsByRequester.expectations, expectation)
@@ -8859,17 +8702,17 @@ func (mmGetPaginatedPipelineRunsByRequester *mRepositoryMockGetPaginatedPipeline
 }
 
 // GetPaginatedPipelineRunsByRequester implements mm_repository.Repository
-func (mmGetPaginatedPipelineRunsByRequester *RepositoryMock) GetPaginatedPipelineRunsByRequester(ctx context.Context, requesterUID string, startTime time.Time, endTime time.Time, page int, pageSize int, filter filtering.Filter, order ordering.OrderBy) (pa1 []datamodel.PipelineRun, i1 int64, err error) {
+func (mmGetPaginatedPipelineRunsByRequester *RepositoryMock) GetPaginatedPipelineRunsByRequester(ctx context.Context, params mm_repository.GetPipelineRunsByRequesterParams) (pa1 []datamodel.PipelineRun, i1 int64, err error) {
 	mm_atomic.AddUint64(&mmGetPaginatedPipelineRunsByRequester.beforeGetPaginatedPipelineRunsByRequesterCounter, 1)
 	defer mm_atomic.AddUint64(&mmGetPaginatedPipelineRunsByRequester.afterGetPaginatedPipelineRunsByRequesterCounter, 1)
 
 	mmGetPaginatedPipelineRunsByRequester.t.Helper()
 
 	if mmGetPaginatedPipelineRunsByRequester.inspectFuncGetPaginatedPipelineRunsByRequester != nil {
-		mmGetPaginatedPipelineRunsByRequester.inspectFuncGetPaginatedPipelineRunsByRequester(ctx, requesterUID, startTime, endTime, page, pageSize, filter, order)
+		mmGetPaginatedPipelineRunsByRequester.inspectFuncGetPaginatedPipelineRunsByRequester(ctx, params)
 	}
 
-	mm_params := RepositoryMockGetPaginatedPipelineRunsByRequesterParams{ctx, requesterUID, startTime, endTime, page, pageSize, filter, order}
+	mm_params := RepositoryMockGetPaginatedPipelineRunsByRequesterParams{ctx, params}
 
 	// Record call args
 	mmGetPaginatedPipelineRunsByRequester.GetPaginatedPipelineRunsByRequesterMock.mutex.Lock()
@@ -8888,7 +8731,7 @@ func (mmGetPaginatedPipelineRunsByRequester *RepositoryMock) GetPaginatedPipelin
 		mm_want := mmGetPaginatedPipelineRunsByRequester.GetPaginatedPipelineRunsByRequesterMock.defaultExpectation.params
 		mm_want_ptrs := mmGetPaginatedPipelineRunsByRequester.GetPaginatedPipelineRunsByRequesterMock.defaultExpectation.paramPtrs
 
-		mm_got := RepositoryMockGetPaginatedPipelineRunsByRequesterParams{ctx, requesterUID, startTime, endTime, page, pageSize, filter, order}
+		mm_got := RepositoryMockGetPaginatedPipelineRunsByRequesterParams{ctx, params}
 
 		if mm_want_ptrs != nil {
 
@@ -8897,39 +8740,9 @@ func (mmGetPaginatedPipelineRunsByRequester *RepositoryMock) GetPaginatedPipelin
 					mmGetPaginatedPipelineRunsByRequester.GetPaginatedPipelineRunsByRequesterMock.defaultExpectation.expectationOrigins.originCtx, *mm_want_ptrs.ctx, mm_got.ctx, minimock.Diff(*mm_want_ptrs.ctx, mm_got.ctx))
 			}
 
-			if mm_want_ptrs.requesterUID != nil && !minimock.Equal(*mm_want_ptrs.requesterUID, mm_got.requesterUID) {
-				mmGetPaginatedPipelineRunsByRequester.t.Errorf("RepositoryMock.GetPaginatedPipelineRunsByRequester got unexpected parameter requesterUID, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
-					mmGetPaginatedPipelineRunsByRequester.GetPaginatedPipelineRunsByRequesterMock.defaultExpectation.expectationOrigins.originRequesterUID, *mm_want_ptrs.requesterUID, mm_got.requesterUID, minimock.Diff(*mm_want_ptrs.requesterUID, mm_got.requesterUID))
-			}
-
-			if mm_want_ptrs.startTime != nil && !minimock.Equal(*mm_want_ptrs.startTime, mm_got.startTime) {
-				mmGetPaginatedPipelineRunsByRequester.t.Errorf("RepositoryMock.GetPaginatedPipelineRunsByRequester got unexpected parameter startTime, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
-					mmGetPaginatedPipelineRunsByRequester.GetPaginatedPipelineRunsByRequesterMock.defaultExpectation.expectationOrigins.originStartTime, *mm_want_ptrs.startTime, mm_got.startTime, minimock.Diff(*mm_want_ptrs.startTime, mm_got.startTime))
-			}
-
-			if mm_want_ptrs.endTime != nil && !minimock.Equal(*mm_want_ptrs.endTime, mm_got.endTime) {
-				mmGetPaginatedPipelineRunsByRequester.t.Errorf("RepositoryMock.GetPaginatedPipelineRunsByRequester got unexpected parameter endTime, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
-					mmGetPaginatedPipelineRunsByRequester.GetPaginatedPipelineRunsByRequesterMock.defaultExpectation.expectationOrigins.originEndTime, *mm_want_ptrs.endTime, mm_got.endTime, minimock.Diff(*mm_want_ptrs.endTime, mm_got.endTime))
-			}
-
-			if mm_want_ptrs.page != nil && !minimock.Equal(*mm_want_ptrs.page, mm_got.page) {
-				mmGetPaginatedPipelineRunsByRequester.t.Errorf("RepositoryMock.GetPaginatedPipelineRunsByRequester got unexpected parameter page, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
-					mmGetPaginatedPipelineRunsByRequester.GetPaginatedPipelineRunsByRequesterMock.defaultExpectation.expectationOrigins.originPage, *mm_want_ptrs.page, mm_got.page, minimock.Diff(*mm_want_ptrs.page, mm_got.page))
-			}
-
-			if mm_want_ptrs.pageSize != nil && !minimock.Equal(*mm_want_ptrs.pageSize, mm_got.pageSize) {
-				mmGetPaginatedPipelineRunsByRequester.t.Errorf("RepositoryMock.GetPaginatedPipelineRunsByRequester got unexpected parameter pageSize, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
-					mmGetPaginatedPipelineRunsByRequester.GetPaginatedPipelineRunsByRequesterMock.defaultExpectation.expectationOrigins.originPageSize, *mm_want_ptrs.pageSize, mm_got.pageSize, minimock.Diff(*mm_want_ptrs.pageSize, mm_got.pageSize))
-			}
-
-			if mm_want_ptrs.filter != nil && !minimock.Equal(*mm_want_ptrs.filter, mm_got.filter) {
-				mmGetPaginatedPipelineRunsByRequester.t.Errorf("RepositoryMock.GetPaginatedPipelineRunsByRequester got unexpected parameter filter, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
-					mmGetPaginatedPipelineRunsByRequester.GetPaginatedPipelineRunsByRequesterMock.defaultExpectation.expectationOrigins.originFilter, *mm_want_ptrs.filter, mm_got.filter, minimock.Diff(*mm_want_ptrs.filter, mm_got.filter))
-			}
-
-			if mm_want_ptrs.order != nil && !minimock.Equal(*mm_want_ptrs.order, mm_got.order) {
-				mmGetPaginatedPipelineRunsByRequester.t.Errorf("RepositoryMock.GetPaginatedPipelineRunsByRequester got unexpected parameter order, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
-					mmGetPaginatedPipelineRunsByRequester.GetPaginatedPipelineRunsByRequesterMock.defaultExpectation.expectationOrigins.originOrder, *mm_want_ptrs.order, mm_got.order, minimock.Diff(*mm_want_ptrs.order, mm_got.order))
+			if mm_want_ptrs.params != nil && !minimock.Equal(*mm_want_ptrs.params, mm_got.params) {
+				mmGetPaginatedPipelineRunsByRequester.t.Errorf("RepositoryMock.GetPaginatedPipelineRunsByRequester got unexpected parameter params, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmGetPaginatedPipelineRunsByRequester.GetPaginatedPipelineRunsByRequesterMock.defaultExpectation.expectationOrigins.originParams, *mm_want_ptrs.params, mm_got.params, minimock.Diff(*mm_want_ptrs.params, mm_got.params))
 			}
 
 		} else if mm_want != nil && !minimock.Equal(*mm_want, mm_got) {
@@ -8944,9 +8757,9 @@ func (mmGetPaginatedPipelineRunsByRequester *RepositoryMock) GetPaginatedPipelin
 		return (*mm_results).pa1, (*mm_results).i1, (*mm_results).err
 	}
 	if mmGetPaginatedPipelineRunsByRequester.funcGetPaginatedPipelineRunsByRequester != nil {
-		return mmGetPaginatedPipelineRunsByRequester.funcGetPaginatedPipelineRunsByRequester(ctx, requesterUID, startTime, endTime, page, pageSize, filter, order)
+		return mmGetPaginatedPipelineRunsByRequester.funcGetPaginatedPipelineRunsByRequester(ctx, params)
 	}
-	mmGetPaginatedPipelineRunsByRequester.t.Fatalf("Unexpected call to RepositoryMock.GetPaginatedPipelineRunsByRequester. %v %v %v %v %v %v %v %v", ctx, requesterUID, startTime, endTime, page, pageSize, filter, order)
+	mmGetPaginatedPipelineRunsByRequester.t.Fatalf("Unexpected call to RepositoryMock.GetPaginatedPipelineRunsByRequester. %v %v", ctx, params)
 	return
 }
 

--- a/pkg/mock/repository_mock.gen.go
+++ b/pkg/mock/repository_mock.gen.go
@@ -5,8 +5,9 @@ package mock
 import (
 	"context"
 	"sync"
-	mm_atomic "sync/atomic"
 	"time"
+
+	mm_atomic "sync/atomic"
 	mm_time "time"
 
 	"github.com/gofrs/uuid"
@@ -174,12 +175,12 @@ type RepositoryMock struct {
 	beforeGetPaginatedComponentRunsByPipelineRunIDWithPermissionsCounter uint64
 	GetPaginatedComponentRunsByPipelineRunIDWithPermissionsMock          mRepositoryMockGetPaginatedComponentRunsByPipelineRunIDWithPermissions
 
-	funcGetPaginatedPipelineRunsByCreditOwner          func(ctx context.Context, requesterUID string, startTime time.Time, endTime time.Time, page int, pageSize int, filter filtering.Filter, order ordering.OrderBy) (pa1 []datamodel.PipelineRun, i1 int64, err error)
-	funcGetPaginatedPipelineRunsByCreditOwnerOrigin    string
-	inspectFuncGetPaginatedPipelineRunsByCreditOwner   func(ctx context.Context, requesterUID string, startTime time.Time, endTime time.Time, page int, pageSize int, filter filtering.Filter, order ordering.OrderBy)
-	afterGetPaginatedPipelineRunsByCreditOwnerCounter  uint64
-	beforeGetPaginatedPipelineRunsByCreditOwnerCounter uint64
-	GetPaginatedPipelineRunsByCreditOwnerMock          mRepositoryMockGetPaginatedPipelineRunsByCreditOwner
+	funcGetPaginatedPipelineRunsByRequester          func(ctx context.Context, requesterUID string, startTime time.Time, endTime time.Time, page int, pageSize int, filter filtering.Filter, order ordering.OrderBy) (pa1 []datamodel.PipelineRun, i1 int64, err error)
+	funcGetPaginatedPipelineRunsByRequesterOrigin    string
+	inspectFuncGetPaginatedPipelineRunsByRequester   func(ctx context.Context, requesterUID string, startTime time.Time, endTime time.Time, page int, pageSize int, filter filtering.Filter, order ordering.OrderBy)
+	afterGetPaginatedPipelineRunsByRequesterCounter  uint64
+	beforeGetPaginatedPipelineRunsByRequesterCounter uint64
+	GetPaginatedPipelineRunsByRequesterMock          mRepositoryMockGetPaginatedPipelineRunsByRequester
 
 	funcGetPaginatedPipelineRunsWithPermissions          func(ctx context.Context, requesterUID string, pipelineUID string, page int, pageSize int, filter filtering.Filter, order ordering.OrderBy, isOwner bool) (pa1 []datamodel.PipelineRun, i1 int64, err error)
 	funcGetPaginatedPipelineRunsWithPermissionsOrigin    string
@@ -456,8 +457,8 @@ func NewRepositoryMock(t minimock.Tester) *RepositoryMock {
 	m.GetPaginatedComponentRunsByPipelineRunIDWithPermissionsMock = mRepositoryMockGetPaginatedComponentRunsByPipelineRunIDWithPermissions{mock: m}
 	m.GetPaginatedComponentRunsByPipelineRunIDWithPermissionsMock.callArgs = []*RepositoryMockGetPaginatedComponentRunsByPipelineRunIDWithPermissionsParams{}
 
-	m.GetPaginatedPipelineRunsByCreditOwnerMock = mRepositoryMockGetPaginatedPipelineRunsByCreditOwner{mock: m}
-	m.GetPaginatedPipelineRunsByCreditOwnerMock.callArgs = []*RepositoryMockGetPaginatedPipelineRunsByCreditOwnerParams{}
+	m.GetPaginatedPipelineRunsByRequesterMock = mRepositoryMockGetPaginatedPipelineRunsByRequester{mock: m}
+	m.GetPaginatedPipelineRunsByRequesterMock.callArgs = []*RepositoryMockGetPaginatedPipelineRunsByRequesterParams{}
 
 	m.GetPaginatedPipelineRunsWithPermissionsMock = mRepositoryMockGetPaginatedPipelineRunsWithPermissions{mock: m}
 	m.GetPaginatedPipelineRunsWithPermissionsMock.callArgs = []*RepositoryMockGetPaginatedPipelineRunsWithPermissionsParams{}
@@ -8487,32 +8488,32 @@ func (m *RepositoryMock) MinimockGetPaginatedComponentRunsByPipelineRunIDWithPer
 	}
 }
 
-type mRepositoryMockGetPaginatedPipelineRunsByCreditOwner struct {
+type mRepositoryMockGetPaginatedPipelineRunsByRequester struct {
 	optional           bool
 	mock               *RepositoryMock
-	defaultExpectation *RepositoryMockGetPaginatedPipelineRunsByCreditOwnerExpectation
-	expectations       []*RepositoryMockGetPaginatedPipelineRunsByCreditOwnerExpectation
+	defaultExpectation *RepositoryMockGetPaginatedPipelineRunsByRequesterExpectation
+	expectations       []*RepositoryMockGetPaginatedPipelineRunsByRequesterExpectation
 
-	callArgs []*RepositoryMockGetPaginatedPipelineRunsByCreditOwnerParams
+	callArgs []*RepositoryMockGetPaginatedPipelineRunsByRequesterParams
 	mutex    sync.RWMutex
 
 	expectedInvocations       uint64
 	expectedInvocationsOrigin string
 }
 
-// RepositoryMockGetPaginatedPipelineRunsByCreditOwnerExpectation specifies expectation struct of the Repository.GetPaginatedPipelineRunsByCreditOwner
-type RepositoryMockGetPaginatedPipelineRunsByCreditOwnerExpectation struct {
+// RepositoryMockGetPaginatedPipelineRunsByRequesterExpectation specifies expectation struct of the Repository.GetPaginatedPipelineRunsByRequester
+type RepositoryMockGetPaginatedPipelineRunsByRequesterExpectation struct {
 	mock               *RepositoryMock
-	params             *RepositoryMockGetPaginatedPipelineRunsByCreditOwnerParams
-	paramPtrs          *RepositoryMockGetPaginatedPipelineRunsByCreditOwnerParamPtrs
-	expectationOrigins RepositoryMockGetPaginatedPipelineRunsByCreditOwnerExpectationOrigins
-	results            *RepositoryMockGetPaginatedPipelineRunsByCreditOwnerResults
+	params             *RepositoryMockGetPaginatedPipelineRunsByRequesterParams
+	paramPtrs          *RepositoryMockGetPaginatedPipelineRunsByRequesterParamPtrs
+	expectationOrigins RepositoryMockGetPaginatedPipelineRunsByRequesterExpectationOrigins
+	results            *RepositoryMockGetPaginatedPipelineRunsByRequesterResults
 	returnOrigin       string
 	Counter            uint64
 }
 
-// RepositoryMockGetPaginatedPipelineRunsByCreditOwnerParams contains parameters of the Repository.GetPaginatedPipelineRunsByCreditOwner
-type RepositoryMockGetPaginatedPipelineRunsByCreditOwnerParams struct {
+// RepositoryMockGetPaginatedPipelineRunsByRequesterParams contains parameters of the Repository.GetPaginatedPipelineRunsByRequester
+type RepositoryMockGetPaginatedPipelineRunsByRequesterParams struct {
 	ctx          context.Context
 	requesterUID string
 	startTime    time.Time
@@ -8523,8 +8524,8 @@ type RepositoryMockGetPaginatedPipelineRunsByCreditOwnerParams struct {
 	order        ordering.OrderBy
 }
 
-// RepositoryMockGetPaginatedPipelineRunsByCreditOwnerParamPtrs contains pointers to parameters of the Repository.GetPaginatedPipelineRunsByCreditOwner
-type RepositoryMockGetPaginatedPipelineRunsByCreditOwnerParamPtrs struct {
+// RepositoryMockGetPaginatedPipelineRunsByRequesterParamPtrs contains pointers to parameters of the Repository.GetPaginatedPipelineRunsByRequester
+type RepositoryMockGetPaginatedPipelineRunsByRequesterParamPtrs struct {
 	ctx          *context.Context
 	requesterUID *string
 	startTime    *time.Time
@@ -8535,15 +8536,15 @@ type RepositoryMockGetPaginatedPipelineRunsByCreditOwnerParamPtrs struct {
 	order        *ordering.OrderBy
 }
 
-// RepositoryMockGetPaginatedPipelineRunsByCreditOwnerResults contains results of the Repository.GetPaginatedPipelineRunsByCreditOwner
-type RepositoryMockGetPaginatedPipelineRunsByCreditOwnerResults struct {
+// RepositoryMockGetPaginatedPipelineRunsByRequesterResults contains results of the Repository.GetPaginatedPipelineRunsByRequester
+type RepositoryMockGetPaginatedPipelineRunsByRequesterResults struct {
 	pa1 []datamodel.PipelineRun
 	i1  int64
 	err error
 }
 
-// RepositoryMockGetPaginatedPipelineRunsByCreditOwnerOrigins contains origins of expectations of the Repository.GetPaginatedPipelineRunsByCreditOwner
-type RepositoryMockGetPaginatedPipelineRunsByCreditOwnerExpectationOrigins struct {
+// RepositoryMockGetPaginatedPipelineRunsByRequesterOrigins contains origins of expectations of the Repository.GetPaginatedPipelineRunsByRequester
+type RepositoryMockGetPaginatedPipelineRunsByRequesterExpectationOrigins struct {
 	origin             string
 	originCtx          string
 	originRequesterUID string
@@ -8560,460 +8561,460 @@ type RepositoryMockGetPaginatedPipelineRunsByCreditOwnerExpectationOrigins struc
 // Optional() makes method check to work in '0 or more' mode.
 // It is NOT RECOMMENDED to use this option unless you really need it, as default behaviour helps to
 // catch the problems when the expected method call is totally skipped during test run.
-func (mmGetPaginatedPipelineRunsByCreditOwner *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner) Optional() *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner {
-	mmGetPaginatedPipelineRunsByCreditOwner.optional = true
-	return mmGetPaginatedPipelineRunsByCreditOwner
+func (mmGetPaginatedPipelineRunsByRequester *mRepositoryMockGetPaginatedPipelineRunsByRequester) Optional() *mRepositoryMockGetPaginatedPipelineRunsByRequester {
+	mmGetPaginatedPipelineRunsByRequester.optional = true
+	return mmGetPaginatedPipelineRunsByRequester
 }
 
-// Expect sets up expected params for Repository.GetPaginatedPipelineRunsByCreditOwner
-func (mmGetPaginatedPipelineRunsByCreditOwner *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner) Expect(ctx context.Context, requesterUID string, startTime time.Time, endTime time.Time, page int, pageSize int, filter filtering.Filter, order ordering.OrderBy) *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner {
-	if mmGetPaginatedPipelineRunsByCreditOwner.mock.funcGetPaginatedPipelineRunsByCreditOwner != nil {
-		mmGetPaginatedPipelineRunsByCreditOwner.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner mock is already set by Set")
+// Expect sets up expected params for Repository.GetPaginatedPipelineRunsByRequester
+func (mmGetPaginatedPipelineRunsByRequester *mRepositoryMockGetPaginatedPipelineRunsByRequester) Expect(ctx context.Context, requesterUID string, startTime time.Time, endTime time.Time, page int, pageSize int, filter filtering.Filter, order ordering.OrderBy) *mRepositoryMockGetPaginatedPipelineRunsByRequester {
+	if mmGetPaginatedPipelineRunsByRequester.mock.funcGetPaginatedPipelineRunsByRequester != nil {
+		mmGetPaginatedPipelineRunsByRequester.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByRequester mock is already set by Set")
 	}
 
-	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation == nil {
-		mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation = &RepositoryMockGetPaginatedPipelineRunsByCreditOwnerExpectation{}
+	if mmGetPaginatedPipelineRunsByRequester.defaultExpectation == nil {
+		mmGetPaginatedPipelineRunsByRequester.defaultExpectation = &RepositoryMockGetPaginatedPipelineRunsByRequesterExpectation{}
 	}
 
-	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.paramPtrs != nil {
-		mmGetPaginatedPipelineRunsByCreditOwner.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner mock is already set by ExpectParams functions")
+	if mmGetPaginatedPipelineRunsByRequester.defaultExpectation.paramPtrs != nil {
+		mmGetPaginatedPipelineRunsByRequester.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByRequester mock is already set by ExpectParams functions")
 	}
 
-	mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.params = &RepositoryMockGetPaginatedPipelineRunsByCreditOwnerParams{ctx, requesterUID, startTime, endTime, page, pageSize, filter, order}
-	mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.expectationOrigins.origin = minimock.CallerInfo(1)
-	for _, e := range mmGetPaginatedPipelineRunsByCreditOwner.expectations {
-		if minimock.Equal(e.params, mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.params) {
-			mmGetPaginatedPipelineRunsByCreditOwner.mock.t.Fatalf("Expectation set by When has same params: %#v", *mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.params)
+	mmGetPaginatedPipelineRunsByRequester.defaultExpectation.params = &RepositoryMockGetPaginatedPipelineRunsByRequesterParams{ctx, requesterUID, startTime, endTime, page, pageSize, filter, order}
+	mmGetPaginatedPipelineRunsByRequester.defaultExpectation.expectationOrigins.origin = minimock.CallerInfo(1)
+	for _, e := range mmGetPaginatedPipelineRunsByRequester.expectations {
+		if minimock.Equal(e.params, mmGetPaginatedPipelineRunsByRequester.defaultExpectation.params) {
+			mmGetPaginatedPipelineRunsByRequester.mock.t.Fatalf("Expectation set by When has same params: %#v", *mmGetPaginatedPipelineRunsByRequester.defaultExpectation.params)
 		}
 	}
 
-	return mmGetPaginatedPipelineRunsByCreditOwner
+	return mmGetPaginatedPipelineRunsByRequester
 }
 
-// ExpectCtxParam1 sets up expected param ctx for Repository.GetPaginatedPipelineRunsByCreditOwner
-func (mmGetPaginatedPipelineRunsByCreditOwner *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner) ExpectCtxParam1(ctx context.Context) *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner {
-	if mmGetPaginatedPipelineRunsByCreditOwner.mock.funcGetPaginatedPipelineRunsByCreditOwner != nil {
-		mmGetPaginatedPipelineRunsByCreditOwner.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner mock is already set by Set")
+// ExpectCtxParam1 sets up expected param ctx for Repository.GetPaginatedPipelineRunsByRequester
+func (mmGetPaginatedPipelineRunsByRequester *mRepositoryMockGetPaginatedPipelineRunsByRequester) ExpectCtxParam1(ctx context.Context) *mRepositoryMockGetPaginatedPipelineRunsByRequester {
+	if mmGetPaginatedPipelineRunsByRequester.mock.funcGetPaginatedPipelineRunsByRequester != nil {
+		mmGetPaginatedPipelineRunsByRequester.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByRequester mock is already set by Set")
 	}
 
-	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation == nil {
-		mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation = &RepositoryMockGetPaginatedPipelineRunsByCreditOwnerExpectation{}
+	if mmGetPaginatedPipelineRunsByRequester.defaultExpectation == nil {
+		mmGetPaginatedPipelineRunsByRequester.defaultExpectation = &RepositoryMockGetPaginatedPipelineRunsByRequesterExpectation{}
 	}
 
-	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.params != nil {
-		mmGetPaginatedPipelineRunsByCreditOwner.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner mock is already set by Expect")
+	if mmGetPaginatedPipelineRunsByRequester.defaultExpectation.params != nil {
+		mmGetPaginatedPipelineRunsByRequester.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByRequester mock is already set by Expect")
 	}
 
-	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.paramPtrs == nil {
-		mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.paramPtrs = &RepositoryMockGetPaginatedPipelineRunsByCreditOwnerParamPtrs{}
+	if mmGetPaginatedPipelineRunsByRequester.defaultExpectation.paramPtrs == nil {
+		mmGetPaginatedPipelineRunsByRequester.defaultExpectation.paramPtrs = &RepositoryMockGetPaginatedPipelineRunsByRequesterParamPtrs{}
 	}
-	mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.paramPtrs.ctx = &ctx
-	mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.expectationOrigins.originCtx = minimock.CallerInfo(1)
+	mmGetPaginatedPipelineRunsByRequester.defaultExpectation.paramPtrs.ctx = &ctx
+	mmGetPaginatedPipelineRunsByRequester.defaultExpectation.expectationOrigins.originCtx = minimock.CallerInfo(1)
 
-	return mmGetPaginatedPipelineRunsByCreditOwner
+	return mmGetPaginatedPipelineRunsByRequester
 }
 
-// ExpectRequesterUIDParam2 sets up expected param requesterUID for Repository.GetPaginatedPipelineRunsByCreditOwner
-func (mmGetPaginatedPipelineRunsByCreditOwner *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner) ExpectRequesterUIDParam2(requesterUID string) *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner {
-	if mmGetPaginatedPipelineRunsByCreditOwner.mock.funcGetPaginatedPipelineRunsByCreditOwner != nil {
-		mmGetPaginatedPipelineRunsByCreditOwner.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner mock is already set by Set")
+// ExpectRequesterUIDParam2 sets up expected param requesterUID for Repository.GetPaginatedPipelineRunsByRequester
+func (mmGetPaginatedPipelineRunsByRequester *mRepositoryMockGetPaginatedPipelineRunsByRequester) ExpectRequesterUIDParam2(requesterUID string) *mRepositoryMockGetPaginatedPipelineRunsByRequester {
+	if mmGetPaginatedPipelineRunsByRequester.mock.funcGetPaginatedPipelineRunsByRequester != nil {
+		mmGetPaginatedPipelineRunsByRequester.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByRequester mock is already set by Set")
 	}
 
-	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation == nil {
-		mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation = &RepositoryMockGetPaginatedPipelineRunsByCreditOwnerExpectation{}
+	if mmGetPaginatedPipelineRunsByRequester.defaultExpectation == nil {
+		mmGetPaginatedPipelineRunsByRequester.defaultExpectation = &RepositoryMockGetPaginatedPipelineRunsByRequesterExpectation{}
 	}
 
-	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.params != nil {
-		mmGetPaginatedPipelineRunsByCreditOwner.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner mock is already set by Expect")
+	if mmGetPaginatedPipelineRunsByRequester.defaultExpectation.params != nil {
+		mmGetPaginatedPipelineRunsByRequester.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByRequester mock is already set by Expect")
 	}
 
-	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.paramPtrs == nil {
-		mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.paramPtrs = &RepositoryMockGetPaginatedPipelineRunsByCreditOwnerParamPtrs{}
+	if mmGetPaginatedPipelineRunsByRequester.defaultExpectation.paramPtrs == nil {
+		mmGetPaginatedPipelineRunsByRequester.defaultExpectation.paramPtrs = &RepositoryMockGetPaginatedPipelineRunsByRequesterParamPtrs{}
 	}
-	mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.paramPtrs.requesterUID = &requesterUID
-	mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.expectationOrigins.originRequesterUID = minimock.CallerInfo(1)
+	mmGetPaginatedPipelineRunsByRequester.defaultExpectation.paramPtrs.requesterUID = &requesterUID
+	mmGetPaginatedPipelineRunsByRequester.defaultExpectation.expectationOrigins.originRequesterUID = minimock.CallerInfo(1)
 
-	return mmGetPaginatedPipelineRunsByCreditOwner
+	return mmGetPaginatedPipelineRunsByRequester
 }
 
-// ExpectStartTimeParam3 sets up expected param startTime for Repository.GetPaginatedPipelineRunsByCreditOwner
-func (mmGetPaginatedPipelineRunsByCreditOwner *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner) ExpectStartTimeParam3(startTime time.Time) *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner {
-	if mmGetPaginatedPipelineRunsByCreditOwner.mock.funcGetPaginatedPipelineRunsByCreditOwner != nil {
-		mmGetPaginatedPipelineRunsByCreditOwner.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner mock is already set by Set")
+// ExpectStartTimeParam3 sets up expected param startTime for Repository.GetPaginatedPipelineRunsByRequester
+func (mmGetPaginatedPipelineRunsByRequester *mRepositoryMockGetPaginatedPipelineRunsByRequester) ExpectStartTimeParam3(startTime time.Time) *mRepositoryMockGetPaginatedPipelineRunsByRequester {
+	if mmGetPaginatedPipelineRunsByRequester.mock.funcGetPaginatedPipelineRunsByRequester != nil {
+		mmGetPaginatedPipelineRunsByRequester.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByRequester mock is already set by Set")
 	}
 
-	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation == nil {
-		mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation = &RepositoryMockGetPaginatedPipelineRunsByCreditOwnerExpectation{}
+	if mmGetPaginatedPipelineRunsByRequester.defaultExpectation == nil {
+		mmGetPaginatedPipelineRunsByRequester.defaultExpectation = &RepositoryMockGetPaginatedPipelineRunsByRequesterExpectation{}
 	}
 
-	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.params != nil {
-		mmGetPaginatedPipelineRunsByCreditOwner.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner mock is already set by Expect")
+	if mmGetPaginatedPipelineRunsByRequester.defaultExpectation.params != nil {
+		mmGetPaginatedPipelineRunsByRequester.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByRequester mock is already set by Expect")
 	}
 
-	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.paramPtrs == nil {
-		mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.paramPtrs = &RepositoryMockGetPaginatedPipelineRunsByCreditOwnerParamPtrs{}
+	if mmGetPaginatedPipelineRunsByRequester.defaultExpectation.paramPtrs == nil {
+		mmGetPaginatedPipelineRunsByRequester.defaultExpectation.paramPtrs = &RepositoryMockGetPaginatedPipelineRunsByRequesterParamPtrs{}
 	}
-	mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.paramPtrs.startTime = &startTime
-	mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.expectationOrigins.originStartTime = minimock.CallerInfo(1)
+	mmGetPaginatedPipelineRunsByRequester.defaultExpectation.paramPtrs.startTime = &startTime
+	mmGetPaginatedPipelineRunsByRequester.defaultExpectation.expectationOrigins.originStartTime = minimock.CallerInfo(1)
 
-	return mmGetPaginatedPipelineRunsByCreditOwner
+	return mmGetPaginatedPipelineRunsByRequester
 }
 
-// ExpectEndTimeParam4 sets up expected param endTime for Repository.GetPaginatedPipelineRunsByCreditOwner
-func (mmGetPaginatedPipelineRunsByCreditOwner *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner) ExpectEndTimeParam4(endTime time.Time) *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner {
-	if mmGetPaginatedPipelineRunsByCreditOwner.mock.funcGetPaginatedPipelineRunsByCreditOwner != nil {
-		mmGetPaginatedPipelineRunsByCreditOwner.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner mock is already set by Set")
+// ExpectEndTimeParam4 sets up expected param endTime for Repository.GetPaginatedPipelineRunsByRequester
+func (mmGetPaginatedPipelineRunsByRequester *mRepositoryMockGetPaginatedPipelineRunsByRequester) ExpectEndTimeParam4(endTime time.Time) *mRepositoryMockGetPaginatedPipelineRunsByRequester {
+	if mmGetPaginatedPipelineRunsByRequester.mock.funcGetPaginatedPipelineRunsByRequester != nil {
+		mmGetPaginatedPipelineRunsByRequester.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByRequester mock is already set by Set")
 	}
 
-	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation == nil {
-		mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation = &RepositoryMockGetPaginatedPipelineRunsByCreditOwnerExpectation{}
+	if mmGetPaginatedPipelineRunsByRequester.defaultExpectation == nil {
+		mmGetPaginatedPipelineRunsByRequester.defaultExpectation = &RepositoryMockGetPaginatedPipelineRunsByRequesterExpectation{}
 	}
 
-	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.params != nil {
-		mmGetPaginatedPipelineRunsByCreditOwner.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner mock is already set by Expect")
+	if mmGetPaginatedPipelineRunsByRequester.defaultExpectation.params != nil {
+		mmGetPaginatedPipelineRunsByRequester.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByRequester mock is already set by Expect")
 	}
 
-	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.paramPtrs == nil {
-		mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.paramPtrs = &RepositoryMockGetPaginatedPipelineRunsByCreditOwnerParamPtrs{}
+	if mmGetPaginatedPipelineRunsByRequester.defaultExpectation.paramPtrs == nil {
+		mmGetPaginatedPipelineRunsByRequester.defaultExpectation.paramPtrs = &RepositoryMockGetPaginatedPipelineRunsByRequesterParamPtrs{}
 	}
-	mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.paramPtrs.endTime = &endTime
-	mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.expectationOrigins.originEndTime = minimock.CallerInfo(1)
+	mmGetPaginatedPipelineRunsByRequester.defaultExpectation.paramPtrs.endTime = &endTime
+	mmGetPaginatedPipelineRunsByRequester.defaultExpectation.expectationOrigins.originEndTime = minimock.CallerInfo(1)
 
-	return mmGetPaginatedPipelineRunsByCreditOwner
+	return mmGetPaginatedPipelineRunsByRequester
 }
 
-// ExpectPageParam5 sets up expected param page for Repository.GetPaginatedPipelineRunsByCreditOwner
-func (mmGetPaginatedPipelineRunsByCreditOwner *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner) ExpectPageParam5(page int) *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner {
-	if mmGetPaginatedPipelineRunsByCreditOwner.mock.funcGetPaginatedPipelineRunsByCreditOwner != nil {
-		mmGetPaginatedPipelineRunsByCreditOwner.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner mock is already set by Set")
+// ExpectPageParam5 sets up expected param page for Repository.GetPaginatedPipelineRunsByRequester
+func (mmGetPaginatedPipelineRunsByRequester *mRepositoryMockGetPaginatedPipelineRunsByRequester) ExpectPageParam5(page int) *mRepositoryMockGetPaginatedPipelineRunsByRequester {
+	if mmGetPaginatedPipelineRunsByRequester.mock.funcGetPaginatedPipelineRunsByRequester != nil {
+		mmGetPaginatedPipelineRunsByRequester.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByRequester mock is already set by Set")
 	}
 
-	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation == nil {
-		mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation = &RepositoryMockGetPaginatedPipelineRunsByCreditOwnerExpectation{}
+	if mmGetPaginatedPipelineRunsByRequester.defaultExpectation == nil {
+		mmGetPaginatedPipelineRunsByRequester.defaultExpectation = &RepositoryMockGetPaginatedPipelineRunsByRequesterExpectation{}
 	}
 
-	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.params != nil {
-		mmGetPaginatedPipelineRunsByCreditOwner.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner mock is already set by Expect")
+	if mmGetPaginatedPipelineRunsByRequester.defaultExpectation.params != nil {
+		mmGetPaginatedPipelineRunsByRequester.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByRequester mock is already set by Expect")
 	}
 
-	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.paramPtrs == nil {
-		mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.paramPtrs = &RepositoryMockGetPaginatedPipelineRunsByCreditOwnerParamPtrs{}
+	if mmGetPaginatedPipelineRunsByRequester.defaultExpectation.paramPtrs == nil {
+		mmGetPaginatedPipelineRunsByRequester.defaultExpectation.paramPtrs = &RepositoryMockGetPaginatedPipelineRunsByRequesterParamPtrs{}
 	}
-	mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.paramPtrs.page = &page
-	mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.expectationOrigins.originPage = minimock.CallerInfo(1)
+	mmGetPaginatedPipelineRunsByRequester.defaultExpectation.paramPtrs.page = &page
+	mmGetPaginatedPipelineRunsByRequester.defaultExpectation.expectationOrigins.originPage = minimock.CallerInfo(1)
 
-	return mmGetPaginatedPipelineRunsByCreditOwner
+	return mmGetPaginatedPipelineRunsByRequester
 }
 
-// ExpectPageSizeParam6 sets up expected param pageSize for Repository.GetPaginatedPipelineRunsByCreditOwner
-func (mmGetPaginatedPipelineRunsByCreditOwner *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner) ExpectPageSizeParam6(pageSize int) *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner {
-	if mmGetPaginatedPipelineRunsByCreditOwner.mock.funcGetPaginatedPipelineRunsByCreditOwner != nil {
-		mmGetPaginatedPipelineRunsByCreditOwner.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner mock is already set by Set")
+// ExpectPageSizeParam6 sets up expected param pageSize for Repository.GetPaginatedPipelineRunsByRequester
+func (mmGetPaginatedPipelineRunsByRequester *mRepositoryMockGetPaginatedPipelineRunsByRequester) ExpectPageSizeParam6(pageSize int) *mRepositoryMockGetPaginatedPipelineRunsByRequester {
+	if mmGetPaginatedPipelineRunsByRequester.mock.funcGetPaginatedPipelineRunsByRequester != nil {
+		mmGetPaginatedPipelineRunsByRequester.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByRequester mock is already set by Set")
 	}
 
-	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation == nil {
-		mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation = &RepositoryMockGetPaginatedPipelineRunsByCreditOwnerExpectation{}
+	if mmGetPaginatedPipelineRunsByRequester.defaultExpectation == nil {
+		mmGetPaginatedPipelineRunsByRequester.defaultExpectation = &RepositoryMockGetPaginatedPipelineRunsByRequesterExpectation{}
 	}
 
-	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.params != nil {
-		mmGetPaginatedPipelineRunsByCreditOwner.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner mock is already set by Expect")
+	if mmGetPaginatedPipelineRunsByRequester.defaultExpectation.params != nil {
+		mmGetPaginatedPipelineRunsByRequester.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByRequester mock is already set by Expect")
 	}
 
-	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.paramPtrs == nil {
-		mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.paramPtrs = &RepositoryMockGetPaginatedPipelineRunsByCreditOwnerParamPtrs{}
+	if mmGetPaginatedPipelineRunsByRequester.defaultExpectation.paramPtrs == nil {
+		mmGetPaginatedPipelineRunsByRequester.defaultExpectation.paramPtrs = &RepositoryMockGetPaginatedPipelineRunsByRequesterParamPtrs{}
 	}
-	mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.paramPtrs.pageSize = &pageSize
-	mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.expectationOrigins.originPageSize = minimock.CallerInfo(1)
+	mmGetPaginatedPipelineRunsByRequester.defaultExpectation.paramPtrs.pageSize = &pageSize
+	mmGetPaginatedPipelineRunsByRequester.defaultExpectation.expectationOrigins.originPageSize = minimock.CallerInfo(1)
 
-	return mmGetPaginatedPipelineRunsByCreditOwner
+	return mmGetPaginatedPipelineRunsByRequester
 }
 
-// ExpectFilterParam7 sets up expected param filter for Repository.GetPaginatedPipelineRunsByCreditOwner
-func (mmGetPaginatedPipelineRunsByCreditOwner *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner) ExpectFilterParam7(filter filtering.Filter) *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner {
-	if mmGetPaginatedPipelineRunsByCreditOwner.mock.funcGetPaginatedPipelineRunsByCreditOwner != nil {
-		mmGetPaginatedPipelineRunsByCreditOwner.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner mock is already set by Set")
+// ExpectFilterParam7 sets up expected param filter for Repository.GetPaginatedPipelineRunsByRequester
+func (mmGetPaginatedPipelineRunsByRequester *mRepositoryMockGetPaginatedPipelineRunsByRequester) ExpectFilterParam7(filter filtering.Filter) *mRepositoryMockGetPaginatedPipelineRunsByRequester {
+	if mmGetPaginatedPipelineRunsByRequester.mock.funcGetPaginatedPipelineRunsByRequester != nil {
+		mmGetPaginatedPipelineRunsByRequester.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByRequester mock is already set by Set")
 	}
 
-	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation == nil {
-		mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation = &RepositoryMockGetPaginatedPipelineRunsByCreditOwnerExpectation{}
+	if mmGetPaginatedPipelineRunsByRequester.defaultExpectation == nil {
+		mmGetPaginatedPipelineRunsByRequester.defaultExpectation = &RepositoryMockGetPaginatedPipelineRunsByRequesterExpectation{}
 	}
 
-	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.params != nil {
-		mmGetPaginatedPipelineRunsByCreditOwner.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner mock is already set by Expect")
+	if mmGetPaginatedPipelineRunsByRequester.defaultExpectation.params != nil {
+		mmGetPaginatedPipelineRunsByRequester.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByRequester mock is already set by Expect")
 	}
 
-	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.paramPtrs == nil {
-		mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.paramPtrs = &RepositoryMockGetPaginatedPipelineRunsByCreditOwnerParamPtrs{}
+	if mmGetPaginatedPipelineRunsByRequester.defaultExpectation.paramPtrs == nil {
+		mmGetPaginatedPipelineRunsByRequester.defaultExpectation.paramPtrs = &RepositoryMockGetPaginatedPipelineRunsByRequesterParamPtrs{}
 	}
-	mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.paramPtrs.filter = &filter
-	mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.expectationOrigins.originFilter = minimock.CallerInfo(1)
+	mmGetPaginatedPipelineRunsByRequester.defaultExpectation.paramPtrs.filter = &filter
+	mmGetPaginatedPipelineRunsByRequester.defaultExpectation.expectationOrigins.originFilter = minimock.CallerInfo(1)
 
-	return mmGetPaginatedPipelineRunsByCreditOwner
+	return mmGetPaginatedPipelineRunsByRequester
 }
 
-// ExpectOrderParam8 sets up expected param order for Repository.GetPaginatedPipelineRunsByCreditOwner
-func (mmGetPaginatedPipelineRunsByCreditOwner *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner) ExpectOrderParam8(order ordering.OrderBy) *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner {
-	if mmGetPaginatedPipelineRunsByCreditOwner.mock.funcGetPaginatedPipelineRunsByCreditOwner != nil {
-		mmGetPaginatedPipelineRunsByCreditOwner.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner mock is already set by Set")
+// ExpectOrderParam8 sets up expected param order for Repository.GetPaginatedPipelineRunsByRequester
+func (mmGetPaginatedPipelineRunsByRequester *mRepositoryMockGetPaginatedPipelineRunsByRequester) ExpectOrderParam8(order ordering.OrderBy) *mRepositoryMockGetPaginatedPipelineRunsByRequester {
+	if mmGetPaginatedPipelineRunsByRequester.mock.funcGetPaginatedPipelineRunsByRequester != nil {
+		mmGetPaginatedPipelineRunsByRequester.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByRequester mock is already set by Set")
 	}
 
-	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation == nil {
-		mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation = &RepositoryMockGetPaginatedPipelineRunsByCreditOwnerExpectation{}
+	if mmGetPaginatedPipelineRunsByRequester.defaultExpectation == nil {
+		mmGetPaginatedPipelineRunsByRequester.defaultExpectation = &RepositoryMockGetPaginatedPipelineRunsByRequesterExpectation{}
 	}
 
-	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.params != nil {
-		mmGetPaginatedPipelineRunsByCreditOwner.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner mock is already set by Expect")
+	if mmGetPaginatedPipelineRunsByRequester.defaultExpectation.params != nil {
+		mmGetPaginatedPipelineRunsByRequester.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByRequester mock is already set by Expect")
 	}
 
-	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.paramPtrs == nil {
-		mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.paramPtrs = &RepositoryMockGetPaginatedPipelineRunsByCreditOwnerParamPtrs{}
+	if mmGetPaginatedPipelineRunsByRequester.defaultExpectation.paramPtrs == nil {
+		mmGetPaginatedPipelineRunsByRequester.defaultExpectation.paramPtrs = &RepositoryMockGetPaginatedPipelineRunsByRequesterParamPtrs{}
 	}
-	mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.paramPtrs.order = &order
-	mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.expectationOrigins.originOrder = minimock.CallerInfo(1)
+	mmGetPaginatedPipelineRunsByRequester.defaultExpectation.paramPtrs.order = &order
+	mmGetPaginatedPipelineRunsByRequester.defaultExpectation.expectationOrigins.originOrder = minimock.CallerInfo(1)
 
-	return mmGetPaginatedPipelineRunsByCreditOwner
+	return mmGetPaginatedPipelineRunsByRequester
 }
 
-// Inspect accepts an inspector function that has same arguments as the Repository.GetPaginatedPipelineRunsByCreditOwner
-func (mmGetPaginatedPipelineRunsByCreditOwner *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner) Inspect(f func(ctx context.Context, requesterUID string, startTime time.Time, endTime time.Time, page int, pageSize int, filter filtering.Filter, order ordering.OrderBy)) *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner {
-	if mmGetPaginatedPipelineRunsByCreditOwner.mock.inspectFuncGetPaginatedPipelineRunsByCreditOwner != nil {
-		mmGetPaginatedPipelineRunsByCreditOwner.mock.t.Fatalf("Inspect function is already set for RepositoryMock.GetPaginatedPipelineRunsByCreditOwner")
+// Inspect accepts an inspector function that has same arguments as the Repository.GetPaginatedPipelineRunsByRequester
+func (mmGetPaginatedPipelineRunsByRequester *mRepositoryMockGetPaginatedPipelineRunsByRequester) Inspect(f func(ctx context.Context, requesterUID string, startTime time.Time, endTime time.Time, page int, pageSize int, filter filtering.Filter, order ordering.OrderBy)) *mRepositoryMockGetPaginatedPipelineRunsByRequester {
+	if mmGetPaginatedPipelineRunsByRequester.mock.inspectFuncGetPaginatedPipelineRunsByRequester != nil {
+		mmGetPaginatedPipelineRunsByRequester.mock.t.Fatalf("Inspect function is already set for RepositoryMock.GetPaginatedPipelineRunsByRequester")
 	}
 
-	mmGetPaginatedPipelineRunsByCreditOwner.mock.inspectFuncGetPaginatedPipelineRunsByCreditOwner = f
+	mmGetPaginatedPipelineRunsByRequester.mock.inspectFuncGetPaginatedPipelineRunsByRequester = f
 
-	return mmGetPaginatedPipelineRunsByCreditOwner
+	return mmGetPaginatedPipelineRunsByRequester
 }
 
-// Return sets up results that will be returned by Repository.GetPaginatedPipelineRunsByCreditOwner
-func (mmGetPaginatedPipelineRunsByCreditOwner *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner) Return(pa1 []datamodel.PipelineRun, i1 int64, err error) *RepositoryMock {
-	if mmGetPaginatedPipelineRunsByCreditOwner.mock.funcGetPaginatedPipelineRunsByCreditOwner != nil {
-		mmGetPaginatedPipelineRunsByCreditOwner.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner mock is already set by Set")
+// Return sets up results that will be returned by Repository.GetPaginatedPipelineRunsByRequester
+func (mmGetPaginatedPipelineRunsByRequester *mRepositoryMockGetPaginatedPipelineRunsByRequester) Return(pa1 []datamodel.PipelineRun, i1 int64, err error) *RepositoryMock {
+	if mmGetPaginatedPipelineRunsByRequester.mock.funcGetPaginatedPipelineRunsByRequester != nil {
+		mmGetPaginatedPipelineRunsByRequester.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByRequester mock is already set by Set")
 	}
 
-	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation == nil {
-		mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation = &RepositoryMockGetPaginatedPipelineRunsByCreditOwnerExpectation{mock: mmGetPaginatedPipelineRunsByCreditOwner.mock}
+	if mmGetPaginatedPipelineRunsByRequester.defaultExpectation == nil {
+		mmGetPaginatedPipelineRunsByRequester.defaultExpectation = &RepositoryMockGetPaginatedPipelineRunsByRequesterExpectation{mock: mmGetPaginatedPipelineRunsByRequester.mock}
 	}
-	mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.results = &RepositoryMockGetPaginatedPipelineRunsByCreditOwnerResults{pa1, i1, err}
-	mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.returnOrigin = minimock.CallerInfo(1)
-	return mmGetPaginatedPipelineRunsByCreditOwner.mock
+	mmGetPaginatedPipelineRunsByRequester.defaultExpectation.results = &RepositoryMockGetPaginatedPipelineRunsByRequesterResults{pa1, i1, err}
+	mmGetPaginatedPipelineRunsByRequester.defaultExpectation.returnOrigin = minimock.CallerInfo(1)
+	return mmGetPaginatedPipelineRunsByRequester.mock
 }
 
-// Set uses given function f to mock the Repository.GetPaginatedPipelineRunsByCreditOwner method
-func (mmGetPaginatedPipelineRunsByCreditOwner *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner) Set(f func(ctx context.Context, requesterUID string, startTime time.Time, endTime time.Time, page int, pageSize int, filter filtering.Filter, order ordering.OrderBy) (pa1 []datamodel.PipelineRun, i1 int64, err error)) *RepositoryMock {
-	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation != nil {
-		mmGetPaginatedPipelineRunsByCreditOwner.mock.t.Fatalf("Default expectation is already set for the Repository.GetPaginatedPipelineRunsByCreditOwner method")
+// Set uses given function f to mock the Repository.GetPaginatedPipelineRunsByRequester method
+func (mmGetPaginatedPipelineRunsByRequester *mRepositoryMockGetPaginatedPipelineRunsByRequester) Set(f func(ctx context.Context, requesterUID string, startTime time.Time, endTime time.Time, page int, pageSize int, filter filtering.Filter, order ordering.OrderBy) (pa1 []datamodel.PipelineRun, i1 int64, err error)) *RepositoryMock {
+	if mmGetPaginatedPipelineRunsByRequester.defaultExpectation != nil {
+		mmGetPaginatedPipelineRunsByRequester.mock.t.Fatalf("Default expectation is already set for the Repository.GetPaginatedPipelineRunsByRequester method")
 	}
 
-	if len(mmGetPaginatedPipelineRunsByCreditOwner.expectations) > 0 {
-		mmGetPaginatedPipelineRunsByCreditOwner.mock.t.Fatalf("Some expectations are already set for the Repository.GetPaginatedPipelineRunsByCreditOwner method")
+	if len(mmGetPaginatedPipelineRunsByRequester.expectations) > 0 {
+		mmGetPaginatedPipelineRunsByRequester.mock.t.Fatalf("Some expectations are already set for the Repository.GetPaginatedPipelineRunsByRequester method")
 	}
 
-	mmGetPaginatedPipelineRunsByCreditOwner.mock.funcGetPaginatedPipelineRunsByCreditOwner = f
-	mmGetPaginatedPipelineRunsByCreditOwner.mock.funcGetPaginatedPipelineRunsByCreditOwnerOrigin = minimock.CallerInfo(1)
-	return mmGetPaginatedPipelineRunsByCreditOwner.mock
+	mmGetPaginatedPipelineRunsByRequester.mock.funcGetPaginatedPipelineRunsByRequester = f
+	mmGetPaginatedPipelineRunsByRequester.mock.funcGetPaginatedPipelineRunsByRequesterOrigin = minimock.CallerInfo(1)
+	return mmGetPaginatedPipelineRunsByRequester.mock
 }
 
-// When sets expectation for the Repository.GetPaginatedPipelineRunsByCreditOwner which will trigger the result defined by the following
+// When sets expectation for the Repository.GetPaginatedPipelineRunsByRequester which will trigger the result defined by the following
 // Then helper
-func (mmGetPaginatedPipelineRunsByCreditOwner *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner) When(ctx context.Context, requesterUID string, startTime time.Time, endTime time.Time, page int, pageSize int, filter filtering.Filter, order ordering.OrderBy) *RepositoryMockGetPaginatedPipelineRunsByCreditOwnerExpectation {
-	if mmGetPaginatedPipelineRunsByCreditOwner.mock.funcGetPaginatedPipelineRunsByCreditOwner != nil {
-		mmGetPaginatedPipelineRunsByCreditOwner.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner mock is already set by Set")
+func (mmGetPaginatedPipelineRunsByRequester *mRepositoryMockGetPaginatedPipelineRunsByRequester) When(ctx context.Context, requesterUID string, startTime time.Time, endTime time.Time, page int, pageSize int, filter filtering.Filter, order ordering.OrderBy) *RepositoryMockGetPaginatedPipelineRunsByRequesterExpectation {
+	if mmGetPaginatedPipelineRunsByRequester.mock.funcGetPaginatedPipelineRunsByRequester != nil {
+		mmGetPaginatedPipelineRunsByRequester.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByRequester mock is already set by Set")
 	}
 
-	expectation := &RepositoryMockGetPaginatedPipelineRunsByCreditOwnerExpectation{
-		mock:               mmGetPaginatedPipelineRunsByCreditOwner.mock,
-		params:             &RepositoryMockGetPaginatedPipelineRunsByCreditOwnerParams{ctx, requesterUID, startTime, endTime, page, pageSize, filter, order},
-		expectationOrigins: RepositoryMockGetPaginatedPipelineRunsByCreditOwnerExpectationOrigins{origin: minimock.CallerInfo(1)},
+	expectation := &RepositoryMockGetPaginatedPipelineRunsByRequesterExpectation{
+		mock:               mmGetPaginatedPipelineRunsByRequester.mock,
+		params:             &RepositoryMockGetPaginatedPipelineRunsByRequesterParams{ctx, requesterUID, startTime, endTime, page, pageSize, filter, order},
+		expectationOrigins: RepositoryMockGetPaginatedPipelineRunsByRequesterExpectationOrigins{origin: minimock.CallerInfo(1)},
 	}
-	mmGetPaginatedPipelineRunsByCreditOwner.expectations = append(mmGetPaginatedPipelineRunsByCreditOwner.expectations, expectation)
+	mmGetPaginatedPipelineRunsByRequester.expectations = append(mmGetPaginatedPipelineRunsByRequester.expectations, expectation)
 	return expectation
 }
 
-// Then sets up Repository.GetPaginatedPipelineRunsByCreditOwner return parameters for the expectation previously defined by the When method
-func (e *RepositoryMockGetPaginatedPipelineRunsByCreditOwnerExpectation) Then(pa1 []datamodel.PipelineRun, i1 int64, err error) *RepositoryMock {
-	e.results = &RepositoryMockGetPaginatedPipelineRunsByCreditOwnerResults{pa1, i1, err}
+// Then sets up Repository.GetPaginatedPipelineRunsByRequester return parameters for the expectation previously defined by the When method
+func (e *RepositoryMockGetPaginatedPipelineRunsByRequesterExpectation) Then(pa1 []datamodel.PipelineRun, i1 int64, err error) *RepositoryMock {
+	e.results = &RepositoryMockGetPaginatedPipelineRunsByRequesterResults{pa1, i1, err}
 	return e.mock
 }
 
-// Times sets number of times Repository.GetPaginatedPipelineRunsByCreditOwner should be invoked
-func (mmGetPaginatedPipelineRunsByCreditOwner *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner) Times(n uint64) *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner {
+// Times sets number of times Repository.GetPaginatedPipelineRunsByRequester should be invoked
+func (mmGetPaginatedPipelineRunsByRequester *mRepositoryMockGetPaginatedPipelineRunsByRequester) Times(n uint64) *mRepositoryMockGetPaginatedPipelineRunsByRequester {
 	if n == 0 {
-		mmGetPaginatedPipelineRunsByCreditOwner.mock.t.Fatalf("Times of RepositoryMock.GetPaginatedPipelineRunsByCreditOwner mock can not be zero")
+		mmGetPaginatedPipelineRunsByRequester.mock.t.Fatalf("Times of RepositoryMock.GetPaginatedPipelineRunsByRequester mock can not be zero")
 	}
-	mm_atomic.StoreUint64(&mmGetPaginatedPipelineRunsByCreditOwner.expectedInvocations, n)
-	mmGetPaginatedPipelineRunsByCreditOwner.expectedInvocationsOrigin = minimock.CallerInfo(1)
-	return mmGetPaginatedPipelineRunsByCreditOwner
+	mm_atomic.StoreUint64(&mmGetPaginatedPipelineRunsByRequester.expectedInvocations, n)
+	mmGetPaginatedPipelineRunsByRequester.expectedInvocationsOrigin = minimock.CallerInfo(1)
+	return mmGetPaginatedPipelineRunsByRequester
 }
 
-func (mmGetPaginatedPipelineRunsByCreditOwner *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner) invocationsDone() bool {
-	if len(mmGetPaginatedPipelineRunsByCreditOwner.expectations) == 0 && mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation == nil && mmGetPaginatedPipelineRunsByCreditOwner.mock.funcGetPaginatedPipelineRunsByCreditOwner == nil {
+func (mmGetPaginatedPipelineRunsByRequester *mRepositoryMockGetPaginatedPipelineRunsByRequester) invocationsDone() bool {
+	if len(mmGetPaginatedPipelineRunsByRequester.expectations) == 0 && mmGetPaginatedPipelineRunsByRequester.defaultExpectation == nil && mmGetPaginatedPipelineRunsByRequester.mock.funcGetPaginatedPipelineRunsByRequester == nil {
 		return true
 	}
 
-	totalInvocations := mm_atomic.LoadUint64(&mmGetPaginatedPipelineRunsByCreditOwner.mock.afterGetPaginatedPipelineRunsByCreditOwnerCounter)
-	expectedInvocations := mm_atomic.LoadUint64(&mmGetPaginatedPipelineRunsByCreditOwner.expectedInvocations)
+	totalInvocations := mm_atomic.LoadUint64(&mmGetPaginatedPipelineRunsByRequester.mock.afterGetPaginatedPipelineRunsByRequesterCounter)
+	expectedInvocations := mm_atomic.LoadUint64(&mmGetPaginatedPipelineRunsByRequester.expectedInvocations)
 
 	return totalInvocations > 0 && (expectedInvocations == 0 || expectedInvocations == totalInvocations)
 }
 
-// GetPaginatedPipelineRunsByCreditOwner implements mm_repository.Repository
-func (mmGetPaginatedPipelineRunsByCreditOwner *RepositoryMock) GetPaginatedPipelineRunsByCreditOwner(ctx context.Context, requesterUID string, startTime time.Time, endTime time.Time, page int, pageSize int, filter filtering.Filter, order ordering.OrderBy) (pa1 []datamodel.PipelineRun, i1 int64, err error) {
-	mm_atomic.AddUint64(&mmGetPaginatedPipelineRunsByCreditOwner.beforeGetPaginatedPipelineRunsByCreditOwnerCounter, 1)
-	defer mm_atomic.AddUint64(&mmGetPaginatedPipelineRunsByCreditOwner.afterGetPaginatedPipelineRunsByCreditOwnerCounter, 1)
+// GetPaginatedPipelineRunsByRequester implements mm_repository.Repository
+func (mmGetPaginatedPipelineRunsByRequester *RepositoryMock) GetPaginatedPipelineRunsByRequester(ctx context.Context, requesterUID string, startTime time.Time, endTime time.Time, page int, pageSize int, filter filtering.Filter, order ordering.OrderBy) (pa1 []datamodel.PipelineRun, i1 int64, err error) {
+	mm_atomic.AddUint64(&mmGetPaginatedPipelineRunsByRequester.beforeGetPaginatedPipelineRunsByRequesterCounter, 1)
+	defer mm_atomic.AddUint64(&mmGetPaginatedPipelineRunsByRequester.afterGetPaginatedPipelineRunsByRequesterCounter, 1)
 
-	mmGetPaginatedPipelineRunsByCreditOwner.t.Helper()
+	mmGetPaginatedPipelineRunsByRequester.t.Helper()
 
-	if mmGetPaginatedPipelineRunsByCreditOwner.inspectFuncGetPaginatedPipelineRunsByCreditOwner != nil {
-		mmGetPaginatedPipelineRunsByCreditOwner.inspectFuncGetPaginatedPipelineRunsByCreditOwner(ctx, requesterUID, startTime, endTime, page, pageSize, filter, order)
+	if mmGetPaginatedPipelineRunsByRequester.inspectFuncGetPaginatedPipelineRunsByRequester != nil {
+		mmGetPaginatedPipelineRunsByRequester.inspectFuncGetPaginatedPipelineRunsByRequester(ctx, requesterUID, startTime, endTime, page, pageSize, filter, order)
 	}
 
-	mm_params := RepositoryMockGetPaginatedPipelineRunsByCreditOwnerParams{ctx, requesterUID, startTime, endTime, page, pageSize, filter, order}
+	mm_params := RepositoryMockGetPaginatedPipelineRunsByRequesterParams{ctx, requesterUID, startTime, endTime, page, pageSize, filter, order}
 
 	// Record call args
-	mmGetPaginatedPipelineRunsByCreditOwner.GetPaginatedPipelineRunsByCreditOwnerMock.mutex.Lock()
-	mmGetPaginatedPipelineRunsByCreditOwner.GetPaginatedPipelineRunsByCreditOwnerMock.callArgs = append(mmGetPaginatedPipelineRunsByCreditOwner.GetPaginatedPipelineRunsByCreditOwnerMock.callArgs, &mm_params)
-	mmGetPaginatedPipelineRunsByCreditOwner.GetPaginatedPipelineRunsByCreditOwnerMock.mutex.Unlock()
+	mmGetPaginatedPipelineRunsByRequester.GetPaginatedPipelineRunsByRequesterMock.mutex.Lock()
+	mmGetPaginatedPipelineRunsByRequester.GetPaginatedPipelineRunsByRequesterMock.callArgs = append(mmGetPaginatedPipelineRunsByRequester.GetPaginatedPipelineRunsByRequesterMock.callArgs, &mm_params)
+	mmGetPaginatedPipelineRunsByRequester.GetPaginatedPipelineRunsByRequesterMock.mutex.Unlock()
 
-	for _, e := range mmGetPaginatedPipelineRunsByCreditOwner.GetPaginatedPipelineRunsByCreditOwnerMock.expectations {
+	for _, e := range mmGetPaginatedPipelineRunsByRequester.GetPaginatedPipelineRunsByRequesterMock.expectations {
 		if minimock.Equal(*e.params, mm_params) {
 			mm_atomic.AddUint64(&e.Counter, 1)
 			return e.results.pa1, e.results.i1, e.results.err
 		}
 	}
 
-	if mmGetPaginatedPipelineRunsByCreditOwner.GetPaginatedPipelineRunsByCreditOwnerMock.defaultExpectation != nil {
-		mm_atomic.AddUint64(&mmGetPaginatedPipelineRunsByCreditOwner.GetPaginatedPipelineRunsByCreditOwnerMock.defaultExpectation.Counter, 1)
-		mm_want := mmGetPaginatedPipelineRunsByCreditOwner.GetPaginatedPipelineRunsByCreditOwnerMock.defaultExpectation.params
-		mm_want_ptrs := mmGetPaginatedPipelineRunsByCreditOwner.GetPaginatedPipelineRunsByCreditOwnerMock.defaultExpectation.paramPtrs
+	if mmGetPaginatedPipelineRunsByRequester.GetPaginatedPipelineRunsByRequesterMock.defaultExpectation != nil {
+		mm_atomic.AddUint64(&mmGetPaginatedPipelineRunsByRequester.GetPaginatedPipelineRunsByRequesterMock.defaultExpectation.Counter, 1)
+		mm_want := mmGetPaginatedPipelineRunsByRequester.GetPaginatedPipelineRunsByRequesterMock.defaultExpectation.params
+		mm_want_ptrs := mmGetPaginatedPipelineRunsByRequester.GetPaginatedPipelineRunsByRequesterMock.defaultExpectation.paramPtrs
 
-		mm_got := RepositoryMockGetPaginatedPipelineRunsByCreditOwnerParams{ctx, requesterUID, startTime, endTime, page, pageSize, filter, order}
+		mm_got := RepositoryMockGetPaginatedPipelineRunsByRequesterParams{ctx, requesterUID, startTime, endTime, page, pageSize, filter, order}
 
 		if mm_want_ptrs != nil {
 
 			if mm_want_ptrs.ctx != nil && !minimock.Equal(*mm_want_ptrs.ctx, mm_got.ctx) {
-				mmGetPaginatedPipelineRunsByCreditOwner.t.Errorf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner got unexpected parameter ctx, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
-					mmGetPaginatedPipelineRunsByCreditOwner.GetPaginatedPipelineRunsByCreditOwnerMock.defaultExpectation.expectationOrigins.originCtx, *mm_want_ptrs.ctx, mm_got.ctx, minimock.Diff(*mm_want_ptrs.ctx, mm_got.ctx))
+				mmGetPaginatedPipelineRunsByRequester.t.Errorf("RepositoryMock.GetPaginatedPipelineRunsByRequester got unexpected parameter ctx, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmGetPaginatedPipelineRunsByRequester.GetPaginatedPipelineRunsByRequesterMock.defaultExpectation.expectationOrigins.originCtx, *mm_want_ptrs.ctx, mm_got.ctx, minimock.Diff(*mm_want_ptrs.ctx, mm_got.ctx))
 			}
 
 			if mm_want_ptrs.requesterUID != nil && !minimock.Equal(*mm_want_ptrs.requesterUID, mm_got.requesterUID) {
-				mmGetPaginatedPipelineRunsByCreditOwner.t.Errorf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner got unexpected parameter requesterUID, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
-					mmGetPaginatedPipelineRunsByCreditOwner.GetPaginatedPipelineRunsByCreditOwnerMock.defaultExpectation.expectationOrigins.originRequesterUID, *mm_want_ptrs.requesterUID, mm_got.requesterUID, minimock.Diff(*mm_want_ptrs.requesterUID, mm_got.requesterUID))
+				mmGetPaginatedPipelineRunsByRequester.t.Errorf("RepositoryMock.GetPaginatedPipelineRunsByRequester got unexpected parameter requesterUID, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmGetPaginatedPipelineRunsByRequester.GetPaginatedPipelineRunsByRequesterMock.defaultExpectation.expectationOrigins.originRequesterUID, *mm_want_ptrs.requesterUID, mm_got.requesterUID, minimock.Diff(*mm_want_ptrs.requesterUID, mm_got.requesterUID))
 			}
 
 			if mm_want_ptrs.startTime != nil && !minimock.Equal(*mm_want_ptrs.startTime, mm_got.startTime) {
-				mmGetPaginatedPipelineRunsByCreditOwner.t.Errorf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner got unexpected parameter startTime, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
-					mmGetPaginatedPipelineRunsByCreditOwner.GetPaginatedPipelineRunsByCreditOwnerMock.defaultExpectation.expectationOrigins.originStartTime, *mm_want_ptrs.startTime, mm_got.startTime, minimock.Diff(*mm_want_ptrs.startTime, mm_got.startTime))
+				mmGetPaginatedPipelineRunsByRequester.t.Errorf("RepositoryMock.GetPaginatedPipelineRunsByRequester got unexpected parameter startTime, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmGetPaginatedPipelineRunsByRequester.GetPaginatedPipelineRunsByRequesterMock.defaultExpectation.expectationOrigins.originStartTime, *mm_want_ptrs.startTime, mm_got.startTime, minimock.Diff(*mm_want_ptrs.startTime, mm_got.startTime))
 			}
 
 			if mm_want_ptrs.endTime != nil && !minimock.Equal(*mm_want_ptrs.endTime, mm_got.endTime) {
-				mmGetPaginatedPipelineRunsByCreditOwner.t.Errorf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner got unexpected parameter endTime, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
-					mmGetPaginatedPipelineRunsByCreditOwner.GetPaginatedPipelineRunsByCreditOwnerMock.defaultExpectation.expectationOrigins.originEndTime, *mm_want_ptrs.endTime, mm_got.endTime, minimock.Diff(*mm_want_ptrs.endTime, mm_got.endTime))
+				mmGetPaginatedPipelineRunsByRequester.t.Errorf("RepositoryMock.GetPaginatedPipelineRunsByRequester got unexpected parameter endTime, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmGetPaginatedPipelineRunsByRequester.GetPaginatedPipelineRunsByRequesterMock.defaultExpectation.expectationOrigins.originEndTime, *mm_want_ptrs.endTime, mm_got.endTime, minimock.Diff(*mm_want_ptrs.endTime, mm_got.endTime))
 			}
 
 			if mm_want_ptrs.page != nil && !minimock.Equal(*mm_want_ptrs.page, mm_got.page) {
-				mmGetPaginatedPipelineRunsByCreditOwner.t.Errorf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner got unexpected parameter page, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
-					mmGetPaginatedPipelineRunsByCreditOwner.GetPaginatedPipelineRunsByCreditOwnerMock.defaultExpectation.expectationOrigins.originPage, *mm_want_ptrs.page, mm_got.page, minimock.Diff(*mm_want_ptrs.page, mm_got.page))
+				mmGetPaginatedPipelineRunsByRequester.t.Errorf("RepositoryMock.GetPaginatedPipelineRunsByRequester got unexpected parameter page, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmGetPaginatedPipelineRunsByRequester.GetPaginatedPipelineRunsByRequesterMock.defaultExpectation.expectationOrigins.originPage, *mm_want_ptrs.page, mm_got.page, minimock.Diff(*mm_want_ptrs.page, mm_got.page))
 			}
 
 			if mm_want_ptrs.pageSize != nil && !minimock.Equal(*mm_want_ptrs.pageSize, mm_got.pageSize) {
-				mmGetPaginatedPipelineRunsByCreditOwner.t.Errorf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner got unexpected parameter pageSize, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
-					mmGetPaginatedPipelineRunsByCreditOwner.GetPaginatedPipelineRunsByCreditOwnerMock.defaultExpectation.expectationOrigins.originPageSize, *mm_want_ptrs.pageSize, mm_got.pageSize, minimock.Diff(*mm_want_ptrs.pageSize, mm_got.pageSize))
+				mmGetPaginatedPipelineRunsByRequester.t.Errorf("RepositoryMock.GetPaginatedPipelineRunsByRequester got unexpected parameter pageSize, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmGetPaginatedPipelineRunsByRequester.GetPaginatedPipelineRunsByRequesterMock.defaultExpectation.expectationOrigins.originPageSize, *mm_want_ptrs.pageSize, mm_got.pageSize, minimock.Diff(*mm_want_ptrs.pageSize, mm_got.pageSize))
 			}
 
 			if mm_want_ptrs.filter != nil && !minimock.Equal(*mm_want_ptrs.filter, mm_got.filter) {
-				mmGetPaginatedPipelineRunsByCreditOwner.t.Errorf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner got unexpected parameter filter, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
-					mmGetPaginatedPipelineRunsByCreditOwner.GetPaginatedPipelineRunsByCreditOwnerMock.defaultExpectation.expectationOrigins.originFilter, *mm_want_ptrs.filter, mm_got.filter, minimock.Diff(*mm_want_ptrs.filter, mm_got.filter))
+				mmGetPaginatedPipelineRunsByRequester.t.Errorf("RepositoryMock.GetPaginatedPipelineRunsByRequester got unexpected parameter filter, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmGetPaginatedPipelineRunsByRequester.GetPaginatedPipelineRunsByRequesterMock.defaultExpectation.expectationOrigins.originFilter, *mm_want_ptrs.filter, mm_got.filter, minimock.Diff(*mm_want_ptrs.filter, mm_got.filter))
 			}
 
 			if mm_want_ptrs.order != nil && !minimock.Equal(*mm_want_ptrs.order, mm_got.order) {
-				mmGetPaginatedPipelineRunsByCreditOwner.t.Errorf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner got unexpected parameter order, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
-					mmGetPaginatedPipelineRunsByCreditOwner.GetPaginatedPipelineRunsByCreditOwnerMock.defaultExpectation.expectationOrigins.originOrder, *mm_want_ptrs.order, mm_got.order, minimock.Diff(*mm_want_ptrs.order, mm_got.order))
+				mmGetPaginatedPipelineRunsByRequester.t.Errorf("RepositoryMock.GetPaginatedPipelineRunsByRequester got unexpected parameter order, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmGetPaginatedPipelineRunsByRequester.GetPaginatedPipelineRunsByRequesterMock.defaultExpectation.expectationOrigins.originOrder, *mm_want_ptrs.order, mm_got.order, minimock.Diff(*mm_want_ptrs.order, mm_got.order))
 			}
 
 		} else if mm_want != nil && !minimock.Equal(*mm_want, mm_got) {
-			mmGetPaginatedPipelineRunsByCreditOwner.t.Errorf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner got unexpected parameters, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
-				mmGetPaginatedPipelineRunsByCreditOwner.GetPaginatedPipelineRunsByCreditOwnerMock.defaultExpectation.expectationOrigins.origin, *mm_want, mm_got, minimock.Diff(*mm_want, mm_got))
+			mmGetPaginatedPipelineRunsByRequester.t.Errorf("RepositoryMock.GetPaginatedPipelineRunsByRequester got unexpected parameters, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+				mmGetPaginatedPipelineRunsByRequester.GetPaginatedPipelineRunsByRequesterMock.defaultExpectation.expectationOrigins.origin, *mm_want, mm_got, minimock.Diff(*mm_want, mm_got))
 		}
 
-		mm_results := mmGetPaginatedPipelineRunsByCreditOwner.GetPaginatedPipelineRunsByCreditOwnerMock.defaultExpectation.results
+		mm_results := mmGetPaginatedPipelineRunsByRequester.GetPaginatedPipelineRunsByRequesterMock.defaultExpectation.results
 		if mm_results == nil {
-			mmGetPaginatedPipelineRunsByCreditOwner.t.Fatal("No results are set for the RepositoryMock.GetPaginatedPipelineRunsByCreditOwner")
+			mmGetPaginatedPipelineRunsByRequester.t.Fatal("No results are set for the RepositoryMock.GetPaginatedPipelineRunsByRequester")
 		}
 		return (*mm_results).pa1, (*mm_results).i1, (*mm_results).err
 	}
-	if mmGetPaginatedPipelineRunsByCreditOwner.funcGetPaginatedPipelineRunsByCreditOwner != nil {
-		return mmGetPaginatedPipelineRunsByCreditOwner.funcGetPaginatedPipelineRunsByCreditOwner(ctx, requesterUID, startTime, endTime, page, pageSize, filter, order)
+	if mmGetPaginatedPipelineRunsByRequester.funcGetPaginatedPipelineRunsByRequester != nil {
+		return mmGetPaginatedPipelineRunsByRequester.funcGetPaginatedPipelineRunsByRequester(ctx, requesterUID, startTime, endTime, page, pageSize, filter, order)
 	}
-	mmGetPaginatedPipelineRunsByCreditOwner.t.Fatalf("Unexpected call to RepositoryMock.GetPaginatedPipelineRunsByCreditOwner. %v %v %v %v %v %v %v %v", ctx, requesterUID, startTime, endTime, page, pageSize, filter, order)
+	mmGetPaginatedPipelineRunsByRequester.t.Fatalf("Unexpected call to RepositoryMock.GetPaginatedPipelineRunsByRequester. %v %v %v %v %v %v %v %v", ctx, requesterUID, startTime, endTime, page, pageSize, filter, order)
 	return
 }
 
-// GetPaginatedPipelineRunsByCreditOwnerAfterCounter returns a count of finished RepositoryMock.GetPaginatedPipelineRunsByCreditOwner invocations
-func (mmGetPaginatedPipelineRunsByCreditOwner *RepositoryMock) GetPaginatedPipelineRunsByCreditOwnerAfterCounter() uint64 {
-	return mm_atomic.LoadUint64(&mmGetPaginatedPipelineRunsByCreditOwner.afterGetPaginatedPipelineRunsByCreditOwnerCounter)
+// GetPaginatedPipelineRunsByRequesterAfterCounter returns a count of finished RepositoryMock.GetPaginatedPipelineRunsByRequester invocations
+func (mmGetPaginatedPipelineRunsByRequester *RepositoryMock) GetPaginatedPipelineRunsByRequesterAfterCounter() uint64 {
+	return mm_atomic.LoadUint64(&mmGetPaginatedPipelineRunsByRequester.afterGetPaginatedPipelineRunsByRequesterCounter)
 }
 
-// GetPaginatedPipelineRunsByCreditOwnerBeforeCounter returns a count of RepositoryMock.GetPaginatedPipelineRunsByCreditOwner invocations
-func (mmGetPaginatedPipelineRunsByCreditOwner *RepositoryMock) GetPaginatedPipelineRunsByCreditOwnerBeforeCounter() uint64 {
-	return mm_atomic.LoadUint64(&mmGetPaginatedPipelineRunsByCreditOwner.beforeGetPaginatedPipelineRunsByCreditOwnerCounter)
+// GetPaginatedPipelineRunsByRequesterBeforeCounter returns a count of RepositoryMock.GetPaginatedPipelineRunsByRequester invocations
+func (mmGetPaginatedPipelineRunsByRequester *RepositoryMock) GetPaginatedPipelineRunsByRequesterBeforeCounter() uint64 {
+	return mm_atomic.LoadUint64(&mmGetPaginatedPipelineRunsByRequester.beforeGetPaginatedPipelineRunsByRequesterCounter)
 }
 
-// Calls returns a list of arguments used in each call to RepositoryMock.GetPaginatedPipelineRunsByCreditOwner.
+// Calls returns a list of arguments used in each call to RepositoryMock.GetPaginatedPipelineRunsByRequester.
 // The list is in the same order as the calls were made (i.e. recent calls have a higher index)
-func (mmGetPaginatedPipelineRunsByCreditOwner *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner) Calls() []*RepositoryMockGetPaginatedPipelineRunsByCreditOwnerParams {
-	mmGetPaginatedPipelineRunsByCreditOwner.mutex.RLock()
+func (mmGetPaginatedPipelineRunsByRequester *mRepositoryMockGetPaginatedPipelineRunsByRequester) Calls() []*RepositoryMockGetPaginatedPipelineRunsByRequesterParams {
+	mmGetPaginatedPipelineRunsByRequester.mutex.RLock()
 
-	argCopy := make([]*RepositoryMockGetPaginatedPipelineRunsByCreditOwnerParams, len(mmGetPaginatedPipelineRunsByCreditOwner.callArgs))
-	copy(argCopy, mmGetPaginatedPipelineRunsByCreditOwner.callArgs)
+	argCopy := make([]*RepositoryMockGetPaginatedPipelineRunsByRequesterParams, len(mmGetPaginatedPipelineRunsByRequester.callArgs))
+	copy(argCopy, mmGetPaginatedPipelineRunsByRequester.callArgs)
 
-	mmGetPaginatedPipelineRunsByCreditOwner.mutex.RUnlock()
+	mmGetPaginatedPipelineRunsByRequester.mutex.RUnlock()
 
 	return argCopy
 }
 
-// MinimockGetPaginatedPipelineRunsByCreditOwnerDone returns true if the count of the GetPaginatedPipelineRunsByCreditOwner invocations corresponds
+// MinimockGetPaginatedPipelineRunsByRequesterDone returns true if the count of the GetPaginatedPipelineRunsByRequester invocations corresponds
 // the number of defined expectations
-func (m *RepositoryMock) MinimockGetPaginatedPipelineRunsByCreditOwnerDone() bool {
-	if m.GetPaginatedPipelineRunsByCreditOwnerMock.optional {
+func (m *RepositoryMock) MinimockGetPaginatedPipelineRunsByRequesterDone() bool {
+	if m.GetPaginatedPipelineRunsByRequesterMock.optional {
 		// Optional methods provide '0 or more' call count restriction.
 		return true
 	}
 
-	for _, e := range m.GetPaginatedPipelineRunsByCreditOwnerMock.expectations {
+	for _, e := range m.GetPaginatedPipelineRunsByRequesterMock.expectations {
 		if mm_atomic.LoadUint64(&e.Counter) < 1 {
 			return false
 		}
 	}
 
-	return m.GetPaginatedPipelineRunsByCreditOwnerMock.invocationsDone()
+	return m.GetPaginatedPipelineRunsByRequesterMock.invocationsDone()
 }
 
-// MinimockGetPaginatedPipelineRunsByCreditOwnerInspect logs each unmet expectation
-func (m *RepositoryMock) MinimockGetPaginatedPipelineRunsByCreditOwnerInspect() {
-	for _, e := range m.GetPaginatedPipelineRunsByCreditOwnerMock.expectations {
+// MinimockGetPaginatedPipelineRunsByRequesterInspect logs each unmet expectation
+func (m *RepositoryMock) MinimockGetPaginatedPipelineRunsByRequesterInspect() {
+	for _, e := range m.GetPaginatedPipelineRunsByRequesterMock.expectations {
 		if mm_atomic.LoadUint64(&e.Counter) < 1 {
-			m.t.Errorf("Expected call to RepositoryMock.GetPaginatedPipelineRunsByCreditOwner at\n%s with params: %#v", e.expectationOrigins.origin, *e.params)
+			m.t.Errorf("Expected call to RepositoryMock.GetPaginatedPipelineRunsByRequester at\n%s with params: %#v", e.expectationOrigins.origin, *e.params)
 		}
 	}
 
-	afterGetPaginatedPipelineRunsByCreditOwnerCounter := mm_atomic.LoadUint64(&m.afterGetPaginatedPipelineRunsByCreditOwnerCounter)
+	afterGetPaginatedPipelineRunsByRequesterCounter := mm_atomic.LoadUint64(&m.afterGetPaginatedPipelineRunsByRequesterCounter)
 	// if default expectation was set then invocations count should be greater than zero
-	if m.GetPaginatedPipelineRunsByCreditOwnerMock.defaultExpectation != nil && afterGetPaginatedPipelineRunsByCreditOwnerCounter < 1 {
-		if m.GetPaginatedPipelineRunsByCreditOwnerMock.defaultExpectation.params == nil {
-			m.t.Errorf("Expected call to RepositoryMock.GetPaginatedPipelineRunsByCreditOwner at\n%s", m.GetPaginatedPipelineRunsByCreditOwnerMock.defaultExpectation.returnOrigin)
+	if m.GetPaginatedPipelineRunsByRequesterMock.defaultExpectation != nil && afterGetPaginatedPipelineRunsByRequesterCounter < 1 {
+		if m.GetPaginatedPipelineRunsByRequesterMock.defaultExpectation.params == nil {
+			m.t.Errorf("Expected call to RepositoryMock.GetPaginatedPipelineRunsByRequester at\n%s", m.GetPaginatedPipelineRunsByRequesterMock.defaultExpectation.returnOrigin)
 		} else {
-			m.t.Errorf("Expected call to RepositoryMock.GetPaginatedPipelineRunsByCreditOwner at\n%s with params: %#v", m.GetPaginatedPipelineRunsByCreditOwnerMock.defaultExpectation.expectationOrigins.origin, *m.GetPaginatedPipelineRunsByCreditOwnerMock.defaultExpectation.params)
+			m.t.Errorf("Expected call to RepositoryMock.GetPaginatedPipelineRunsByRequester at\n%s with params: %#v", m.GetPaginatedPipelineRunsByRequesterMock.defaultExpectation.expectationOrigins.origin, *m.GetPaginatedPipelineRunsByRequesterMock.defaultExpectation.params)
 		}
 	}
 	// if func was set then invocations count should be greater than zero
-	if m.funcGetPaginatedPipelineRunsByCreditOwner != nil && afterGetPaginatedPipelineRunsByCreditOwnerCounter < 1 {
-		m.t.Errorf("Expected call to RepositoryMock.GetPaginatedPipelineRunsByCreditOwner at\n%s", m.funcGetPaginatedPipelineRunsByCreditOwnerOrigin)
+	if m.funcGetPaginatedPipelineRunsByRequester != nil && afterGetPaginatedPipelineRunsByRequesterCounter < 1 {
+		m.t.Errorf("Expected call to RepositoryMock.GetPaginatedPipelineRunsByRequester at\n%s", m.funcGetPaginatedPipelineRunsByRequesterOrigin)
 	}
 
-	if !m.GetPaginatedPipelineRunsByCreditOwnerMock.invocationsDone() && afterGetPaginatedPipelineRunsByCreditOwnerCounter > 0 {
-		m.t.Errorf("Expected %d calls to RepositoryMock.GetPaginatedPipelineRunsByCreditOwner at\n%s but found %d calls",
-			mm_atomic.LoadUint64(&m.GetPaginatedPipelineRunsByCreditOwnerMock.expectedInvocations), m.GetPaginatedPipelineRunsByCreditOwnerMock.expectedInvocationsOrigin, afterGetPaginatedPipelineRunsByCreditOwnerCounter)
+	if !m.GetPaginatedPipelineRunsByRequesterMock.invocationsDone() && afterGetPaginatedPipelineRunsByRequesterCounter > 0 {
+		m.t.Errorf("Expected %d calls to RepositoryMock.GetPaginatedPipelineRunsByRequester at\n%s but found %d calls",
+			mm_atomic.LoadUint64(&m.GetPaginatedPipelineRunsByRequesterMock.expectedInvocations), m.GetPaginatedPipelineRunsByRequesterMock.expectedInvocationsOrigin, afterGetPaginatedPipelineRunsByRequesterCounter)
 	}
 }
 
@@ -20780,7 +20781,7 @@ func (m *RepositoryMock) MinimockFinish() {
 
 			m.MinimockGetPaginatedComponentRunsByPipelineRunIDWithPermissionsInspect()
 
-			m.MinimockGetPaginatedPipelineRunsByCreditOwnerInspect()
+			m.MinimockGetPaginatedPipelineRunsByRequesterInspect()
 
 			m.MinimockGetPaginatedPipelineRunsWithPermissionsInspect()
 
@@ -20883,7 +20884,7 @@ func (m *RepositoryMock) minimockDone() bool {
 		m.MinimockGetNamespacePipelineReleaseByIDDone() &&
 		m.MinimockGetNamespaceSecretByIDDone() &&
 		m.MinimockGetPaginatedComponentRunsByPipelineRunIDWithPermissionsDone() &&
-		m.MinimockGetPaginatedPipelineRunsByCreditOwnerDone() &&
+		m.MinimockGetPaginatedPipelineRunsByRequesterDone() &&
 		m.MinimockGetPaginatedPipelineRunsWithPermissionsDone() &&
 		m.MinimockGetPipelineByIDAdminDone() &&
 		m.MinimockGetPipelineByUIDDone() &&

--- a/pkg/mock/repository_mock.gen.go
+++ b/pkg/mock/repository_mock.gen.go
@@ -6,17 +6,20 @@ import (
 	"context"
 	"sync"
 	mm_atomic "sync/atomic"
+	"time"
 	mm_time "time"
 
 	"github.com/gofrs/uuid"
 	"github.com/gojuno/minimock/v3"
-	"github.com/instill-ai/pipeline-backend/pkg/datamodel"
-	mm_repository "github.com/instill-ai/pipeline-backend/pkg/repository"
-	pb "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 	"go.einride.tech/aip/filtering"
 	"go.einride.tech/aip/ordering"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
+
+	"github.com/instill-ai/pipeline-backend/pkg/datamodel"
+
+	mm_repository "github.com/instill-ai/pipeline-backend/pkg/repository"
+	pb "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
 
 // RepositoryMock implements mm_repository.Repository
@@ -170,6 +173,13 @@ type RepositoryMock struct {
 	afterGetPaginatedComponentRunsByPipelineRunIDWithPermissionsCounter  uint64
 	beforeGetPaginatedComponentRunsByPipelineRunIDWithPermissionsCounter uint64
 	GetPaginatedComponentRunsByPipelineRunIDWithPermissionsMock          mRepositoryMockGetPaginatedComponentRunsByPipelineRunIDWithPermissions
+
+	funcGetPaginatedPipelineRunsByCreditOwner          func(ctx context.Context, requesterUID string, startTime time.Time, endTime time.Time, page int, pageSize int, filter filtering.Filter, order ordering.OrderBy) (pa1 []datamodel.PipelineRun, i1 int64, err error)
+	funcGetPaginatedPipelineRunsByCreditOwnerOrigin    string
+	inspectFuncGetPaginatedPipelineRunsByCreditOwner   func(ctx context.Context, requesterUID string, startTime time.Time, endTime time.Time, page int, pageSize int, filter filtering.Filter, order ordering.OrderBy)
+	afterGetPaginatedPipelineRunsByCreditOwnerCounter  uint64
+	beforeGetPaginatedPipelineRunsByCreditOwnerCounter uint64
+	GetPaginatedPipelineRunsByCreditOwnerMock          mRepositoryMockGetPaginatedPipelineRunsByCreditOwner
 
 	funcGetPaginatedPipelineRunsWithPermissions          func(ctx context.Context, requesterUID string, pipelineUID string, page int, pageSize int, filter filtering.Filter, order ordering.OrderBy, isOwner bool) (pa1 []datamodel.PipelineRun, i1 int64, err error)
 	funcGetPaginatedPipelineRunsWithPermissionsOrigin    string
@@ -445,6 +455,9 @@ func NewRepositoryMock(t minimock.Tester) *RepositoryMock {
 
 	m.GetPaginatedComponentRunsByPipelineRunIDWithPermissionsMock = mRepositoryMockGetPaginatedComponentRunsByPipelineRunIDWithPermissions{mock: m}
 	m.GetPaginatedComponentRunsByPipelineRunIDWithPermissionsMock.callArgs = []*RepositoryMockGetPaginatedComponentRunsByPipelineRunIDWithPermissionsParams{}
+
+	m.GetPaginatedPipelineRunsByCreditOwnerMock = mRepositoryMockGetPaginatedPipelineRunsByCreditOwner{mock: m}
+	m.GetPaginatedPipelineRunsByCreditOwnerMock.callArgs = []*RepositoryMockGetPaginatedPipelineRunsByCreditOwnerParams{}
 
 	m.GetPaginatedPipelineRunsWithPermissionsMock = mRepositoryMockGetPaginatedPipelineRunsWithPermissions{mock: m}
 	m.GetPaginatedPipelineRunsWithPermissionsMock.callArgs = []*RepositoryMockGetPaginatedPipelineRunsWithPermissionsParams{}
@@ -8471,6 +8484,536 @@ func (m *RepositoryMock) MinimockGetPaginatedComponentRunsByPipelineRunIDWithPer
 	if !m.GetPaginatedComponentRunsByPipelineRunIDWithPermissionsMock.invocationsDone() && afterGetPaginatedComponentRunsByPipelineRunIDWithPermissionsCounter > 0 {
 		m.t.Errorf("Expected %d calls to RepositoryMock.GetPaginatedComponentRunsByPipelineRunIDWithPermissions at\n%s but found %d calls",
 			mm_atomic.LoadUint64(&m.GetPaginatedComponentRunsByPipelineRunIDWithPermissionsMock.expectedInvocations), m.GetPaginatedComponentRunsByPipelineRunIDWithPermissionsMock.expectedInvocationsOrigin, afterGetPaginatedComponentRunsByPipelineRunIDWithPermissionsCounter)
+	}
+}
+
+type mRepositoryMockGetPaginatedPipelineRunsByCreditOwner struct {
+	optional           bool
+	mock               *RepositoryMock
+	defaultExpectation *RepositoryMockGetPaginatedPipelineRunsByCreditOwnerExpectation
+	expectations       []*RepositoryMockGetPaginatedPipelineRunsByCreditOwnerExpectation
+
+	callArgs []*RepositoryMockGetPaginatedPipelineRunsByCreditOwnerParams
+	mutex    sync.RWMutex
+
+	expectedInvocations       uint64
+	expectedInvocationsOrigin string
+}
+
+// RepositoryMockGetPaginatedPipelineRunsByCreditOwnerExpectation specifies expectation struct of the Repository.GetPaginatedPipelineRunsByCreditOwner
+type RepositoryMockGetPaginatedPipelineRunsByCreditOwnerExpectation struct {
+	mock               *RepositoryMock
+	params             *RepositoryMockGetPaginatedPipelineRunsByCreditOwnerParams
+	paramPtrs          *RepositoryMockGetPaginatedPipelineRunsByCreditOwnerParamPtrs
+	expectationOrigins RepositoryMockGetPaginatedPipelineRunsByCreditOwnerExpectationOrigins
+	results            *RepositoryMockGetPaginatedPipelineRunsByCreditOwnerResults
+	returnOrigin       string
+	Counter            uint64
+}
+
+// RepositoryMockGetPaginatedPipelineRunsByCreditOwnerParams contains parameters of the Repository.GetPaginatedPipelineRunsByCreditOwner
+type RepositoryMockGetPaginatedPipelineRunsByCreditOwnerParams struct {
+	ctx          context.Context
+	requesterUID string
+	startTime    time.Time
+	endTime      time.Time
+	page         int
+	pageSize     int
+	filter       filtering.Filter
+	order        ordering.OrderBy
+}
+
+// RepositoryMockGetPaginatedPipelineRunsByCreditOwnerParamPtrs contains pointers to parameters of the Repository.GetPaginatedPipelineRunsByCreditOwner
+type RepositoryMockGetPaginatedPipelineRunsByCreditOwnerParamPtrs struct {
+	ctx          *context.Context
+	requesterUID *string
+	startTime    *time.Time
+	endTime      *time.Time
+	page         *int
+	pageSize     *int
+	filter       *filtering.Filter
+	order        *ordering.OrderBy
+}
+
+// RepositoryMockGetPaginatedPipelineRunsByCreditOwnerResults contains results of the Repository.GetPaginatedPipelineRunsByCreditOwner
+type RepositoryMockGetPaginatedPipelineRunsByCreditOwnerResults struct {
+	pa1 []datamodel.PipelineRun
+	i1  int64
+	err error
+}
+
+// RepositoryMockGetPaginatedPipelineRunsByCreditOwnerOrigins contains origins of expectations of the Repository.GetPaginatedPipelineRunsByCreditOwner
+type RepositoryMockGetPaginatedPipelineRunsByCreditOwnerExpectationOrigins struct {
+	origin             string
+	originCtx          string
+	originRequesterUID string
+	originStartTime    string
+	originEndTime      string
+	originPage         string
+	originPageSize     string
+	originFilter       string
+	originOrder        string
+}
+
+// Marks this method to be optional. The default behavior of any method with Return() is '1 or more', meaning
+// the test will fail minimock's automatic final call check if the mocked method was not called at least once.
+// Optional() makes method check to work in '0 or more' mode.
+// It is NOT RECOMMENDED to use this option unless you really need it, as default behaviour helps to
+// catch the problems when the expected method call is totally skipped during test run.
+func (mmGetPaginatedPipelineRunsByCreditOwner *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner) Optional() *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner {
+	mmGetPaginatedPipelineRunsByCreditOwner.optional = true
+	return mmGetPaginatedPipelineRunsByCreditOwner
+}
+
+// Expect sets up expected params for Repository.GetPaginatedPipelineRunsByCreditOwner
+func (mmGetPaginatedPipelineRunsByCreditOwner *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner) Expect(ctx context.Context, requesterUID string, startTime time.Time, endTime time.Time, page int, pageSize int, filter filtering.Filter, order ordering.OrderBy) *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner {
+	if mmGetPaginatedPipelineRunsByCreditOwner.mock.funcGetPaginatedPipelineRunsByCreditOwner != nil {
+		mmGetPaginatedPipelineRunsByCreditOwner.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner mock is already set by Set")
+	}
+
+	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation == nil {
+		mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation = &RepositoryMockGetPaginatedPipelineRunsByCreditOwnerExpectation{}
+	}
+
+	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.paramPtrs != nil {
+		mmGetPaginatedPipelineRunsByCreditOwner.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner mock is already set by ExpectParams functions")
+	}
+
+	mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.params = &RepositoryMockGetPaginatedPipelineRunsByCreditOwnerParams{ctx, requesterUID, startTime, endTime, page, pageSize, filter, order}
+	mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.expectationOrigins.origin = minimock.CallerInfo(1)
+	for _, e := range mmGetPaginatedPipelineRunsByCreditOwner.expectations {
+		if minimock.Equal(e.params, mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.params) {
+			mmGetPaginatedPipelineRunsByCreditOwner.mock.t.Fatalf("Expectation set by When has same params: %#v", *mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.params)
+		}
+	}
+
+	return mmGetPaginatedPipelineRunsByCreditOwner
+}
+
+// ExpectCtxParam1 sets up expected param ctx for Repository.GetPaginatedPipelineRunsByCreditOwner
+func (mmGetPaginatedPipelineRunsByCreditOwner *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner) ExpectCtxParam1(ctx context.Context) *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner {
+	if mmGetPaginatedPipelineRunsByCreditOwner.mock.funcGetPaginatedPipelineRunsByCreditOwner != nil {
+		mmGetPaginatedPipelineRunsByCreditOwner.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner mock is already set by Set")
+	}
+
+	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation == nil {
+		mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation = &RepositoryMockGetPaginatedPipelineRunsByCreditOwnerExpectation{}
+	}
+
+	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.params != nil {
+		mmGetPaginatedPipelineRunsByCreditOwner.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner mock is already set by Expect")
+	}
+
+	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.paramPtrs == nil {
+		mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.paramPtrs = &RepositoryMockGetPaginatedPipelineRunsByCreditOwnerParamPtrs{}
+	}
+	mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.paramPtrs.ctx = &ctx
+	mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.expectationOrigins.originCtx = minimock.CallerInfo(1)
+
+	return mmGetPaginatedPipelineRunsByCreditOwner
+}
+
+// ExpectRequesterUIDParam2 sets up expected param requesterUID for Repository.GetPaginatedPipelineRunsByCreditOwner
+func (mmGetPaginatedPipelineRunsByCreditOwner *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner) ExpectRequesterUIDParam2(requesterUID string) *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner {
+	if mmGetPaginatedPipelineRunsByCreditOwner.mock.funcGetPaginatedPipelineRunsByCreditOwner != nil {
+		mmGetPaginatedPipelineRunsByCreditOwner.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner mock is already set by Set")
+	}
+
+	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation == nil {
+		mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation = &RepositoryMockGetPaginatedPipelineRunsByCreditOwnerExpectation{}
+	}
+
+	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.params != nil {
+		mmGetPaginatedPipelineRunsByCreditOwner.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner mock is already set by Expect")
+	}
+
+	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.paramPtrs == nil {
+		mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.paramPtrs = &RepositoryMockGetPaginatedPipelineRunsByCreditOwnerParamPtrs{}
+	}
+	mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.paramPtrs.requesterUID = &requesterUID
+	mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.expectationOrigins.originRequesterUID = minimock.CallerInfo(1)
+
+	return mmGetPaginatedPipelineRunsByCreditOwner
+}
+
+// ExpectStartTimeParam3 sets up expected param startTime for Repository.GetPaginatedPipelineRunsByCreditOwner
+func (mmGetPaginatedPipelineRunsByCreditOwner *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner) ExpectStartTimeParam3(startTime time.Time) *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner {
+	if mmGetPaginatedPipelineRunsByCreditOwner.mock.funcGetPaginatedPipelineRunsByCreditOwner != nil {
+		mmGetPaginatedPipelineRunsByCreditOwner.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner mock is already set by Set")
+	}
+
+	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation == nil {
+		mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation = &RepositoryMockGetPaginatedPipelineRunsByCreditOwnerExpectation{}
+	}
+
+	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.params != nil {
+		mmGetPaginatedPipelineRunsByCreditOwner.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner mock is already set by Expect")
+	}
+
+	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.paramPtrs == nil {
+		mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.paramPtrs = &RepositoryMockGetPaginatedPipelineRunsByCreditOwnerParamPtrs{}
+	}
+	mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.paramPtrs.startTime = &startTime
+	mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.expectationOrigins.originStartTime = minimock.CallerInfo(1)
+
+	return mmGetPaginatedPipelineRunsByCreditOwner
+}
+
+// ExpectEndTimeParam4 sets up expected param endTime for Repository.GetPaginatedPipelineRunsByCreditOwner
+func (mmGetPaginatedPipelineRunsByCreditOwner *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner) ExpectEndTimeParam4(endTime time.Time) *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner {
+	if mmGetPaginatedPipelineRunsByCreditOwner.mock.funcGetPaginatedPipelineRunsByCreditOwner != nil {
+		mmGetPaginatedPipelineRunsByCreditOwner.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner mock is already set by Set")
+	}
+
+	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation == nil {
+		mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation = &RepositoryMockGetPaginatedPipelineRunsByCreditOwnerExpectation{}
+	}
+
+	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.params != nil {
+		mmGetPaginatedPipelineRunsByCreditOwner.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner mock is already set by Expect")
+	}
+
+	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.paramPtrs == nil {
+		mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.paramPtrs = &RepositoryMockGetPaginatedPipelineRunsByCreditOwnerParamPtrs{}
+	}
+	mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.paramPtrs.endTime = &endTime
+	mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.expectationOrigins.originEndTime = minimock.CallerInfo(1)
+
+	return mmGetPaginatedPipelineRunsByCreditOwner
+}
+
+// ExpectPageParam5 sets up expected param page for Repository.GetPaginatedPipelineRunsByCreditOwner
+func (mmGetPaginatedPipelineRunsByCreditOwner *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner) ExpectPageParam5(page int) *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner {
+	if mmGetPaginatedPipelineRunsByCreditOwner.mock.funcGetPaginatedPipelineRunsByCreditOwner != nil {
+		mmGetPaginatedPipelineRunsByCreditOwner.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner mock is already set by Set")
+	}
+
+	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation == nil {
+		mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation = &RepositoryMockGetPaginatedPipelineRunsByCreditOwnerExpectation{}
+	}
+
+	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.params != nil {
+		mmGetPaginatedPipelineRunsByCreditOwner.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner mock is already set by Expect")
+	}
+
+	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.paramPtrs == nil {
+		mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.paramPtrs = &RepositoryMockGetPaginatedPipelineRunsByCreditOwnerParamPtrs{}
+	}
+	mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.paramPtrs.page = &page
+	mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.expectationOrigins.originPage = minimock.CallerInfo(1)
+
+	return mmGetPaginatedPipelineRunsByCreditOwner
+}
+
+// ExpectPageSizeParam6 sets up expected param pageSize for Repository.GetPaginatedPipelineRunsByCreditOwner
+func (mmGetPaginatedPipelineRunsByCreditOwner *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner) ExpectPageSizeParam6(pageSize int) *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner {
+	if mmGetPaginatedPipelineRunsByCreditOwner.mock.funcGetPaginatedPipelineRunsByCreditOwner != nil {
+		mmGetPaginatedPipelineRunsByCreditOwner.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner mock is already set by Set")
+	}
+
+	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation == nil {
+		mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation = &RepositoryMockGetPaginatedPipelineRunsByCreditOwnerExpectation{}
+	}
+
+	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.params != nil {
+		mmGetPaginatedPipelineRunsByCreditOwner.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner mock is already set by Expect")
+	}
+
+	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.paramPtrs == nil {
+		mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.paramPtrs = &RepositoryMockGetPaginatedPipelineRunsByCreditOwnerParamPtrs{}
+	}
+	mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.paramPtrs.pageSize = &pageSize
+	mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.expectationOrigins.originPageSize = minimock.CallerInfo(1)
+
+	return mmGetPaginatedPipelineRunsByCreditOwner
+}
+
+// ExpectFilterParam7 sets up expected param filter for Repository.GetPaginatedPipelineRunsByCreditOwner
+func (mmGetPaginatedPipelineRunsByCreditOwner *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner) ExpectFilterParam7(filter filtering.Filter) *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner {
+	if mmGetPaginatedPipelineRunsByCreditOwner.mock.funcGetPaginatedPipelineRunsByCreditOwner != nil {
+		mmGetPaginatedPipelineRunsByCreditOwner.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner mock is already set by Set")
+	}
+
+	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation == nil {
+		mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation = &RepositoryMockGetPaginatedPipelineRunsByCreditOwnerExpectation{}
+	}
+
+	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.params != nil {
+		mmGetPaginatedPipelineRunsByCreditOwner.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner mock is already set by Expect")
+	}
+
+	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.paramPtrs == nil {
+		mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.paramPtrs = &RepositoryMockGetPaginatedPipelineRunsByCreditOwnerParamPtrs{}
+	}
+	mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.paramPtrs.filter = &filter
+	mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.expectationOrigins.originFilter = minimock.CallerInfo(1)
+
+	return mmGetPaginatedPipelineRunsByCreditOwner
+}
+
+// ExpectOrderParam8 sets up expected param order for Repository.GetPaginatedPipelineRunsByCreditOwner
+func (mmGetPaginatedPipelineRunsByCreditOwner *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner) ExpectOrderParam8(order ordering.OrderBy) *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner {
+	if mmGetPaginatedPipelineRunsByCreditOwner.mock.funcGetPaginatedPipelineRunsByCreditOwner != nil {
+		mmGetPaginatedPipelineRunsByCreditOwner.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner mock is already set by Set")
+	}
+
+	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation == nil {
+		mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation = &RepositoryMockGetPaginatedPipelineRunsByCreditOwnerExpectation{}
+	}
+
+	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.params != nil {
+		mmGetPaginatedPipelineRunsByCreditOwner.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner mock is already set by Expect")
+	}
+
+	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.paramPtrs == nil {
+		mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.paramPtrs = &RepositoryMockGetPaginatedPipelineRunsByCreditOwnerParamPtrs{}
+	}
+	mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.paramPtrs.order = &order
+	mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.expectationOrigins.originOrder = minimock.CallerInfo(1)
+
+	return mmGetPaginatedPipelineRunsByCreditOwner
+}
+
+// Inspect accepts an inspector function that has same arguments as the Repository.GetPaginatedPipelineRunsByCreditOwner
+func (mmGetPaginatedPipelineRunsByCreditOwner *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner) Inspect(f func(ctx context.Context, requesterUID string, startTime time.Time, endTime time.Time, page int, pageSize int, filter filtering.Filter, order ordering.OrderBy)) *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner {
+	if mmGetPaginatedPipelineRunsByCreditOwner.mock.inspectFuncGetPaginatedPipelineRunsByCreditOwner != nil {
+		mmGetPaginatedPipelineRunsByCreditOwner.mock.t.Fatalf("Inspect function is already set for RepositoryMock.GetPaginatedPipelineRunsByCreditOwner")
+	}
+
+	mmGetPaginatedPipelineRunsByCreditOwner.mock.inspectFuncGetPaginatedPipelineRunsByCreditOwner = f
+
+	return mmGetPaginatedPipelineRunsByCreditOwner
+}
+
+// Return sets up results that will be returned by Repository.GetPaginatedPipelineRunsByCreditOwner
+func (mmGetPaginatedPipelineRunsByCreditOwner *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner) Return(pa1 []datamodel.PipelineRun, i1 int64, err error) *RepositoryMock {
+	if mmGetPaginatedPipelineRunsByCreditOwner.mock.funcGetPaginatedPipelineRunsByCreditOwner != nil {
+		mmGetPaginatedPipelineRunsByCreditOwner.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner mock is already set by Set")
+	}
+
+	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation == nil {
+		mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation = &RepositoryMockGetPaginatedPipelineRunsByCreditOwnerExpectation{mock: mmGetPaginatedPipelineRunsByCreditOwner.mock}
+	}
+	mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.results = &RepositoryMockGetPaginatedPipelineRunsByCreditOwnerResults{pa1, i1, err}
+	mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation.returnOrigin = minimock.CallerInfo(1)
+	return mmGetPaginatedPipelineRunsByCreditOwner.mock
+}
+
+// Set uses given function f to mock the Repository.GetPaginatedPipelineRunsByCreditOwner method
+func (mmGetPaginatedPipelineRunsByCreditOwner *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner) Set(f func(ctx context.Context, requesterUID string, startTime time.Time, endTime time.Time, page int, pageSize int, filter filtering.Filter, order ordering.OrderBy) (pa1 []datamodel.PipelineRun, i1 int64, err error)) *RepositoryMock {
+	if mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation != nil {
+		mmGetPaginatedPipelineRunsByCreditOwner.mock.t.Fatalf("Default expectation is already set for the Repository.GetPaginatedPipelineRunsByCreditOwner method")
+	}
+
+	if len(mmGetPaginatedPipelineRunsByCreditOwner.expectations) > 0 {
+		mmGetPaginatedPipelineRunsByCreditOwner.mock.t.Fatalf("Some expectations are already set for the Repository.GetPaginatedPipelineRunsByCreditOwner method")
+	}
+
+	mmGetPaginatedPipelineRunsByCreditOwner.mock.funcGetPaginatedPipelineRunsByCreditOwner = f
+	mmGetPaginatedPipelineRunsByCreditOwner.mock.funcGetPaginatedPipelineRunsByCreditOwnerOrigin = minimock.CallerInfo(1)
+	return mmGetPaginatedPipelineRunsByCreditOwner.mock
+}
+
+// When sets expectation for the Repository.GetPaginatedPipelineRunsByCreditOwner which will trigger the result defined by the following
+// Then helper
+func (mmGetPaginatedPipelineRunsByCreditOwner *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner) When(ctx context.Context, requesterUID string, startTime time.Time, endTime time.Time, page int, pageSize int, filter filtering.Filter, order ordering.OrderBy) *RepositoryMockGetPaginatedPipelineRunsByCreditOwnerExpectation {
+	if mmGetPaginatedPipelineRunsByCreditOwner.mock.funcGetPaginatedPipelineRunsByCreditOwner != nil {
+		mmGetPaginatedPipelineRunsByCreditOwner.mock.t.Fatalf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner mock is already set by Set")
+	}
+
+	expectation := &RepositoryMockGetPaginatedPipelineRunsByCreditOwnerExpectation{
+		mock:               mmGetPaginatedPipelineRunsByCreditOwner.mock,
+		params:             &RepositoryMockGetPaginatedPipelineRunsByCreditOwnerParams{ctx, requesterUID, startTime, endTime, page, pageSize, filter, order},
+		expectationOrigins: RepositoryMockGetPaginatedPipelineRunsByCreditOwnerExpectationOrigins{origin: minimock.CallerInfo(1)},
+	}
+	mmGetPaginatedPipelineRunsByCreditOwner.expectations = append(mmGetPaginatedPipelineRunsByCreditOwner.expectations, expectation)
+	return expectation
+}
+
+// Then sets up Repository.GetPaginatedPipelineRunsByCreditOwner return parameters for the expectation previously defined by the When method
+func (e *RepositoryMockGetPaginatedPipelineRunsByCreditOwnerExpectation) Then(pa1 []datamodel.PipelineRun, i1 int64, err error) *RepositoryMock {
+	e.results = &RepositoryMockGetPaginatedPipelineRunsByCreditOwnerResults{pa1, i1, err}
+	return e.mock
+}
+
+// Times sets number of times Repository.GetPaginatedPipelineRunsByCreditOwner should be invoked
+func (mmGetPaginatedPipelineRunsByCreditOwner *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner) Times(n uint64) *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner {
+	if n == 0 {
+		mmGetPaginatedPipelineRunsByCreditOwner.mock.t.Fatalf("Times of RepositoryMock.GetPaginatedPipelineRunsByCreditOwner mock can not be zero")
+	}
+	mm_atomic.StoreUint64(&mmGetPaginatedPipelineRunsByCreditOwner.expectedInvocations, n)
+	mmGetPaginatedPipelineRunsByCreditOwner.expectedInvocationsOrigin = minimock.CallerInfo(1)
+	return mmGetPaginatedPipelineRunsByCreditOwner
+}
+
+func (mmGetPaginatedPipelineRunsByCreditOwner *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner) invocationsDone() bool {
+	if len(mmGetPaginatedPipelineRunsByCreditOwner.expectations) == 0 && mmGetPaginatedPipelineRunsByCreditOwner.defaultExpectation == nil && mmGetPaginatedPipelineRunsByCreditOwner.mock.funcGetPaginatedPipelineRunsByCreditOwner == nil {
+		return true
+	}
+
+	totalInvocations := mm_atomic.LoadUint64(&mmGetPaginatedPipelineRunsByCreditOwner.mock.afterGetPaginatedPipelineRunsByCreditOwnerCounter)
+	expectedInvocations := mm_atomic.LoadUint64(&mmGetPaginatedPipelineRunsByCreditOwner.expectedInvocations)
+
+	return totalInvocations > 0 && (expectedInvocations == 0 || expectedInvocations == totalInvocations)
+}
+
+// GetPaginatedPipelineRunsByCreditOwner implements mm_repository.Repository
+func (mmGetPaginatedPipelineRunsByCreditOwner *RepositoryMock) GetPaginatedPipelineRunsByCreditOwner(ctx context.Context, requesterUID string, startTime time.Time, endTime time.Time, page int, pageSize int, filter filtering.Filter, order ordering.OrderBy) (pa1 []datamodel.PipelineRun, i1 int64, err error) {
+	mm_atomic.AddUint64(&mmGetPaginatedPipelineRunsByCreditOwner.beforeGetPaginatedPipelineRunsByCreditOwnerCounter, 1)
+	defer mm_atomic.AddUint64(&mmGetPaginatedPipelineRunsByCreditOwner.afterGetPaginatedPipelineRunsByCreditOwnerCounter, 1)
+
+	mmGetPaginatedPipelineRunsByCreditOwner.t.Helper()
+
+	if mmGetPaginatedPipelineRunsByCreditOwner.inspectFuncGetPaginatedPipelineRunsByCreditOwner != nil {
+		mmGetPaginatedPipelineRunsByCreditOwner.inspectFuncGetPaginatedPipelineRunsByCreditOwner(ctx, requesterUID, startTime, endTime, page, pageSize, filter, order)
+	}
+
+	mm_params := RepositoryMockGetPaginatedPipelineRunsByCreditOwnerParams{ctx, requesterUID, startTime, endTime, page, pageSize, filter, order}
+
+	// Record call args
+	mmGetPaginatedPipelineRunsByCreditOwner.GetPaginatedPipelineRunsByCreditOwnerMock.mutex.Lock()
+	mmGetPaginatedPipelineRunsByCreditOwner.GetPaginatedPipelineRunsByCreditOwnerMock.callArgs = append(mmGetPaginatedPipelineRunsByCreditOwner.GetPaginatedPipelineRunsByCreditOwnerMock.callArgs, &mm_params)
+	mmGetPaginatedPipelineRunsByCreditOwner.GetPaginatedPipelineRunsByCreditOwnerMock.mutex.Unlock()
+
+	for _, e := range mmGetPaginatedPipelineRunsByCreditOwner.GetPaginatedPipelineRunsByCreditOwnerMock.expectations {
+		if minimock.Equal(*e.params, mm_params) {
+			mm_atomic.AddUint64(&e.Counter, 1)
+			return e.results.pa1, e.results.i1, e.results.err
+		}
+	}
+
+	if mmGetPaginatedPipelineRunsByCreditOwner.GetPaginatedPipelineRunsByCreditOwnerMock.defaultExpectation != nil {
+		mm_atomic.AddUint64(&mmGetPaginatedPipelineRunsByCreditOwner.GetPaginatedPipelineRunsByCreditOwnerMock.defaultExpectation.Counter, 1)
+		mm_want := mmGetPaginatedPipelineRunsByCreditOwner.GetPaginatedPipelineRunsByCreditOwnerMock.defaultExpectation.params
+		mm_want_ptrs := mmGetPaginatedPipelineRunsByCreditOwner.GetPaginatedPipelineRunsByCreditOwnerMock.defaultExpectation.paramPtrs
+
+		mm_got := RepositoryMockGetPaginatedPipelineRunsByCreditOwnerParams{ctx, requesterUID, startTime, endTime, page, pageSize, filter, order}
+
+		if mm_want_ptrs != nil {
+
+			if mm_want_ptrs.ctx != nil && !minimock.Equal(*mm_want_ptrs.ctx, mm_got.ctx) {
+				mmGetPaginatedPipelineRunsByCreditOwner.t.Errorf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner got unexpected parameter ctx, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmGetPaginatedPipelineRunsByCreditOwner.GetPaginatedPipelineRunsByCreditOwnerMock.defaultExpectation.expectationOrigins.originCtx, *mm_want_ptrs.ctx, mm_got.ctx, minimock.Diff(*mm_want_ptrs.ctx, mm_got.ctx))
+			}
+
+			if mm_want_ptrs.requesterUID != nil && !minimock.Equal(*mm_want_ptrs.requesterUID, mm_got.requesterUID) {
+				mmGetPaginatedPipelineRunsByCreditOwner.t.Errorf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner got unexpected parameter requesterUID, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmGetPaginatedPipelineRunsByCreditOwner.GetPaginatedPipelineRunsByCreditOwnerMock.defaultExpectation.expectationOrigins.originRequesterUID, *mm_want_ptrs.requesterUID, mm_got.requesterUID, minimock.Diff(*mm_want_ptrs.requesterUID, mm_got.requesterUID))
+			}
+
+			if mm_want_ptrs.startTime != nil && !minimock.Equal(*mm_want_ptrs.startTime, mm_got.startTime) {
+				mmGetPaginatedPipelineRunsByCreditOwner.t.Errorf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner got unexpected parameter startTime, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmGetPaginatedPipelineRunsByCreditOwner.GetPaginatedPipelineRunsByCreditOwnerMock.defaultExpectation.expectationOrigins.originStartTime, *mm_want_ptrs.startTime, mm_got.startTime, minimock.Diff(*mm_want_ptrs.startTime, mm_got.startTime))
+			}
+
+			if mm_want_ptrs.endTime != nil && !minimock.Equal(*mm_want_ptrs.endTime, mm_got.endTime) {
+				mmGetPaginatedPipelineRunsByCreditOwner.t.Errorf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner got unexpected parameter endTime, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmGetPaginatedPipelineRunsByCreditOwner.GetPaginatedPipelineRunsByCreditOwnerMock.defaultExpectation.expectationOrigins.originEndTime, *mm_want_ptrs.endTime, mm_got.endTime, minimock.Diff(*mm_want_ptrs.endTime, mm_got.endTime))
+			}
+
+			if mm_want_ptrs.page != nil && !minimock.Equal(*mm_want_ptrs.page, mm_got.page) {
+				mmGetPaginatedPipelineRunsByCreditOwner.t.Errorf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner got unexpected parameter page, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmGetPaginatedPipelineRunsByCreditOwner.GetPaginatedPipelineRunsByCreditOwnerMock.defaultExpectation.expectationOrigins.originPage, *mm_want_ptrs.page, mm_got.page, minimock.Diff(*mm_want_ptrs.page, mm_got.page))
+			}
+
+			if mm_want_ptrs.pageSize != nil && !minimock.Equal(*mm_want_ptrs.pageSize, mm_got.pageSize) {
+				mmGetPaginatedPipelineRunsByCreditOwner.t.Errorf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner got unexpected parameter pageSize, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmGetPaginatedPipelineRunsByCreditOwner.GetPaginatedPipelineRunsByCreditOwnerMock.defaultExpectation.expectationOrigins.originPageSize, *mm_want_ptrs.pageSize, mm_got.pageSize, minimock.Diff(*mm_want_ptrs.pageSize, mm_got.pageSize))
+			}
+
+			if mm_want_ptrs.filter != nil && !minimock.Equal(*mm_want_ptrs.filter, mm_got.filter) {
+				mmGetPaginatedPipelineRunsByCreditOwner.t.Errorf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner got unexpected parameter filter, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmGetPaginatedPipelineRunsByCreditOwner.GetPaginatedPipelineRunsByCreditOwnerMock.defaultExpectation.expectationOrigins.originFilter, *mm_want_ptrs.filter, mm_got.filter, minimock.Diff(*mm_want_ptrs.filter, mm_got.filter))
+			}
+
+			if mm_want_ptrs.order != nil && !minimock.Equal(*mm_want_ptrs.order, mm_got.order) {
+				mmGetPaginatedPipelineRunsByCreditOwner.t.Errorf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner got unexpected parameter order, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmGetPaginatedPipelineRunsByCreditOwner.GetPaginatedPipelineRunsByCreditOwnerMock.defaultExpectation.expectationOrigins.originOrder, *mm_want_ptrs.order, mm_got.order, minimock.Diff(*mm_want_ptrs.order, mm_got.order))
+			}
+
+		} else if mm_want != nil && !minimock.Equal(*mm_want, mm_got) {
+			mmGetPaginatedPipelineRunsByCreditOwner.t.Errorf("RepositoryMock.GetPaginatedPipelineRunsByCreditOwner got unexpected parameters, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+				mmGetPaginatedPipelineRunsByCreditOwner.GetPaginatedPipelineRunsByCreditOwnerMock.defaultExpectation.expectationOrigins.origin, *mm_want, mm_got, minimock.Diff(*mm_want, mm_got))
+		}
+
+		mm_results := mmGetPaginatedPipelineRunsByCreditOwner.GetPaginatedPipelineRunsByCreditOwnerMock.defaultExpectation.results
+		if mm_results == nil {
+			mmGetPaginatedPipelineRunsByCreditOwner.t.Fatal("No results are set for the RepositoryMock.GetPaginatedPipelineRunsByCreditOwner")
+		}
+		return (*mm_results).pa1, (*mm_results).i1, (*mm_results).err
+	}
+	if mmGetPaginatedPipelineRunsByCreditOwner.funcGetPaginatedPipelineRunsByCreditOwner != nil {
+		return mmGetPaginatedPipelineRunsByCreditOwner.funcGetPaginatedPipelineRunsByCreditOwner(ctx, requesterUID, startTime, endTime, page, pageSize, filter, order)
+	}
+	mmGetPaginatedPipelineRunsByCreditOwner.t.Fatalf("Unexpected call to RepositoryMock.GetPaginatedPipelineRunsByCreditOwner. %v %v %v %v %v %v %v %v", ctx, requesterUID, startTime, endTime, page, pageSize, filter, order)
+	return
+}
+
+// GetPaginatedPipelineRunsByCreditOwnerAfterCounter returns a count of finished RepositoryMock.GetPaginatedPipelineRunsByCreditOwner invocations
+func (mmGetPaginatedPipelineRunsByCreditOwner *RepositoryMock) GetPaginatedPipelineRunsByCreditOwnerAfterCounter() uint64 {
+	return mm_atomic.LoadUint64(&mmGetPaginatedPipelineRunsByCreditOwner.afterGetPaginatedPipelineRunsByCreditOwnerCounter)
+}
+
+// GetPaginatedPipelineRunsByCreditOwnerBeforeCounter returns a count of RepositoryMock.GetPaginatedPipelineRunsByCreditOwner invocations
+func (mmGetPaginatedPipelineRunsByCreditOwner *RepositoryMock) GetPaginatedPipelineRunsByCreditOwnerBeforeCounter() uint64 {
+	return mm_atomic.LoadUint64(&mmGetPaginatedPipelineRunsByCreditOwner.beforeGetPaginatedPipelineRunsByCreditOwnerCounter)
+}
+
+// Calls returns a list of arguments used in each call to RepositoryMock.GetPaginatedPipelineRunsByCreditOwner.
+// The list is in the same order as the calls were made (i.e. recent calls have a higher index)
+func (mmGetPaginatedPipelineRunsByCreditOwner *mRepositoryMockGetPaginatedPipelineRunsByCreditOwner) Calls() []*RepositoryMockGetPaginatedPipelineRunsByCreditOwnerParams {
+	mmGetPaginatedPipelineRunsByCreditOwner.mutex.RLock()
+
+	argCopy := make([]*RepositoryMockGetPaginatedPipelineRunsByCreditOwnerParams, len(mmGetPaginatedPipelineRunsByCreditOwner.callArgs))
+	copy(argCopy, mmGetPaginatedPipelineRunsByCreditOwner.callArgs)
+
+	mmGetPaginatedPipelineRunsByCreditOwner.mutex.RUnlock()
+
+	return argCopy
+}
+
+// MinimockGetPaginatedPipelineRunsByCreditOwnerDone returns true if the count of the GetPaginatedPipelineRunsByCreditOwner invocations corresponds
+// the number of defined expectations
+func (m *RepositoryMock) MinimockGetPaginatedPipelineRunsByCreditOwnerDone() bool {
+	if m.GetPaginatedPipelineRunsByCreditOwnerMock.optional {
+		// Optional methods provide '0 or more' call count restriction.
+		return true
+	}
+
+	for _, e := range m.GetPaginatedPipelineRunsByCreditOwnerMock.expectations {
+		if mm_atomic.LoadUint64(&e.Counter) < 1 {
+			return false
+		}
+	}
+
+	return m.GetPaginatedPipelineRunsByCreditOwnerMock.invocationsDone()
+}
+
+// MinimockGetPaginatedPipelineRunsByCreditOwnerInspect logs each unmet expectation
+func (m *RepositoryMock) MinimockGetPaginatedPipelineRunsByCreditOwnerInspect() {
+	for _, e := range m.GetPaginatedPipelineRunsByCreditOwnerMock.expectations {
+		if mm_atomic.LoadUint64(&e.Counter) < 1 {
+			m.t.Errorf("Expected call to RepositoryMock.GetPaginatedPipelineRunsByCreditOwner at\n%s with params: %#v", e.expectationOrigins.origin, *e.params)
+		}
+	}
+
+	afterGetPaginatedPipelineRunsByCreditOwnerCounter := mm_atomic.LoadUint64(&m.afterGetPaginatedPipelineRunsByCreditOwnerCounter)
+	// if default expectation was set then invocations count should be greater than zero
+	if m.GetPaginatedPipelineRunsByCreditOwnerMock.defaultExpectation != nil && afterGetPaginatedPipelineRunsByCreditOwnerCounter < 1 {
+		if m.GetPaginatedPipelineRunsByCreditOwnerMock.defaultExpectation.params == nil {
+			m.t.Errorf("Expected call to RepositoryMock.GetPaginatedPipelineRunsByCreditOwner at\n%s", m.GetPaginatedPipelineRunsByCreditOwnerMock.defaultExpectation.returnOrigin)
+		} else {
+			m.t.Errorf("Expected call to RepositoryMock.GetPaginatedPipelineRunsByCreditOwner at\n%s with params: %#v", m.GetPaginatedPipelineRunsByCreditOwnerMock.defaultExpectation.expectationOrigins.origin, *m.GetPaginatedPipelineRunsByCreditOwnerMock.defaultExpectation.params)
+		}
+	}
+	// if func was set then invocations count should be greater than zero
+	if m.funcGetPaginatedPipelineRunsByCreditOwner != nil && afterGetPaginatedPipelineRunsByCreditOwnerCounter < 1 {
+		m.t.Errorf("Expected call to RepositoryMock.GetPaginatedPipelineRunsByCreditOwner at\n%s", m.funcGetPaginatedPipelineRunsByCreditOwnerOrigin)
+	}
+
+	if !m.GetPaginatedPipelineRunsByCreditOwnerMock.invocationsDone() && afterGetPaginatedPipelineRunsByCreditOwnerCounter > 0 {
+		m.t.Errorf("Expected %d calls to RepositoryMock.GetPaginatedPipelineRunsByCreditOwner at\n%s but found %d calls",
+			mm_atomic.LoadUint64(&m.GetPaginatedPipelineRunsByCreditOwnerMock.expectedInvocations), m.GetPaginatedPipelineRunsByCreditOwnerMock.expectedInvocationsOrigin, afterGetPaginatedPipelineRunsByCreditOwnerCounter)
 	}
 }
 
@@ -20237,6 +20780,8 @@ func (m *RepositoryMock) MinimockFinish() {
 
 			m.MinimockGetPaginatedComponentRunsByPipelineRunIDWithPermissionsInspect()
 
+			m.MinimockGetPaginatedPipelineRunsByCreditOwnerInspect()
+
 			m.MinimockGetPaginatedPipelineRunsWithPermissionsInspect()
 
 			m.MinimockGetPipelineByIDAdminInspect()
@@ -20338,6 +20883,7 @@ func (m *RepositoryMock) minimockDone() bool {
 		m.MinimockGetNamespacePipelineReleaseByIDDone() &&
 		m.MinimockGetNamespaceSecretByIDDone() &&
 		m.MinimockGetPaginatedComponentRunsByPipelineRunIDWithPermissionsDone() &&
+		m.MinimockGetPaginatedPipelineRunsByCreditOwnerDone() &&
 		m.MinimockGetPaginatedPipelineRunsWithPermissionsDone() &&
 		m.MinimockGetPipelineByIDAdminDone() &&
 		m.MinimockGetPipelineByUIDDone() &&

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -104,7 +104,7 @@ type Repository interface {
 
 	GetPaginatedPipelineRunsWithPermissions(ctx context.Context, requesterUID, pipelineUID string, page, pageSize int, filter filtering.Filter, order ordering.OrderBy, isOwner bool) ([]datamodel.PipelineRun, int64, error)
 	GetPaginatedComponentRunsByPipelineRunIDWithPermissions(ctx context.Context, pipelineRunID string, page, pageSize int, filter filtering.Filter, order ordering.OrderBy) ([]datamodel.ComponentRun, int64, error)
-	GetPaginatedPipelineRunsByCreditOwner(ctx context.Context, requesterUID string, startTime, endTime time.Time, page, pageSize int, filter filtering.Filter, order ordering.OrderBy) ([]datamodel.PipelineRun, int64, error)
+	GetPaginatedPipelineRunsByRequester(ctx context.Context, requesterUID string, startTime, endTime time.Time, page, pageSize int, filter filtering.Filter, order ordering.OrderBy) ([]datamodel.PipelineRun, int64, error)
 }
 
 type repository struct {
@@ -1270,7 +1270,7 @@ func (r *repository) GetPaginatedComponentRunsByPipelineRunIDWithPermissions(ctx
 	return componentRuns, totalRows, nil
 }
 
-func (r *repository) GetPaginatedPipelineRunsByCreditOwner(ctx context.Context, requesterUID string, startTimeBegin, startTimeEnd time.Time, page, pageSize int, filter filtering.Filter, order ordering.OrderBy) ([]datamodel.PipelineRun, int64, error) {
+func (r *repository) GetPaginatedPipelineRunsByRequester(ctx context.Context, requesterUID string, startTimeBegin, startTimeEnd time.Time, page, pageSize int, filter filtering.Filter, order ordering.OrderBy) ([]datamodel.PipelineRun, int64, error) {
 	var pipelineRuns []datamodel.PipelineRun
 	var totalRows int64
 

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -24,11 +24,9 @@ import (
 	"github.com/instill-ai/pipeline-backend/pkg/datamodel"
 	"github.com/instill-ai/pipeline-backend/pkg/logger"
 	"github.com/instill-ai/pipeline-backend/pkg/resource"
-
-	errdomain "github.com/instill-ai/pipeline-backend/pkg/errors"
-
 	"github.com/instill-ai/x/paginate"
 
+	errdomain "github.com/instill-ai/pipeline-backend/pkg/errors"
 	pb "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
 
@@ -106,6 +104,7 @@ type Repository interface {
 
 	GetPaginatedPipelineRunsWithPermissions(ctx context.Context, requesterUID, pipelineUID string, page, pageSize int, filter filtering.Filter, order ordering.OrderBy, isOwner bool) ([]datamodel.PipelineRun, int64, error)
 	GetPaginatedComponentRunsByPipelineRunIDWithPermissions(ctx context.Context, pipelineRunID string, page, pageSize int, filter filtering.Filter, order ordering.OrderBy) ([]datamodel.ComponentRun, int64, error)
+	GetPaginatedPipelineRunsByCreditOwner(ctx context.Context, requesterUID string, startTime, endTime time.Time, page, pageSize int, filter filtering.Filter, order ordering.OrderBy) ([]datamodel.PipelineRun, int64, error)
 }
 
 type repository struct {
@@ -1130,7 +1129,7 @@ func (r *repository) AddPipelineClones(ctx context.Context, pipelineUID uuid.UUI
 
 func (r *repository) GetPipelineRunByUID(ctx context.Context, pipelineTriggerUID uuid.UUID) (*datamodel.PipelineRun, error) {
 	pipelineRun := &datamodel.PipelineRun{PipelineTriggerUID: pipelineTriggerUID}
-	err := r.db.First(pipelineRun).Error
+	err := r.db.Preload(clause.Associations).First(pipelineRun).Error
 	if err != nil {
 		return nil, err
 	}
@@ -1269,6 +1268,60 @@ func (r *repository) GetPaginatedComponentRunsByPipelineRunIDWithPermissions(ctx
 	}
 
 	return componentRuns, totalRows, nil
+}
+
+func (r *repository) GetPaginatedPipelineRunsByCreditOwner(ctx context.Context, requesterUID string, startTimeBegin, startTimeEnd time.Time, page, pageSize int, filter filtering.Filter, order ordering.OrderBy) ([]datamodel.PipelineRun, int64, error) {
+	var pipelineRuns []datamodel.PipelineRun
+	var totalRows int64
+
+	whereConditions := []string{"namespace = ? and started_time >= ? and started_time <= ?"}
+	whereArgs := []any{requesterUID, startTimeBegin, startTimeEnd}
+
+	var expr *clause.Expr
+	var err error
+	if expr, err = r.TranspileFilter(filter); err != nil {
+		return nil, 0, err
+	}
+	if expr != nil {
+		whereConditions = append(whereConditions, "(?)")
+		whereArgs = append(whereArgs, expr)
+	}
+
+	var where string
+	if len(whereConditions) > 0 {
+		where = strings.Join(whereConditions, " and ")
+	}
+
+	err = r.db.Model(&datamodel.PipelineRun{}).
+		Where(where, whereArgs...).
+		Count(&totalRows).Error
+	if err != nil {
+		return nil, 0, err
+	}
+
+	queryBuilder := r.db.Preload(clause.Associations).Where(where, whereArgs...)
+
+	if len(order.Fields) == 0 {
+		order.Fields = append(order.Fields, ordering.Field{
+			Path: "started_time",
+			Desc: true,
+		})
+	}
+
+	for _, field := range order.Fields {
+		orderString := strcase.ToSnake(field.Path) + transformBoolToDescString(field.Desc)
+		queryBuilder.Order(orderString)
+	}
+
+	// Retrieve paginated results with permissions
+	err = queryBuilder.
+		Offset(page * pageSize).Limit(pageSize).
+		Find(&pipelineRuns).Error
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return pipelineRuns, totalRows, nil
 }
 
 func (r *repository) CreateNamespaceConnection(ctx context.Context, conn *datamodel.Connection) (*datamodel.Connection, error) {

--- a/pkg/repository/repository_test.go
+++ b/pkg/repository/repository_test.go
@@ -613,8 +613,6 @@ func TestRepository_GetPaginatedPipelineRunsWithPermissions(t *testing.T) {
 			c.Assert(err, qt.IsNil)
 			if testCase.canView {
 				c.Check(len(response), qt.Equals, 1)
-				// c.Log(response[0].Pipeline.ID)
-				// c.Check(response[0].Pipeline.ID, qt.Equals, p.ID)
 			} else {
 				c.Check(len(response), qt.Equals, 0)
 			}
@@ -698,11 +696,11 @@ func TestRepository_GetPaginatedPipelineRunsByCreditOwner(t *testing.T) {
 	err = repo.UpsertPipelineRun(ctx, pipelineRun)
 	require.NoError(t, err)
 
-	resp, _, err := repo.GetPaginatedPipelineRunsByCreditOwner(ctx, namespace1, now.Add(-3*time.Hour), now.Add(-2*time.Hour), 0, 10, filtering.Filter{}, ordering.OrderBy{})
+	resp, _, err := repo.GetPaginatedPipelineRunsByRequester(ctx, namespace1, now.Add(-3*time.Hour), now.Add(-2*time.Hour), 0, 10, filtering.Filter{}, ordering.OrderBy{})
 	require.NoError(t, err)
 	require.Len(t, resp, 0)
 
-	resp, _, err = repo.GetPaginatedPipelineRunsByCreditOwner(ctx, namespace1, now.Add(-2*time.Hour), now, 0, 10, filtering.Filter{}, ordering.OrderBy{})
+	resp, _, err = repo.GetPaginatedPipelineRunsByRequester(ctx, namespace1, now.Add(-2*time.Hour), now, 0, 10, filtering.Filter{}, ordering.OrderBy{})
 	require.NoError(t, err)
 	require.Len(t, resp, 1)
 	require.Equal(t, resp[0].PipelineTriggerUID, pipelineRun.PipelineTriggerUID)
@@ -723,7 +721,7 @@ func TestRepository_GetPaginatedPipelineRunsByCreditOwner(t *testing.T) {
 	err = repo.UpsertPipelineRun(ctx, pipelineRun2)
 	require.NoError(t, err)
 
-	resp, _, err = repo.GetPaginatedPipelineRunsByCreditOwner(ctx, namespace1, now.Add(-2*time.Hour), now, 0, 10, filtering.Filter{}, ordering.OrderBy{})
+	resp, _, err = repo.GetPaginatedPipelineRunsByRequester(ctx, namespace1, now.Add(-2*time.Hour), now, 0, 10, filtering.Filter{}, ordering.OrderBy{})
 	require.NoError(t, err)
 	require.Len(t, resp, 2)
 	require.Equal(t, resp[0].PipelineTriggerUID, pipelineRun.PipelineTriggerUID)

--- a/pkg/service/component_definition.go
+++ b/pkg/service/component_definition.go
@@ -14,10 +14,12 @@ import (
 	"github.com/instill-ai/pipeline-backend/config"
 	"github.com/instill-ai/pipeline-backend/pkg/recipe"
 	"github.com/instill-ai/pipeline-backend/pkg/repository"
-	"github.com/instill-ai/x/paginate"
 
 	component "github.com/instill-ai/pipeline-backend/pkg/component/store"
 	errdomain "github.com/instill-ai/pipeline-backend/pkg/errors"
+
+	"github.com/instill-ai/x/paginate"
+
 	pb "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
 

--- a/pkg/service/component_definition.go
+++ b/pkg/service/component_definition.go
@@ -14,12 +14,10 @@ import (
 	"github.com/instill-ai/pipeline-backend/config"
 	"github.com/instill-ai/pipeline-backend/pkg/recipe"
 	"github.com/instill-ai/pipeline-backend/pkg/repository"
+	"github.com/instill-ai/x/paginate"
 
 	component "github.com/instill-ai/pipeline-backend/pkg/component/store"
 	errdomain "github.com/instill-ai/pipeline-backend/pkg/errors"
-
-	"github.com/instill-ai/x/paginate"
-
 	pb "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
 

--- a/pkg/service/main.go
+++ b/pkg/service/main.go
@@ -78,7 +78,7 @@ type Service interface {
 
 	ListPipelineRuns(ctx context.Context, req *pb.ListPipelineRunsRequest, filter filtering.Filter) (*pb.ListPipelineRunsResponse, error)
 	ListComponentRuns(ctx context.Context, req *pb.ListComponentRunsRequest, filter filtering.Filter) (*pb.ListComponentRunsResponse, error)
-	ListPipelineRunsByCreditOwner(ctx context.Context, req *pb.ListPipelineRunsByCreditOwnerRequest, filter filtering.Filter) (*pb.ListPipelineRunsByCreditOwnerResponse, error)
+	ListPipelineRunsByRequester(ctx context.Context, req *pb.ListPipelineRunsByCreditOwnerRequest) (*pb.ListPipelineRunsByCreditOwnerResponse, error)
 
 	GetIntegration(_ context.Context, id string, _ pb.View) (*pb.Integration, error)
 	ListIntegrations(context.Context, *pb.ListIntegrationsRequest) (*pb.ListIntegrationsResponse, error)

--- a/pkg/service/main.go
+++ b/pkg/service/main.go
@@ -78,6 +78,7 @@ type Service interface {
 
 	ListPipelineRuns(ctx context.Context, req *pb.ListPipelineRunsRequest, filter filtering.Filter) (*pb.ListPipelineRunsResponse, error)
 	ListComponentRuns(ctx context.Context, req *pb.ListComponentRunsRequest, filter filtering.Filter) (*pb.ListComponentRunsResponse, error)
+	ListPipelineRunsByCreditOwner(ctx context.Context, req *pb.ListPipelineRunsByCreditOwnerRequest, filter filtering.Filter) (*pb.ListPipelineRunsByCreditOwnerResponse, error)
 
 	GetIntegration(_ context.Context, id string, _ pb.View) (*pb.Integration, error)
 	ListIntegrations(context.Context, *pb.ListIntegrationsRequest) (*pb.ListIntegrationsResponse, error)

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -1960,8 +1960,6 @@ func (s *service) ListPipelineRunsByRequester(ctx context.Context, req *pipeline
 	pageSize := s.pageSizeInRange(req.GetPageSize())
 	requesterUID, _ := utils.GetRequesterUIDAndUserUID(ctx)
 
-	log, _ := logger.GetZapLogger(ctx)
-
 	declarations, err := filtering.NewDeclarations([]filtering.DeclarationOption{
 		filtering.DeclareStandardFunctions(),
 		filtering.DeclareIdent("status", filtering.TypeString),
@@ -1992,7 +1990,6 @@ func (s *service) ListPipelineRunsByRequester(ctx context.Context, req *pipeline
 	}
 
 	if startedTimeBegin.After(startedTimeEnd) {
-		log.Error("time range end time is earlier than start time", zap.Time("startedTimeEnd", startedTimeEnd), zap.Time("startedTimeBegin", startedTimeBegin))
 		return nil, fmt.Errorf("time range end time is earlier than start time")
 	}
 

--- a/pkg/service/utils.go
+++ b/pkg/service/utils.go
@@ -101,6 +101,7 @@ func (s *service) GetRscNamespace(ctx context.Context, namespaceID string) (reso
 func (s *service) convertPipelineRunToPB(run datamodel.PipelineRun) (*pipelinepb.PipelineRun, error) {
 	result := &pipelinepb.PipelineRun{
 		PipelineUid:     run.PipelineUID.String(),
+		PipelineId:      &run.Pipeline.ID,
 		PipelineRunUid:  run.PipelineTriggerUID.String(),
 		PipelineVersion: run.PipelineVersion,
 		Status:          runpb.RunStatus(run.Status),


### PR DESCRIPTION
Because

- the data that users could see on dashboard are different from what they can see on Runs page in a single pipeline or model

This commit

- add new run logging API for dashboard

![image](https://github.com/user-attachments/assets/7ff10845-4b99-4a55-a08a-90652ee67454)
