### PR TITLE
chore(test): disable OAuth integration tests temporarily

### DIFF
--- a/integration-test/pipeline/rest-integration.js
+++ b/integration-test/pipeline/rest-integration.js
@@ -58,7 +58,9 @@ export function CheckIntegrations() {
     check(http.request("GET", `${pipelinePublicHost}/v1beta/integrations/${id}?view=VIEW_FULL`, null, null), {
       [`GET /v1beta/integrations/${id}?view=VIEW_FULL response status is 200`]: (r) => r.status === 200,
       [`GET /v1beta/integrations/${id}?view=VIEW_FULL response contains schema`]: (r) => r.json().integration.setupSchema.required[0] === "token",
-      [`GET /v1beta/integrations/${id}?view=VIEW_FULL response contains OAuth config`]: (r) => deepEqual(r.json().integration.oAuthConfig, oAuthConfig),
+      // TODO INS-6570 scope OAuth tests to this repository (enable them with a
+      // flag) and reintroduce this check.
+      // [`GET /v1beta/integrations/${id}?view=VIEW_FULL response contains OAuth config`]: (r) => deepEqual(r.json().integration.oAuthConfig, oAuthConfig),
       // Deprecated
       [`DEPRECATED GET /v1beta/integrations/${id}?view=VIEW_FULL response contains schema`]: (r) => r.json().integration.schemas[0].method === "METHOD_DICTIONARY",
     });
@@ -103,7 +105,7 @@ export function CheckConnections(data) {
   var connectionID = dbIDPrefix + randomString(8);
   var collectionPath = `/v1beta/namespaces/${defaultUsername}/connections`;
   var resourcePath = `${collectionPath}/${connectionID}`;
-  var integrationID = "github";
+  var integrationID = "asana"; // TODO reintroduce "github" with INS-6570
 
   var setup = {"token": "one2THREE"};
   var identity = "identitti";
@@ -131,6 +133,10 @@ export function CheckConnections(data) {
       [`POST ${path} (dictionary) has a creation time`]: (r) => new Date(r.json().connection.createTime).getTime() > new Date().setTime(0),
     });
 
+    // TODO INS-6570 scope OAuth tests to this repository (enable them with a
+    // flag) and reintroduce this check.
+
+    /*
     // Besides an OAuth configuration on the component definition, OAuth
     // support requires the client ID and secret to be defined in the config
     // (as environment variables). Make sure .env.component contains a client
@@ -161,6 +167,7 @@ export function CheckConnections(data) {
       [`POST ${path} (OAuth) has an identity`]: (r) => r.json().connection.identity === identity,
       [`POST ${path} (OAuth) has a creation time`]: (r) => new Date(r.json().connection.createTime).getTime() > new Date().setTime(0),
     });
+    */
 
     // Check OAuth support.
     var unsupportedOAuthReq = http.request(
@@ -241,7 +248,7 @@ export function CheckConnections(data) {
   });
 
   group("Integration API: Get connection", () => {
-    var path = resourcePath + "-oauth";
+    var path = resourcePath; // + "-oauth"; TODO reintroduce with INS-6570
 
     check(http.request("GET", pipelinePublicHost + path + "aaa", null, data.header), {
       [`GET ${path + "aaa"} response status is 404`]: (r) => r.status === 404,
@@ -253,8 +260,9 @@ export function CheckConnections(data) {
       [`GET ${path} has basic view`]: (r) => r.json().connection.view === "VIEW_BASIC",
       [`GET ${path} has setup hidden`]: (r) => r.json().connection.setup === null,
       [`GET ${path} has integration ID`]: (r) => r.json().connection.integrationId === integrationID,
-      [`GET ${path} has integration title`]: (r) => r.json().connection.integrationTitle === "GitHub",
-      [`GET ${path} has an identity`]: (r) => r.json().connection.identity === identity,
+      [`GET ${path} has integration title`]: (r) => r.json().connection.integrationTitle === "Asana", // TODO reintroduce "GitHub" with INS-6570
+      // TODO reintroduce with INS-6570
+      // [`GET ${path} has an identity`]: (r) => r.json().connection.identity === identity,
     });
 
     // Full view
@@ -263,8 +271,9 @@ export function CheckConnections(data) {
       [`GET ${path + "?view=VIEW_FULL"} has full view`]: (r) => r.json().connection.view === "VIEW_FULL",
       [`GET ${path + "?view=VIEW_FULL"} has setup`]: (r) => r.json().connection.setup != null,
       [`GET ${path + "?view=VIEW_FULL"} has setup value`]: (r) => r.json().connection.setup.password === setup.password, // TODO: redact
-      [`GET ${path + "?view=VIEW_FULL"} has scopes`]: (r) => r.json().connection.scopes.length > 0,
-      [`GET ${path + "?view=VIEW_FULL"} has OAuth details`]: (r) => r.json().connection.oAuthAccessDetails.access_token.length > 0, // TODO redact
+      // TODO reintroduce with INS-6570
+      // [`GET ${path + "?view=VIEW_FULL"} has scopes`]: (r) => r.json().connection.scopes.length > 0,
+      // [`GET ${path + "?view=VIEW_FULL"} has OAuth details`]: (r) => r.json().connection.oAuthAccessDetails.access_token.length > 0, // TODO redact
     });
   });
 
@@ -272,7 +281,7 @@ export function CheckConnections(data) {
     var path = collectionPath;
     var nConnections = 12;
     // Connections have been created in previous tests.
-    var totalConnections = nConnections + 2;
+    var totalConnections = nConnections + 1; // TODO +2 with INS-6570
     var integrationID = "openai";
 
     for (var i = 0; i < nConnections; i++) {
@@ -400,6 +409,9 @@ component:
   });
 
   group("Integration API: Update connection", () => {
+
+    // TODO reintroduce with INS-6570
+    /*
     var path = resourcePath + "-oauth";
     var originalConn = http.request(
       "GET",
@@ -459,6 +471,7 @@ component:
       [`GET ${path + "?view=VIEW_FULL"} has new setup value`]: (r) =>
         r.json().connection.setup.token === newToken,
     });
+    */
   });
 
   group("Integration API: Delete connection", () => {


### PR DESCRIPTION
Because

- Integration tests are run from different repos (`instill-core`, `api-gateway`), and a dependency on an env variable was introduced.

This commit

- Disables the tests until all CIs have been updated to provide these variables. Alternatively, the affected tests can be optional and run only when a flag is provided.
