### PR TITLE
fix(service): add MIME type detection in the backend binaryFetcher

### DIFF
--- a/pkg/data/struct.go
+++ b/pkg/data/struct.go
@@ -361,7 +361,17 @@ func (u *Unmarshaler) unmarshalInterface(v format.Value, field reflect.Value, st
 				}
 			}
 		}
-		field.Set(reflect.ValueOf(v))
+		if f, ok := v.(*fileData); ok {
+			file, err := NewBinaryFromBytes(f.raw, f.contentType, f.filename)
+			if err != nil {
+				return err
+			}
+			field.Set(reflect.ValueOf(file))
+			return nil
+		} else {
+			field.Set(reflect.ValueOf(v))
+		}
+
 		return nil
 	}
 	return fmt.Errorf("cannot unmarshal %T into %v", v, field.Type())

--- a/pkg/external/external.go
+++ b/pkg/external/external.go
@@ -170,9 +170,7 @@ func (f *binaryFetcher) FetchFromURL(ctx context.Context, url string) (body []by
 	}
 
 	body = resp.Body()
-	if h := resp.Header().Get("Content-Type"); h != "" {
-		contentType = h
-	}
+	contentType = strings.Split(mimetype.Detect(body).String(), ";")[0]
 
 	if disposition := resp.Header().Get("Content-Disposition"); disposition == "" {
 		if strings.HasPrefix(disposition, "attachment") {
@@ -272,10 +270,11 @@ func (f *artifactBinaryFetcher) fetchFromBlobStorage(ctx context.Context, urlUID
 	bucketName := "instill-ai-blob"
 	objectPath := *objectRes.Object.Path
 
-	b, contentType, err = f.minIOClient.GetFile(ctx, bucketName, objectPath)
+	b, _, err = f.minIOClient.GetFile(ctx, bucketName, objectPath)
 	if err != nil {
 		return nil, "", "", err
 	}
+	contentType = strings.Split(mimetype.Detect(b).String(), ";")[0]
 	return b, contentType, objectRes.Object.Name, nil
 }
 


### PR DESCRIPTION
Because

- Previously, we trusted the MIME type retrieved from MinIO or other data sources, which might be incorrect.

This commit

- Adds MIME type detection in the backend binaryFetcher.