### PR TITLE
fix(github): fix time format bug

### DIFF
--- a/pkg/component/application/github/v0/README.mdx
+++ b/pkg/component/application/github/v0/README.mdx
@@ -296,7 +296,7 @@ Get the review comments in a pull request. The comments can be on a specific lin
 | PR Number | `pr-number` | integer | Number of the PR. Default is `0`, which retrieves all comments on all PRs in the repository. |
 | Sort | `sort` | string | Sort the comments by created, updated. Default is created. |
 | Direction | `direction` | string | Direction of the sort, including asc or desc. Default is desc. |
-| Since | `since` | string | Only comments updated at or after this time are returned. Default is 2021-01-01T00:00:00Z. |
+| Since | `since` | string | Date (in `YYYY-MM-DD` format) from which comments will start to be fetched. The date will be in the UTC timezone. |
 | Page | `page` | integer | Page number of the results to fetch. Default is 1. |
 | Per Page | `per-page` | integer | Number of results to fetch per page. Default is 30. |
 </div>
@@ -437,7 +437,7 @@ Get the list of all issues in a repository,This can be a pull request or a gener
 | State | `state` | string | State of the issues, can be one of: open, closed, all. Default is open. |
 | Sort | `sort` | string | Sort the issues by created, updated, popularity, or long-running. Default is created. |
 | Direction | `direction` | string | Direction of the sort, can be one of: asc, desc. Default is desc. |
-| Since | `since` | string | Only issues updated at or after this time are returned. Default is 2021-01-01T00:00:00Z. |
+| Since | `since` | string | Date (in `YYYY-MM-DD` format) from which issues will start to be fetched. The date will be in the UTC timezone. |
 | No Pull Request | `no-pull-request` | boolean | Whether to `not` include pull requests in the response. Since issue and pr use the same indexing system in GitHub, the API returns all relevant objects (issues and pr). Default is false. |
 | Page | `page` | integer | Page number of the results to fetch. Default is 1. |
 | Per Page | `per-page` | integer | Number of results to fetch per page. Default is 30. |

--- a/pkg/component/application/github/v0/component_test.go
+++ b/pkg/component/application/github/v0/component_test.go
@@ -260,7 +260,7 @@ func TestComponent_ListReviewCommentsTask(t *testing.T) {
 				PrNumber:  1,
 				Sort:      "created",
 				Direction: "asc",
-				Since:     "2021-01-01T00:00:00Z",
+				Since:     "2021-01-01",
 			},
 			wantResp: ListReviewCommentsResp{
 				ReviewComments: []ReviewComment{
@@ -284,7 +284,7 @@ func TestComponent_ListReviewCommentsTask(t *testing.T) {
 				PrNumber:  1,
 				Sort:      "created",
 				Direction: "asc",
-				Since:     "2021-01-01T00:00:00Z",
+				Since:     "2021-01-01",
 			},
 			wantErr: `403 API rate limit exceeded`,
 		},
@@ -299,7 +299,7 @@ func TestComponent_ListReviewCommentsTask(t *testing.T) {
 				PrNumber:  1,
 				Sort:      "created",
 				Direction: "asc",
-				Since:     "2021-01-01T00:00:00Z",
+				Since:     "2021-01-01",
 			},
 			wantErr: `404 Not Found`,
 		},
@@ -316,7 +316,7 @@ func TestComponent_ListReviewCommentsTask(t *testing.T) {
 				Direction: "asc",
 				Since:     "2021-0100:00:00Z",
 			},
-			wantErr: `invalid time format`,
+			wantErr: `^parse since time:.*cannot parse.*$`,
 		},
 	}
 	taskTesting(testcases, taskGetReviewComments, t)
@@ -537,7 +537,7 @@ func TestComponent_ListIssuesTask(t *testing.T) {
 				State:         "open",
 				Direction:     "asc",
 				Sort:          "created",
-				Since:         "2021-01-01T00:00:00Z",
+				Since:         "2021-01-01",
 				NoPullRequest: true,
 			},
 			wantResp: ListIssuesResp{
@@ -565,7 +565,7 @@ func TestComponent_ListIssuesTask(t *testing.T) {
 				State:         "open",
 				Direction:     "asc",
 				Sort:          "created",
-				Since:         "2021-01-01T00:00:00Z",
+				Since:         "2021-01-01",
 				NoPullRequest: true,
 			},
 			wantErr: `403 API rate limit exceeded`,
@@ -581,7 +581,7 @@ func TestComponent_ListIssuesTask(t *testing.T) {
 				State:         "open",
 				Direction:     "asc",
 				Sort:          "created",
-				Since:         "2021-01-01T00:00:00Z",
+				Since:         "2021-01-01",
 				NoPullRequest: true,
 			},
 			wantErr: `404 Not Found`,
@@ -600,7 +600,7 @@ func TestComponent_ListIssuesTask(t *testing.T) {
 				Since:         "2021-0Z",
 				NoPullRequest: true,
 			},
-			wantErr: `invalid time format`,
+			wantErr: `^parse since time:.*cannot parse.*$`,
 		},
 	}
 	taskTesting(testcases, taskListIssues, t)

