### PR TITLE
chore(component,http): auto-detect file type when the response is binary

### DIFF
--- a/pkg/component/generic/http/v0/main.go
+++ b/pkg/component/generic/http/v0/main.go
@@ -203,7 +203,7 @@ func (e *execution) executeHTTP(ctx context.Context, job *base.Job) error {
 			}
 		}
 		// For other content types, return raw bytes wrapped in format.Value
-		value, err := data.NewFileFromBytes(resp.Body(), contentType, filename)
+		value, err := data.NewBinaryFromBytes(resp.Body(), contentType, filename)
 		if err != nil {
 			return fmt.Errorf("failed to convert response to format.Value: %w", err)
 		}


### PR DESCRIPTION
Because

- Previously, HTTP response data could include files, documents, images, videos, or audio, and assigning them to the correct Instill format was necessary for pipeline usability.

This commit:

- Automatically detects the file type when the response is in binary format.
