### PR TITLE
chore(service): wrap the event message in `on.event-id.message`

### DIFF
--- a/pkg/service/webhook.go
+++ b/pkg/service/webhook.go
@@ -251,12 +251,14 @@ func (s *service) initEventWorkflow(ctx context.Context, params initEventWorkflo
 				return fmt.Errorf("cannot listen to data outside of `on`")
 			}
 
-			p, err := path.NewPath(strings.Join(s[2:], "."))
-			if err != nil {
-				return err
-			}
-
 			if s[1] == params.eventID {
+				if s[2] != "message" {
+					return fmt.Errorf("only `message` is supported for event %s", params.eventID)
+				}
+				p, err := path.NewPath(strings.Join(s[3:], "."))
+				if err != nil {
+					return err
+				}
 				messageValue, err := params.parsedMessage.Get(p)
 				if err != nil {
 					return err


### PR DESCRIPTION
Because

 - We want to place the event message under `on.event-id.message` instead of `on.event-id` to allow support for non-message data in the future.

This commit

 - Wraps the event message within `on.event-id.message`.