### PR TITLE
feat(component): update documentation URL to component ID

### DIFF
--- a/pkg/component/ai/cohere/v0/config/definition.json
+++ b/pkg/component/ai/cohere/v0/config/definition.json
@@ -4,7 +4,7 @@
     "TASK_TEXT_EMBEDDINGS",
     "TASK_TEXT_RERANKING"
   ],
-  "documentationUrl": "https://www.instill.tech/docs/latest/vdp/ai/cohere",
+  "documentationUrl": "https://www.instill.tech/docs/component/ai/cohere",
   "icon": "assets/cohere.svg",
   "id": "cohere",
   "public": true,

--- a/pkg/component/ai/fireworksai/v0/config/definition.json
+++ b/pkg/component/ai/fireworksai/v0/config/definition.json
@@ -4,7 +4,7 @@
     "TASK_TEXT_EMBEDDINGS"
   ],
   "custom": false,
-  "documentationUrl": "https://www.instill.tech/docs/component/ai/fireworksai",
+  "documentationUrl": "https://www.instill.tech/docs/component/ai/fireworks-ai",
   "icon": "assets/fireworks-ai.svg",
   "id": "fireworks-ai",
   "public": true,

--- a/pkg/component/ai/huggingface/v0/config/definition.json
+++ b/pkg/component/ai/huggingface/v0/config/definition.json
@@ -19,7 +19,7 @@
     "TASK_AUDIO_CLASSIFICATION"
   ],
   "custom": false,
-  "documentationUrl": "https://www.instill.tech/docs/component/ai/huggingface",
+  "documentationUrl": "https://www.instill.tech/docs/component/ai/hugging-face",
   "icon": "assets/hugging-face.svg",
   "iconUrl": "",
   "id": "hugging-face",

--- a/pkg/component/ai/instill/v0/config/definition.json
+++ b/pkg/component/ai/instill/v0/config/definition.json
@@ -13,7 +13,7 @@
     "TASK_CHAT"
   ],
   "custom": false,
-  "documentationUrl": "https://www.instill.tech/docs/component/ai/instill",
+  "documentationUrl": "https://www.instill.tech/docs/component/ai/instill-model",
   "icon": "assets/instill-model.svg",
   "iconUrl": "",
   "id": "instill-model",

--- a/pkg/component/ai/mistralai/v0/config/definition.json
+++ b/pkg/component/ai/mistralai/v0/config/definition.json
@@ -4,7 +4,7 @@
     "TASK_TEXT_EMBEDDINGS"
   ],
   "custom": false,
-  "documentationUrl": "https://www.instill.tech/docs/component/ai/mistralai",
+  "documentationUrl": "https://www.instill.tech/docs/component/ai/mistral-ai",
   "icon": "assets/mistral-ai.svg",
   "id": "mistral-ai",
   "public": true,

--- a/pkg/component/ai/openai/v0/config/definition.json
+++ b/pkg/component/ai/openai/v0/config/definition.json
@@ -7,7 +7,6 @@
     "TASK_TEXT_TO_IMAGE"
   ],
   "custom": false,
-  "documentation_url": "https://www.instill.tech/docs/component/ai/openai",
   "icon": "assets/openai.svg",
   "iconUrl": "",
   "id": "openai",
@@ -20,5 +19,6 @@
   "vendorAttributes": {},
   "version": "0.1.1",
   "sourceUrl": "https://github.com/instill-ai/pipeline-backend/blob/main/pkg/component/ai/openai/v0",
-  "releaseStage": "RELEASE_STAGE_ALPHA"
+  "releaseStage": "RELEASE_STAGE_ALPHA",
+  "documentationUrl": "https://www.instill.tech/docs/component/ai/openai"
 }

--- a/pkg/component/ai/stabilityai/v0/config/definition.json
+++ b/pkg/component/ai/stabilityai/v0/config/definition.json
@@ -4,7 +4,7 @@
     "TASK_IMAGE_TO_IMAGE"
   ],
   "custom": false,
-  "documentationUrl": "https://www.instill.tech/docs/component/ai/stabilityai",
+  "documentationUrl": "https://www.instill.tech/docs/component/ai/stability-ai",
   "icon": "assets/stability-ai.svg",
   "iconUrl": "",
   "id": "stability-ai",

--- a/pkg/component/ai/universalai/v0/config/definition.json
+++ b/pkg/component/ai/universalai/v0/config/definition.json
@@ -3,7 +3,6 @@
     "TASK_CHAT"
   ],
   "custom": false,
-  "documentation_url": "https://www.instill.tech/docs/component/ai/universalai",
   "icon": "assets/universal-ai.svg",
   "id": "universal-ai",
   "public": true,
