### PR TITLE
feat: standardize the tag naming convention

### DIFF
--- a/pkg/repository/transpiler.go
+++ b/pkg/repository/transpiler.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/iancoleman/strcase"
@@ -218,7 +219,7 @@ func (t *transpiler) transpileComparisonCallExpr(e *expr.Expr, op interface{}) (
 			vars = append(vars, con.Vars...)
 		case "tag":
 			sql = "tag.tag_name = ?"
-			vars = append(vars, con.Vars...)
+			vars = append(vars, strings.ToLower(con.Vars[0].(string)))
 		default:
 			sql = fmt.Sprintf("%s = ?", ident.SQL)
 			vars = append(vars, con.Vars...)

--- a/pkg/service/convert.go
+++ b/pkg/service/convert.go
@@ -23,6 +23,8 @@ import (
 	"github.com/redis/go-redis/v9"
 	"go.uber.org/zap"
 	"golang.org/x/image/draw"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -558,9 +560,13 @@ func (c *converter) ConvertPipelineToPB(ctx context.Context, dbPipelineOrigin *d
 		pbSharing.ShareCode.Code = dbPipeline.ShareCode
 	}
 
-	tags := []string{}
-	for _, t := range dbPipeline.Tags {
-		tags = append(tags, t.TagName)
+	tags := make([]string, len(dbPipeline.Tags))
+	for i, tag := range dbPipeline.TagNames() {
+		if slices.Contains(preserveTags, tag) {
+			tags[i] = cases.Title(language.English).String(tag)
+		} else {
+			tags[i] = tag
+		}
 	}
 
 	var pbRecipe *structpb.Struct


### PR DESCRIPTION
Because

- We didn't apply any naming convention on tags

This commit

- Standardizes the tag naming convention to match the following criteria:
  - All user-defined tags will be converted to lowercase.
  - All system/reserved tags will be capitalized.