### PR TITLE
chore(service): add run-on-event support for pipeline release

### DIFF
--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -1299,6 +1299,15 @@ func (s *service) CreateNamespacePipelineRelease(ctx context.Context, ns resourc
 		return nil, err
 	}
 
+	if err := s.configureRunOn(ctx, configureRunOnParams{
+		Namespace:   ns,
+		pipelineUID: dbPipeline.UID,
+		releaseUID:  dbCreatedPipelineRelease.UID,
+		recipe:      dbCreatedPipelineRelease.Recipe,
+	}); err != nil {
+		return nil, err
+	}
+
 	return s.converter.ConvertPipelineReleaseToPB(ctx, dbPipeline, dbCreatedPipelineRelease, pipelinepb.Pipeline_VIEW_FULL)
 
 }

--- a/pkg/service/webhook.go
+++ b/pkg/service/webhook.go
@@ -178,6 +178,17 @@ func (s *service) DispatchPipelineWebhookEvent(ctx context.Context, params Dispa
 				if err != nil {
 					return DispatchPipelineWebhookEventResult{}, err
 				}
+			} else {
+				_, err = s.triggerAsyncPipeline(ctx, triggerParams{
+					ns:                 loadPipelineResult.ns,
+					pipelineID:         loadPipelineResult.pipeline.ID,
+					pipelineUID:        loadPipelineResult.pipeline.UID,
+					pipelineReleaseID:  loadPipelineResult.release.ID,
+					pipelineReleaseUID: loadPipelineResult.release.UID,
+					userUID:            loadPipelineResult.ns.NsUID,
+					requesterUID:       loadPipelineResult.ns.NsUID,
+					pipelineTriggerID:  pipelineTriggerID.String(),
+				})
 			}
 		}
 	}


### PR DESCRIPTION
Because

- We haven't support run-on-event for pipeline release

This commit

- add run-on-event support for pipeline release