### PR TITLE
docs(CONTRIBUTING): update doc

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -44,7 +44,7 @@ $ make latest PROFILE=exclude-pipeline # launch all the dependent services excep
 ```sh
 $ cd $MY_WORKSPACE
 $ git clone https://github.com/instill-ai/pipeline-backend && cd pipeline-backend
-$ make build && make dev
+$ make build-dev && make dev
 ```
 
 Now, you have the Go project set up in the container, in which you can compile

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ latest:							## Run latest container
 rm:								## Remove all running containers
 	@docker rm -f ${SERVICE_NAME} ${SERVICE_NAME}-worker >/dev/null 2>&1
 
-.PHONY: build
+.PHONY: build-dev
 build-dev:							## Build dev docker image
 	@docker build \
 		--build-arg SERVICE_NAME=${SERVICE_NAME} \


### PR DESCRIPTION
Because

- `make build` is now `make build-dev` to clearly separate dev and latest image build

This commit

- update the contribution guideline doc
