### PR TITLE
fix(run): not return minio error in list pipeline run

### DIFF
--- a/pkg/handler/pipeline.go
+++ b/pkg/handler/pipeline.go
@@ -26,12 +26,10 @@ import (
 	"github.com/instill-ai/pipeline-backend/pkg/logger"
 	"github.com/instill-ai/pipeline-backend/pkg/resource"
 	"github.com/instill-ai/pipeline-backend/pkg/service"
+	"github.com/instill-ai/x/checkfield"
 
 	errdomain "github.com/instill-ai/pipeline-backend/pkg/errors"
 	customotel "github.com/instill-ai/pipeline-backend/pkg/logger/otel"
-
-	"github.com/instill-ai/x/checkfield"
-
 	pb "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
 

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -39,12 +39,10 @@ import (
 	"github.com/instill-ai/pipeline-backend/pkg/resource"
 	"github.com/instill-ai/pipeline-backend/pkg/utils"
 	"github.com/instill-ai/pipeline-backend/pkg/worker"
-
-	errdomain "github.com/instill-ai/pipeline-backend/pkg/errors"
-
 	"github.com/instill-ai/x/errmsg"
 
 	componentbase "github.com/instill-ai/pipeline-backend/pkg/component/base"
+	errdomain "github.com/instill-ai/pipeline-backend/pkg/errors"
 	mgmtpb "github.com/instill-ai/protogen-go/core/mgmt/v1beta"
 	pipelinepb "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
@@ -65,8 +63,8 @@ func (s *service) GetHubStats(ctx context.Context) (*pipelinepb.GetHubStatsRespo
 	}
 
 	return &pipelinepb.GetHubStatsResponse{
-		NumberOfPublicPipelines:   int32(hubStats.NumberOfPublicPipelines),
-		NumberOfFeaturedPipelines: int32(hubStats.NumberOfFeaturedPipelines),
+		NumberOfPublicPipelines:   hubStats.NumberOfPublicPipelines,
+		NumberOfFeaturedPipelines: hubStats.NumberOfFeaturedPipelines,
 	}, nil
 }
 
@@ -1792,7 +1790,6 @@ func (s *service) ListPipelineRuns(ctx context.Context, req *pipelinepb.ListPipe
 	fileContents, err := s.minioClient.GetFilesByPaths(ctx, referenceIDs)
 	if err != nil {
 		log.Error("failed to get files from minio", zap.Error(err))
-		return nil, err
 	}
 
 	metadataMap := make(map[string][]byte)
@@ -1826,60 +1823,21 @@ func (s *service) ListPipelineRuns(ctx context.Context, req *pipelinepb.ListPipe
 
 		if CanViewPrivateData(run.Namespace, requesterUID) {
 			if len(run.Inputs) == 1 {
-				md, ok := metadataMap[run.Inputs[0].Name]
-				if !ok {
-					return nil, fmt.Errorf("failed to load input metadata. pipeline UID: %s input reference ID: %s", run.PipelineUID.String(), run.Inputs[0].Name)
-				}
-				pbRun.Inputs = make([]*structpb.Struct, 0)
-				err = json.Unmarshal(md, &pbRun.Inputs)
-				if err != nil {
-					return nil, err
-				}
-
+				key := run.Inputs[0].Name
+				pbRun.Inputs = parseMetadataToStructArray(metadataMap, log, key, "input",
+					zap.String("pipelineUID", run.PipelineUID.String()), zap.String("inputReferenceID", key))
 			}
+
 			if len(run.Outputs) == 1 {
-				md, ok := metadataMap[run.Outputs[0].Name]
-				if !ok {
-					return nil, fmt.Errorf("failed to load output metadata. pipeline UID: %s output reference ID: %s", run.PipelineUID.String(), run.Outputs[0].Name)
-				}
-				pbRun.Outputs = make([]*structpb.Struct, 0)
-				err = json.Unmarshal(md, &pbRun.Outputs)
-				if err != nil {
-					return nil, err
-				}
+				key := run.Outputs[0].Name
+				pbRun.Outputs = parseMetadataToStructArray(metadataMap, log, key, "output",
+					zap.String("pipelineUID", run.PipelineUID.String()), zap.String("outputReferenceID", key))
 			}
+
 			if len(run.RecipeSnapshot) == 1 {
-				md, ok := metadataMap[run.RecipeSnapshot[0].Name]
-				if !ok {
-					return nil, fmt.Errorf("failed to load recipe metadata. pipeline UID: %s recipe reference ID: %s", run.PipelineUID.String(), run.RecipeSnapshot[0].Name)
-				}
-				r := make(map[string]any)
-				err = json.Unmarshal(md, &r)
-				if err != nil {
-					return nil, fmt.Errorf("failed to load recipe metadata. pipeline UID: %s recipe reference ID: %s", run.PipelineUID.String(), run.RecipeSnapshot[0].Name)
-				}
-				pbRun.RecipeSnapshot, err = structpb.NewStruct(r)
-				if err != nil {
-					return nil, err
-				}
-
-				dbRecipe := &datamodel.Recipe{}
-				err = json.Unmarshal(md, dbRecipe)
-				if err != nil {
-					return nil, fmt.Errorf("failed to load recipe metadata. pipeline UID: %s recipe reference ID: %s", run.PipelineUID.String(), run.RecipeSnapshot[0].Name)
-				}
-
-				err = s.converter.IncludeDetailInRecipe(ctx, "", dbRecipe, false)
-				if err != nil {
-					return nil, fmt.Errorf("failed to load recipe metadata. pipeline UID: %s recipe reference ID: %s", run.PipelineUID.String(), run.RecipeSnapshot[0].Name)
-				}
-				pbRun.DataSpecification, err = s.converter.GeneratePipelineDataSpec(dbRecipe.Variable, dbRecipe.Output, dbRecipe.Component)
-				if err != nil {
-					// Some recipes cannot generate a DataSpecification, so we
-					// can skip them.
-					pbRun.DataSpecification = nil
-				}
-
+				key := run.RecipeSnapshot[0].Name
+				pbRun.RecipeSnapshot, pbRun.DataSpecification = parseRecipeMetadata(metadataMap, log, s.converter, key, "recipe",
+					zap.String("pipelineUID", run.PipelineUID.String()), zap.String("recipeReferenceID", key))
 			}
 		}
 
@@ -1942,7 +1900,6 @@ func (s *service) ListComponentRuns(ctx context.Context, req *pipelinepb.ListCom
 	fileContents, err := s.minioClient.GetFilesByPaths(ctx, referenceIDs)
 	if err != nil {
 		log.Error("failed to get files from minio", zap.Error(err))
-		return nil, err
 	}
 
 	metadataMap := make(map[string][]byte)
@@ -1960,27 +1917,14 @@ func (s *service) ListComponentRuns(ctx context.Context, req *pipelinepb.ListCom
 
 		if CanViewPrivateData(dbPipelineRun.Namespace, requesterUID) {
 			if len(run.Inputs) == 1 {
-				md, ok := metadataMap[run.Inputs[0].Name]
-				if !ok {
-					return nil, fmt.Errorf("failed to load input metadata. component UID: %s input reference ID: %s", run.ComponentID, run.Inputs[0].Name)
-				}
-				pbRun.Inputs = make([]*structpb.Struct, 0)
-				err = json.Unmarshal(md, &pbRun.Inputs)
-				if err != nil {
-					return nil, err
-				}
-
+				key := run.Inputs[0].Name
+				pbRun.Inputs = parseMetadataToStructArray(metadataMap, log, key, "input",
+					zap.String("ComponentID", run.ComponentID), zap.String("inputReferenceID", key))
 			}
 			if len(run.Outputs) == 1 {
-				md, ok := metadataMap[run.Outputs[0].Name]
-				if !ok {
-					return nil, fmt.Errorf("failed to load output metadata. component UID: %s output reference ID: %s", run.ComponentID, run.Outputs[0].Name)
-				}
-				pbRun.Outputs = make([]*structpb.Struct, 0)
-				err = json.Unmarshal(md, &pbRun.Outputs)
-				if err != nil {
-					return nil, err
-				}
+				key := run.Outputs[0].Name
+				pbRun.Outputs = parseMetadataToStructArray(metadataMap, log, key, "output",
+					zap.String("ComponentID", run.ComponentID), zap.String("outputReferenceID", key))
 			}
 		}
 		pbComponentRuns[i] = pbRun

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -1824,20 +1824,29 @@ func (s *service) ListPipelineRuns(ctx context.Context, req *pipelinepb.ListPipe
 		if CanViewPrivateData(run.Namespace, requesterUID) {
 			if len(run.Inputs) == 1 {
 				key := run.Inputs[0].Name
-				pbRun.Inputs = parseMetadataToStructArray(metadataMap, log, key, "input",
-					zap.String("pipelineUID", run.PipelineUID.String()), zap.String("inputReferenceID", key))
+				pbRun.Inputs, err = parseMetadataToStructArray(metadataMap, key)
+				if err != nil {
+					log.Error("Failed to load input metadata", zap.Error(err), zap.String("pipelineUID", run.PipelineUID.String()),
+						zap.String("inputReferenceID", key))
+				}
 			}
 
 			if len(run.Outputs) == 1 {
 				key := run.Outputs[0].Name
-				pbRun.Outputs = parseMetadataToStructArray(metadataMap, log, key, "output",
-					zap.String("pipelineUID", run.PipelineUID.String()), zap.String("outputReferenceID", key))
+				pbRun.Outputs, err = parseMetadataToStructArray(metadataMap, key)
+				if err != nil {
+					log.Error("Failed to load output metadata", zap.Error(err), zap.String("pipelineUID", run.PipelineUID.String()),
+						zap.String("outputReferenceID", key))
+				}
 			}
 
 			if len(run.RecipeSnapshot) == 1 {
 				key := run.RecipeSnapshot[0].Name
-				pbRun.RecipeSnapshot, pbRun.DataSpecification = parseRecipeMetadata(metadataMap, log, s.converter, key, "recipe",
-					zap.String("pipelineUID", run.PipelineUID.String()), zap.String("recipeReferenceID", key))
+				pbRun.RecipeSnapshot, pbRun.DataSpecification, err = parseRecipeMetadata(ctx, metadataMap, s.converter, key)
+				if err != nil {
+					log.Error("Failed to load recipe snapshot", zap.Error(err), zap.String("pipelineUID", run.PipelineUID.String()),
+						zap.String("recipeReferenceID", key))
+				}
 			}
 		}
 
@@ -1918,13 +1927,20 @@ func (s *service) ListComponentRuns(ctx context.Context, req *pipelinepb.ListCom
 		if CanViewPrivateData(dbPipelineRun.Namespace, requesterUID) {
 			if len(run.Inputs) == 1 {
 				key := run.Inputs[0].Name
-				pbRun.Inputs = parseMetadataToStructArray(metadataMap, log, key, "input",
-					zap.String("ComponentID", run.ComponentID), zap.String("inputReferenceID", key))
+				pbRun.Inputs, err = parseMetadataToStructArray(metadataMap, key)
+				if err != nil {
+					log.Error("Failed to load input metadata", zap.Error(err), zap.String("ComponentID", run.ComponentID),
+						zap.String("inputReferenceID", key))
+				}
 			}
 			if len(run.Outputs) == 1 {
 				key := run.Outputs[0].Name
-				pbRun.Outputs = parseMetadataToStructArray(metadataMap, log, key, "output",
-					zap.String("ComponentID", run.ComponentID), zap.String("outputReferenceID", key))
+				pbRun.Outputs, err = parseMetadataToStructArray(metadataMap, key)
+				if err != nil {
+					log.Error("Failed to load output metadata", zap.Error(err), zap.String("ComponentID", run.ComponentID),
+						zap.String("outputReferenceID", key))
+				}
+
 			}
 		}
 		pbComponentRuns[i] = pbRun

--- a/pkg/service/pipeline_repository_test.go
+++ b/pkg/service/pipeline_repository_test.go
@@ -172,7 +172,7 @@ func TestService_ListPipelineRuns(t *testing.T) {
 	}, nil)
 
 	mockMinio := mock.NewMinioIMock(mc)
-	mockMinio.GetFilesByPathsMock.Return(nil, nil)
+	mockMinio.GetFilesByPathsMock.Return(nil, fmt.Errorf("some errors"))
 
 	for i, testCase := range testCases {
 		c.Run(fmt.Sprintf("get pipeline run with permissions test case %d %s", i+1, testCase.description), func(c *qt.C) {
@@ -396,7 +396,7 @@ func TestService_ListPipelineRuns_OrgResource(t *testing.T) {
 	}, nil)
 
 	mockMinio := mock.NewMinioIMock(mc)
-	mockMinio.GetFilesByPathsMock.Return(nil, nil)
+	mockMinio.GetFilesByPathsMock.Return(nil, fmt.Errorf("some error happens"))
 
 	for i, testCase := range testCases {
 		c.Run(fmt.Sprintf("get pipeline run with permissions test case %d %s", i+1, testCase.description), func(c *qt.C) {


### PR DESCRIPTION
Because

- list pipeline run should return results even if there is an error in minio

This commit

- log errors instead of return error
