### PR TITLE
feat: allow users to enter partial/complete channel to fetch conversation

### DIFF
--- a/pkg/component/application/slack/v0/config/tasks.json
+++ b/pkg/component/application/slack/v0/config/tasks.json
@@ -21,10 +21,10 @@
       "description": "Please input the channel name and the date that we want to start to read",
       "instillUIOrder": 0,
       "properties": {
-        "channel-name": {
-          "description": "Channel name, as displayed on Slack",
+        "channel-names": {
+          "description": "Enter a partial or complete channel name to fetch conversations. For example, typing 'dev' retrieves conversations from all channels containing 'dev'.",
           "instillAcceptFormats": [
-            "string"
+            "array"
           ],
           "instillUIMultiline": true,
           "instillUIOrder": 0,
@@ -34,7 +34,10 @@
             "template"
           ],
           "title": "Channel Name",
-          "type": "string"
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "start-to-read-date": {
           "description": "Date (in `YYYY-MM-DD` format) from which messages will start to be fetched",


### PR DESCRIPTION
Updated the tasks.json file.
Allowing slack to read multiple channel-names by changing  type from (string-->array).
For example:
typing 'dev' retrieves conversations from all channels containing 'dev'."

Because

- Currently users need to type the entire channel name to fetch conversation.
By implementing this functionality users can fetch by partial/complete typing.

Fixes Issue #1110
https://github.com/instill-ai/instill-core/issues/1110

This commit

Code changes in pkg/component/application/slack/v0/config/tasks.json

Changed datatype of Channel-names in "TASK_READ_MESSAGE"
from string --> array.
