### PR TITLE
chore: fix file url in audio test-cases

### DIFF
--- a/pkg/data/audio_test.go
+++ b/pkg/data/audio_test.go
@@ -59,7 +59,7 @@ func TestNewAudioFromURL(t *testing.T) {
 		name string
 		url  string
 	}{
-		{"Valid audio URL", "https://raw.githubusercontent.com/instill-ai/pipeline-backend/refs/heads/huitang/format/pkg/data/testdata/sample1.wav"},
+		{"Valid audio URL", "https://raw.githubusercontent.com/instill-ai/pipeline-backend/24153e2c57ba4ce508059a0bd1af8528b07b5ed3/pkg/data/testdata/sample1.wav"},
 		{"Invalid URL", "https://invalid-url.com/audio.wav"},
 		{"Non-existent URL", "https://filesamples.com/samples/audio/wav/non_existent.wav"},
 	}


### PR DESCRIPTION
Because
 - The file URL in test cases used a link to the feature branch

This commit
 - fixes the link