### PR TITLE
chore(integration-test): maximize build space on image build & push

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -9,6 +9,16 @@ jobs:
   docker-hub:
     runs-on: ubuntu-latest
     steps:
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@master
+        with:
+          overprovision-lvm: "true"
+          remove-dotnet: "true"
+          build-mount-path: "/var/lib/docker/"
+
+      - name: Restart docker
+        run: sudo service docker restart
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         with:


### PR DESCRIPTION
Because

- Previous commit maximized the space only for the PR workflow, not the `images.yml` one.
- The other dependency, located on `instill-core`, already contains this step.

This commit

- Add space maximization step to `images.yml`.
