### PR TITLE
chore: use `filename` instead of `fileName`

### DIFF
--- a/pkg/data/audio.go
+++ b/pkg/data/audio.go
@@ -46,19 +46,19 @@ var audioGetter = map[string]func(*audioData) (format.Value, error){
 	"aiff":        func(a *audioData) (format.Value, error) { return a.Convert(AIFF) },
 }
 
-func NewAudioFromBytes(b []byte, contentType, fileName string) (*audioData, error) {
-	return createAudioData(b, contentType, fileName)
+func NewAudioFromBytes(b []byte, contentType, filename string) (*audioData, error) {
+	return createAudioData(b, contentType, filename)
 }
 
 func NewAudioFromURL(url string) (*audioData, error) {
-	b, contentType, fileName, err := convertURLToBytes(url)
+	b, contentType, filename, err := convertURLToBytes(url)
 	if err != nil {
 		return nil, err
 	}
-	return createAudioData(b, contentType, fileName)
+	return createAudioData(b, contentType, filename)
 }
 
-func createAudioData(b []byte, contentType, fileName string) (*audioData, error) {
+func createAudioData(b []byte, contentType, filename string) (*audioData, error) {
 	if contentType != OGG {
 		var err error
 		b, err = convertAudio(b, contentType, OGG)
@@ -68,7 +68,7 @@ func createAudioData(b []byte, contentType, fileName string) (*audioData, error)
 		contentType = OGG
 	}
 
-	f, err := NewFileFromBytes(b, contentType, fileName)
+	f, err := NewFileFromBytes(b, contentType, filename)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/data/document.go
+++ b/pkg/data/document.go
@@ -34,21 +34,21 @@ var documentGetters = map[string]func(*documentData) (format.Value, error){
 
 func (documentData) IsValue() {}
 
-func NewDocumentFromBytes(b []byte, contentType, fileName string) (*documentData, error) {
-	return createDocumentData(b, contentType, fileName)
+func NewDocumentFromBytes(b []byte, contentType, filename string) (*documentData, error) {
+	return createDocumentData(b, contentType, filename)
 }
 
 func NewDocumentFromURL(url string) (*documentData, error) {
-	b, contentType, fileName, err := convertURLToBytes(url)
+	b, contentType, filename, err := convertURLToBytes(url)
 	if err != nil {
 		return nil, err
 	}
 
-	return createDocumentData(b, contentType, fileName)
+	return createDocumentData(b, contentType, filename)
 }
 
-func createDocumentData(b []byte, contentType, fileName string) (*documentData, error) {
-	f, err := NewFileFromBytes(b, contentType, fileName)
+func createDocumentData(b []byte, contentType, filename string) (*documentData, error) {
+	f, err := NewFileFromBytes(b, contentType, filename)
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +92,7 @@ func (d *documentData) Text() (val format.String, err error) {
 	res, err := transformer.ConvertDocumentToMarkdown(
 		&transformer.ConvertDocumentToMarkdownTransformerInput{
 			Document: dataURI.String(),
-			Filename: d.fileName,
+			Filename: d.filename,
 		}, transformer.GetMarkdownTransformer)
 	if err != nil {
 		return nil, err
@@ -159,7 +159,7 @@ func (d *documentData) Images() (mp Array, err error) {
 	}
 	res, err := transformer.ConvertDocumentToImage(&transformer.ConvertDocumentToImagesTransformerInput{
 		Document: dataURI.String(),
-		Filename: d.fileName,
+		Filename: d.filename,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/data/format/format.go
+++ b/pkg/data/format/format.go
@@ -44,7 +44,7 @@ type File interface {
 	Base64() (url String, err error)
 	FileSize() (size Number)
 	ContentType() (t String)
-	FileName() (t String)
+	Filename() (t String)
 	SourceURL() (t String)
 	String() string
 }

--- a/pkg/data/image.go
+++ b/pkg/data/image.go
@@ -46,27 +46,27 @@ var imageGetters = map[string]func(*imageData) (format.Value, error){
 }
 
 // NewImageFromBytes creates a new imageData from byte slice
-func NewImageFromBytes(b []byte, contentType, fileName string) (*imageData, error) {
-	return createImageData(b, contentType, fileName)
+func NewImageFromBytes(b []byte, contentType, filename string) (*imageData, error) {
+	return createImageData(b, contentType, filename)
 }
 
 // NewImageFromURL creates a new imageData from a URL
 func NewImageFromURL(url string) (*imageData, error) {
-	b, contentType, fileName, err := convertURLToBytes(url)
+	b, contentType, filename, err := convertURLToBytes(url)
 	if err != nil {
 		return nil, err
 	}
-	return createImageData(b, contentType, fileName)
+	return createImageData(b, contentType, filename)
 }
 
 // createImageData is a helper function to create imageData
-func createImageData(b []byte, contentType, fileName string) (*imageData, error) {
+func createImageData(b []byte, contentType, filename string) (*imageData, error) {
 	b, err := convertImage(b, contentType, PNG)
 	if err != nil {
 		return nil, err
 	}
 
-	f, err := NewFileFromBytes(b, PNG, fileName)
+	f, err := NewFileFromBytes(b, PNG, filename)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/data/utils.go
+++ b/pkg/data/utils.go
@@ -10,7 +10,7 @@ import (
 	"github.com/instill-ai/pipeline-backend/pkg/data/format"
 )
 
-func decodeDataURI(s string) (b []byte, contentType string, fileName string, err error) {
+func decodeDataURI(s string) (b []byte, contentType string, filename string, err error) {
 	slices := strings.Split(s, ",")
 	if len(slices) == 1 {
 		b, err = base64.StdEncoding.DecodeString(s)
@@ -24,7 +24,7 @@ func decodeDataURI(s string) (b []byte, contentType string, fileName string, err
 
 			key, value, _ := strings.Cut(tag, "=")
 			if key == "filename" || key == "fileName" || key == "file-name" {
-				fileName = value
+				filename = value
 			}
 		}
 	}
@@ -52,27 +52,27 @@ func StandardizePath(path string) (newPath string, err error) {
 	}
 	return newPath, err
 }
-func NewBinaryFromBytes(b []byte, contentType, fileName string) (format.Value, error) {
+func NewBinaryFromBytes(b []byte, contentType, filename string) (format.Value, error) {
 	if contentType == "" {
 		contentType = strings.Split(mimetype.Detect(b).String(), ";")[0]
 	}
 
 	switch {
 	case isImageContentType(contentType):
-		return NewImageFromBytes(b, contentType, fileName)
+		return NewImageFromBytes(b, contentType, filename)
 	case isAudioContentType(contentType):
-		return NewAudioFromBytes(b, contentType, fileName)
+		return NewAudioFromBytes(b, contentType, filename)
 	case isVideoContentType(contentType):
-		return NewVideoFromBytes(b, contentType, fileName)
+		return NewVideoFromBytes(b, contentType, filename)
 	case isDocumentContentType(contentType):
-		return NewDocumentFromBytes(b, contentType, fileName)
+		return NewDocumentFromBytes(b, contentType, filename)
 	default:
-		return NewFileFromBytes(b, contentType, fileName)
+		return NewFileFromBytes(b, contentType, filename)
 	}
 }
 
 func NewBinaryFromURL(url string) (format.Value, error) {
-	b, contentType, fileName, err := convertURLToBytes(url)
+	b, contentType, filename, err := convertURLToBytes(url)
 	if err != nil {
 		return nil, err
 	}
@@ -83,15 +83,15 @@ func NewBinaryFromURL(url string) (format.Value, error) {
 
 	switch {
 	case isImageContentType(contentType):
-		return NewImageFromBytes(b, contentType, fileName)
+		return NewImageFromBytes(b, contentType, filename)
 	case isAudioContentType(contentType):
-		return NewAudioFromBytes(b, contentType, fileName)
+		return NewAudioFromBytes(b, contentType, filename)
 	case isVideoContentType(contentType):
-		return NewVideoFromBytes(b, contentType, fileName)
+		return NewVideoFromBytes(b, contentType, filename)
 	case isDocumentContentType(contentType):
-		return NewDocumentFromBytes(b, contentType, fileName)
+		return NewDocumentFromBytes(b, contentType, filename)
 	default:
-		return NewFileFromBytes(b, contentType, fileName)
+		return NewFileFromBytes(b, contentType, filename)
 	}
 }
 

--- a/pkg/data/video.go
+++ b/pkg/data/video.go
@@ -48,19 +48,19 @@ var videoGetters = map[string]func(*videoData) (format.Value, error){
 	"webm":       func(v *videoData) (format.Value, error) { return v.Convert(WEBM) },
 }
 
-func NewVideoFromBytes(b []byte, contentType, fileName string) (video *videoData, err error) {
-	return createVideoData(b, contentType, fileName)
+func NewVideoFromBytes(b []byte, contentType, filename string) (video *videoData, err error) {
+	return createVideoData(b, contentType, filename)
 }
 
 func NewVideoFromURL(url string) (video *videoData, err error) {
-	b, contentType, fileName, err := convertURLToBytes(url)
+	b, contentType, filename, err := convertURLToBytes(url)
 	if err != nil {
 		return nil, err
 	}
-	return createVideoData(b, contentType, fileName)
+	return createVideoData(b, contentType, filename)
 }
 
-func createVideoData(b []byte, contentType, fileName string) (*videoData, error) {
+func createVideoData(b []byte, contentType, filename string) (*videoData, error) {
 	if contentType != MP4 {
 		var err error
 		b, err = convertVideo(b, contentType, MP4)
@@ -69,7 +69,7 @@ func createVideoData(b []byte, contentType, fileName string) (*videoData, error)
 		}
 		contentType = MP4
 	}
-	f, err := NewFileFromBytes(b, contentType, fileName)
+	f, err := NewFileFromBytes(b, contentType, filename)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/data/video_test.go
+++ b/pkg/data/video_test.go
@@ -16,7 +16,7 @@ func TestNewVideoFromBytes(t *testing.T) {
 
 	testCases := []struct {
 		name        string
-		fileName    string
+		filename    string
 		contentType string
 		expectError bool
 	}{
@@ -28,10 +28,10 @@ func TestNewVideoFromBytes(t *testing.T) {
 
 	for _, tc := range testCases {
 		c.Run(tc.name, func(c *qt.C) {
-			videoBytes, err := os.ReadFile(filepath.Join("testdata", tc.fileName))
+			videoBytes, err := os.ReadFile(filepath.Join("testdata", tc.filename))
 			c.Assert(err, qt.IsNil)
 
-			video, err := NewVideoFromBytes(videoBytes, tc.contentType, tc.fileName)
+			video, err := NewVideoFromBytes(videoBytes, tc.contentType, tc.filename)
 
 			if tc.expectError {
 				c.Assert(err, qt.Not(qt.IsNil))
@@ -39,7 +39,7 @@ func TestNewVideoFromBytes(t *testing.T) {
 				c.Assert(err, qt.IsNil)
 				c.Assert(video, qt.Not(qt.IsNil))
 				c.Assert(video.ContentType().String(), qt.Equals, tc.contentType)
-				c.Assert(video.FileName().String(), qt.Equals, tc.fileName)
+				c.Assert(video.Filename().String(), qt.Equals, tc.filename)
 			}
 		})
 	}
@@ -47,18 +47,18 @@ func TestNewVideoFromBytes(t *testing.T) {
 	c.Run("Invalid video format", func(c *qt.C) {
 		invalidBytes := []byte("not a video")
 		contentType := "invalid/type"
-		fileName := "invalid.txt"
+		filename := "invalid.txt"
 
-		_, err := NewVideoFromBytes(invalidBytes, contentType, fileName)
+		_, err := NewVideoFromBytes(invalidBytes, contentType, filename)
 		c.Assert(err, qt.Not(qt.IsNil))
 	})
 
 	c.Run("Empty video bytes", func(c *qt.C) {
 		emptyBytes := []byte{}
 		contentType := "video/mp4"
-		fileName := "empty.mp4"
+		filename := "empty.mp4"
 
-		_, err := NewVideoFromBytes(emptyBytes, contentType, fileName)
+		_, err := NewVideoFromBytes(emptyBytes, contentType, filename)
 		c.Assert(err, qt.Not(qt.IsNil))
 	})
 }
@@ -98,7 +98,7 @@ func TestVideoProperties(t *testing.T) {
 
 	testCases := []struct {
 		name        string
-		fileName    string
+		filename    string
 		contentType string
 		width       int
 		height      int
@@ -112,14 +112,14 @@ func TestVideoProperties(t *testing.T) {
 
 	for _, tc := range testCases {
 		c.Run(tc.name, func(c *qt.C) {
-			videoBytes, err := os.ReadFile(filepath.Join("testdata", tc.fileName))
+			videoBytes, err := os.ReadFile(filepath.Join("testdata", tc.filename))
 			c.Assert(err, qt.IsNil)
 
-			video, err := NewVideoFromBytes(videoBytes, tc.contentType, tc.fileName)
+			video, err := NewVideoFromBytes(videoBytes, tc.contentType, tc.filename)
 			c.Assert(err, qt.IsNil)
 			qt.CmpEquals()
 			c.Assert(video.ContentType().String(), qt.Equals, "video/mp4")
-			c.Assert(video.FileName().String(), qt.Equals, tc.fileName)
+			c.Assert(video.Filename().String(), qt.Equals, tc.filename)
 			c.Assert(video.Width().Integer(), qt.Equals, tc.width)
 			c.Assert(video.Height().Integer(), qt.Equals, tc.height)
 			c.Assert(video.Duration().Float64(), qt.CmpEquals(cmpopts.EquateApprox(0, 0.001)), tc.duration)
@@ -135,7 +135,7 @@ func TestVideoConvert(t *testing.T) {
 
 	testCases := []struct {
 		name           string
-		fileName       string
+		filename       string
 		contentType    string
 		expectedFormat string
 	}{
@@ -146,10 +146,10 @@ func TestVideoConvert(t *testing.T) {
 
 	for _, tc := range testCases {
 		c.Run(tc.name, func(c *qt.C) {
-			videoBytes, err := os.ReadFile(filepath.Join("testdata", tc.fileName))
+			videoBytes, err := os.ReadFile(filepath.Join("testdata", tc.filename))
 			c.Assert(err, qt.IsNil)
 
-			video, err := NewVideoFromBytes(videoBytes, tc.contentType, tc.fileName)
+			video, err := NewVideoFromBytes(videoBytes, tc.contentType, tc.filename)
 			c.Assert(err, qt.IsNil)
 
 			convertedVideo, err := video.Convert(tc.expectedFormat)


### PR DESCRIPTION
Because

- we want to standardize naming conventions across the codebase by using lowercase `filename` instead of camelCase `fileName`.

This commit

- replaces all instances of `fileName` with `filename`.