### PR TITLE
chore: add guide to resolve ONNXRuntime build issue during pre-commit

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -117,7 +117,7 @@ $ make rm
    ```bash
    sudo mkdir -p /usr/local/onnxruntime
    sudo tar -xzf onnxruntime-*-*-*.tgz -C /usr/local/onnxruntime --strip-components=1
-   export ONNXRUNTIME_ROOT_PATH=/usr/local/onnxruntime  
+   export ONNXRUNTIME_ROOT_PATH=/usr/local/onnxruntime
    export LD_RUN_PATH=$ONNXRUNTIME_ROOT_PATH/lib
    export LIBRARY_PATH=$ONNXRUNTIME_ROOT_PATH/lib
    export C_INCLUDE_PATH=$ONNXRUNTIME_ROOT_PATH/include

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -33,7 +33,7 @@ jobs:
           wget https://github.com/microsoft/onnxruntime/releases/download/${LATEST_VERSION}/onnxruntime-linux-${ONNX_ARCH}-${LATEST_VERSION#v}.tgz
           tar -xzf onnxruntime-linux-${ONNX_ARCH}-${LATEST_VERSION#v}.tgz
           mv onnxruntime-linux-${ONNX_ARCH}-${LATEST_VERSION#v} ${ONNXRUNTIME_ROOT_PATH}
-          rm onnxruntime-linux-${ONNX_ARCH}-${LATEST_VERSION#v}.tgz          
+          rm onnxruntime-linux-${ONNX_ARCH}-${LATEST_VERSION#v}.tgz
           echo "C_INCLUDE_PATH=${ONNXRUNTIME_ROOT_PATH}/include" >> $GITHUB_ENV
           echo "LD_RUN_PATH=${ONNXRUNTIME_ROOT_PATH}/lib" >> $GITHUB_ENV
           echo "LIBRARY_PATH=${ONNXRUNTIME_ROOT_PATH}/lib" >> $GITHUB_ENV

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,16 @@ repos:
   - repo: https://github.com/dnephin/pre-commit-golang
     rev: v0.5.1
     hooks:
+      # To make the golangci-lint hook work with ONNX:
+      # 1. Install ONNX runtime locally:
+      #    - Mac: `brew install onnxruntime`
+      #    - Linux: Follow https://github.com/streamer45/silero-vad-go
+      # 2. For Mac OS with Homebrew:
+      #    a. Get install path: `brew info onnxruntime`
+      #    b. Set environment variables:
+      #       export LIBRARY_PATH=/opt/homebrew/Cellar/onnxruntime/1.17.1/lib
+      #       export C_INCLUDE_PATH=/opt/homebrew/Cellar/onnxruntime/1.17.1/include/onnxruntime
+      #    c. Run: sudo update_dyld_shared_cache
       - id: golangci-lint
         args: ["--build-tags", "onnx"]
       - id: go-mod-tidy

--- a/pkg/component/operator/audio/v0/.compogen/bottom.mdx
+++ b/pkg/component/operator/audio/v0/.compogen/bottom.mdx
@@ -16,7 +16,7 @@ component:
     type: audio
     input:
       audio: ${variable.audio}
-      segments: ${audio-vad.output.segments}    
+      segments: ${audio-vad.output.segments}
     task: TASK_SEGMENT
 variable:
   audio:
@@ -26,6 +26,6 @@ variable:
 output:
   samples:
     title: Output audio segments
-    description: Output extracted audio segments    
-    value: ${audio-segment.output.audio-segments}  
+    description: Output extracted audio segments
+    value: ${audio-segment.output.audio-segments}
 ```

--- a/pkg/component/operator/audio/v0/README.mdx
+++ b/pkg/component/operator/audio/v0/README.mdx
@@ -127,7 +127,7 @@ component:
     type: audio
     input:
       audio: ${variable.audio}
-      segments: ${audio-vad.output.segments}    
+      segments: ${audio-vad.output.segments}
     task: TASK_SEGMENT
 variable:
   audio:
@@ -137,6 +137,6 @@ variable:
 output:
   samples:
     title: Output audio segments
-    description: Output extracted audio segments    
-    value: ${audio-segment.output.audio-segments}  
+    description: Output extracted audio segments
+    value: ${audio-segment.output.audio-segments}
 ```


### PR DESCRIPTION
Because

- Previously, the pre-commit hooks failed due to an ONNXRuntime header issue.

This commit:

- Adds a guide to resolve the ONNXRuntime build issue during pre-commit