### PR TITLE
feat(slack): enable OAuth 2.0 integration

### DIFF
--- a/pkg/component/application/slack/v0/config/setup.json
+++ b/pkg/component/application/slack/v0/config/setup.json
@@ -33,7 +33,7 @@
     "bot-token"
   ],
   "instillEditOnNodeFields": [
-    "token"
+    "bot-token"
   ],
   "title": "Slack Connection",
   "type": "object"

--- a/pkg/component/application/slack/v0/config/setup.json
+++ b/pkg/component/application/slack/v0/config/setup.json
@@ -35,6 +35,20 @@
   "instillEditOnNodeFields": [
     "bot-token"
   ],
+  "instillOAuthConfig": {
+    "authUrl": "https://slack.com/oauth/v2/authorize",
+    "accessUrl": "https://slack.com/api/oauth.v2.access",
+    "scopes": [
+      "channels:history",
+      "channels:read",
+      "groups:history",
+      "groups:read",
+      "chat:write",
+      "users:read",
+      "users:read.email",
+      "users.profile:read"
+    ]
+  },
   "title": "Slack Connection",
   "type": "object"
 }


### PR DESCRIPTION
Because

- Frontend is implementing OAuth 2.0 flow for the Slack component.

This commit

- Adds the OAuth information to the component.
