### PR TITLE
chore: fix wrong mp3 content-type

### DIFF
--- a/pkg/data/bytearray.go
+++ b/pkg/data/bytearray.go
@@ -1,6 +1,7 @@
 package data
 
 import (
+	"bytes"
 	"encoding/base64"
 	"fmt"
 
@@ -45,7 +46,7 @@ func (b byteArrayData) ToStructValue() (v *structpb.Value, err error) {
 
 func (b *byteArrayData) Equal(other format.Value) bool {
 	if other, ok := other.(format.ByteArray); ok {
-		return fmt.Sprintf("%x", b.Raw) == fmt.Sprintf("%x", other.ByteArray())
+		return bytes.Equal(b.Raw, other.ByteArray())
 	}
 	return false
 }

--- a/pkg/data/file.go
+++ b/pkg/data/file.go
@@ -1,6 +1,7 @@
 package data
 
 import (
+	"bytes"
 	"fmt"
 	"mime"
 	"strings"
@@ -202,7 +203,7 @@ func (f *fileData) Equal(other format.Value) bool {
 		if err != nil {
 			return false
 		}
-		return fmt.Sprintf("%x", f.raw) == fmt.Sprintf("%x", ba.ByteArray()) &&
+		return bytes.Equal(f.raw, ba.ByteArray()) &&
 			f.contentType == other.ContentType().String() &&
 			f.fileName == other.FileName().String() &&
 			f.sourceURL == other.SourceURL().String()

--- a/pkg/data/struct.go
+++ b/pkg/data/struct.go
@@ -35,7 +35,7 @@ import (
 // The format portion of the tag supports:
 //   - For Image: "image/png", "image/jpeg", etc
 //   - For Video: "video/mp4", "video/webm", etc
-//   - For Audio: "audio/mp3", "audio/wav", etc
+//   - For Audio: "audio/mpeg", "audio/wav", etc
 //   - For Document: "application/pdf", "text/plain", etc
 
 // Unmarshal converts a Map value into the provided struct s using `instill` tags.


### PR DESCRIPTION
Because

 - The mp3 content-type was incorrect in the comment.

This commit

 - Fixes the incorrect mp3 content-type
 - Uses the built-in Equal function to compare byte arrays