### PR TITLE
fix(service): skip empty component definition in API response

### DIFF
--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -762,10 +762,15 @@ func (r *repository) ListComponentDefinitionUIDs(_ context.Context, p ListCompon
 		whereArgs = []any{expr}
 	}
 
+	skipComponentsInCE := []string{}
+	if config.Config.Server.Edition == "local-ce:dev" {
+		skipComponentsInCE = []string{"instill-app"}
+	}
+
 	queryBuilder := db.Model(&datamodel.ComponentDefinition{}).
 		Where(where, whereArgs...).
-		Where("is_visible IS TRUE")
-
+		Where("is_visible IS TRUE").
+		Where("id NOT IN (?)", skipComponentsInCE)
 	queryBuilder.Count(&totalSize)
 
 	// Several results might have the same score and release stage. We need to

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -762,15 +762,15 @@ func (r *repository) ListComponentDefinitionUIDs(_ context.Context, p ListCompon
 		whereArgs = []any{expr}
 	}
 
-	skipComponentsInCE := []string{}
-	if config.Config.Server.Edition == "local-ce:dev" {
-		skipComponentsInCE = []string{"instill-app"}
-	}
-
 	queryBuilder := db.Model(&datamodel.ComponentDefinition{}).
 		Where(where, whereArgs...).
-		Where("is_visible IS TRUE").
-		Where("id NOT IN (?)", skipComponentsInCE)
+		Where("is_visible IS TRUE")
+
+	if config.Config.Server.Edition == "local-ce:dev" {
+		skipComponentsInCE := []string{"instill-app"}
+		queryBuilder = queryBuilder.Where("id NOT IN (?)", skipComponentsInCE)
+	}
+
 	queryBuilder.Count(&totalSize)
 
 	// Several results might have the same score and release stage. We need to

--- a/pkg/service/component_definition.go
+++ b/pkg/service/component_definition.go
@@ -7,7 +7,6 @@ import (
 
 	"go.einride.tech/aip/filtering"
 
-	"github.com/instill-ai/pipeline-backend/config"
 	"github.com/instill-ai/pipeline-backend/pkg/recipe"
 	"github.com/instill-ai/pipeline-backend/pkg/repository"
 
@@ -85,12 +84,6 @@ func (s *service) ListComponentDefinitions(ctx context.Context, req *pb.ListComp
 			def.Spec = nil
 		}
 
-		// Temporary solution to filter out the instill-app component for local-ce:dev edition
-		// In the future the non-CE definitions shouldn't be in the CE repositories and Cloud should extend the CE component store to initialize the private components.
-		if skipComponentInCE(def.GetId()) {
-			continue
-		}
-
 		defs[i] = def
 	}
 
@@ -102,17 +95,6 @@ func (s *service) ListComponentDefinitions(ctx context.Context, req *pb.ListComp
 	}
 
 	return resp, nil
-}
-
-var skipComponentsInCE = map[string]bool{
-	"instill-app": true,
-}
-
-func skipComponentInCE(componentID string) bool {
-	if skipComponentsInCE[componentID] && config.Config.Server.Edition == "local-ce:dev" {
-		return true
-	}
-	return false
 }
 
 func (s *service) getComponentDefinitionByID(ctx context.Context, id string) (*pb.ComponentDefinition, error) {


### PR DESCRIPTION
Because

 - Previously, the instill-app component was excluded, resulting in an empty item in the API response, which caused the Console to fail.
![image](https://github.com/user-attachments/assets/cec60c96-c5c8-474f-8caf-52f2b983002a)


This commit

- skips empty component definition in API response
