### PR TITLE
test(integration): fix test cases for integrations

### DIFF
--- a/integration-test/pipeline/rest-integration.js
+++ b/integration-test/pipeline/rest-integration.js
@@ -27,8 +27,16 @@ export function CheckIntegrations() {
     });
 
     var id = "github";
-    var cdef = http.request("GET", `${pipelinePublicHost}/v1beta/connector-definitions/${id}`, null, null).
-      json().connectorDefinition;
+    var cdefs = http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?pageSize=100`, null, null).
+      json().componentDefinitions;
+
+    var cdef = null;
+    for (var i = 0; i < cdefs.length; i++) {
+      if (cdefs[i].id === id) {
+        cdef = cdefs[i];
+        break;
+      }
+    }
 
     var integration = {
       uid: cdef.uid,
@@ -45,7 +53,7 @@ export function CheckIntegrations() {
     var oAuthConfig = {
       authUrl: "https://github.com/login/oauth/authorize",
       accessUrl: "https://github.com/login/oauth/access_token",
-      scopes: ["repo", "write:repo_hook"],
+      scopes: ["repo", "admin:repo_hook"],
     };
 
     // Basic view

--- a/integration-test/pipeline/rest-integration.js
+++ b/integration-test/pipeline/rest-integration.js
@@ -27,7 +27,7 @@ export function CheckIntegrations() {
     });
 
     var id = "github";
-    var cdefs = http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?pageSize=100`, null, null).
+    var cdefs = http.request("GET", `${pipelinePublicHost}/v1beta/component-definitions?filter=qTitle="GitHub"`, null, null).
       json().componentDefinitions;
 
     var cdef = null;


### PR DESCRIPTION
Because

- The original test case for integration failed due to:
  1. Removal of the connector-definition endpoint
  2. Changes in OAuth scope

This commit:

- Fixes the test cases for integrations

Note:

- Investigate why the test did not raise an error in CI.