### PR TITLE
feat(recipe): refactor run-on-event recipe structure

### DIFF
--- a/pkg/datamodel/datamodel.go
+++ b/pkg/datamodel/datamodel.go
@@ -289,9 +289,10 @@ type Output struct {
 }
 
 type Event struct {
-	Type  string         `json:"type,omitempty" yaml:"type,omitempty"`
-	Event string         `json:"event,omitempty" yaml:"event,omitempty"`
-	Setup map[string]any `json:"setup,omitempty" yaml:"setup,omitempty"`
+	Type   string         `json:"type,omitempty" yaml:"type,omitempty"`
+	Event  string         `json:"event,omitempty" yaml:"event,omitempty"`
+	Config map[string]any `json:"config,omitempty" yaml:"config,omitempty"`
+	Setup  any            `json:"setup,omitempty" yaml:"setup,omitempty"`
 }
 
 type Schedule struct {

--- a/pkg/datamodel/datamodel.go
+++ b/pkg/datamodel/datamodel.go
@@ -149,7 +149,7 @@ type ComponentMap map[string]*Component
 // Recipe is the data model of the pipeline recipe
 type Recipe struct {
 	Version   string               `json:"version,omitempty" yaml:"version,omitempty"`
-	On        *On                  `json:"on,omitempty" yaml:"on,omitempty"`
+	On        map[string]*Event    `json:"on,omitempty" yaml:"on,omitempty"`
 	Component ComponentMap         `json:"component,omitempty" yaml:"component,omitempty"`
 	Variable  map[string]*Variable `json:"variable,omitempty" yaml:"variable,omitempty"`
 	Secret    map[string]string    `json:"secret,omitempty" yaml:"secret,omitempty"`
@@ -286,11 +286,6 @@ type Output struct {
 	Description    string `json:"description,omitempty" yaml:"description,omitempty"`
 	Value          string `json:"value,omitempty" yaml:"value,omitempty"`
 	InstillUIOrder int32  `json:"instillUiOrder,omitempty" yaml:"instill-ui-order,omitempty"`
-}
-
-type On struct {
-	Event    map[string]*Event    `json:"event,omitempty" yaml:"event,omitempty"`
-	Schedule map[string]*Schedule `json:"schedule,omitempty" yaml:"schedule,omitempty"`
 }
 
 type Event struct {

--- a/pkg/service/convert.go
+++ b/pkg/service/convert.go
@@ -577,7 +577,7 @@ func (c *converter) ConvertPipelineToPB(ctx context.Context, dbPipelineOrigin *d
 			return nil, err
 		}
 		if dbPipeline.Recipe.On != nil {
-			for w := range dbPipeline.Recipe.On.Event {
+			for w := range dbPipeline.Recipe.On {
 				webhooks[w] = &pb.Endpoints_WebhookEndpoint{
 					Url: fmt.Sprintf(
 						"%s/v1beta/namespaces/%s/pipelines/%s/events?event=%s&code=%s",
@@ -803,7 +803,7 @@ func (c *converter) ConvertPipelineReleaseToPB(ctx context.Context, dbPipeline *
 			return nil, err
 		}
 		if dbPipelineRelease.Recipe.On != nil {
-			for w := range dbPipelineRelease.Recipe.On.Event {
+			for w := range dbPipelineRelease.Recipe.On {
 				webhooks[w] = &pb.Endpoints_WebhookEndpoint{
 					Url: fmt.Sprintf(
 						"%s/v1beta/namespaces/%s/pipelines/%s/releases/%s/events?event=%s&code=%s",

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -331,7 +331,7 @@ func (s *service) setSchedulePipeline(ctx context.Context, ns resource.Namespace
 			// TODO: Introduce Schedule Component to define structured schema
 			// for schedule setup configuration
 			if v.Type == "schedule" {
-				crons = append(crons, v.Setup["cron"].(string))
+				crons = append(crons, v.Config["cron"].(string))
 			}
 		}
 	}

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -326,9 +326,13 @@ func (s *service) setSchedulePipeline(ctx context.Context, ns resource.Namespace
 	}
 
 	crons := []string{}
-	if recipe != nil && recipe.On != nil && recipe.On.Schedule != nil {
-		for _, v := range recipe.On.Schedule {
-			crons = append(crons, v.Cron)
+	if recipe != nil && recipe.On != nil {
+		for _, v := range recipe.On {
+			// TODO: Introduce Schedule Component to define structured schema
+			// for schedule setup configuration
+			if v.Type == "schedule" {
+				crons = append(crons, v.Setup["cron"].(string))
+			}
 		}
 	}
 
@@ -1654,8 +1658,7 @@ func (s *service) HandleNamespacePipelineEventByID(ctx context.Context, ns resou
 		}
 	}()
 
-	if e, ok := dbPipeline.Recipe.On.Event[eventID]; ok {
-
+	if e, ok := dbPipeline.Recipe.On[eventID]; ok {
 		targetType = e.Type
 	} else {
 		return nil, fmt.Errorf("eventID not correct")


### PR DESCRIPTION
Because

- Previously, we used the following format to set up the run-on-event and run-on-schedule recipes. For certain application events, we'll use a polling method to capture the event, which overlaps with the run-on-schedule functionality.
    ```
    on:
      event:
        <event-id>:
          type: slack
          event: EVENT_NEW_MESSAGE
      schedule:
        <schedule-id>:
          cron:
    ```

This commit

- merges run-on-event and run-on-schedule and refactors recipe structure to use the following new format
    ```
    on:
      <event-id>:
        type: slack
        event: EVENT_NEW_MESSAGE
        config:
          channel: xxx
        setup: ${connection.xxx}
    
      <schedule-id>:
        type: schedule
        event: EVENT_SCHEDULE
        config:
          schedule: 
            cron: 
              - '30 2 * * *' 
    ```
