### PR TITLE
fix(run): add namespace id in response

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/h2non/filetype v1.1.3
 	github.com/iancoleman/strcase v0.3.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241029162707-1398399a24ee
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241105082344-134e33b0893e
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.5.0-alpha.0.20241028101056-3b853d0b8656
 	github.com/itchyny/gojq v0.12.14

--- a/go.sum
+++ b/go.sum
@@ -1281,8 +1281,8 @@ github.com/influxdata/influxdb-client-go/v2 v2.12.3 h1:28nRlNMRIV4QbtIUvxhWqaxn0
 github.com/influxdata/influxdb-client-go/v2 v2.12.3/go.mod h1:IrrLUbCjjfkmRuaCiGQg4m2GbkaeJDcuWoxiWdQEbA0=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241029162707-1398399a24ee h1:onnzrn5jabO3jDLPo2193Ql6YMRyDWDx9K834Bfi8V0=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241029162707-1398399a24ee/go.mod h1:rf0UY7VpEgpaLudYEcjx5rnbuwlBaaLyD4FQmWLtgAY=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241105082344-134e33b0893e h1:7y4coZNWIHxpJGwO5iPhKsKLfQpywUUIqtI9KacHxxA=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241105082344-134e33b0893e/go.mod h1:rf0UY7VpEgpaLudYEcjx5rnbuwlBaaLyD4FQmWLtgAY=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a/go.mod h1:EpX3Yr661uWULtZf5UnJHfr5rw2PDyX8ku4Kx0UtYFw=
 github.com/instill-ai/x v0.5.0-alpha.0.20241028101056-3b853d0b8656 h1:/7XGEVLGiEaXf8mzzvWqg15DJO2yDMww/TC5ZlE1yUY=

--- a/pkg/service/utils.go
+++ b/pkg/service/utils.go
@@ -100,6 +100,7 @@ func (s *service) convertPipelineRunToPB(run datamodel.PipelineRun) (*pipelinepb
 	result := &pipelinepb.PipelineRun{
 		PipelineUid:     run.PipelineUID.String(),
 		PipelineId:      &run.Pipeline.ID,
+		NamespaceId:     run.Pipeline.NamespaceID,
 		PipelineRunUid:  run.PipelineTriggerUID.String(),
 		PipelineVersion: run.PipelineVersion,
 		Status:          runpb.RunStatus(run.Status),


### PR DESCRIPTION
Because

- dashboard needs pipeline/model namespace id to redirect

This commit

- add namespace id in response

![image](https://github.com/user-attachments/assets/84f08fa2-da18-4d4c-9db2-4210c57294b1)
