### PR TITLE
chore(service): add instillUIOrder attribute for varialbe and outpu back

### DIFF
--- a/pkg/datamodel/datamodel.go
+++ b/pkg/datamodel/datamodel.go
@@ -272,17 +272,19 @@ func (p *PipelineRelease) AfterFind(tx *gorm.DB) (err error) {
 }
 
 type Variable struct {
-	Title       string   `json:"title,omitempty" yaml:"title,omitempty"`
-	Description string   `json:"description,omitempty" yaml:"description,omitempty"`
-	Format      string   `json:"instillFormat,omitempty" yaml:"format,omitempty"`
-	Listen      []string `json:"listen,omitempty" yaml:"listen,omitempty"`
-	Default     any      `json:"default,omitempty" yaml:"default,omitempty"`
+	Title          string   `json:"title,omitempty" yaml:"title,omitempty"`
+	Description    string   `json:"description,omitempty" yaml:"description,omitempty"`
+	Format         string   `json:"instillFormat,omitempty" yaml:"format,omitempty"`
+	Listen         []string `json:"listen,omitempty" yaml:"listen,omitempty"`
+	Default        any      `json:"default,omitempty" yaml:"default,omitempty"`
+	InstillUIOrder int32    `json:"instillUiOrder,omitempty" yaml:"instill-ui-order,omitempty"`
 }
 
 type Output struct {
-	Title       string `json:"title,omitempty" yaml:"title,omitempty"`
-	Description string `json:"description,omitempty" yaml:"description,omitempty"`
-	Value       string `json:"value,omitempty" yaml:"value,omitempty"`
+	Title          string `json:"title,omitempty" yaml:"title,omitempty"`
+	Description    string `json:"description,omitempty" yaml:"description,omitempty"`
+	Value          string `json:"value,omitempty" yaml:"value,omitempty"`
+	InstillUIOrder int32  `json:"instillUiOrder,omitempty" yaml:"instill-ui-order,omitempty"`
 }
 
 type Event struct {

--- a/pkg/service/convert.go
+++ b/pkg/service/convert.go
@@ -1060,9 +1060,10 @@ func (c *converter) GeneratePipelineDataSpec(variables map[string]*datamodel.Var
 						}
 					} else {
 						walk, _ = structpb.NewValue(map[string]interface{}{
-							"title":         v.Title,
-							"description":   v.Description,
-							"instillFormat": "json",
+							"title":          v.Title,
+							"description":    v.Description,
+							"instillFormat":  "json",
+							"instillUIOrder": v.InstillUIOrder,
 						})
 					}
 
@@ -1070,10 +1071,11 @@ func (c *converter) GeneratePipelineDataSpec(variables map[string]*datamodel.Var
 				if walk.GetStructValue() != nil && walk.GetStructValue().Fields != nil {
 					instillFormat := walk.GetStructValue().Fields["instillFormat"].GetStringValue()
 					m, err = structpb.NewValue(map[string]interface{}{
-						"title":         v.Title,
-						"description":   v.Description,
-						"type":          walk.GetStructValue().Fields["type"].GetStringValue(),
-						"instillFormat": checkFormat(instillFormat),
+						"title":          v.Title,
+						"description":    v.Description,
+						"type":           walk.GetStructValue().Fields["type"].GetStringValue(),
+						"instillFormat":  checkFormat(instillFormat),
+						"instillUIOrder": v.InstillUIOrder,
 					})
 					if err != nil {
 						return nil, err
@@ -1086,10 +1088,11 @@ func (c *converter) GeneratePipelineDataSpec(variables map[string]*datamodel.Var
 
 		} else {
 			m, err = structpb.NewValue(map[string]interface{}{
-				"title":         v.Title,
-				"description":   v.Description,
-				"type":          "string",
-				"instillFormat": "string",
+				"title":          v.Title,
+				"description":    v.Description,
+				"type":           "string",
+				"instillFormat":  "string",
+				"instillUIOrder": v.InstillUIOrder,
 			})
 		}
 


### PR DESCRIPTION
Because:

- We removed the instillUIOrder attribute for variable and output, but the Console still requires it for display.

This commit:

- Adds the instillUIOrder attribute back.