### PR TITLE
fix(slack): correct link to OAuth config in documentation

### DIFF
--- a/pkg/component/application/slack/v0/.compogen/extra-setup.mdx
+++ b/pkg/component/application/slack/v0/.compogen/extra-setup.mdx
@@ -19,4 +19,4 @@ that app is installed.
 If you want to connect with Slack via OAuth 2.0 on **Instill Core**, you will
 need to provide your app's **client ID** and **client secret** [as environment
 variables on Instill
-Core](https://github.com/instill-ai/instill-core/blob/main/.env).
+Core](https://github.com/instill-ai/instill-core/blob/main/.env.component).


### PR DESCRIPTION
Because

- https://github.com/instill-ai/instill-core/pull/1143/files changed the location to set the component environment variables.

This commit

- Fixes reference in Slack docs.
