### PR TITLE
chore(workflow): add tlsEnabled configuration for blob data uploads

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -43,6 +43,7 @@ type AppConfig struct {
 type APIGatewayConfig struct {
 	Host       string `koanf:"host"`
 	PublicPort int    `koanf:"publicport"`
+	TLSEnabled bool   `koanf:"tlsenabled"`
 }
 
 // InstillCloud config

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -100,3 +100,4 @@ appbackend:
 apigateway:
   host: api-gateway
   publicport: 8080
+  tlsenabled: false

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241117145210-23cd7077019e
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
-	github.com/instill-ai/x v0.5.0-alpha.0.20241119004613-36280f178120
+	github.com/instill-ai/x v0.5.0-alpha.0.20241119141833-e4a78ca87792
 	github.com/itchyny/gojq v0.12.14
 	github.com/jackc/pgx/v5 v5.5.5
 	github.com/jmoiron/sqlx v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -1285,8 +1285,8 @@ github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241117145210-23cd7077019e h1:
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241117145210-23cd7077019e/go.mod h1:rf0UY7VpEgpaLudYEcjx5rnbuwlBaaLyD4FQmWLtgAY=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a/go.mod h1:EpX3Yr661uWULtZf5UnJHfr5rw2PDyX8ku4Kx0UtYFw=
-github.com/instill-ai/x v0.5.0-alpha.0.20241119004613-36280f178120 h1:7aTYdBXwI+c+1eXFK3VYib1nHLVJ96kBTP5J0ilsOzM=
-github.com/instill-ai/x v0.5.0-alpha.0.20241119004613-36280f178120/go.mod h1:jkVtaq9T2zAFA5N46tlV4K5EEVE7FcOVNbqY4wFWYz8=
+github.com/instill-ai/x v0.5.0-alpha.0.20241119141833-e4a78ca87792 h1:b4lhXcFJ/kGGC1RErtItoI57paf9WXBCVpaPIAApldY=
+github.com/instill-ai/x v0.5.0-alpha.0.20241119141833-e4a78ca87792/go.mod h1:jkVtaq9T2zAFA5N46tlV4K5EEVE7FcOVNbqY4wFWYz8=
 github.com/intel/goresctrl v0.2.0/go.mod h1:+CZdzouYFn5EsxgqAQTEzMfwKwuc0fVdMrT9FCCAVRQ=
 github.com/itchyny/gojq v0.12.14 h1:6k8vVtsrhQSYgSGg827AD+PVVaB1NLXEdX+dda2oZCc=
 github.com/itchyny/gojq v0.12.14/go.mod h1:y1G7oO7XkcR1LPZO59KyoCRy08T3j9vDYRV0GgYSS+s=

--- a/pkg/worker/workflow.go
+++ b/pkg/worker/workflow.go
@@ -738,7 +738,11 @@ func uploadBlobData(ctx context.Context, uploadURL string, value *format.File, l
 	if err != nil {
 		return fmt.Errorf("parsing upload URL: %w", err)
 	}
-	parsedURL.Scheme = "http"
+	if config.Config.APIGateway.TLSEnabled {
+		parsedURL.Scheme = "https"
+	} else {
+		parsedURL.Scheme = "http"
+	}
 	parsedURL.Host = fmt.Sprintf("%s:%d", config.Config.APIGateway.Host, config.Config.APIGateway.PublicPort)
 	fullURL := parsedURL.String()
 	contentType := (*value).ContentType().String()


### PR DESCRIPTION
Because

- The API Gateway may operate in TLS-enabled mode. When uploading blob data, the data passes through the API Gateway. A configuration is needed to determine whether to connect via TLS.

This Commit

- Adds a tlsEnabled configuration for blob data uploads.