### PR TITLE
ci(Dockerfile,Makefile): refine targets and fix warnings

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-* @donch1989 @pinglin @xiaofei-du @jvallesm
+* @donch1989 @jvallesm @chuang8511
 *.md @GeorgeWilliamStrong
 *.mdx @GeorgeWilliamStrong

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM --platform=$TARGETPLATFORM golang:1.22.5-alpine3.19 AS build
+ARG GOLANG_VERSION=1.22.5
+FROM golang:${GOLANG_VERSION}-alpine3.19 AS build
 
 RUN apk add --no-cache build-base leptonica-dev tesseract-ocr-dev musl-dev
 
@@ -60,7 +61,7 @@ ARG SERVICE_NAME
 
 WORKDIR /${SERVICE_NAME}
 
-ENV GODEBUG tlsrsakex=1
+ENV GODEBUG=tlsrsakex=1
 
 COPY --from=build --chown=nobody:nogroup /src/config ./config
 COPY --from=build --chown=nobody:nogroup /src/release-please ./release-please

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,5 @@
-FROM golang:1.22.5
+ARG GOLANG_VERSION=1.22.5
+FROM golang:${GOLANG_VERSION}
 
 ARG SERVICE_NAME
 
@@ -29,12 +30,12 @@ RUN go mod download
 COPY . .
 
 RUN chown -R nobody:nogroup /go
-ENV GOCACHE /go/.cache/go-build
-ENV GOENV /go/.config/go/env
+ENV GOCACHE=/go/.cache/go-build
+ENV GOENV=/go/.config/go/env
 
 # Go 1.22 has dropped support for some TLS versions. This configuration is
 # required to restore compatibility with those versions.
-ENV GODEBUG tlsrsakex=1
+ENV GODEBUG=tlsrsakex=1
 
 USER nobody:nogroup
 


### PR DESCRIPTION
Because

- there are confusing and unuseful Makefile targets
- the latest Docker version warns ENV syntax and default ARG value

This commit

- fixes the issues
- updates CODEOWNERS
