### PR TITLE
refactor(component,openai): resize the images before sending them to OpenAI

### DIFF
--- a/pkg/data/format/format.go
+++ b/pkg/data/format/format.go
@@ -56,6 +56,7 @@ type Image interface {
 	Width() Number
 	Height() Number
 	Convert(contentType string) (val Image, err error)
+	Resize(width, height int) (val Image, err error)
 }
 
 type Video interface {


### PR DESCRIPTION
Because:

- OpenAI does not support large images.

This commit:

- Resizes images exceeding 8192 pixels before sending them to OpenAI.