@@ -14,5 +13,6 @@
   "vendorAttributes": {},
   "version": "0.2.0",
   "sourceUrl": "https://github.com/instill-ai/pipeline-backend/blob/main/pkg/component/ai/universalai/v0",
-  "releaseStage": "RELEASE_STAGE_ALPHA"
+  "releaseStage": "RELEASE_STAGE_ALPHA",
+  "documentationUrl": "https://www.instill.tech/docs/component/ai/universal-ai"
 }

--- a/pkg/component/application/googlesearch/v0/config/definition.json
+++ b/pkg/component/application/googlesearch/v0/config/definition.json
@@ -3,7 +3,7 @@
     "TASK_SEARCH"
   ],
   "custom": false,
-  "documentationUrl": "https://www.instill.tech/docs/component/application/googlesearch",
+  "documentationUrl": "https://www.instill.tech/docs/component/application/google-search",
   "icon": "assets/google-search.svg",
   "iconUrl": "",
   "id": "google-search",

--- a/pkg/component/application/instillapp/v0/config/definition.json
+++ b/pkg/component/application/instillapp/v0/config/definition.json
@@ -3,7 +3,7 @@
     "TASK_READ_CHAT_HISTORY",
     "TASK_WRITE_CHAT_MESSAGE"
   ],
-  "documentationUrl": "https://www.instill.tech/docs/component/application/instillapp",
+  "documentationUrl": "https://www.instill.tech/docs/component/application/instill-app",
   "icon": "assets/instill-app.svg",
   "id": "instill-app",
   "public": true,

--- a/pkg/component/application/slack/v0/README.mdx
+++ b/pkg/component/application/slack/v0/README.mdx
@@ -65,7 +65,7 @@ Get the latest message since specific date
 | :--- | :--- | :--- | :--- |
 | Task ID (required) | `task` | string | `TASK_READ_MESSAGE` |
 | Channel Name (required) | `channel-name` | string | Channel name, as displayed on Slack |
-| Start to read date | `start-to-read-date` | string | Date (in <code>YYYY-MM-DD<code> format) from which messages will start to be fetched |
+| Start to read date | `start-to-read-date` | string | Date (in `YYYY-MM-DD` format) from which messages will start to be fetched |
 </div>
 
 

--- a/pkg/component/application/slack/v0/config/tasks.json
+++ b/pkg/component/application/slack/v0/config/tasks.json
@@ -37,7 +37,7 @@
           "type": "string"
         },
         "start-to-read-date": {
-          "description": "Date (in <code>YYYY-MM-DD<code> format) from which messages will start to be fetched",
+          "description": "Date (in `YYYY-MM-DD` format) from which messages will start to be fetched",
           "instillAcceptFormats": [
             "string"
           ],

--- a/pkg/component/data/elasticsearch/v0/config/definition.json
+++ b/pkg/component/data/elasticsearch/v0/config/definition.json
@@ -9,7 +9,7 @@
     "TASK_CREATE_INDEX",
     "TASK_DELETE_INDEX"
   ],
-  "documentationUrl": "https://www.instill.tech/docs/component/application/elasticsearch",
+  "documentationUrl": "https://www.instill.tech/docs/component/data/elasticsearch",
   "icon": "assets/elasticsearch.svg",
   "id": "elasticsearch",
   "public": true,

--- a/pkg/component/data/googlecloudstorage/v0/config/definition.json
+++ b/pkg/component/data/googlecloudstorage/v0/config/definition.json
@@ -5,7 +5,7 @@
     "TASK_CREATE_BUCKET"
   ],
   "custom": false,
-  "documentationUrl": "https://www.instill.tech/docs/component/data/googlecloudstorage",
+  "documentationUrl": "https://www.instill.tech/docs/component/data/gcs",
   "icon": "assets/gcs.svg",
   "iconUrl": "",
   "id": "gcs",

--- a/pkg/component/data/instillartifact/v0/config/definition.json
+++ b/pkg/component/data/instillartifact/v0/config/definition.json
@@ -9,7 +9,7 @@
     "TASK_RETRIEVE",
     "TASK_ASK"
   ],
-  "documentationUrl": "https://www.instill.tech/docs/component/data/instillartifact",
+  "documentationUrl": "https://www.instill.tech/docs/component/data/instill-artifact",
   "icon": "assets/instill-artifact.svg",
   "id": "instill-artifact",
   "public": true,


### PR DESCRIPTION
Because

- Documentation website paths follow the same convention as the IDs, not the Go packages.
- This PR is a prerequisite for doc generation in https://github.com/instill-ai/instill.tech/pull/1184.

This commit

- Updates the documentation URL references.
