### PR TITLE
fix(document): fix bug about convert to image

### DIFF
--- a/pkg/component/operator/document/v0/convert_to_images.go
+++ b/pkg/component/operator/document/v0/convert_to_images.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 
 	"github.com/instill-ai/pipeline-backend/pkg/component/base"
+	"github.com/instill-ai/pipeline-backend/pkg/component/internal/util"
 	"github.com/instill-ai/pipeline-backend/pkg/component/operator/document/v0/transformer"
 	"github.com/instill-ai/pipeline-backend/pkg/data"
 	"github.com/instill-ai/pipeline-backend/pkg/data/format"
@@ -36,7 +37,7 @@ func (e *execution) convertDocumentToImages(ctx context.Context, job *base.Job) 
 		Images: func() []format.Image {
 			images := make([]format.Image, len(transformerOutputStruct.Images))
 			for i, image := range transformerOutputStruct.Images {
-				b, _ := base64.StdEncoding.DecodeString(image)
+				b, _ := base64.StdEncoding.DecodeString(util.TrimBase64Mime(image))
 				images[i], _ = data.NewImageFromBytes(b, data.PNG, "")
 				// TODO: handle error
 			}


### PR DESCRIPTION
Because

- there is a bug when converting doc to images

This commit

- trim base64 prefix
