### PR TITLE
chore(component,github): fix webhook registration

### DIFF
--- a/pkg/component/application/github/v0/main.go
+++ b/pkg/component/application/github/v0/main.go
@@ -232,11 +232,15 @@ func (c *component) RegisterEvent(ctx context.Context, settings *base.RegisterEv
 	}
 
 	if !existingHook {
+		insecureSSL := github.String("1")
+		if strings.HasPrefix(host, "https://") {
+			insecureSSL = github.String("0")
+		}
 		hook, _, err := githubClient.Repositories.CreateHook(ctx, namespace, repo, &github.Hook{
 			Config: &github.HookConfig{
 				URL:         github.String(url),
-				ContentType: github.String("application/json"),
-				InsecureSSL: github.String("1"),
+				ContentType: github.String("json"),
+				InsecureSSL: insecureSSL,
 			},
 			Events: []string{"star"},
 			Active: github.Bool(true),


### PR DESCRIPTION
Because

 - The content type for GitHub webhook registration was incorrect.

This commit

 - Fixes the bug.