--- a/pkg/component/application/github/v0/config/tasks.json
+++ b/pkg/component/application/github/v0/config/tasks.json
@@ -717,9 +717,9 @@
           "type": "string"
         },
         "since": {
-          "default": "2021-01-01T00:00:00Z",
+          "default": "2021-01-01",
           "title": "Since",
-          "description": "Only comments updated at or after this time are returned. Default is 2021-01-01T00:00:00Z.",
+          "description": "Date (in `YYYY-MM-DD` format) from which comments will start to be fetched. The date will be in the UTC timezone.",
           "instillFormat": "string",
           "instillAcceptFormats": [
             "string"
@@ -1063,9 +1063,9 @@
           "type": "string"
         },
         "since": {
-          "default": "2021-01-01T00:00:00Z",
+          "default": "2021-01-01",
           "title": "Since",
-          "description": "Only issues updated at or after this time are returned. Default is 2021-01-01T00:00:00Z.",
+          "description": "Date (in `YYYY-MM-DD` format) from which issues will start to be fetched. The date will be in the UTC timezone.",
           "instillFormat": "string",
           "instillAcceptFormats": [
             "string"

--- a/pkg/component/application/github/v0/issues.go
+++ b/pkg/component/application/github/v0/issues.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/google/go-github/v62/github"
@@ -102,7 +103,7 @@ func (githubClient *Client) listIssuesTask(ctx context.Context, props *structpb.
 	// The time will be 2006-01-02 00:00:00 +0000 UTC exactly
 	sinceTime, err := time.Parse(time.DateOnly, inputStruct.Since)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("parse since time: %w", err)
 	}
 	opts := &github.IssueListByRepoOptions{
 		State:     inputStruct.State,

--- a/pkg/component/application/github/v0/issues.go
+++ b/pkg/component/application/github/v0/issues.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"time"
 
 	"github.com/google/go-github/v62/github"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -97,8 +98,9 @@ func (githubClient *Client) listIssuesTask(ctx context.Context, props *structpb.
 	if err != nil {
 		return nil, err
 	}
-	// from format like `2006-01-02T15:04:05Z07:00` to time.Time
-	sinceTime, err := parseTime(inputStruct.Since)
+	// from format like `2006-01-02` parse it into UTC time
+	// The time will be 2006-01-02 00:00:00 +0000 UTC exactly
+	sinceTime, err := time.Parse(time.DateOnly, inputStruct.Since)
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +108,7 @@ func (githubClient *Client) listIssuesTask(ctx context.Context, props *structpb.
 		State:     inputStruct.State,
 		Sort:      inputStruct.Sort,
 		Direction: inputStruct.Direction,
-		Since:     *sinceTime,
+		Since:     sinceTime,
 		ListOptions: github.ListOptions{
 			Page:    inputStruct.Page,
 			PerPage: min(inputStruct.PerPage, 100), // GitHub API only allows 100 per page

--- a/pkg/component/application/github/v0/review_comment.go
+++ b/pkg/component/application/github/v0/review_comment.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"time"
 
 	"github.com/google/go-github/v62/github"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -47,15 +48,16 @@ func (githubClient *Client) listReviewCommentsTask(ctx context.Context, props *s
 	if err != nil {
 		return nil, err
 	}
-	// from format like `2006-01-02T15:04:05Z07:00` to time.Time
-	sinceTime, err := parseTime(inputStruct.Since)
+	// from format like `2006-01-02` parse it into UTC time
+	// The time will be 2006-01-02 00:00:00 +0000 UTC exactly
+	sinceTime, err := time.Parse(time.DateOnly, inputStruct.Since)
 	if err != nil {
 		return nil, err
 	}
 	opts := &github.PullRequestListCommentsOptions{
 		Sort:      inputStruct.Sort,
 		Direction: inputStruct.Direction,
-		Since:     *sinceTime,
+		Since:     sinceTime,
 		ListOptions: github.ListOptions{
 			Page:    inputStruct.Page,
 			PerPage: min(inputStruct.PerPage, 100), // GitHub API only allows 100 per page

--- a/pkg/component/application/github/v0/review_comment.go
+++ b/pkg/component/application/github/v0/review_comment.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/google/go-github/v62/github"
@@ -52,7 +53,7 @@ func (githubClient *Client) listReviewCommentsTask(ctx context.Context, props *s
 	// The time will be 2006-01-02 00:00:00 +0000 UTC exactly
 	sinceTime, err := time.Parse(time.DateOnly, inputStruct.Since)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("parse since time: %w", err)
 	}
 	opts := &github.PullRequestListCommentsOptions{
 		Sort:      inputStruct.Sort,

--- a/pkg/component/application/github/v0/utils.go
+++ b/pkg/component/application/github/v0/utils.go
@@ -1,24 +1,6 @@
 package github
 
-import (
-	"fmt"
-	"time"
-
-	"github.com/instill-ai/x/errmsg"
-)
-
 type PageOptions struct {
 	Page    int `json:"page"`
 	PerPage int `json:"per-page"`
-}
-
-func parseTime(since string) (*time.Time, error) {
-	sinceTime, err := time.Parse(time.RFC3339, since)
-	if err != nil {
-		return nil, errmsg.AddMessage(
-			fmt.Errorf("invalid time format"),
-			fmt.Sprintf("Cannot parse time: \"%s\". Please provide RFC3339 format(like %s)", since, time.RFC3339),
-		)
-	}
-	return &sinceTime, nil
 }


### PR DESCRIPTION
Because

- in ymal parser, we only provide date only string format

This commit

- convert GitHub DateTime input to DateOnly

Note
- We will need to find a solution about how to provide the Date and DateTime at the same time. Now, the current YAML parser cannot read the original users' input.