### PR TITLE
fix(integration-test): maximize build space on image build & push

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -37,13 +37,15 @@ jobs:
           sudo kill -9 `sudo lsof -t -i:8084`
           sudo lsof -i -P -n | grep LISTEN
 
-      - name: Free disk space
-        run: |
-          df --human-readable
-          sudo apt clean
-          docker rmi $(docker image ls --all --quiet)
-          rm --recursive --force "$AGENT_TOOLSDIRECTORY"
-          df --human-readable
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@master
+        with:
+          overprovision-lvm: "true"
+          remove-dotnet: "true"
+          build-mount-path: "/var/lib/docker/"
+
+      - name: Restart docker
+        run: sudo service docker restart
 
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Because

- Build & push step is [failing](https://github.com/instill-ai/pipeline-backend/actions/runs/11739667642/job/32710453549) due to lack of disk space
```
#31 [linux/arm64 build  8/11] RUN --mount=target=. --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg GOOS=linux GOARCH=arm64 go build -tags=ocr,onnx -o /pipeline-backend ./cmd/main
#31 1722.9 # github.com/instill-ai/pipeline-backend/cmd/main
#31 1722.9 /usr/local/go/pkg/tool/linux_arm64/link: mapping output file failed: no space left on device
#31 ERROR: process "/bin/sh -c GOOS=$TARGETOS GOARCH=$TARGETARCH go build -tags=ocr,onnx -o /${SERVICE_NAME} ./cmd/main" did not complete successfully: exit code: 1
------
 > [linux/arm64 build  8/11] RUN --mount=target=. --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg GOOS=linux GOARCH=arm64 go build -tags=ocr,onnx -o /pipeline-backend ./cmd/main:
13.18 go: downloading github.com/tidwall/match v1.1.1
13.19 go: downloading github.com/tidwall/pretty v1.2.1
13.22 go: downloading github.com/aws/smithy-go v1.20.3
13.58 go: downloading github.com/google/flatbuffers v23.5.26+incompatible
14.01 go: downloading github.com/pierrec/lz4/v4 v4.1.18
15.29 go: downloading cloud.google.com/go/auth/oauth2adapt v0.2.3
15.30 go: downloading go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0
15.32 go: downloading github.com/google/s2a-go v0.1.7
1722.9 # github.com/instill-ai/pipeline-backend/cmd/main
1722.9 /usr/local/go/pkg/tool/linux_arm64/link: mapping output file failed: no space left on device
------
Dockerfile:39
--------------------
  37 |     
  38 |     ARG SERVICE_NAME TARGETOS TARGETARCH
  39 | >>> RUN --mount=target=. --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg GOOS=$TARGETOS GOARCH=$TARGETARCH go build -tags=ocr,onnx -o /${SERVICE_NAME} ./cmd/main
  40 |     RUN --mount=target=. --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /${SERVICE_NAME}-worker ./cmd/worker
  41 |     RUN --mount=target=. --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /${SERVICE_NAME}-migrate ./cmd/migration
--------------------
ERROR: failed to solve: process "/bin/sh -c GOOS=$TARGETOS GOARCH=$TARGETARCH go build -tags=ocr,onnx -o /${SERVICE_NAME} ./cmd/main" did not complete successfully: exit code: 1
Error: buildx failed with: ERROR: failed to solve: process "/bin/sh -c GOOS=$TARGETOS GOARCH=$TARGETARCH go build -tags=ocr,onnx -o /${SERVICE_NAME} ./cmd/main" did not complete successfully: exit code: 1
```
This commit

- Adds step in the CI to maximize the disk space.