### PR TITLE
ci(workflows): add PR title scope check

### DIFF
--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -13,5 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v4
+        with:
+          requireScope: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Because

- the codebase now includes additional components, it’s better for PRs to mention the specific scope.

This commit

- add PR title scope requirement.
