### PR TITLE
fix(groq): use credential-supported model in example

### DIFF
--- a/pkg/component/ai/groq/v0/config/tasks.json
+++ b/pkg/component/ai/groq/v0/config/tasks.json
@@ -152,7 +152,7 @@
             "gemma2-9b-it",
             "gemma-7b-it"
           ],
-          "example": "llama-3.1-8b-instant",
+          "example": "llama3-8b-8192",
           "description": "The OSS model to be used",
           "instillAcceptFormats": [
             "string"


### PR DESCRIPTION
Because

- The example model in the `groq` component (the one that will appear when adding a new component in the editor) doesn't support Instill Credentials (i.e. it requires a custom `setup.api-key`.

This commit

- Shows by default a model that supports credentials.
- Part of INS-6643