### PR TITLE
chore(component,github): adjust webhook registration flow

### DIFF
--- a/pkg/component/base/component.go
+++ b/pkg/component/base/component.go
@@ -127,7 +127,7 @@ type EventSettings struct {
 
 type RegisterEventSettings struct {
 	EventSettings
-	WebhookURL string
+	RegistrationUID uuid.UUID
 }
 
 type UnregisterEventSettings struct {


### PR DESCRIPTION
Because

- The original webhook registration flow could cause conflicts when multiple pipelines register to the same repository.

This commit

- Adjusts the webhook registration flow to prevent conflicts.