### PR TITLE
refactor(service): remove component intermediate data in pipeline response

### DIFF
--- a/pkg/memory/memory.go
+++ b/pkg/memory/memory.go
@@ -283,15 +283,6 @@ func (wfm *workflowMemory) SetComponentData(ctx context.Context, batchIdx int, c
 	}
 	wfm.Data[batchIdx].(data.Map)[componentID].(data.Map)[string(t)] = value
 
-	if t == ComponentDataInput {
-		if err := wfm.sendComponentEvent(ctx, batchIdx, componentID, ComponentInputUpdated); err != nil {
-			return err
-		}
-	} else if t == ComponentDataOutput {
-		if err := wfm.sendComponentEvent(ctx, batchIdx, componentID, ComponentOutputUpdated); err != nil {
-			return err
-		}
-	}
 	return nil
 }
 func (wfm *workflowMemory) GetComponentData(ctx context.Context, batchIdx int, componentID string, t ComponentDataType) (value format.Value, err error) {

--- a/pkg/recipe/dag.go
+++ b/pkg/recipe/dag.go
@@ -636,8 +636,6 @@ func GenerateTraces(ctx context.Context, wfm memory.WorkflowMemory, full bool) (
 
 	for compID := range wfm.GetRecipe().Component {
 
-		inputs := make([]*structpb.Struct, batchSize)
-		outputs := make([]*structpb.Struct, batchSize)
 		errors := make([]*structpb.Struct, batchSize)
 		traceStatuses := make([]pb.Trace_Status, batchSize)
 
@@ -667,30 +665,10 @@ func GenerateTraces(ctx context.Context, wfm memory.WorkflowMemory, full bool) (
 				errors[dataIdx] = structVal.GetStructValue()
 			}
 
-			if full {
-				if input, err := wfm.GetComponentData(ctx, dataIdx, compID, memory.ComponentDataInput); err == nil {
-					structVal, err := input.ToStructValue()
-					if err != nil {
-						return nil, err
-					}
-					inputs[dataIdx] = structVal.GetStructValue()
-				}
-
-				if output, err := wfm.GetComponentData(ctx, dataIdx, compID, memory.ComponentDataOutput); err == nil {
-					structVal, err := output.ToStructValue()
-					if err != nil {
-						return nil, err
-					}
-					outputs[dataIdx] = structVal.GetStructValue()
-				}
-			}
 		}
 
 		trace[compID] = &pb.Trace{
 			Statuses: traceStatuses,
-			Inputs:   inputs,
-			Outputs:  outputs,
-
 			// Note: Currently, all errors in a batch are the same.
 			Error: errors[0],
 		}


### PR DESCRIPTION
Because:

- Previously, component intermediate data was included in the pipeline response to inform users about pipeline activity. However, with the introduction of the pipeline run log, which provides access to this data, including it in the trigger response is redundant and adds significant latency.

This commit:

- Removes component intermediate data from the pipeline response.