### PR TITLE
chore(component): trim mime type in base64 string

### DIFF
--- a/pkg/component/ai/openai/v0/main.go
+++ b/pkg/component/ai/openai/v0/main.go
@@ -17,6 +17,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/instill-ai/pipeline-backend/pkg/component/base"
+	"github.com/instill-ai/pipeline-backend/pkg/component/internal/util"
 	"github.com/instill-ai/pipeline-backend/pkg/component/internal/util/httpclient"
 	"github.com/instill-ai/pipeline-backend/pkg/data"
 	"github.com/instill-ai/x/errmsg"
@@ -463,7 +464,7 @@ func (e *execution) worker(ctx context.Context, client *httpclient.Client, job *
 
 		results := []imageGenerationsOutputResult{}
 		for _, d := range resp.Data {
-			b, err := base64.StdEncoding.DecodeString(d.Image)
+			b, err := base64.StdEncoding.DecodeString(util.TrimBase64Mime(d.Image))
 			if err != nil {
 				job.Error.Error(ctx, err)
 				return

--- a/pkg/component/operator/document/v0/convert_document_to_markdown.go
+++ b/pkg/component/operator/document/v0/convert_document_to_markdown.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 
 	"github.com/instill-ai/pipeline-backend/pkg/component/base"
+	"github.com/instill-ai/pipeline-backend/pkg/component/internal/util"
 	"github.com/instill-ai/pipeline-backend/pkg/component/operator/document/v0/transformer"
 	"github.com/instill-ai/pipeline-backend/pkg/data"
 	"github.com/instill-ai/pipeline-backend/pkg/data/format"
@@ -41,7 +42,7 @@ func (e *execution) convertDocumentToMarkdown(ctx context.Context, job *base.Job
 		Images: func() []format.Image {
 			images := make([]format.Image, len(transformerOutputStruct.Images))
 			for i, image := range transformerOutputStruct.Images {
-				b, _ := base64.StdEncoding.DecodeString(image)
+				b, _ := base64.StdEncoding.DecodeString(util.TrimBase64Mime(image))
 				images[i], _ = data.NewImageFromBytes(b, data.PNG, "")
 				// TODO: handle error
 			}
@@ -51,7 +52,7 @@ func (e *execution) convertDocumentToMarkdown(ctx context.Context, job *base.Job
 		AllPageImages: func() []format.Image {
 			images := make([]format.Image, len(transformerOutputStruct.AllPageImages))
 			for i, image := range transformerOutputStruct.AllPageImages {
-				b, _ := base64.StdEncoding.DecodeString(image)
+				b, _ := base64.StdEncoding.DecodeString(util.TrimBase64Mime(image))
 				images[i], _ = data.NewImageFromBytes(b, data.PNG, "")
 				// TODO: handle error
 			}


### PR DESCRIPTION
Because

- We cannot convert a base64 string to a bytearray when it includes a MIME type prefix.

This Commit

- Trims the MIME type from the base64 string.