### PR TITLE
fix: fix iterator upstream check

### DIFF
--- a/pkg/recipe/dag.go
+++ b/pkg/recipe/dag.go
@@ -560,6 +560,18 @@ func GenerateDAG(componentMap datamodel.ComponentMap) (*dag, error) {
 			if component.Input != nil {
 				parents = append(parents, FindReferenceParent(component.Input.(string))...)
 			}
+			if component.Range != nil {
+				switch rangeVal := component.Range.(type) {
+				case []any:
+					for _, v := range rangeVal {
+						parents = append(parents, FindReferenceParent(fmt.Sprintf("%v", v))...)
+					}
+				case map[string]any:
+					for _, v := range rangeVal {
+						parents = append(parents, FindReferenceParent(fmt.Sprintf("%v", v))...)
+					}
+				}
+			}
 			nestedComponentIDs := []string{id}
 			for nestedID := range component.Component {
 				nestedComponentIDs = append(nestedComponentIDs, nestedID)


### PR DESCRIPTION
Because

- When a reference is present in the `range` field, the iterator fails to identify the correct upstreams.

This commit

- The pipeline should construct the correct DAG based on each component’s upstream dependencies.
