### PR TITLE
fix(data): refactor numberData to support both float and integer types

### DIFF
--- a/pkg/data/number.go
+++ b/pkg/data/number.go
@@ -9,30 +9,44 @@ import (
 	"github.com/instill-ai/pipeline-backend/pkg/data/path"
 )
 
+// TODO(huitang): Currently, we put float and int in the same struct.
+// We can consider separating them into two structs.
+
 type numberData struct {
-	Raw float64
+	RawFloat   float64
+	RawInteger int
+	IsInteger  bool
 }
 
 func NewNumberFromFloat(f float64) *numberData {
-	return &numberData{Raw: f}
+	return &numberData{RawFloat: f, IsInteger: false}
 }
 
 func NewNumberFromInteger(i int) *numberData {
-	return &numberData{Raw: float64(i)}
+	return &numberData{RawInteger: i, IsInteger: true}
 }
 
 func (numberData) IsValue() {}
 
 func (n *numberData) Integer() int {
-	return int(n.Raw)
+	if n.IsInteger {
+		return n.RawInteger
+	}
+	return int(n.RawFloat)
 }
 
 func (n *numberData) Float64() float64 {
-	return n.Raw
+	if n.IsInteger {
+		return float64(n.RawInteger)
+	}
+	return n.RawFloat
 }
 
 func (n *numberData) String() string {
-	return fmt.Sprintf("%f", n.Raw)
+	if n.IsInteger {
+		return fmt.Sprintf("%d", n.RawInteger)
+	}
+	return fmt.Sprintf("%f", n.RawFloat)
 }
 
 func (n *numberData) Get(p *path.Path) (v format.Value, err error) {
@@ -46,13 +60,17 @@ func (n *numberData) Get(p *path.Path) (v format.Value, err error) {
 // version. structpb is not suitable for handling binary data and will be phased
 // out gradually.
 func (n numberData) ToStructValue() (v *structpb.Value, err error) {
-	v = structpb.NewNumberValue(n.Raw)
+	if n.IsInteger {
+		v = structpb.NewNumberValue(float64(n.RawInteger))
+	} else {
+		v = structpb.NewNumberValue(n.RawFloat)
+	}
 	return
 }
 
 func (n *numberData) Equal(other format.Value) bool {
 	if other, ok := other.(format.Number); ok {
-		return n.Raw == other.Float64()
+		return n.Float64() == other.Float64()
 	}
 	return false
 }

--- a/pkg/data/number_test.go
+++ b/pkg/data/number_test.go
@@ -1,0 +1,123 @@
+package data
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/instill-ai/pipeline-backend/pkg/data/format"
+)
+
+func TestNewNumberFromFloat(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+
+	testCases := []struct {
+		name     string
+		input    float64
+		expected float64
+	}{
+		{"Zero", 0.0, 0.0},
+		{"Positive integer", 42.0, 42.0},
+		{"Negative integer", -42.0, -42.0},
+		{"Positive decimal", 3.14159, 3.14159},
+		{"Negative decimal", -3.14159, -3.14159},
+	}
+
+	for _, tc := range testCases {
+		c.Run(tc.name, func(c *qt.C) {
+			num := NewNumberFromFloat(tc.input)
+			c.Assert(num, qt.Not(qt.IsNil))
+			c.Assert(num.Float64(), qt.Equals, tc.expected)
+			c.Assert(num.IsInteger, qt.IsFalse)
+		})
+	}
+}
+
+func TestNewNumberFromInteger(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+
+	testCases := []struct {
+		name     string
+		input    int
+		expected int
+	}{
+		{"Zero", 0, 0},
+		{"Positive integer", 42, 42},
+		{"Negative integer", -42, -42},
+		{"Large positive", 999999, 999999},
+		{"Large negative", -999999, -999999},
+	}
+
+	for _, tc := range testCases {
+		c.Run(tc.name, func(c *qt.C) {
+			num := NewNumberFromInteger(tc.input)
+			c.Assert(num, qt.Not(qt.IsNil))
+			c.Assert(num.Integer(), qt.Equals, tc.expected)
+			c.Assert(num.IsInteger, qt.IsTrue)
+		})
+	}
+}
+
+func TestNumberConversion(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+
+	c.Run("Float to Integer conversion", func(c *qt.C) {
+		num := NewNumberFromFloat(42.9)
+		c.Assert(num.Integer(), qt.Equals, 42)
+	})
+
+	c.Run("Integer to Float conversion", func(c *qt.C) {
+		num := NewNumberFromInteger(42)
+		c.Assert(num.Float64(), qt.Equals, 42.0)
+	})
+}
+
+func TestNumberString(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+
+	testCases := []struct {
+		name     string
+		number   *numberData
+		expected string
+	}{
+		{"Integer zero", NewNumberFromInteger(0), "0"},
+		{"Float zero", NewNumberFromFloat(0.0), "0.000000"},
+		{"Positive integer", NewNumberFromInteger(42), "42"},
+		{"Negative integer", NewNumberFromInteger(-42), "-42"},
+		{"Positive float", NewNumberFromFloat(3.14159), "3.141590"},
+		{"Negative float", NewNumberFromFloat(-3.14159), "-3.141590"},
+	}
+
+	for _, tc := range testCases {
+		c.Run(tc.name, func(c *qt.C) {
+			c.Assert(tc.number.String(), qt.Equals, tc.expected)
+		})
+	}
+}
+
+func TestNumberEqual(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+
+	testCases := []struct {
+		name     string
+		a        *numberData
+		b        format.Value
+		expected bool
+	}{
+		{"Equal integers", NewNumberFromInteger(42), NewNumberFromInteger(42), true},
+		{"Equal floats", NewNumberFromFloat(3.14), NewNumberFromFloat(3.14), true},
+		{"Integer equals float", NewNumberFromInteger(42), NewNumberFromFloat(42.0), true},
+		{"Different numbers", NewNumberFromInteger(42), NewNumberFromInteger(43), false},
+		{"Number vs null", NewNumberFromInteger(42), NewNull(), false},
+	}
+
+	for _, tc := range testCases {
+		c.Run(tc.name, func(c *qt.C) {
+			c.Assert(tc.a.Equal(tc.b), qt.Equals, tc.expected)
+		})
+	}
+}


### PR DESCRIPTION
Because

 - Previously, numberData only supported float data, making it difficult to determine whether to stringify it as an original float or integer.

This commit

 - Refactors numberData to support both float and integer types.