### PR TITLE
feat: convert time type to string

### DIFF
--- a/pkg/component/CONTRIBUTING.md
+++ b/pkg/component/CONTRIBUTING.md
@@ -220,6 +220,7 @@ This file defines the input and output schema of each task:
 - **`instillAcceptFormats`** is an array indicating the data types of acceptable
   input fields. It should be an array of [**Instill
   Format**](https://www.instill.tech/docs/vdp/instill-format).
+  - Currently, we do not support the `time` type. When the input is a `date` or `datetime`, it should be represented as a string. The `date` or `datetime` will be automatically parsed in UTC timezone by the YAML parser. Please ensure this point is noted in the documentation, specifically for the `start-to-read-date` in the Slack component.
 - **`instillUpstreamTypes`** defines how an input property can be set: as a
   direct value, a reference to another value in the pipeline, or a combination
   of both (e.g., `${variable.name}` or `my dear ${variable.name}`).

--- a/pkg/component/application/slack/v0/README.mdx
+++ b/pkg/component/application/slack/v0/README.mdx
@@ -65,7 +65,7 @@ that app is installed.
 If you want to connect with Slack via OAuth 2.0 on **Instill Core**, you will
 need to provide your app's **client ID** and **client secret** [as environment
 variables on Instill
-Core](https://github.com/instill-ai/instill-core/blob/main/.env).
+Core](https://github.com/instill-ai/instill-core/blob/main/.env.component).
 
 
 
@@ -81,7 +81,7 @@ Get the latest message since specific date
 | :--- | :--- | :--- | :--- |
 | Task ID (required) | `task` | string | `TASK_READ_MESSAGE` |
 | Channel Name (required) | `channel-name` | string | Channel name, as displayed on Slack |
-| Start to Read Date | `start-to-read-date` | string | Date (in `YYYY-MM-DD` format) from which messages will start to be fetched |
+| Start to Read Date | `start-to-read-date` | string | Date (in `YYYY-MM-DD` format) from which messages will start to be fetched. If not provided, it will be 7 days before the current date. The date will be in the UTC timezone. |
 </div>
 
 

--- a/pkg/component/application/slack/v0/config/tasks.json
+++ b/pkg/component/application/slack/v0/config/tasks.json
@@ -37,7 +37,7 @@
           "type": "string"
         },
         "start-to-read-date": {
-          "description": "Date (in `YYYY-MM-DD` format) from which messages will start to be fetched",
+          "description": "Date (in `YYYY-MM-DD` format) from which messages will start to be fetched. If not provided, it will be 7 days before the current date. The date will be in the UTC timezone.",
           "instillAcceptFormats": [
             "string"
           ],

--- a/pkg/data/data.go
+++ b/pkg/data/data.go
@@ -2,6 +2,7 @@ package data
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/instill-ai/pipeline-backend/pkg/data/format"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -27,6 +28,12 @@ func NewValue(in any) (val format.Value, err error) {
 	switch in := in.(type) {
 	case nil:
 		return NewNull(), nil
+	case time.Time:
+		// Now, we don't provide time format in pipeline recipe.
+		// However, in YAML, it read the time format and convert it to time.Time.
+		// So, we need to convert it back to string.
+		// In the future, we may need to provide time format in pipeline recipe.
+		return NewString(in.Format(time.DateOnly)), nil
 	case bool:
 		return NewBoolean(in), nil
 	case float64:


### PR DESCRIPTION
Because

- we want to YYYY-MM-DD be able to parse in string type

This commit

- convert time to string
- add explanation in guideline