### PR TITLE
chore(integration): remove deprecated `schemas` field

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/h2non/filetype v1.1.3
 	github.com/iancoleman/strcase v0.3.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241117145210-23cd7077019e
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241127083047-e2cb3b0062e6
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.5.0-alpha.0.20241119141833-e4a78ca87792
 	github.com/itchyny/gojq v0.12.14

--- a/go.sum
+++ b/go.sum
@@ -1281,8 +1281,8 @@ github.com/influxdata/influxdb-client-go/v2 v2.12.3 h1:28nRlNMRIV4QbtIUvxhWqaxn0
 github.com/influxdata/influxdb-client-go/v2 v2.12.3/go.mod h1:IrrLUbCjjfkmRuaCiGQg4m2GbkaeJDcuWoxiWdQEbA0=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241117145210-23cd7077019e h1:rCclalq8AZUWZhcT2NQ4E6JHw2vSkLqqv7NzLnszxA0=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241117145210-23cd7077019e/go.mod h1:rf0UY7VpEgpaLudYEcjx5rnbuwlBaaLyD4FQmWLtgAY=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241127083047-e2cb3b0062e6 h1:NOinVUfrb8dHiIYtSk9ELGRBb/cJbfqine94XeM+mdI=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241127083047-e2cb3b0062e6/go.mod h1:rf0UY7VpEgpaLudYEcjx5rnbuwlBaaLyD4FQmWLtgAY=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a/go.mod h1:EpX3Yr661uWULtZf5UnJHfr5rw2PDyX8ku4Kx0UtYFw=
 github.com/instill-ai/x v0.5.0-alpha.0.20241119141833-e4a78ca87792 h1:b4lhXcFJ/kGGC1RErtItoI57paf9WXBCVpaPIAApldY=

--- a/integration-test/pipeline/rest-integration.js
+++ b/integration-test/pipeline/rest-integration.js
@@ -38,7 +38,6 @@ export function CheckIntegrations() {
       vendor: cdef.vendor,
       icon: cdef.icon,
       setupSchema: null,
-      schemas: [], // Deprecated
       view: "VIEW_BASIC"
     };
 
@@ -59,8 +58,6 @@ export function CheckIntegrations() {
       [`GET /v1beta/integrations/${id}?view=VIEW_FULL response status is 200`]: (r) => r.status === 200,
       [`GET /v1beta/integrations/${id}?view=VIEW_FULL response contains schema`]: (r) => r.json().integration.setupSchema.required[0] === "token",
       [`GET /v1beta/integrations/${id}?view=VIEW_FULL response contains OAuth config`]: (r) => deepEqual(r.json().integration.oAuthConfig, oAuthConfig),
-      // Deprecated
-      [`DEPRECATED GET /v1beta/integrations/${id}?view=VIEW_FULL response contains schema`]: (r) => r.json().integration.schemas[0].method === "METHOD_DICTIONARY",
     });
   });
 

--- a/integration-test/proto/vdp/pipeline/v1beta/common.proto
+++ b/integration-test/proto/vdp/pipeline/v1beta/common.proto
@@ -104,6 +104,17 @@ message ComponentTask {
   string description = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
+// ComponentEvent contains information about an event that a component can
+// produce.
+message ComponentEvent {
+  // The event name, e.g. `EVENT_NEW`.
+  string name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Title is the event name in a human-friendly format.
+  string title = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Description contains information about the event.
+  string description = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
 // ComponentType defines the component type based on its task features.
 enum ComponentType {
   // Unspecified.

--- a/integration-test/proto/vdp/pipeline/v1beta/component_definition.proto
+++ b/integration-test/proto/vdp/pipeline/v1beta/component_definition.proto
@@ -72,10 +72,14 @@ message ComponentDefinition {
   // Spec represents a specification data model.
   message Spec {
     // Component specification.
-    google.protobuf.Struct component_specification = 3 [(google.api.field_behavior) = REQUIRED];
+    google.protobuf.Struct component_specification = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
     // Data specifications.
     // The key represents the task, and the value is the corresponding data_specification.
-    map<string, DataSpecification> data_specifications = 5 [(google.api.field_behavior) = REQUIRED];
+    // Note: This field will be renamed to task_specifications in the future.
+    map<string, DataSpecification> data_specifications = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
+    // Event specifications.
+    // The key represents the event, and the value is the corresponding event_specification.
+    map<string, EventSpecification> event_specifications = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
   }
 
   // The name of the component definition, defined by its ID.
@@ -125,9 +129,12 @@ message ComponentDefinition {
   string description = 17 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Release stage.
   ComponentDefinition.ReleaseStage release_stage = 18 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // List of events that can be produced by the component.
+  repeated ComponentEvent events = 19 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // DataSpecification describes the JSON schema of component input and output.
+// Note: This message will be renamed to TaskSpecifications in the future.
 message DataSpecification {
   // JSON schema describing the component input data.
   google.protobuf.Struct input = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
@@ -135,174 +142,18 @@ message DataSpecification {
   google.protobuf.Struct output = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// ConnectorSpec represents a specification data model.
-message ConnectorSpec {
-  // Deleted
-  reserved 2;
-  // Component specification.
-  google.protobuf.Struct component_specification = 3 [(google.api.field_behavior) = REQUIRED];
-  // Deleted field.
-  reserved 4;
-  // Data specifications.
-  // The key represents the task, and the value is the corresponding data_specification.
-  map<string, DataSpecification> data_specifications = 5 [(google.api.field_behavior) = REQUIRED];
-}
-
-// ConnectorType defines the connector type based on its task features.
-enum ConnectorType {
-  // Unspecified.
-  CONNECTOR_TYPE_UNSPECIFIED = 0;
-  // 1 Is reserved for the source connector.
-  reserved 1;
-  // 2 Is reserved for the destination connector.
-  reserved 2;
-  // AI connector.
-  CONNECTOR_TYPE_AI = 3;
-  // 4 is reserved for the blockchain connector (deprecated by
-  // CONNECTOR_TYPE_APPLICATION).
-  reserved 4;
-  // Data connector.
-  CONNECTOR_TYPE_DATA = 5;
-  // Operator connector.
-  CONNECTOR_TYPE_OPERATOR = 6;
-  // Application connector.
-  CONNECTOR_TYPE_APPLICATION = 7;
-  // Generic.
-  CONNECTOR_TYPE_GENERIC = 8;
-}
-
-// A Connector is a type of pipeline component that queries, processes or sends
-// the ingested unstructured data to a service or app. Users need to configure
-// their connectors (e.g. by providing an API token to a remote service). A
-// ConnectorDefinition describes a certain type of Connector.
-//
-// For more information, see
-// [Component](https://www.instill.tech/docs/component/introduction)
-// in the official documentation.
-message ConnectorDefinition {
-  option (google.api.resource) = {
-    type: "api.instill.tech/ConnectorDefinition"
-    pattern: "connector-definitions/{id}"
-    pattern: "connector-definitions/{uid}"
-  };
-
-  // The name of the connector definition, defined by its ID.
-  // - Format: `connector-definitions/{id}
-  string name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Connector definition UUID.
-  string uid = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Connector definition resource ID (used in `name` as the last segment). This
-  // conforms to RFC-1034, which restricts to letters, numbers, and hyphen,
-  // with the first character a letter, the last a letter or a number, and a 63
-  // character maximum.
-  string id = 3 [(google.api.field_behavior) = IMMUTABLE];
-  // Connector definition title.
-  string title = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Connector definition documentation URL.
-  string documentation_url = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Connector definition icon. This is a path that's relative to the root of
-  // the connector implementation (see `source_url`) and that allows clients
-  // frontend applications to pull and locate the icons.
-  string icon = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Connector definition specification.
-  ConnectorSpec spec = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Connector definition type.
-  ConnectorType type = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Connector definition tombstone. If true, this configuration is permanently
-  // off. Otherwise, the configuration is active.
-  bool tombstone = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // The public flag determines whether this connector definition is available
-  // to all workspaces.
-  bool public = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Connector definition custom flag, i.e., whether this is a custom
-  // connector definition.
-  bool custom = 11 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // field 12 is reserved for 'icon_url'.
-  reserved 12;
-  // Connector definition vendor name.
-  string vendor = 13 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Vendor-specific attributes.
-  google.protobuf.Struct vendor_attributes = 14 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Source code URL. This points to the source code where the connector is
-  // implemented.
-  string source_url = 15 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Connector definition version. This is a string that fulfills the SemVer
-  // specification (e.g. `1.0.0-beta`).
-  string version = 16 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // List of tasks that can be executed by the connector.
-  repeated ComponentTask tasks = 17 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Short description of the connector.
-  string description = 18 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Release stage.
-  ComponentDefinition.ReleaseStage release_stage = 19 [(google.api.field_behavior) = OUTPUT_ONLY];
-}
-
-// OperatorSpec represents a specification data model.
-message OperatorSpec {
-  // Component specification.
-  google.protobuf.Struct component_specification = 1 [(google.api.field_behavior) = REQUIRED];
-  // Deleted field.
-  reserved 2;
-  // Data specifications.
-  // The key represents the task, and the value is the corresponding data_specification.
-  map<string, DataSpecification> data_specifications = 3 [(google.api.field_behavior) = REQUIRED];
-}
-
-// An Operator is a type of pipeline component that performs data injection and
-// manipulation. OperatorDefinition describes a certain type of operator.
-//
-// For more information, see
-// [Component](https://www.instill.tech/docs/component/introduction)
-// in the official documentation.
-message OperatorDefinition {
-  option (google.api.resource) = {
-    type: "api.instill.tech/OperatorDefinition"
-    pattern: "operator-definitions/{id}"
-    pattern: "operator-definitions/{uid}"
-  };
-
-  // The name of the operator definition.
-  // - Format: `operator-definitions/*`
-  string name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Operator definition UUID.
-  string uid = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Operator definition resource ID (used in `name` as the last segment).
-  // This conforms to RFC-1034, which restricts to letters, numbers, and
-  // hyphen, with the first character a letter, the last a letter or a number,
-  // and a 63 character maximum.
-  string id = 3 [(google.api.field_behavior) = IMMUTABLE];
-  // Operator definition title.
-  string title = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Operator definition documentation URL.
-  string documentation_url = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Operator definition icon. This is a path that's relative to the root of
-  // the operator implementation (see `source_url`) and that allows clients
-  // frontend applications to pull and locate the icons.
-  string icon = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Operator definition specification.
-  OperatorSpec spec = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Operator definition tombstone. If true, this configuration is permanently
-  // off. Otherwise, the configuration is active.
-  bool tombstone = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // The public flag determines whether this operator definition is available
-  // to all workspaces.
-  bool public = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // The custom flag determines whether this is a custom operator definition.
-  bool custom = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // field 11 is reserved for 'icon_url'.
-  reserved 11;
-  // Source code URL. This points to the source code where the operator is
-  // implemented.
-  string source_url = 15 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Operator definition version. This is a string that fulfills the SemVer
-  // specification (e.g. `1.0.0-beta`).
-  string version = 16 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // List of tasks that can be executed by the operator.
-  repeated ComponentTask tasks = 17 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Short description of the operator.
-  string description = 18 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Release stage.
-  ComponentDefinition.ReleaseStage release_stage = 19 [(google.api.field_behavior) = OUTPUT_ONLY];
+// EventSpecification describes the JSON schema of component event setup and examples.
+message EventSpecification {
+  // Event title.
+  string title = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Event description.
+  string description = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // JSON schema describing the component event config data.
+  google.protobuf.Struct config_schema = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // JSON schema describing the component event message data.
+  google.protobuf.Struct message_schema = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // JSON schema describing the component event examples.
+  repeated google.protobuf.Struct message_examples = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 ///////////////////////////////////////////////////////////////////////
@@ -346,115 +197,4 @@ message ListComponentDefinitionsResponse {
   int32 page_size = 4;
   // The requested page offset.
   int32 page = 5;
-}
-
-// ListConnectorDefinitionsRequest represents a request to list connector
-// definitions.
-message ListConnectorDefinitionsRequest {
-  // The maximum number of connector definitions to return. If this parameter
-  // is unspecified, at most 10 definitions will be returned. The cap value for
-  // this parameter is 100 (i.e. any value above that will be coerced to 100).
-  optional int32 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
-  // Page token.
-  optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
-  // field 3 is reserved for the "view" property of ConnectorDefinition.View
-  // type, removed in favour of ComponentDefinition.View.
-  reserved 3;
-  // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
-  // expression.
-  // - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
-  optional string filter = 4 [(google.api.field_behavior) = OPTIONAL];
-  // View allows clients to specify the desired resource view in the response.
-  optional ComponentDefinition.View view = 5 [(google.api.field_behavior) = OPTIONAL];
-}
-
-// ListConnectorDefinitionsResponse contains a list of connector definitions.
-message ListConnectorDefinitionsResponse {
-  // A list of connector definition resources.
-  repeated ConnectorDefinition connector_definitions = 1;
-  // Next page token.
-  string next_page_token = 2;
-  // Total number of connector definitions.
-  int32 total_size = 3;
-}
-
-// GetConnectorDefinitionRequest represents a request to fetch the details of a
-// connector definition.
-message GetConnectorDefinitionRequest {
-  // The resource name of the connector definition, which allows its access by ID.
-  // - Format: `connector-definitions/{id}`.
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {type: "api.instill.tech/ConnectorDefinition"},
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "connector_definition_name"}
-    }
-  ];
-  // field 2 is reserved for the "view" property of ConnectorDefinition.View
-  // type, removed in favour of ComponentDefinition.View.
-  reserved 2;
-  // View allows clients to specify the desired resource view in the response.
-  optional ComponentDefinition.View view = 3 [(google.api.field_behavior) = OPTIONAL];
-}
-
-// GetConnectorDefinitionResponse contains the requested connector definition.
-message GetConnectorDefinitionResponse {
-  // The connector definition resource.
-  ConnectorDefinition connector_definition = 1;
-}
-
-// ListOperatorDefinitionsRequest represents a request to list operator
-// definitions.
-message ListOperatorDefinitionsRequest {
-  // The maximum number of OperatorDefinitions to return. The
-  // service may return fewer than this value. If unspecified, at most 10
-  // OperatorDefinitions will be returned. The maximum value is 100;
-  // values above 100 will be coerced to 100.
-  optional int32 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
-  // Page token.
-  optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
-  // field 3 is reserved for the "view" property of OperatorDefinition.View
-  // type, removed in favour of ComponentDefinition.View.
-  reserved 3;
-  // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
-  // expression.
-  // - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
-  optional string filter = 4 [(google.api.field_behavior) = OPTIONAL];
-  // View allows clients to specify the desired resource view in the response.
-  optional ComponentDefinition.View view = 5 [(google.api.field_behavior) = OPTIONAL];
-}
-
-// ListOperatorDefinitionsResponse contains a list of operator definitions.
-message ListOperatorDefinitionsResponse {
-  // A list of operator definition resources.
-  repeated OperatorDefinition operator_definitions = 1;
-  // Next page token.
-  string next_page_token = 2;
-  // Total number of operator definitions.
-  int32 total_size = 3;
-}
-
-// GetOperatorDefinitionRequest represents a request to fetch the details of a
-// operator definition.
-message GetOperatorDefinitionRequest {
-  // The resource name of the operator definition, which allows its access by ID.
-  // - Format: `operator-definitions/{id}`.
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {type: "api.instill.tech/OperatorDefinition"},
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "operator_definition_name"}
-    }
-  ];
-  // field 2 is reserved for the "view" property of OperatorDefinition.View
-  // type, removed in favour of ComponentDefinition.View.
-  reserved 2;
-  // View allows clients to specify the desired resource view in the response.
-  optional ComponentDefinition.View view = 3 [(google.api.field_behavior) = OPTIONAL];
-}
-
-// GetOperatorDefinitionResponse contains the requested operator definition.
-message GetOperatorDefinitionResponse {
-  // The operator definition resource.
-  OperatorDefinition operator_definition = 1;
 }

--- a/integration-test/proto/vdp/pipeline/v1beta/integration.proto
+++ b/integration-test/proto/vdp/pipeline/v1beta/integration.proto
@@ -234,36 +234,9 @@ message Integration {
   optional OAuthConfig o_auth_config = 11 [(google.api.field_behavior) = OUTPUT_ONLY];
   // View defines how the integration is presented. The following fields are
   // only shown in the FULL view:
-  // - schemas
   // - setupSchema
   // - oAuthConfig
   View view = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
-
-  // SetupSchema defines the schema for a connection setup.
-  // This message is deprecated.
-  message SetupSchema {
-    // The connection method, which will define the fields in the schema.
-    Connection.Method method = 1 [
-      deprecated = true,
-      (google.api.field_behavior) = OUTPUT_ONLY
-    ];
-    // The connection setup field definitions. Each integration will require
-    // different data to connect to the 3rd party app.
-    google.protobuf.Struct schema = 2 [
-      deprecated = true,
-      (google.api.field_behavior) = OUTPUT_ONLY
-    ];
-  }
-
-  // Schemas defines the supported schemas for the connection setup.
-  // We haven't found a case for a schema that changes on the connection method
-  // (components don't care about how the connection was built), so the schema
-  // will be provided in the setupSchema field and the OAuth support and
-  // configuration will be provided in oAuthConfig.
-  repeated SetupSchema schemas = 8 [
-    deprecated = true,
-    (google.api.field_behavior) = OUTPUT_ONLY
-  ];
 }
 
 // ListPipelineIDsByConnectionIDRequest represents a request to list the

--- a/integration-test/proto/vdp/pipeline/v1beta/pipeline.proto
+++ b/integration-test/proto/vdp/pipeline/v1beta/pipeline.proto
@@ -495,8 +495,8 @@ message CloneNamespacePipelineReleaseRequest {
 // CloneNamespacePipelineReleaseResponse contains a cloned pipeline.
 message CloneNamespacePipelineReleaseResponse {}
 
-//SendNamespacePipelineEventRequest
-message SendNamespacePipelineEventRequest {
+//HandleNamespacePipelineWebhookEventRequest
+message HandleNamespacePipelineWebhookEventRequest {
   // Namespace ID
   string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
   // Pipeline ID
@@ -509,14 +509,14 @@ message SendNamespacePipelineEventRequest {
   google.protobuf.Struct data = 5;
 }
 
-//SendNamespacePipelineEventResponse
-message SendNamespacePipelineEventResponse {
+//HandleNamespacePipelineWebhookEventResponse
+message HandleNamespacePipelineWebhookEventResponse {
   // data
   google.protobuf.Struct data = 1;
 }
 
-//SendNamespacePipelineReleaseEventRequest
-message SendNamespacePipelineReleaseEventRequest {
+//HandleNamespacePipelineReleaseWebhookEventRequest
+message HandleNamespacePipelineReleaseWebhookEventRequest {
   // Namespace ID
   string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
   // Pipeline ID
@@ -531,10 +531,30 @@ message SendNamespacePipelineReleaseEventRequest {
   google.protobuf.Struct data = 6;
 }
 
-//SendNamespacePipelineReleaseEventResponse
-message SendNamespacePipelineReleaseEventResponse {
+//HandleNamespacePipelineReleaseWebhookEventResponse
+message HandleNamespacePipelineReleaseWebhookEventResponse {
   // data
   google.protobuf.Struct data = 1;
+}
+
+// DispatchPipelineWebhookEventRequest represents a request to dispatch webhook events
+// for a pipeline. The request contains the webhook type and event message that
+// will be processed by the event router and dispatched to the appropriate pipeline
+// based on the webhook type and message. The event message contains the payload
+// data that will be used to trigger pipeline execution.
+message DispatchPipelineWebhookEventRequest {
+  // Webhook Type
+  string webhook_type = 1 [(google.api.field_behavior) = REQUIRED];
+  // Event
+  google.protobuf.Struct message = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// DispatchPipelineWebhookEventResponse represents a response to dispatch webhook events
+// for a pipeline. The response contains the response message that will be sent
+// back to the webhook sender.
+message DispatchPipelineWebhookEventResponse {
+  // Response
+  google.protobuf.Struct response = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // TriggerNamespacePipelineRequest represents a request to trigger a user-owned
@@ -2075,6 +2095,9 @@ message PipelineRun {
   // Requester ID. This field might be empty if the pipeline run belongs to a
   // deleted namespace.
   string requester_id = 20 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Namespace ID
+  string namespace_id = 21 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // ComponentRun represents the execution details of a single component within a pipeline run.

--- a/integration-test/proto/vdp/pipeline/v1beta/pipeline_public_service.proto
+++ b/integration-test/proto/vdp/pipeline/v1beta/pipeline_public_service.proto
@@ -46,7 +46,13 @@ service PipelinePublicService {
   // Return the stats of the hub
   rpc GetHubStats(GetHubStatsRequest) returns (GetHubStatsResponse) {
     option (google.api.http) = {get: "/v1beta/hub-stats"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
     option (google.api.method_visibility).restriction = "INTERNAL";
   }
 
@@ -55,7 +61,13 @@ service PipelinePublicService {
   // Returns a paginated list of pipelines that are visible to the requester.
   rpc ListPipelines(ListPipelinesRequest) returns (ListPipelinesResponse) {
     option (google.api.http) = {get: "/v1beta/pipelines"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Get a pipeline by UID
@@ -64,7 +76,13 @@ service PipelinePublicService {
   // UID.
   rpc LookUpPipeline(LookUpPipelineRequest) returns (LookUpPipelineResponse) {
     option (google.api.http) = {get: "/v1beta/{permalink=pipelines/*}/lookUp"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
     option (google.api.method_visibility).restriction = "INTERNAL";
   }
 
@@ -73,7 +91,13 @@ service PipelinePublicService {
   // Returns a paginated list of pipelines of a namespace
   rpc ListNamespacePipelines(ListNamespacePipelinesRequest) returns (ListNamespacePipelinesResponse) {
     option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/pipelines"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Create a new pipeline
@@ -84,7 +108,13 @@ service PipelinePublicService {
       post: "/v1beta/namespaces/{namespace_id}/pipelines"
       body: "pipeline"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Get a pipeline
@@ -92,7 +122,13 @@ service PipelinePublicService {
   // Returns the details of a pipeline.
   rpc GetNamespacePipeline(GetNamespacePipelineRequest) returns (GetNamespacePipelineResponse) {
     option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Update a pipeline
@@ -108,7 +144,13 @@ service PipelinePublicService {
       patch: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}"
       body: "pipeline"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Delete a pipeline
@@ -118,7 +160,13 @@ service PipelinePublicService {
   // the parent of the pipeline in order to delete it.
   rpc DeleteNamespacePipeline(DeleteNamespacePipelineRequest) returns (DeleteNamespacePipelineResponse) {
     option (google.api.http) = {delete: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Validate a pipeline
@@ -132,7 +180,13 @@ service PipelinePublicService {
       post: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/validate"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Rename a pipeline
@@ -151,7 +205,13 @@ service PipelinePublicService {
       post: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/rename"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Clone a pipeline
@@ -163,25 +223,46 @@ service PipelinePublicService {
       post: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/clone"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
-  // SendNamespacePipelineEvent
-  rpc SendNamespacePipelineEvent(SendNamespacePipelineEventRequest) returns (SendNamespacePipelineEventResponse) {
+  // HandleNamespacePipelineWebhookEvent
+  rpc HandleNamespacePipelineWebhookEvent(HandleNamespacePipelineWebhookEventRequest) returns (HandleNamespacePipelineWebhookEventResponse) {
     option (google.api.http) = {
-      post: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/events"
+      post: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/webhooks"
       body: "data"
       response_body: "data"
     };
     option (google.api.method_visibility).restriction = "INTERNAL";
   }
 
-  // SendNamespacePipelineReleaseEvent
-  rpc SendNamespacePipelineReleaseEvent(SendNamespacePipelineReleaseEventRequest) returns (SendNamespacePipelineReleaseEventResponse) {
+  // HandleNamespacePipelineReleaseWebhookEvent
+  rpc HandleNamespacePipelineReleaseWebhookEvent(HandleNamespacePipelineReleaseWebhookEventRequest) returns (HandleNamespacePipelineReleaseWebhookEventResponse) {
     option (google.api.http) = {
-      post: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/releases/{release_id}/events"
+      post: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/releases/{release_id}/webhooks"
       body: "data"
       response_body: "data"
+    };
+    option (google.api.method_visibility).restriction = "INTERNAL";
+  }
+
+  // Dispatch Pipeline Webhook Event
+  //
+  // Handles webhook events by routing them to the appropriate pipeline based on the webhook type and message.
+  // The webhook type determines which component processes the event, while the message payload contains data
+  // that triggers pipeline execution. The pipeline processes the event using configured handlers and returns
+  // a response to the webhook sender.
+  rpc DispatchPipelineWebhookEvent(DispatchPipelineWebhookEventRequest) returns (DispatchPipelineWebhookEventResponse) {
+    option (google.api.http) = {
+      post: "/v1beta/pipeline-webhooks/{webhook_type}"
+      body: "message"
+      response_body: "response"
     };
     option (google.api.method_visibility).restriction = "INTERNAL";
   }
@@ -278,7 +359,13 @@ service PipelinePublicService {
       post: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/releases"
       body: "release"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // List the releases in a pipeline
@@ -287,7 +374,13 @@ service PipelinePublicService {
   // name, which is formed by the parent namespace and ID of the pipeline.
   rpc ListNamespacePipelineReleases(ListNamespacePipelineReleasesRequest) returns (ListNamespacePipelineReleasesResponse) {
     option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/releases"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Get a pipeline release
@@ -296,7 +389,13 @@ service PipelinePublicService {
   // by its resource name, formed by its parent namespace and ID.
   rpc GetNamespacePipelineRelease(GetNamespacePipelineReleaseRequest) returns (GetNamespacePipelineReleaseResponse) {
     option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/releases/{release_id}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Update a pipeline release
@@ -311,7 +410,13 @@ service PipelinePublicService {
       patch: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/releases/{release_id}"
       body: "release"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Delete a pipeline release
@@ -323,7 +428,13 @@ service PipelinePublicService {
   // perform this action.
   rpc DeleteNamespacePipelineRelease(DeleteNamespacePipelineReleaseRequest) returns (DeleteNamespacePipelineReleaseResponse) {
     option (google.api.http) = {delete: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/releases/{release_id}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Clone a pipeline release
@@ -335,7 +446,13 @@ service PipelinePublicService {
       post: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/releases/{release_id}/clone"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Trigger a pipeline release
@@ -398,7 +515,13 @@ service PipelinePublicService {
       post: "/v1beta/namespaces/{namespace_id}/secrets"
       body: "secret"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // List secrets
@@ -407,7 +530,13 @@ service PipelinePublicService {
   // namespace.
   rpc ListNamespaceSecrets(ListNamespaceSecretsRequest) returns (ListNamespaceSecretsResponse) {
     option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/secrets"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Get a secret
@@ -416,7 +545,13 @@ service PipelinePublicService {
   // which is defined by the parent namespace and the ID of the secret.
   rpc GetNamespaceSecret(GetNamespaceSecretRequest) returns (GetNamespaceSecretResponse) {
     option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/secrets/{secret_id}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Update a secret
@@ -430,7 +565,13 @@ service PipelinePublicService {
       patch: "/v1beta/namespaces/{namespace_id}/secrets/{secret_id}"
       body: "secret"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Delete a secret
@@ -439,7 +580,13 @@ service PipelinePublicService {
   // the parent namespace and the ID of the secret.
   rpc DeleteNamespaceSecret(DeleteNamespaceSecretRequest) returns (DeleteNamespaceSecretResponse) {
     option (google.api.http) = {delete: "/v1beta/namespaces/{namespace_id}/secrets/{secret_id}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // List component definitions
@@ -449,7 +596,13 @@ service PipelinePublicService {
   // capabilities, for the components that might be used in a VDP pipeline.
   rpc ListComponentDefinitions(ListComponentDefinitionsRequest) returns (ListComponentDefinitionsResponse) {
     option (google.api.http) = {get: "/v1beta/component-definitions"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Get the details of a long-running operation
@@ -1034,42 +1187,6 @@ service PipelinePublicService {
     option (google.api.method_visibility).restriction = "INTERNAL";
   }
 
-  // List connector definitions
-  //
-  // Returns a paginated list of connector definitions.
-  rpc ListConnectorDefinitions(ListConnectorDefinitionsRequest) returns (ListConnectorDefinitionsResponse) {
-    option (google.api.http) = {get: "/v1beta/connector-definitions"};
-    option deprecated = true;
-    option (google.api.method_visibility).restriction = "INTERNAL";
-  }
-
-  // Get connector definition
-  //
-  // Returns the details of a connector definition.
-  rpc GetConnectorDefinition(GetConnectorDefinitionRequest) returns (GetConnectorDefinitionResponse) {
-    option (google.api.http) = {get: "/v1beta/{name=connector-definitions/*}"};
-    option deprecated = true;
-    option (google.api.method_visibility).restriction = "INTERNAL";
-  }
-
-  // List operator definitions
-  //
-  // Returns a paginated list of operator definitions.
-  rpc ListOperatorDefinitions(ListOperatorDefinitionsRequest) returns (ListOperatorDefinitionsResponse) {
-    option (google.api.http) = {get: "/v1beta/operator-definitions"};
-    option deprecated = true;
-    option (google.api.method_visibility).restriction = "INTERNAL";
-  }
-
-  // Get operator definition
-  //
-  // Returns the details of an operator definition.
-  rpc GetOperatorDefinition(GetOperatorDefinitionRequest) returns (GetOperatorDefinitionResponse) {
-    option (google.api.http) = {get: "/v1beta/{name=operator-definitions/*}"};
-    option deprecated = true;
-    option (google.api.method_visibility).restriction = "INTERNAL";
-  }
-
   // Check the availibity of a resource name
   //
   // Check whether a resource name is already in use. Currently this endpoint
@@ -1257,7 +1374,13 @@ service PipelinePublicService {
   // Returns a paginated list of connections created by a namespace.
   rpc ListNamespaceConnections(ListNamespaceConnectionsRequest) returns (ListNamespaceConnectionsResponse) {
     option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/connections"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Get a namespace connection
@@ -1265,7 +1388,13 @@ service PipelinePublicService {
   // Returns the details of a connection.
   rpc GetNamespaceConnection(GetNamespaceConnectionRequest) returns (GetNamespaceConnectionResponse) {
     option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/connections/{connection_id}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Create a connection
@@ -1276,7 +1405,13 @@ service PipelinePublicService {
       post: "/v1beta/namespaces/{namespace_id}/connections"
       body: "connection"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Update a connection
@@ -1287,7 +1422,13 @@ service PipelinePublicService {
       patch: "/v1beta/namespaces/{namespace_id}/connections/{connection_id}"
       body: "connection"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Delete a connection
@@ -1295,7 +1436,13 @@ service PipelinePublicService {
   // Deletes a connection.
   rpc DeleteNamespaceConnection(DeleteNamespaceConnectionRequest) returns (DeleteNamespaceConnectionResponse) {
     option (google.api.http) = {delete: "/v1beta/namespaces/{namespace_id}/connections/{connection_id}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Test a connection
@@ -1309,7 +1456,13 @@ service PipelinePublicService {
   // account in the 3rd party app.
   rpc TestNamespaceConnection(TestNamespaceConnectionRequest) returns (TestNamespaceConnectionResponse) {
     option (google.api.http) = {post: "/v1beta/namespaces/{namespace_id}/connections/{connection_id}/test"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // List pipelines that reference a connection
@@ -1319,7 +1472,13 @@ service PipelinePublicService {
   // the connection.
   rpc ListPipelineIDsByConnectionID(ListPipelineIDsByConnectionIDRequest) returns (ListPipelineIDsByConnectionIDResponse) {
     option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/connections/{connection_id}/referenced-pipelines"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // List integrations
@@ -1327,7 +1486,13 @@ service PipelinePublicService {
   // Returns a paginated list of available integrations.
   rpc ListIntegrations(ListIntegrationsRequest) returns (ListIntegrationsResponse) {
     option (google.api.http) = {get: "/v1beta/integrations"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Get an integration
@@ -1335,6 +1500,12 @@ service PipelinePublicService {
   // Returns the details of an integration.
   rpc GetIntegration(GetIntegrationRequest) returns (GetIntegrationResponse) {
     option (google.api.http) = {get: "/v1beta/integrations/{integration_id}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 }

--- a/pkg/component/internal/mock/app_public_service_server_mock.gen.go
+++ b/pkg/component/internal/mock/app_public_service_server_mock.gen.go
@@ -31,6 +31,13 @@ type AppPublicServiceServerMock struct {
 	beforeCreateAppCounter uint64
 	CreateAppMock          mAppPublicServiceServerMockCreateApp
 
+	funcCreateChat          func(ctx context.Context, cp1 *mm_appv1alpha.CreateChatRequest) (cp2 *mm_appv1alpha.CreateChatResponse, err error)
+	funcCreateChatOrigin    string
+	inspectFuncCreateChat   func(ctx context.Context, cp1 *mm_appv1alpha.CreateChatRequest)
+	afterCreateChatCounter  uint64
+	beforeCreateChatCounter uint64
+	CreateChatMock          mAppPublicServiceServerMockCreateChat
+
 	funcCreateConversation          func(ctx context.Context, cp1 *mm_appv1alpha.CreateConversationRequest) (cp2 *mm_appv1alpha.CreateConversationResponse, err error)
 	funcCreateConversationOrigin    string
 	inspectFuncCreateConversation   func(ctx context.Context, cp1 *mm_appv1alpha.CreateConversationRequest)
@@ -51,6 +58,13 @@ type AppPublicServiceServerMock struct {
 	afterDeleteAppCounter  uint64
 	beforeDeleteAppCounter uint64
 	DeleteAppMock          mAppPublicServiceServerMockDeleteApp
+
+	funcDeleteChat          func(ctx context.Context, dp1 *mm_appv1alpha.DeleteChatRequest) (dp2 *mm_appv1alpha.DeleteChatResponse, err error)
+	funcDeleteChatOrigin    string
+	inspectFuncDeleteChat   func(ctx context.Context, dp1 *mm_appv1alpha.DeleteChatRequest)
+	afterDeleteChatCounter  uint64
+	beforeDeleteChatCounter uint64
+	DeleteChatMock          mAppPublicServiceServerMockDeleteChat
 
 	funcDeleteConversation          func(ctx context.Context, dp1 *mm_appv1alpha.DeleteConversationRequest) (dp2 *mm_appv1alpha.DeleteConversationResponse, err error)
 	funcDeleteConversationOrigin    string
@@ -79,6 +93,20 @@ type AppPublicServiceServerMock struct {
 	afterListAppsCounter  uint64
 	beforeListAppsCounter uint64
 	ListAppsMock          mAppPublicServiceServerMockListApps
+
+	funcListChatMessages          func(ctx context.Context, lp1 *mm_appv1alpha.ListChatMessagesRequest) (lp2 *mm_appv1alpha.ListChatMessagesResponse, err error)
+	funcListChatMessagesOrigin    string
+	inspectFuncListChatMessages   func(ctx context.Context, lp1 *mm_appv1alpha.ListChatMessagesRequest)
+	afterListChatMessagesCounter  uint64
+	beforeListChatMessagesCounter uint64
+	ListChatMessagesMock          mAppPublicServiceServerMockListChatMessages
+
+	funcListChats          func(ctx context.Context, lp1 *mm_appv1alpha.ListChatsRequest) (lp2 *mm_appv1alpha.ListChatsResponse, err error)
+	funcListChatsOrigin    string
+	inspectFuncListChats   func(ctx context.Context, lp1 *mm_appv1alpha.ListChatsRequest)
+	afterListChatsCounter  uint64
+	beforeListChatsCounter uint64
+	ListChatsMock          mAppPublicServiceServerMockListChats
 
 	funcListConversations          func(ctx context.Context, lp1 *mm_appv1alpha.ListConversationsRequest) (lp2 *mm_appv1alpha.ListConversationsResponse, err error)
 	funcListConversationsOrigin    string
@@ -122,6 +150,13 @@ type AppPublicServiceServerMock struct {
 	beforeUpdateAppCounter uint64
 	UpdateAppMock          mAppPublicServiceServerMockUpdateApp
 
+	funcUpdateChat          func(ctx context.Context, up1 *mm_appv1alpha.UpdateChatRequest) (up2 *mm_appv1alpha.UpdateChatResponse, err error)
+	funcUpdateChatOrigin    string
+	inspectFuncUpdateChat   func(ctx context.Context, up1 *mm_appv1alpha.UpdateChatRequest)
+	afterUpdateChatCounter  uint64
+	beforeUpdateChatCounter uint64
+	UpdateChatMock          mAppPublicServiceServerMockUpdateChat
+
 	funcUpdateConversation          func(ctx context.Context, up1 *mm_appv1alpha.UpdateConversationRequest) (up2 *mm_appv1alpha.UpdateConversationResponse, err error)
 	funcUpdateConversationOrigin    string
 	inspectFuncUpdateConversation   func(ctx context.Context, up1 *mm_appv1alpha.UpdateConversationRequest)
@@ -151,6 +186,9 @@ func NewAppPublicServiceServerMock(t minimock.Tester) *AppPublicServiceServerMoc
 	m.CreateAppMock = mAppPublicServiceServerMockCreateApp{mock: m}
 	m.CreateAppMock.callArgs = []*AppPublicServiceServerMockCreateAppParams{}
 
+	m.CreateChatMock = mAppPublicServiceServerMockCreateChat{mock: m}
+	m.CreateChatMock.callArgs = []*AppPublicServiceServerMockCreateChatParams{}
+
 	m.CreateConversationMock = mAppPublicServiceServerMockCreateConversation{mock: m}
 	m.CreateConversationMock.callArgs = []*AppPublicServiceServerMockCreateConversationParams{}
 
@@ -159,6 +197,9 @@ func NewAppPublicServiceServerMock(t minimock.Tester) *AppPublicServiceServerMoc
 
 	m.DeleteAppMock = mAppPublicServiceServerMockDeleteApp{mock: m}
 	m.DeleteAppMock.callArgs = []*AppPublicServiceServerMockDeleteAppParams{}
+
+	m.DeleteChatMock = mAppPublicServiceServerMockDeleteChat{mock: m}
+	m.DeleteChatMock.callArgs = []*AppPublicServiceServerMockDeleteChatParams{}
 
 	m.DeleteConversationMock = mAppPublicServiceServerMockDeleteConversation{mock: m}
 	m.DeleteConversationMock.callArgs = []*AppPublicServiceServerMockDeleteConversationParams{}
@@ -171,6 +212,12 @@ func NewAppPublicServiceServerMock(t minimock.Tester) *AppPublicServiceServerMoc
 
 	m.ListAppsMock = mAppPublicServiceServerMockListApps{mock: m}
 	m.ListAppsMock.callArgs = []*AppPublicServiceServerMockListAppsParams{}
+
+	m.ListChatMessagesMock = mAppPublicServiceServerMockListChatMessages{mock: m}
+	m.ListChatMessagesMock.callArgs = []*AppPublicServiceServerMockListChatMessagesParams{}
+
+	m.ListChatsMock = mAppPublicServiceServerMockListChats{mock: m}
+	m.ListChatsMock.callArgs = []*AppPublicServiceServerMockListChatsParams{}
 
 	m.ListConversationsMock = mAppPublicServiceServerMockListConversations{mock: m}
 	m.ListConversationsMock.callArgs = []*AppPublicServiceServerMockListConversationsParams{}
@@ -189,6 +236,9 @@ func NewAppPublicServiceServerMock(t minimock.Tester) *AppPublicServiceServerMoc
 
 	m.UpdateAppMock = mAppPublicServiceServerMockUpdateApp{mock: m}
 	m.UpdateAppMock.callArgs = []*AppPublicServiceServerMockUpdateAppParams{}
+
+	m.UpdateChatMock = mAppPublicServiceServerMockUpdateChat{mock: m}
+	m.UpdateChatMock.callArgs = []*AppPublicServiceServerMockUpdateChatParams{}
 
 	m.UpdateConversationMock = mAppPublicServiceServerMockUpdateConversation{mock: m}
 	m.UpdateConversationMock.callArgs = []*AppPublicServiceServerMockUpdateConversationParams{}
@@ -884,6 +934,349 @@ func (m *AppPublicServiceServerMock) MinimockCreateAppInspect() {
 	if !m.CreateAppMock.invocationsDone() && afterCreateAppCounter > 0 {
 		m.t.Errorf("Expected %d calls to AppPublicServiceServerMock.CreateApp at\n%s but found %d calls",
 			mm_atomic.LoadUint64(&m.CreateAppMock.expectedInvocations), m.CreateAppMock.expectedInvocationsOrigin, afterCreateAppCounter)
+	}
+}
+
+type mAppPublicServiceServerMockCreateChat struct {
+	optional           bool
+	mock               *AppPublicServiceServerMock
+	defaultExpectation *AppPublicServiceServerMockCreateChatExpectation
+	expectations       []*AppPublicServiceServerMockCreateChatExpectation
+
+	callArgs []*AppPublicServiceServerMockCreateChatParams
+	mutex    sync.RWMutex
+
+	expectedInvocations       uint64
+	expectedInvocationsOrigin string
+}
+
+// AppPublicServiceServerMockCreateChatExpectation specifies expectation struct of the AppPublicServiceServer.CreateChat
+type AppPublicServiceServerMockCreateChatExpectation struct {
+	mock               *AppPublicServiceServerMock
+	params             *AppPublicServiceServerMockCreateChatParams
+	paramPtrs          *AppPublicServiceServerMockCreateChatParamPtrs
+	expectationOrigins AppPublicServiceServerMockCreateChatExpectationOrigins
+	results            *AppPublicServiceServerMockCreateChatResults
+	returnOrigin       string
+	Counter            uint64
+}
+
+// AppPublicServiceServerMockCreateChatParams contains parameters of the AppPublicServiceServer.CreateChat
+type AppPublicServiceServerMockCreateChatParams struct {
+	ctx context.Context
+	cp1 *mm_appv1alpha.CreateChatRequest
+}
+
+// AppPublicServiceServerMockCreateChatParamPtrs contains pointers to parameters of the AppPublicServiceServer.CreateChat
+type AppPublicServiceServerMockCreateChatParamPtrs struct {
+	ctx *context.Context
+	cp1 **mm_appv1alpha.CreateChatRequest
+}
+
+// AppPublicServiceServerMockCreateChatResults contains results of the AppPublicServiceServer.CreateChat
+type AppPublicServiceServerMockCreateChatResults struct {
+	cp2 *mm_appv1alpha.CreateChatResponse
+	err error
+}
+
+// AppPublicServiceServerMockCreateChatOrigins contains origins of expectations of the AppPublicServiceServer.CreateChat
+type AppPublicServiceServerMockCreateChatExpectationOrigins struct {
+	origin    string
+	originCtx string
+	originCp1 string
+}
+
+// Marks this method to be optional. The default behavior of any method with Return() is '1 or more', meaning
+// the test will fail minimock's automatic final call check if the mocked method was not called at least once.
+// Optional() makes method check to work in '0 or more' mode.
+// It is NOT RECOMMENDED to use this option unless you really need it, as default behaviour helps to
+// catch the problems when the expected method call is totally skipped during test run.
+func (mmCreateChat *mAppPublicServiceServerMockCreateChat) Optional() *mAppPublicServiceServerMockCreateChat {
+	mmCreateChat.optional = true
+	return mmCreateChat
+}
+
+// Expect sets up expected params for AppPublicServiceServer.CreateChat
+func (mmCreateChat *mAppPublicServiceServerMockCreateChat) Expect(ctx context.Context, cp1 *mm_appv1alpha.CreateChatRequest) *mAppPublicServiceServerMockCreateChat {
+	if mmCreateChat.mock.funcCreateChat != nil {
+		mmCreateChat.mock.t.Fatalf("AppPublicServiceServerMock.CreateChat mock is already set by Set")
+	}
+
+	if mmCreateChat.defaultExpectation == nil {
+		mmCreateChat.defaultExpectation = &AppPublicServiceServerMockCreateChatExpectation{}
+	}
+
+	if mmCreateChat.defaultExpectation.paramPtrs != nil {
+		mmCreateChat.mock.t.Fatalf("AppPublicServiceServerMock.CreateChat mock is already set by ExpectParams functions")
+	}
+
+	mmCreateChat.defaultExpectation.params = &AppPublicServiceServerMockCreateChatParams{ctx, cp1}
+	mmCreateChat.defaultExpectation.expectationOrigins.origin = minimock.CallerInfo(1)
+	for _, e := range mmCreateChat.expectations {
+		if minimock.Equal(e.params, mmCreateChat.defaultExpectation.params) {
+			mmCreateChat.mock.t.Fatalf("Expectation set by When has same params: %#v", *mmCreateChat.defaultExpectation.params)
+		}
+	}
+
+	return mmCreateChat
+}
+
+// ExpectCtxParam1 sets up expected param ctx for AppPublicServiceServer.CreateChat
+func (mmCreateChat *mAppPublicServiceServerMockCreateChat) ExpectCtxParam1(ctx context.Context) *mAppPublicServiceServerMockCreateChat {
+	if mmCreateChat.mock.funcCreateChat != nil {
+		mmCreateChat.mock.t.Fatalf("AppPublicServiceServerMock.CreateChat mock is already set by Set")
+	}
+
+	if mmCreateChat.defaultExpectation == nil {
+		mmCreateChat.defaultExpectation = &AppPublicServiceServerMockCreateChatExpectation{}
+	}
+
+	if mmCreateChat.defaultExpectation.params != nil {
+		mmCreateChat.mock.t.Fatalf("AppPublicServiceServerMock.CreateChat mock is already set by Expect")
+	}
+
+	if mmCreateChat.defaultExpectation.paramPtrs == nil {
+		mmCreateChat.defaultExpectation.paramPtrs = &AppPublicServiceServerMockCreateChatParamPtrs{}
+	}
+	mmCreateChat.defaultExpectation.paramPtrs.ctx = &ctx
+	mmCreateChat.defaultExpectation.expectationOrigins.originCtx = minimock.CallerInfo(1)
+
+	return mmCreateChat
+}
+
+// ExpectCp1Param2 sets up expected param cp1 for AppPublicServiceServer.CreateChat
+func (mmCreateChat *mAppPublicServiceServerMockCreateChat) ExpectCp1Param2(cp1 *mm_appv1alpha.CreateChatRequest) *mAppPublicServiceServerMockCreateChat {
+	if mmCreateChat.mock.funcCreateChat != nil {
+		mmCreateChat.mock.t.Fatalf("AppPublicServiceServerMock.CreateChat mock is already set by Set")
+	}
+
+	if mmCreateChat.defaultExpectation == nil {
+		mmCreateChat.defaultExpectation = &AppPublicServiceServerMockCreateChatExpectation{}
+	}
+
+	if mmCreateChat.defaultExpectation.params != nil {
+		mmCreateChat.mock.t.Fatalf("AppPublicServiceServerMock.CreateChat mock is already set by Expect")
+	}
+
+	if mmCreateChat.defaultExpectation.paramPtrs == nil {
+		mmCreateChat.defaultExpectation.paramPtrs = &AppPublicServiceServerMockCreateChatParamPtrs{}
+	}
+	mmCreateChat.defaultExpectation.paramPtrs.cp1 = &cp1
+	mmCreateChat.defaultExpectation.expectationOrigins.originCp1 = minimock.CallerInfo(1)
+
+	return mmCreateChat
+}
+
+// Inspect accepts an inspector function that has same arguments as the AppPublicServiceServer.CreateChat
+func (mmCreateChat *mAppPublicServiceServerMockCreateChat) Inspect(f func(ctx context.Context, cp1 *mm_appv1alpha.CreateChatRequest)) *mAppPublicServiceServerMockCreateChat {
+	if mmCreateChat.mock.inspectFuncCreateChat != nil {
+		mmCreateChat.mock.t.Fatalf("Inspect function is already set for AppPublicServiceServerMock.CreateChat")
+	}
+
+	mmCreateChat.mock.inspectFuncCreateChat = f
+
+	return mmCreateChat
+}
+
+// Return sets up results that will be returned by AppPublicServiceServer.CreateChat
+func (mmCreateChat *mAppPublicServiceServerMockCreateChat) Return(cp2 *mm_appv1alpha.CreateChatResponse, err error) *AppPublicServiceServerMock {
+	if mmCreateChat.mock.funcCreateChat != nil {
+		mmCreateChat.mock.t.Fatalf("AppPublicServiceServerMock.CreateChat mock is already set by Set")
+	}
+
+	if mmCreateChat.defaultExpectation == nil {
+		mmCreateChat.defaultExpectation = &AppPublicServiceServerMockCreateChatExpectation{mock: mmCreateChat.mock}
+	}
+	mmCreateChat.defaultExpectation.results = &AppPublicServiceServerMockCreateChatResults{cp2, err}
+	mmCreateChat.defaultExpectation.returnOrigin = minimock.CallerInfo(1)
+	return mmCreateChat.mock
+}
+
+// Set uses given function f to mock the AppPublicServiceServer.CreateChat method
+func (mmCreateChat *mAppPublicServiceServerMockCreateChat) Set(f func(ctx context.Context, cp1 *mm_appv1alpha.CreateChatRequest) (cp2 *mm_appv1alpha.CreateChatResponse, err error)) *AppPublicServiceServerMock {
+	if mmCreateChat.defaultExpectation != nil {
+		mmCreateChat.mock.t.Fatalf("Default expectation is already set for the AppPublicServiceServer.CreateChat method")
+	}
+
+	if len(mmCreateChat.expectations) > 0 {
+		mmCreateChat.mock.t.Fatalf("Some expectations are already set for the AppPublicServiceServer.CreateChat method")
+	}
+
+	mmCreateChat.mock.funcCreateChat = f
+	mmCreateChat.mock.funcCreateChatOrigin = minimock.CallerInfo(1)
+	return mmCreateChat.mock
+}
+
+// When sets expectation for the AppPublicServiceServer.CreateChat which will trigger the result defined by the following
+// Then helper
+func (mmCreateChat *mAppPublicServiceServerMockCreateChat) When(ctx context.Context, cp1 *mm_appv1alpha.CreateChatRequest) *AppPublicServiceServerMockCreateChatExpectation {
+	if mmCreateChat.mock.funcCreateChat != nil {
+		mmCreateChat.mock.t.Fatalf("AppPublicServiceServerMock.CreateChat mock is already set by Set")
+	}
+
+	expectation := &AppPublicServiceServerMockCreateChatExpectation{
+		mock:               mmCreateChat.mock,
+		params:             &AppPublicServiceServerMockCreateChatParams{ctx, cp1},
+		expectationOrigins: AppPublicServiceServerMockCreateChatExpectationOrigins{origin: minimock.CallerInfo(1)},
+	}
+	mmCreateChat.expectations = append(mmCreateChat.expectations, expectation)
+	return expectation
+}
+
+// Then sets up AppPublicServiceServer.CreateChat return parameters for the expectation previously defined by the When method
+func (e *AppPublicServiceServerMockCreateChatExpectation) Then(cp2 *mm_appv1alpha.CreateChatResponse, err error) *AppPublicServiceServerMock {
+	e.results = &AppPublicServiceServerMockCreateChatResults{cp2, err}
+	return e.mock
+}
+
+// Times sets number of times AppPublicServiceServer.CreateChat should be invoked
+func (mmCreateChat *mAppPublicServiceServerMockCreateChat) Times(n uint64) *mAppPublicServiceServerMockCreateChat {
+	if n == 0 {
+		mmCreateChat.mock.t.Fatalf("Times of AppPublicServiceServerMock.CreateChat mock can not be zero")
+	}
+	mm_atomic.StoreUint64(&mmCreateChat.expectedInvocations, n)
+	mmCreateChat.expectedInvocationsOrigin = minimock.CallerInfo(1)
+	return mmCreateChat
+}
+
+func (mmCreateChat *mAppPublicServiceServerMockCreateChat) invocationsDone() bool {
+	if len(mmCreateChat.expectations) == 0 && mmCreateChat.defaultExpectation == nil && mmCreateChat.mock.funcCreateChat == nil {
+		return true
+	}
+
+	totalInvocations := mm_atomic.LoadUint64(&mmCreateChat.mock.afterCreateChatCounter)
+	expectedInvocations := mm_atomic.LoadUint64(&mmCreateChat.expectedInvocations)
+
+	return totalInvocations > 0 && (expectedInvocations == 0 || expectedInvocations == totalInvocations)
+}
+
+// CreateChat implements mm_appv1alpha.AppPublicServiceServer
+func (mmCreateChat *AppPublicServiceServerMock) CreateChat(ctx context.Context, cp1 *mm_appv1alpha.CreateChatRequest) (cp2 *mm_appv1alpha.CreateChatResponse, err error) {
+	mm_atomic.AddUint64(&mmCreateChat.beforeCreateChatCounter, 1)
+	defer mm_atomic.AddUint64(&mmCreateChat.afterCreateChatCounter, 1)
+
+	mmCreateChat.t.Helper()
+
+	if mmCreateChat.inspectFuncCreateChat != nil {
+		mmCreateChat.inspectFuncCreateChat(ctx, cp1)
+	}
+
+	mm_params := AppPublicServiceServerMockCreateChatParams{ctx, cp1}
+
+	// Record call args
+	mmCreateChat.CreateChatMock.mutex.Lock()
+	mmCreateChat.CreateChatMock.callArgs = append(mmCreateChat.CreateChatMock.callArgs, &mm_params)
+	mmCreateChat.CreateChatMock.mutex.Unlock()
+
+	for _, e := range mmCreateChat.CreateChatMock.expectations {
+		if minimock.Equal(*e.params, mm_params) {
+			mm_atomic.AddUint64(&e.Counter, 1)
+			return e.results.cp2, e.results.err
+		}
+	}
+
+	if mmCreateChat.CreateChatMock.defaultExpectation != nil {
+		mm_atomic.AddUint64(&mmCreateChat.CreateChatMock.defaultExpectation.Counter, 1)
+		mm_want := mmCreateChat.CreateChatMock.defaultExpectation.params
+		mm_want_ptrs := mmCreateChat.CreateChatMock.defaultExpectation.paramPtrs
+
+		mm_got := AppPublicServiceServerMockCreateChatParams{ctx, cp1}
+
+		if mm_want_ptrs != nil {
+
+			if mm_want_ptrs.ctx != nil && !minimock.Equal(*mm_want_ptrs.ctx, mm_got.ctx) {
+				mmCreateChat.t.Errorf("AppPublicServiceServerMock.CreateChat got unexpected parameter ctx, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmCreateChat.CreateChatMock.defaultExpectation.expectationOrigins.originCtx, *mm_want_ptrs.ctx, mm_got.ctx, minimock.Diff(*mm_want_ptrs.ctx, mm_got.ctx))
+			}
+
+			if mm_want_ptrs.cp1 != nil && !minimock.Equal(*mm_want_ptrs.cp1, mm_got.cp1) {
+				mmCreateChat.t.Errorf("AppPublicServiceServerMock.CreateChat got unexpected parameter cp1, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmCreateChat.CreateChatMock.defaultExpectation.expectationOrigins.originCp1, *mm_want_ptrs.cp1, mm_got.cp1, minimock.Diff(*mm_want_ptrs.cp1, mm_got.cp1))
+			}
+
+		} else if mm_want != nil && !minimock.Equal(*mm_want, mm_got) {
+			mmCreateChat.t.Errorf("AppPublicServiceServerMock.CreateChat got unexpected parameters, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+				mmCreateChat.CreateChatMock.defaultExpectation.expectationOrigins.origin, *mm_want, mm_got, minimock.Diff(*mm_want, mm_got))
+		}
+
+		mm_results := mmCreateChat.CreateChatMock.defaultExpectation.results
+		if mm_results == nil {
+			mmCreateChat.t.Fatal("No results are set for the AppPublicServiceServerMock.CreateChat")
+		}
+		return (*mm_results).cp2, (*mm_results).err
+	}
+	if mmCreateChat.funcCreateChat != nil {
+		return mmCreateChat.funcCreateChat(ctx, cp1)
+	}
+	mmCreateChat.t.Fatalf("Unexpected call to AppPublicServiceServerMock.CreateChat. %v %v", ctx, cp1)
+	return
+}
+
+// CreateChatAfterCounter returns a count of finished AppPublicServiceServerMock.CreateChat invocations
+func (mmCreateChat *AppPublicServiceServerMock) CreateChatAfterCounter() uint64 {
+	return mm_atomic.LoadUint64(&mmCreateChat.afterCreateChatCounter)
+}
+
+// CreateChatBeforeCounter returns a count of AppPublicServiceServerMock.CreateChat invocations
+func (mmCreateChat *AppPublicServiceServerMock) CreateChatBeforeCounter() uint64 {
+	return mm_atomic.LoadUint64(&mmCreateChat.beforeCreateChatCounter)
+}
+
+// Calls returns a list of arguments used in each call to AppPublicServiceServerMock.CreateChat.
+// The list is in the same order as the calls were made (i.e. recent calls have a higher index)
+func (mmCreateChat *mAppPublicServiceServerMockCreateChat) Calls() []*AppPublicServiceServerMockCreateChatParams {
+	mmCreateChat.mutex.RLock()
+
+	argCopy := make([]*AppPublicServiceServerMockCreateChatParams, len(mmCreateChat.callArgs))
+	copy(argCopy, mmCreateChat.callArgs)
+
+	mmCreateChat.mutex.RUnlock()
+
+	return argCopy
+}
+
+// MinimockCreateChatDone returns true if the count of the CreateChat invocations corresponds
+// the number of defined expectations
+func (m *AppPublicServiceServerMock) MinimockCreateChatDone() bool {
+	if m.CreateChatMock.optional {
+		// Optional methods provide '0 or more' call count restriction.
+		return true
+	}
+
+	for _, e := range m.CreateChatMock.expectations {
+		if mm_atomic.LoadUint64(&e.Counter) < 1 {
+			return false
+		}
+	}
+
+	return m.CreateChatMock.invocationsDone()
+}
+
+// MinimockCreateChatInspect logs each unmet expectation
+func (m *AppPublicServiceServerMock) MinimockCreateChatInspect() {
+	for _, e := range m.CreateChatMock.expectations {
+		if mm_atomic.LoadUint64(&e.Counter) < 1 {
+			m.t.Errorf("Expected call to AppPublicServiceServerMock.CreateChat at\n%s with params: %#v", e.expectationOrigins.origin, *e.params)
+		}
+	}
+
+	afterCreateChatCounter := mm_atomic.LoadUint64(&m.afterCreateChatCounter)
+	// if default expectation was set then invocations count should be greater than zero
+	if m.CreateChatMock.defaultExpectation != nil && afterCreateChatCounter < 1 {
+		if m.CreateChatMock.defaultExpectation.params == nil {
+			m.t.Errorf("Expected call to AppPublicServiceServerMock.CreateChat at\n%s", m.CreateChatMock.defaultExpectation.returnOrigin)
+		} else {
+			m.t.Errorf("Expected call to AppPublicServiceServerMock.CreateChat at\n%s with params: %#v", m.CreateChatMock.defaultExpectation.expectationOrigins.origin, *m.CreateChatMock.defaultExpectation.params)
+		}
+	}
+	// if func was set then invocations count should be greater than zero
+	if m.funcCreateChat != nil && afterCreateChatCounter < 1 {
+		m.t.Errorf("Expected call to AppPublicServiceServerMock.CreateChat at\n%s", m.funcCreateChatOrigin)
+	}
+
+	if !m.CreateChatMock.invocationsDone() && afterCreateChatCounter > 0 {
+		m.t.Errorf("Expected %d calls to AppPublicServiceServerMock.CreateChat at\n%s but found %d calls",
+			mm_atomic.LoadUint64(&m.CreateChatMock.expectedInvocations), m.CreateChatMock.expectedInvocationsOrigin, afterCreateChatCounter)
 	}
 }
 
@@ -1913,6 +2306,349 @@ func (m *AppPublicServiceServerMock) MinimockDeleteAppInspect() {
 	if !m.DeleteAppMock.invocationsDone() && afterDeleteAppCounter > 0 {
 		m.t.Errorf("Expected %d calls to AppPublicServiceServerMock.DeleteApp at\n%s but found %d calls",
 			mm_atomic.LoadUint64(&m.DeleteAppMock.expectedInvocations), m.DeleteAppMock.expectedInvocationsOrigin, afterDeleteAppCounter)
+	}
+}
+
+type mAppPublicServiceServerMockDeleteChat struct {
+	optional           bool
+	mock               *AppPublicServiceServerMock
+	defaultExpectation *AppPublicServiceServerMockDeleteChatExpectation
+	expectations       []*AppPublicServiceServerMockDeleteChatExpectation
+
+	callArgs []*AppPublicServiceServerMockDeleteChatParams
+	mutex    sync.RWMutex
+
+	expectedInvocations       uint64
+	expectedInvocationsOrigin string
+}
+
+// AppPublicServiceServerMockDeleteChatExpectation specifies expectation struct of the AppPublicServiceServer.DeleteChat
+type AppPublicServiceServerMockDeleteChatExpectation struct {
+	mock               *AppPublicServiceServerMock
+	params             *AppPublicServiceServerMockDeleteChatParams
+	paramPtrs          *AppPublicServiceServerMockDeleteChatParamPtrs
+	expectationOrigins AppPublicServiceServerMockDeleteChatExpectationOrigins
+	results            *AppPublicServiceServerMockDeleteChatResults
+	returnOrigin       string
+	Counter            uint64
+}
+
+// AppPublicServiceServerMockDeleteChatParams contains parameters of the AppPublicServiceServer.DeleteChat
+type AppPublicServiceServerMockDeleteChatParams struct {
+	ctx context.Context
+	dp1 *mm_appv1alpha.DeleteChatRequest
+}
+
+// AppPublicServiceServerMockDeleteChatParamPtrs contains pointers to parameters of the AppPublicServiceServer.DeleteChat
+type AppPublicServiceServerMockDeleteChatParamPtrs struct {
+	ctx *context.Context
+	dp1 **mm_appv1alpha.DeleteChatRequest
+}
+
+// AppPublicServiceServerMockDeleteChatResults contains results of the AppPublicServiceServer.DeleteChat
+type AppPublicServiceServerMockDeleteChatResults struct {
+	dp2 *mm_appv1alpha.DeleteChatResponse
+	err error
+}
+
+// AppPublicServiceServerMockDeleteChatOrigins contains origins of expectations of the AppPublicServiceServer.DeleteChat
+type AppPublicServiceServerMockDeleteChatExpectationOrigins struct {
+	origin    string
+	originCtx string
+	originDp1 string
+}
+
+// Marks this method to be optional. The default behavior of any method with Return() is '1 or more', meaning
+// the test will fail minimock's automatic final call check if the mocked method was not called at least once.
+// Optional() makes method check to work in '0 or more' mode.
+// It is NOT RECOMMENDED to use this option unless you really need it, as default behaviour helps to
+// catch the problems when the expected method call is totally skipped during test run.
+func (mmDeleteChat *mAppPublicServiceServerMockDeleteChat) Optional() *mAppPublicServiceServerMockDeleteChat {
+	mmDeleteChat.optional = true
+	return mmDeleteChat
+}
+
+// Expect sets up expected params for AppPublicServiceServer.DeleteChat
+func (mmDeleteChat *mAppPublicServiceServerMockDeleteChat) Expect(ctx context.Context, dp1 *mm_appv1alpha.DeleteChatRequest) *mAppPublicServiceServerMockDeleteChat {
+	if mmDeleteChat.mock.funcDeleteChat != nil {
+		mmDeleteChat.mock.t.Fatalf("AppPublicServiceServerMock.DeleteChat mock is already set by Set")
+	}
+
+	if mmDeleteChat.defaultExpectation == nil {
+		mmDeleteChat.defaultExpectation = &AppPublicServiceServerMockDeleteChatExpectation{}
+	}
+
+	if mmDeleteChat.defaultExpectation.paramPtrs != nil {
+		mmDeleteChat.mock.t.Fatalf("AppPublicServiceServerMock.DeleteChat mock is already set by ExpectParams functions")
+	}
+
+	mmDeleteChat.defaultExpectation.params = &AppPublicServiceServerMockDeleteChatParams{ctx, dp1}
+	mmDeleteChat.defaultExpectation.expectationOrigins.origin = minimock.CallerInfo(1)
+	for _, e := range mmDeleteChat.expectations {
+		if minimock.Equal(e.params, mmDeleteChat.defaultExpectation.params) {
+			mmDeleteChat.mock.t.Fatalf("Expectation set by When has same params: %#v", *mmDeleteChat.defaultExpectation.params)
+		}
+	}
+
+	return mmDeleteChat
+}
+
+// ExpectCtxParam1 sets up expected param ctx for AppPublicServiceServer.DeleteChat
+func (mmDeleteChat *mAppPublicServiceServerMockDeleteChat) ExpectCtxParam1(ctx context.Context) *mAppPublicServiceServerMockDeleteChat {
+	if mmDeleteChat.mock.funcDeleteChat != nil {
+		mmDeleteChat.mock.t.Fatalf("AppPublicServiceServerMock.DeleteChat mock is already set by Set")
+	}
+
+	if mmDeleteChat.defaultExpectation == nil {
+		mmDeleteChat.defaultExpectation = &AppPublicServiceServerMockDeleteChatExpectation{}
+	}
+
+	if mmDeleteChat.defaultExpectation.params != nil {
+		mmDeleteChat.mock.t.Fatalf("AppPublicServiceServerMock.DeleteChat mock is already set by Expect")
+	}
+
+	if mmDeleteChat.defaultExpectation.paramPtrs == nil {
+		mmDeleteChat.defaultExpectation.paramPtrs = &AppPublicServiceServerMockDeleteChatParamPtrs{}
+	}
+	mmDeleteChat.defaultExpectation.paramPtrs.ctx = &ctx
+	mmDeleteChat.defaultExpectation.expectationOrigins.originCtx = minimock.CallerInfo(1)
+
+	return mmDeleteChat
+}
+
+// ExpectDp1Param2 sets up expected param dp1 for AppPublicServiceServer.DeleteChat
+func (mmDeleteChat *mAppPublicServiceServerMockDeleteChat) ExpectDp1Param2(dp1 *mm_appv1alpha.DeleteChatRequest) *mAppPublicServiceServerMockDeleteChat {
+	if mmDeleteChat.mock.funcDeleteChat != nil {
+		mmDeleteChat.mock.t.Fatalf("AppPublicServiceServerMock.DeleteChat mock is already set by Set")
+	}
+
+	if mmDeleteChat.defaultExpectation == nil {
+		mmDeleteChat.defaultExpectation = &AppPublicServiceServerMockDeleteChatExpectation{}
+	}
+
+	if mmDeleteChat.defaultExpectation.params != nil {
+		mmDeleteChat.mock.t.Fatalf("AppPublicServiceServerMock.DeleteChat mock is already set by Expect")
+	}
+
+	if mmDeleteChat.defaultExpectation.paramPtrs == nil {
+		mmDeleteChat.defaultExpectation.paramPtrs = &AppPublicServiceServerMockDeleteChatParamPtrs{}
+	}
+	mmDeleteChat.defaultExpectation.paramPtrs.dp1 = &dp1
+	mmDeleteChat.defaultExpectation.expectationOrigins.originDp1 = minimock.CallerInfo(1)
+
+	return mmDeleteChat
+}
+
+// Inspect accepts an inspector function that has same arguments as the AppPublicServiceServer.DeleteChat
+func (mmDeleteChat *mAppPublicServiceServerMockDeleteChat) Inspect(f func(ctx context.Context, dp1 *mm_appv1alpha.DeleteChatRequest)) *mAppPublicServiceServerMockDeleteChat {
+	if mmDeleteChat.mock.inspectFuncDeleteChat != nil {
+		mmDeleteChat.mock.t.Fatalf("Inspect function is already set for AppPublicServiceServerMock.DeleteChat")
+	}
+
+	mmDeleteChat.mock.inspectFuncDeleteChat = f
+
+	return mmDeleteChat
+}
+
+// Return sets up results that will be returned by AppPublicServiceServer.DeleteChat
+func (mmDeleteChat *mAppPublicServiceServerMockDeleteChat) Return(dp2 *mm_appv1alpha.DeleteChatResponse, err error) *AppPublicServiceServerMock {
+	if mmDeleteChat.mock.funcDeleteChat != nil {
+		mmDeleteChat.mock.t.Fatalf("AppPublicServiceServerMock.DeleteChat mock is already set by Set")
+	}
+
+	if mmDeleteChat.defaultExpectation == nil {
+		mmDeleteChat.defaultExpectation = &AppPublicServiceServerMockDeleteChatExpectation{mock: mmDeleteChat.mock}
+	}
+	mmDeleteChat.defaultExpectation.results = &AppPublicServiceServerMockDeleteChatResults{dp2, err}
+	mmDeleteChat.defaultExpectation.returnOrigin = minimock.CallerInfo(1)
+	return mmDeleteChat.mock
+}
+
+// Set uses given function f to mock the AppPublicServiceServer.DeleteChat method
+func (mmDeleteChat *mAppPublicServiceServerMockDeleteChat) Set(f func(ctx context.Context, dp1 *mm_appv1alpha.DeleteChatRequest) (dp2 *mm_appv1alpha.DeleteChatResponse, err error)) *AppPublicServiceServerMock {
+	if mmDeleteChat.defaultExpectation != nil {
+		mmDeleteChat.mock.t.Fatalf("Default expectation is already set for the AppPublicServiceServer.DeleteChat method")
+	}
+
+	if len(mmDeleteChat.expectations) > 0 {
+		mmDeleteChat.mock.t.Fatalf("Some expectations are already set for the AppPublicServiceServer.DeleteChat method")
+	}
+
+	mmDeleteChat.mock.funcDeleteChat = f
+	mmDeleteChat.mock.funcDeleteChatOrigin = minimock.CallerInfo(1)
+	return mmDeleteChat.mock
+}
+
+// When sets expectation for the AppPublicServiceServer.DeleteChat which will trigger the result defined by the following
+// Then helper
+func (mmDeleteChat *mAppPublicServiceServerMockDeleteChat) When(ctx context.Context, dp1 *mm_appv1alpha.DeleteChatRequest) *AppPublicServiceServerMockDeleteChatExpectation {
+	if mmDeleteChat.mock.funcDeleteChat != nil {
+		mmDeleteChat.mock.t.Fatalf("AppPublicServiceServerMock.DeleteChat mock is already set by Set")
+	}
+
+	expectation := &AppPublicServiceServerMockDeleteChatExpectation{
+		mock:               mmDeleteChat.mock,
+		params:             &AppPublicServiceServerMockDeleteChatParams{ctx, dp1},
+		expectationOrigins: AppPublicServiceServerMockDeleteChatExpectationOrigins{origin: minimock.CallerInfo(1)},
+	}
+	mmDeleteChat.expectations = append(mmDeleteChat.expectations, expectation)
+	return expectation
+}
+
+// Then sets up AppPublicServiceServer.DeleteChat return parameters for the expectation previously defined by the When method
+func (e *AppPublicServiceServerMockDeleteChatExpectation) Then(dp2 *mm_appv1alpha.DeleteChatResponse, err error) *AppPublicServiceServerMock {
+	e.results = &AppPublicServiceServerMockDeleteChatResults{dp2, err}
+	return e.mock
+}
+
+// Times sets number of times AppPublicServiceServer.DeleteChat should be invoked
+func (mmDeleteChat *mAppPublicServiceServerMockDeleteChat) Times(n uint64) *mAppPublicServiceServerMockDeleteChat {
+	if n == 0 {
+		mmDeleteChat.mock.t.Fatalf("Times of AppPublicServiceServerMock.DeleteChat mock can not be zero")
+	}
+	mm_atomic.StoreUint64(&mmDeleteChat.expectedInvocations, n)
+	mmDeleteChat.expectedInvocationsOrigin = minimock.CallerInfo(1)
+	return mmDeleteChat
+}
+
+func (mmDeleteChat *mAppPublicServiceServerMockDeleteChat) invocationsDone() bool {
+	if len(mmDeleteChat.expectations) == 0 && mmDeleteChat.defaultExpectation == nil && mmDeleteChat.mock.funcDeleteChat == nil {
+		return true
+	}
+
+	totalInvocations := mm_atomic.LoadUint64(&mmDeleteChat.mock.afterDeleteChatCounter)
+	expectedInvocations := mm_atomic.LoadUint64(&mmDeleteChat.expectedInvocations)
+
+	return totalInvocations > 0 && (expectedInvocations == 0 || expectedInvocations == totalInvocations)
+}
+
+// DeleteChat implements mm_appv1alpha.AppPublicServiceServer
+func (mmDeleteChat *AppPublicServiceServerMock) DeleteChat(ctx context.Context, dp1 *mm_appv1alpha.DeleteChatRequest) (dp2 *mm_appv1alpha.DeleteChatResponse, err error) {
+	mm_atomic.AddUint64(&mmDeleteChat.beforeDeleteChatCounter, 1)
+	defer mm_atomic.AddUint64(&mmDeleteChat.afterDeleteChatCounter, 1)
+
+	mmDeleteChat.t.Helper()
+
+	if mmDeleteChat.inspectFuncDeleteChat != nil {
+		mmDeleteChat.inspectFuncDeleteChat(ctx, dp1)
+	}
+
+	mm_params := AppPublicServiceServerMockDeleteChatParams{ctx, dp1}
+
+	// Record call args
+	mmDeleteChat.DeleteChatMock.mutex.Lock()
+	mmDeleteChat.DeleteChatMock.callArgs = append(mmDeleteChat.DeleteChatMock.callArgs, &mm_params)
+	mmDeleteChat.DeleteChatMock.mutex.Unlock()
+
+	for _, e := range mmDeleteChat.DeleteChatMock.expectations {
+		if minimock.Equal(*e.params, mm_params) {
+			mm_atomic.AddUint64(&e.Counter, 1)
+			return e.results.dp2, e.results.err
+		}
+	}
+
+	if mmDeleteChat.DeleteChatMock.defaultExpectation != nil {
+		mm_atomic.AddUint64(&mmDeleteChat.DeleteChatMock.defaultExpectation.Counter, 1)
+		mm_want := mmDeleteChat.DeleteChatMock.defaultExpectation.params
+		mm_want_ptrs := mmDeleteChat.DeleteChatMock.defaultExpectation.paramPtrs
+
+		mm_got := AppPublicServiceServerMockDeleteChatParams{ctx, dp1}
+
+		if mm_want_ptrs != nil {
+
+			if mm_want_ptrs.ctx != nil && !minimock.Equal(*mm_want_ptrs.ctx, mm_got.ctx) {
+				mmDeleteChat.t.Errorf("AppPublicServiceServerMock.DeleteChat got unexpected parameter ctx, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmDeleteChat.DeleteChatMock.defaultExpectation.expectationOrigins.originCtx, *mm_want_ptrs.ctx, mm_got.ctx, minimock.Diff(*mm_want_ptrs.ctx, mm_got.ctx))
+			}
+
+			if mm_want_ptrs.dp1 != nil && !minimock.Equal(*mm_want_ptrs.dp1, mm_got.dp1) {
+				mmDeleteChat.t.Errorf("AppPublicServiceServerMock.DeleteChat got unexpected parameter dp1, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmDeleteChat.DeleteChatMock.defaultExpectation.expectationOrigins.originDp1, *mm_want_ptrs.dp1, mm_got.dp1, minimock.Diff(*mm_want_ptrs.dp1, mm_got.dp1))
+			}
+
+		} else if mm_want != nil && !minimock.Equal(*mm_want, mm_got) {
+			mmDeleteChat.t.Errorf("AppPublicServiceServerMock.DeleteChat got unexpected parameters, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+				mmDeleteChat.DeleteChatMock.defaultExpectation.expectationOrigins.origin, *mm_want, mm_got, minimock.Diff(*mm_want, mm_got))
+		}
+
+		mm_results := mmDeleteChat.DeleteChatMock.defaultExpectation.results
+		if mm_results == nil {
+			mmDeleteChat.t.Fatal("No results are set for the AppPublicServiceServerMock.DeleteChat")
+		}
+		return (*mm_results).dp2, (*mm_results).err
+	}
+	if mmDeleteChat.funcDeleteChat != nil {
+		return mmDeleteChat.funcDeleteChat(ctx, dp1)
+	}
+	mmDeleteChat.t.Fatalf("Unexpected call to AppPublicServiceServerMock.DeleteChat. %v %v", ctx, dp1)
+	return
+}
+
+// DeleteChatAfterCounter returns a count of finished AppPublicServiceServerMock.DeleteChat invocations
+func (mmDeleteChat *AppPublicServiceServerMock) DeleteChatAfterCounter() uint64 {
+	return mm_atomic.LoadUint64(&mmDeleteChat.afterDeleteChatCounter)
+}
+
+// DeleteChatBeforeCounter returns a count of AppPublicServiceServerMock.DeleteChat invocations
+func (mmDeleteChat *AppPublicServiceServerMock) DeleteChatBeforeCounter() uint64 {
+	return mm_atomic.LoadUint64(&mmDeleteChat.beforeDeleteChatCounter)
+}
+
+// Calls returns a list of arguments used in each call to AppPublicServiceServerMock.DeleteChat.
+// The list is in the same order as the calls were made (i.e. recent calls have a higher index)
+func (mmDeleteChat *mAppPublicServiceServerMockDeleteChat) Calls() []*AppPublicServiceServerMockDeleteChatParams {
+	mmDeleteChat.mutex.RLock()
+
+	argCopy := make([]*AppPublicServiceServerMockDeleteChatParams, len(mmDeleteChat.callArgs))
+	copy(argCopy, mmDeleteChat.callArgs)
+
+	mmDeleteChat.mutex.RUnlock()
+
+	return argCopy
+}
+
+// MinimockDeleteChatDone returns true if the count of the DeleteChat invocations corresponds
+// the number of defined expectations
+func (m *AppPublicServiceServerMock) MinimockDeleteChatDone() bool {
+	if m.DeleteChatMock.optional {
+		// Optional methods provide '0 or more' call count restriction.
+		return true
+	}
+
+	for _, e := range m.DeleteChatMock.expectations {
+		if mm_atomic.LoadUint64(&e.Counter) < 1 {
+			return false
+		}
+	}
+
+	return m.DeleteChatMock.invocationsDone()
+}
+
+// MinimockDeleteChatInspect logs each unmet expectation
+func (m *AppPublicServiceServerMock) MinimockDeleteChatInspect() {
+	for _, e := range m.DeleteChatMock.expectations {
+		if mm_atomic.LoadUint64(&e.Counter) < 1 {
+			m.t.Errorf("Expected call to AppPublicServiceServerMock.DeleteChat at\n%s with params: %#v", e.expectationOrigins.origin, *e.params)
+		}
+	}
+
+	afterDeleteChatCounter := mm_atomic.LoadUint64(&m.afterDeleteChatCounter)
+	// if default expectation was set then invocations count should be greater than zero
+	if m.DeleteChatMock.defaultExpectation != nil && afterDeleteChatCounter < 1 {
+		if m.DeleteChatMock.defaultExpectation.params == nil {
+			m.t.Errorf("Expected call to AppPublicServiceServerMock.DeleteChat at\n%s", m.DeleteChatMock.defaultExpectation.returnOrigin)
+		} else {
+			m.t.Errorf("Expected call to AppPublicServiceServerMock.DeleteChat at\n%s with params: %#v", m.DeleteChatMock.defaultExpectation.expectationOrigins.origin, *m.DeleteChatMock.defaultExpectation.params)
+		}
+	}
+	// if func was set then invocations count should be greater than zero
+	if m.funcDeleteChat != nil && afterDeleteChatCounter < 1 {
+		m.t.Errorf("Expected call to AppPublicServiceServerMock.DeleteChat at\n%s", m.funcDeleteChatOrigin)
+	}
+
+	if !m.DeleteChatMock.invocationsDone() && afterDeleteChatCounter > 0 {
+		m.t.Errorf("Expected %d calls to AppPublicServiceServerMock.DeleteChat at\n%s but found %d calls",
+			mm_atomic.LoadUint64(&m.DeleteChatMock.expectedInvocations), m.DeleteChatMock.expectedInvocationsOrigin, afterDeleteChatCounter)
 	}
 }
 
@@ -3285,6 +4021,692 @@ func (m *AppPublicServiceServerMock) MinimockListAppsInspect() {
 	if !m.ListAppsMock.invocationsDone() && afterListAppsCounter > 0 {
 		m.t.Errorf("Expected %d calls to AppPublicServiceServerMock.ListApps at\n%s but found %d calls",
 			mm_atomic.LoadUint64(&m.ListAppsMock.expectedInvocations), m.ListAppsMock.expectedInvocationsOrigin, afterListAppsCounter)
+	}
+}
+
+type mAppPublicServiceServerMockListChatMessages struct {
+	optional           bool
+	mock               *AppPublicServiceServerMock
+	defaultExpectation *AppPublicServiceServerMockListChatMessagesExpectation
+	expectations       []*AppPublicServiceServerMockListChatMessagesExpectation
+
+	callArgs []*AppPublicServiceServerMockListChatMessagesParams
+	mutex    sync.RWMutex
+
+	expectedInvocations       uint64
+	expectedInvocationsOrigin string
+}
+
+// AppPublicServiceServerMockListChatMessagesExpectation specifies expectation struct of the AppPublicServiceServer.ListChatMessages
+type AppPublicServiceServerMockListChatMessagesExpectation struct {
+	mock               *AppPublicServiceServerMock
+	params             *AppPublicServiceServerMockListChatMessagesParams
+	paramPtrs          *AppPublicServiceServerMockListChatMessagesParamPtrs
+	expectationOrigins AppPublicServiceServerMockListChatMessagesExpectationOrigins
+	results            *AppPublicServiceServerMockListChatMessagesResults
+	returnOrigin       string
+	Counter            uint64
+}
+
+// AppPublicServiceServerMockListChatMessagesParams contains parameters of the AppPublicServiceServer.ListChatMessages
+type AppPublicServiceServerMockListChatMessagesParams struct {
+	ctx context.Context
+	lp1 *mm_appv1alpha.ListChatMessagesRequest
+}
+
+// AppPublicServiceServerMockListChatMessagesParamPtrs contains pointers to parameters of the AppPublicServiceServer.ListChatMessages
+type AppPublicServiceServerMockListChatMessagesParamPtrs struct {
+	ctx *context.Context
+	lp1 **mm_appv1alpha.ListChatMessagesRequest
+}
+
+// AppPublicServiceServerMockListChatMessagesResults contains results of the AppPublicServiceServer.ListChatMessages
+type AppPublicServiceServerMockListChatMessagesResults struct {
+	lp2 *mm_appv1alpha.ListChatMessagesResponse
+	err error
+}
+
+// AppPublicServiceServerMockListChatMessagesOrigins contains origins of expectations of the AppPublicServiceServer.ListChatMessages
+type AppPublicServiceServerMockListChatMessagesExpectationOrigins struct {
+	origin    string
+	originCtx string
+	originLp1 string
+}
+
+// Marks this method to be optional. The default behavior of any method with Return() is '1 or more', meaning
+// the test will fail minimock's automatic final call check if the mocked method was not called at least once.
+// Optional() makes method check to work in '0 or more' mode.
+// It is NOT RECOMMENDED to use this option unless you really need it, as default behaviour helps to
+// catch the problems when the expected method call is totally skipped during test run.
+func (mmListChatMessages *mAppPublicServiceServerMockListChatMessages) Optional() *mAppPublicServiceServerMockListChatMessages {
+	mmListChatMessages.optional = true
+	return mmListChatMessages
+}
+
+// Expect sets up expected params for AppPublicServiceServer.ListChatMessages
+func (mmListChatMessages *mAppPublicServiceServerMockListChatMessages) Expect(ctx context.Context, lp1 *mm_appv1alpha.ListChatMessagesRequest) *mAppPublicServiceServerMockListChatMessages {
+	if mmListChatMessages.mock.funcListChatMessages != nil {
+		mmListChatMessages.mock.t.Fatalf("AppPublicServiceServerMock.ListChatMessages mock is already set by Set")
+	}
+
+	if mmListChatMessages.defaultExpectation == nil {
+		mmListChatMessages.defaultExpectation = &AppPublicServiceServerMockListChatMessagesExpectation{}
+	}
+
+	if mmListChatMessages.defaultExpectation.paramPtrs != nil {
+		mmListChatMessages.mock.t.Fatalf("AppPublicServiceServerMock.ListChatMessages mock is already set by ExpectParams functions")
+	}
+
+	mmListChatMessages.defaultExpectation.params = &AppPublicServiceServerMockListChatMessagesParams{ctx, lp1}
+	mmListChatMessages.defaultExpectation.expectationOrigins.origin = minimock.CallerInfo(1)
+	for _, e := range mmListChatMessages.expectations {
+		if minimock.Equal(e.params, mmListChatMessages.defaultExpectation.params) {
+			mmListChatMessages.mock.t.Fatalf("Expectation set by When has same params: %#v", *mmListChatMessages.defaultExpectation.params)
+		}
+	}
+
+	return mmListChatMessages
+}
+
+// ExpectCtxParam1 sets up expected param ctx for AppPublicServiceServer.ListChatMessages
+func (mmListChatMessages *mAppPublicServiceServerMockListChatMessages) ExpectCtxParam1(ctx context.Context) *mAppPublicServiceServerMockListChatMessages {
+	if mmListChatMessages.mock.funcListChatMessages != nil {
+		mmListChatMessages.mock.t.Fatalf("AppPublicServiceServerMock.ListChatMessages mock is already set by Set")
+	}
+
+	if mmListChatMessages.defaultExpectation == nil {
+		mmListChatMessages.defaultExpectation = &AppPublicServiceServerMockListChatMessagesExpectation{}
+	}
+
+	if mmListChatMessages.defaultExpectation.params != nil {
+		mmListChatMessages.mock.t.Fatalf("AppPublicServiceServerMock.ListChatMessages mock is already set by Expect")
+	}
+
+	if mmListChatMessages.defaultExpectation.paramPtrs == nil {
+		mmListChatMessages.defaultExpectation.paramPtrs = &AppPublicServiceServerMockListChatMessagesParamPtrs{}
+	}
+	mmListChatMessages.defaultExpectation.paramPtrs.ctx = &ctx
+	mmListChatMessages.defaultExpectation.expectationOrigins.originCtx = minimock.CallerInfo(1)
+
+	return mmListChatMessages
+}
+
+// ExpectLp1Param2 sets up expected param lp1 for AppPublicServiceServer.ListChatMessages
+func (mmListChatMessages *mAppPublicServiceServerMockListChatMessages) ExpectLp1Param2(lp1 *mm_appv1alpha.ListChatMessagesRequest) *mAppPublicServiceServerMockListChatMessages {
+	if mmListChatMessages.mock.funcListChatMessages != nil {
+		mmListChatMessages.mock.t.Fatalf("AppPublicServiceServerMock.ListChatMessages mock is already set by Set")
+	}
+
+	if mmListChatMessages.defaultExpectation == nil {
+		mmListChatMessages.defaultExpectation = &AppPublicServiceServerMockListChatMessagesExpectation{}
+	}
+
+	if mmListChatMessages.defaultExpectation.params != nil {
+		mmListChatMessages.mock.t.Fatalf("AppPublicServiceServerMock.ListChatMessages mock is already set by Expect")
+	}
+
+	if mmListChatMessages.defaultExpectation.paramPtrs == nil {
+		mmListChatMessages.defaultExpectation.paramPtrs = &AppPublicServiceServerMockListChatMessagesParamPtrs{}
+	}
+	mmListChatMessages.defaultExpectation.paramPtrs.lp1 = &lp1
+	mmListChatMessages.defaultExpectation.expectationOrigins.originLp1 = minimock.CallerInfo(1)
+
+	return mmListChatMessages
+}
+
+// Inspect accepts an inspector function that has same arguments as the AppPublicServiceServer.ListChatMessages
+func (mmListChatMessages *mAppPublicServiceServerMockListChatMessages) Inspect(f func(ctx context.Context, lp1 *mm_appv1alpha.ListChatMessagesRequest)) *mAppPublicServiceServerMockListChatMessages {
+	if mmListChatMessages.mock.inspectFuncListChatMessages != nil {
+		mmListChatMessages.mock.t.Fatalf("Inspect function is already set for AppPublicServiceServerMock.ListChatMessages")
+	}
+
+	mmListChatMessages.mock.inspectFuncListChatMessages = f
+
+	return mmListChatMessages
+}
+
+// Return sets up results that will be returned by AppPublicServiceServer.ListChatMessages
+func (mmListChatMessages *mAppPublicServiceServerMockListChatMessages) Return(lp2 *mm_appv1alpha.ListChatMessagesResponse, err error) *AppPublicServiceServerMock {
+	if mmListChatMessages.mock.funcListChatMessages != nil {
+		mmListChatMessages.mock.t.Fatalf("AppPublicServiceServerMock.ListChatMessages mock is already set by Set")
+	}
+
+	if mmListChatMessages.defaultExpectation == nil {
+		mmListChatMessages.defaultExpectation = &AppPublicServiceServerMockListChatMessagesExpectation{mock: mmListChatMessages.mock}
+	}
+	mmListChatMessages.defaultExpectation.results = &AppPublicServiceServerMockListChatMessagesResults{lp2, err}
+	mmListChatMessages.defaultExpectation.returnOrigin = minimock.CallerInfo(1)
+	return mmListChatMessages.mock
+}
+
+// Set uses given function f to mock the AppPublicServiceServer.ListChatMessages method
+func (mmListChatMessages *mAppPublicServiceServerMockListChatMessages) Set(f func(ctx context.Context, lp1 *mm_appv1alpha.ListChatMessagesRequest) (lp2 *mm_appv1alpha.ListChatMessagesResponse, err error)) *AppPublicServiceServerMock {
+	if mmListChatMessages.defaultExpectation != nil {
+		mmListChatMessages.mock.t.Fatalf("Default expectation is already set for the AppPublicServiceServer.ListChatMessages method")
+	}
+
+	if len(mmListChatMessages.expectations) > 0 {
+		mmListChatMessages.mock.t.Fatalf("Some expectations are already set for the AppPublicServiceServer.ListChatMessages method")
+	}
+
+	mmListChatMessages.mock.funcListChatMessages = f
+	mmListChatMessages.mock.funcListChatMessagesOrigin = minimock.CallerInfo(1)
+	return mmListChatMessages.mock
+}
+
+// When sets expectation for the AppPublicServiceServer.ListChatMessages which will trigger the result defined by the following
+// Then helper
+func (mmListChatMessages *mAppPublicServiceServerMockListChatMessages) When(ctx context.Context, lp1 *mm_appv1alpha.ListChatMessagesRequest) *AppPublicServiceServerMockListChatMessagesExpectation {
+	if mmListChatMessages.mock.funcListChatMessages != nil {
+		mmListChatMessages.mock.t.Fatalf("AppPublicServiceServerMock.ListChatMessages mock is already set by Set")
+	}
+
+	expectation := &AppPublicServiceServerMockListChatMessagesExpectation{
+		mock:               mmListChatMessages.mock,
+		params:             &AppPublicServiceServerMockListChatMessagesParams{ctx, lp1},
+		expectationOrigins: AppPublicServiceServerMockListChatMessagesExpectationOrigins{origin: minimock.CallerInfo(1)},
+	}
+	mmListChatMessages.expectations = append(mmListChatMessages.expectations, expectation)
+	return expectation
+}
+
+// Then sets up AppPublicServiceServer.ListChatMessages return parameters for the expectation previously defined by the When method
+func (e *AppPublicServiceServerMockListChatMessagesExpectation) Then(lp2 *mm_appv1alpha.ListChatMessagesResponse, err error) *AppPublicServiceServerMock {
+	e.results = &AppPublicServiceServerMockListChatMessagesResults{lp2, err}
+	return e.mock
+}
+
+// Times sets number of times AppPublicServiceServer.ListChatMessages should be invoked
+func (mmListChatMessages *mAppPublicServiceServerMockListChatMessages) Times(n uint64) *mAppPublicServiceServerMockListChatMessages {
+	if n == 0 {
+		mmListChatMessages.mock.t.Fatalf("Times of AppPublicServiceServerMock.ListChatMessages mock can not be zero")
+	}
+	mm_atomic.StoreUint64(&mmListChatMessages.expectedInvocations, n)
+	mmListChatMessages.expectedInvocationsOrigin = minimock.CallerInfo(1)
+	return mmListChatMessages
+}
+
+func (mmListChatMessages *mAppPublicServiceServerMockListChatMessages) invocationsDone() bool {
+	if len(mmListChatMessages.expectations) == 0 && mmListChatMessages.defaultExpectation == nil && mmListChatMessages.mock.funcListChatMessages == nil {
+		return true
+	}
+
+	totalInvocations := mm_atomic.LoadUint64(&mmListChatMessages.mock.afterListChatMessagesCounter)
+	expectedInvocations := mm_atomic.LoadUint64(&mmListChatMessages.expectedInvocations)
+
+	return totalInvocations > 0 && (expectedInvocations == 0 || expectedInvocations == totalInvocations)
+}
+
+// ListChatMessages implements mm_appv1alpha.AppPublicServiceServer
+func (mmListChatMessages *AppPublicServiceServerMock) ListChatMessages(ctx context.Context, lp1 *mm_appv1alpha.ListChatMessagesRequest) (lp2 *mm_appv1alpha.ListChatMessagesResponse, err error) {
+	mm_atomic.AddUint64(&mmListChatMessages.beforeListChatMessagesCounter, 1)
+	defer mm_atomic.AddUint64(&mmListChatMessages.afterListChatMessagesCounter, 1)
+
+	mmListChatMessages.t.Helper()
+
+	if mmListChatMessages.inspectFuncListChatMessages != nil {
+		mmListChatMessages.inspectFuncListChatMessages(ctx, lp1)
+	}
+
+	mm_params := AppPublicServiceServerMockListChatMessagesParams{ctx, lp1}
+
+	// Record call args
+	mmListChatMessages.ListChatMessagesMock.mutex.Lock()
+	mmListChatMessages.ListChatMessagesMock.callArgs = append(mmListChatMessages.ListChatMessagesMock.callArgs, &mm_params)
+	mmListChatMessages.ListChatMessagesMock.mutex.Unlock()
+
+	for _, e := range mmListChatMessages.ListChatMessagesMock.expectations {
+		if minimock.Equal(*e.params, mm_params) {
+			mm_atomic.AddUint64(&e.Counter, 1)
+			return e.results.lp2, e.results.err
+		}
+	}
+
+	if mmListChatMessages.ListChatMessagesMock.defaultExpectation != nil {
+		mm_atomic.AddUint64(&mmListChatMessages.ListChatMessagesMock.defaultExpectation.Counter, 1)
+		mm_want := mmListChatMessages.ListChatMessagesMock.defaultExpectation.params
+		mm_want_ptrs := mmListChatMessages.ListChatMessagesMock.defaultExpectation.paramPtrs
+
+		mm_got := AppPublicServiceServerMockListChatMessagesParams{ctx, lp1}
+
+		if mm_want_ptrs != nil {
+
+			if mm_want_ptrs.ctx != nil && !minimock.Equal(*mm_want_ptrs.ctx, mm_got.ctx) {
+				mmListChatMessages.t.Errorf("AppPublicServiceServerMock.ListChatMessages got unexpected parameter ctx, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmListChatMessages.ListChatMessagesMock.defaultExpectation.expectationOrigins.originCtx, *mm_want_ptrs.ctx, mm_got.ctx, minimock.Diff(*mm_want_ptrs.ctx, mm_got.ctx))
+			}
+
+			if mm_want_ptrs.lp1 != nil && !minimock.Equal(*mm_want_ptrs.lp1, mm_got.lp1) {
+				mmListChatMessages.t.Errorf("AppPublicServiceServerMock.ListChatMessages got unexpected parameter lp1, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmListChatMessages.ListChatMessagesMock.defaultExpectation.expectationOrigins.originLp1, *mm_want_ptrs.lp1, mm_got.lp1, minimock.Diff(*mm_want_ptrs.lp1, mm_got.lp1))
+			}
+
+		} else if mm_want != nil && !minimock.Equal(*mm_want, mm_got) {
+			mmListChatMessages.t.Errorf("AppPublicServiceServerMock.ListChatMessages got unexpected parameters, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+				mmListChatMessages.ListChatMessagesMock.defaultExpectation.expectationOrigins.origin, *mm_want, mm_got, minimock.Diff(*mm_want, mm_got))
+		}
+
+		mm_results := mmListChatMessages.ListChatMessagesMock.defaultExpectation.results
+		if mm_results == nil {
+			mmListChatMessages.t.Fatal("No results are set for the AppPublicServiceServerMock.ListChatMessages")
+		}
+		return (*mm_results).lp2, (*mm_results).err
+	}
+	if mmListChatMessages.funcListChatMessages != nil {
+		return mmListChatMessages.funcListChatMessages(ctx, lp1)
+	}
+	mmListChatMessages.t.Fatalf("Unexpected call to AppPublicServiceServerMock.ListChatMessages. %v %v", ctx, lp1)
+	return
+}
+
+// ListChatMessagesAfterCounter returns a count of finished AppPublicServiceServerMock.ListChatMessages invocations
+func (mmListChatMessages *AppPublicServiceServerMock) ListChatMessagesAfterCounter() uint64 {
+	return mm_atomic.LoadUint64(&mmListChatMessages.afterListChatMessagesCounter)
+}
+
+// ListChatMessagesBeforeCounter returns a count of AppPublicServiceServerMock.ListChatMessages invocations
+func (mmListChatMessages *AppPublicServiceServerMock) ListChatMessagesBeforeCounter() uint64 {
+	return mm_atomic.LoadUint64(&mmListChatMessages.beforeListChatMessagesCounter)
+}
+
+// Calls returns a list of arguments used in each call to AppPublicServiceServerMock.ListChatMessages.
+// The list is in the same order as the calls were made (i.e. recent calls have a higher index)
+func (mmListChatMessages *mAppPublicServiceServerMockListChatMessages) Calls() []*AppPublicServiceServerMockListChatMessagesParams {
+	mmListChatMessages.mutex.RLock()
+
+	argCopy := make([]*AppPublicServiceServerMockListChatMessagesParams, len(mmListChatMessages.callArgs))
+	copy(argCopy, mmListChatMessages.callArgs)
+
+	mmListChatMessages.mutex.RUnlock()
+
+	return argCopy
+}
+
+// MinimockListChatMessagesDone returns true if the count of the ListChatMessages invocations corresponds
+// the number of defined expectations
+func (m *AppPublicServiceServerMock) MinimockListChatMessagesDone() bool {
+	if m.ListChatMessagesMock.optional {
+		// Optional methods provide '0 or more' call count restriction.
+		return true
+	}
+
+	for _, e := range m.ListChatMessagesMock.expectations {
+		if mm_atomic.LoadUint64(&e.Counter) < 1 {
+			return false
+		}
+	}
+
+	return m.ListChatMessagesMock.invocationsDone()
+}
+
+// MinimockListChatMessagesInspect logs each unmet expectation
+func (m *AppPublicServiceServerMock) MinimockListChatMessagesInspect() {
+	for _, e := range m.ListChatMessagesMock.expectations {
+		if mm_atomic.LoadUint64(&e.Counter) < 1 {
+			m.t.Errorf("Expected call to AppPublicServiceServerMock.ListChatMessages at\n%s with params: %#v", e.expectationOrigins.origin, *e.params)
+		}
+	}
+
+	afterListChatMessagesCounter := mm_atomic.LoadUint64(&m.afterListChatMessagesCounter)
+	// if default expectation was set then invocations count should be greater than zero
+	if m.ListChatMessagesMock.defaultExpectation != nil && afterListChatMessagesCounter < 1 {
+		if m.ListChatMessagesMock.defaultExpectation.params == nil {
+			m.t.Errorf("Expected call to AppPublicServiceServerMock.ListChatMessages at\n%s", m.ListChatMessagesMock.defaultExpectation.returnOrigin)
+		} else {
+			m.t.Errorf("Expected call to AppPublicServiceServerMock.ListChatMessages at\n%s with params: %#v", m.ListChatMessagesMock.defaultExpectation.expectationOrigins.origin, *m.ListChatMessagesMock.defaultExpectation.params)
+		}
+	}
+	// if func was set then invocations count should be greater than zero
+	if m.funcListChatMessages != nil && afterListChatMessagesCounter < 1 {
+		m.t.Errorf("Expected call to AppPublicServiceServerMock.ListChatMessages at\n%s", m.funcListChatMessagesOrigin)
+	}
+
+	if !m.ListChatMessagesMock.invocationsDone() && afterListChatMessagesCounter > 0 {
+		m.t.Errorf("Expected %d calls to AppPublicServiceServerMock.ListChatMessages at\n%s but found %d calls",
+			mm_atomic.LoadUint64(&m.ListChatMessagesMock.expectedInvocations), m.ListChatMessagesMock.expectedInvocationsOrigin, afterListChatMessagesCounter)
+	}
+}
+
+type mAppPublicServiceServerMockListChats struct {
+	optional           bool
+	mock               *AppPublicServiceServerMock
+	defaultExpectation *AppPublicServiceServerMockListChatsExpectation
+	expectations       []*AppPublicServiceServerMockListChatsExpectation
+
+	callArgs []*AppPublicServiceServerMockListChatsParams
+	mutex    sync.RWMutex
+
+	expectedInvocations       uint64
+	expectedInvocationsOrigin string
+}
+
+// AppPublicServiceServerMockListChatsExpectation specifies expectation struct of the AppPublicServiceServer.ListChats
+type AppPublicServiceServerMockListChatsExpectation struct {
+	mock               *AppPublicServiceServerMock
+	params             *AppPublicServiceServerMockListChatsParams
+	paramPtrs          *AppPublicServiceServerMockListChatsParamPtrs
+	expectationOrigins AppPublicServiceServerMockListChatsExpectationOrigins
+	results            *AppPublicServiceServerMockListChatsResults
+	returnOrigin       string
+	Counter            uint64
+}
+
+// AppPublicServiceServerMockListChatsParams contains parameters of the AppPublicServiceServer.ListChats
+type AppPublicServiceServerMockListChatsParams struct {
+	ctx context.Context
+	lp1 *mm_appv1alpha.ListChatsRequest
+}
+
+// AppPublicServiceServerMockListChatsParamPtrs contains pointers to parameters of the AppPublicServiceServer.ListChats
+type AppPublicServiceServerMockListChatsParamPtrs struct {
+	ctx *context.Context
+	lp1 **mm_appv1alpha.ListChatsRequest
+}
+
+// AppPublicServiceServerMockListChatsResults contains results of the AppPublicServiceServer.ListChats
+type AppPublicServiceServerMockListChatsResults struct {
+	lp2 *mm_appv1alpha.ListChatsResponse
+	err error
+}
+
+// AppPublicServiceServerMockListChatsOrigins contains origins of expectations of the AppPublicServiceServer.ListChats
+type AppPublicServiceServerMockListChatsExpectationOrigins struct {
+	origin    string
+	originCtx string
+	originLp1 string
+}
+
+// Marks this method to be optional. The default behavior of any method with Return() is '1 or more', meaning
+// the test will fail minimock's automatic final call check if the mocked method was not called at least once.
+// Optional() makes method check to work in '0 or more' mode.
+// It is NOT RECOMMENDED to use this option unless you really need it, as default behaviour helps to
+// catch the problems when the expected method call is totally skipped during test run.
+func (mmListChats *mAppPublicServiceServerMockListChats) Optional() *mAppPublicServiceServerMockListChats {
+	mmListChats.optional = true
+	return mmListChats
+}
+
+// Expect sets up expected params for AppPublicServiceServer.ListChats
+func (mmListChats *mAppPublicServiceServerMockListChats) Expect(ctx context.Context, lp1 *mm_appv1alpha.ListChatsRequest) *mAppPublicServiceServerMockListChats {
+	if mmListChats.mock.funcListChats != nil {
+		mmListChats.mock.t.Fatalf("AppPublicServiceServerMock.ListChats mock is already set by Set")
+	}
+
+	if mmListChats.defaultExpectation == nil {
+		mmListChats.defaultExpectation = &AppPublicServiceServerMockListChatsExpectation{}
+	}
+
+	if mmListChats.defaultExpectation.paramPtrs != nil {
+		mmListChats.mock.t.Fatalf("AppPublicServiceServerMock.ListChats mock is already set by ExpectParams functions")
+	}
+
+	mmListChats.defaultExpectation.params = &AppPublicServiceServerMockListChatsParams{ctx, lp1}
+	mmListChats.defaultExpectation.expectationOrigins.origin = minimock.CallerInfo(1)
+	for _, e := range mmListChats.expectations {
+		if minimock.Equal(e.params, mmListChats.defaultExpectation.params) {
+			mmListChats.mock.t.Fatalf("Expectation set by When has same params: %#v", *mmListChats.defaultExpectation.params)
+		}
+	}
+
+	return mmListChats
+}
+
+// ExpectCtxParam1 sets up expected param ctx for AppPublicServiceServer.ListChats
+func (mmListChats *mAppPublicServiceServerMockListChats) ExpectCtxParam1(ctx context.Context) *mAppPublicServiceServerMockListChats {
+	if mmListChats.mock.funcListChats != nil {
+		mmListChats.mock.t.Fatalf("AppPublicServiceServerMock.ListChats mock is already set by Set")
+	}
+
+	if mmListChats.defaultExpectation == nil {
+		mmListChats.defaultExpectation = &AppPublicServiceServerMockListChatsExpectation{}
+	}
+
+	if mmListChats.defaultExpectation.params != nil {
+		mmListChats.mock.t.Fatalf("AppPublicServiceServerMock.ListChats mock is already set by Expect")
+	}
+
+	if mmListChats.defaultExpectation.paramPtrs == nil {
+		mmListChats.defaultExpectation.paramPtrs = &AppPublicServiceServerMockListChatsParamPtrs{}
+	}
+	mmListChats.defaultExpectation.paramPtrs.ctx = &ctx
+	mmListChats.defaultExpectation.expectationOrigins.originCtx = minimock.CallerInfo(1)
+
+	return mmListChats
+}
+
+// ExpectLp1Param2 sets up expected param lp1 for AppPublicServiceServer.ListChats
+func (mmListChats *mAppPublicServiceServerMockListChats) ExpectLp1Param2(lp1 *mm_appv1alpha.ListChatsRequest) *mAppPublicServiceServerMockListChats {
+	if mmListChats.mock.funcListChats != nil {
+		mmListChats.mock.t.Fatalf("AppPublicServiceServerMock.ListChats mock is already set by Set")
+	}
+
+	if mmListChats.defaultExpectation == nil {
+		mmListChats.defaultExpectation = &AppPublicServiceServerMockListChatsExpectation{}
+	}
+
+	if mmListChats.defaultExpectation.params != nil {
+		mmListChats.mock.t.Fatalf("AppPublicServiceServerMock.ListChats mock is already set by Expect")
+	}
+
+	if mmListChats.defaultExpectation.paramPtrs == nil {
+		mmListChats.defaultExpectation.paramPtrs = &AppPublicServiceServerMockListChatsParamPtrs{}
+	}
+	mmListChats.defaultExpectation.paramPtrs.lp1 = &lp1
+	mmListChats.defaultExpectation.expectationOrigins.originLp1 = minimock.CallerInfo(1)
+
+	return mmListChats
+}
+
+// Inspect accepts an inspector function that has same arguments as the AppPublicServiceServer.ListChats
+func (mmListChats *mAppPublicServiceServerMockListChats) Inspect(f func(ctx context.Context, lp1 *mm_appv1alpha.ListChatsRequest)) *mAppPublicServiceServerMockListChats {
+	if mmListChats.mock.inspectFuncListChats != nil {
+		mmListChats.mock.t.Fatalf("Inspect function is already set for AppPublicServiceServerMock.ListChats")
+	}
+
+	mmListChats.mock.inspectFuncListChats = f
+
+	return mmListChats
+}
+
+// Return sets up results that will be returned by AppPublicServiceServer.ListChats
+func (mmListChats *mAppPublicServiceServerMockListChats) Return(lp2 *mm_appv1alpha.ListChatsResponse, err error) *AppPublicServiceServerMock {
+	if mmListChats.mock.funcListChats != nil {
+		mmListChats.mock.t.Fatalf("AppPublicServiceServerMock.ListChats mock is already set by Set")
+	}
+
+	if mmListChats.defaultExpectation == nil {
+		mmListChats.defaultExpectation = &AppPublicServiceServerMockListChatsExpectation{mock: mmListChats.mock}
+	}
+	mmListChats.defaultExpectation.results = &AppPublicServiceServerMockListChatsResults{lp2, err}
+	mmListChats.defaultExpectation.returnOrigin = minimock.CallerInfo(1)
+	return mmListChats.mock
+}
+
+// Set uses given function f to mock the AppPublicServiceServer.ListChats method
+func (mmListChats *mAppPublicServiceServerMockListChats) Set(f func(ctx context.Context, lp1 *mm_appv1alpha.ListChatsRequest) (lp2 *mm_appv1alpha.ListChatsResponse, err error)) *AppPublicServiceServerMock {
+	if mmListChats.defaultExpectation != nil {
+		mmListChats.mock.t.Fatalf("Default expectation is already set for the AppPublicServiceServer.ListChats method")
+	}
+
+	if len(mmListChats.expectations) > 0 {
+		mmListChats.mock.t.Fatalf("Some expectations are already set for the AppPublicServiceServer.ListChats method")
+	}
+
+	mmListChats.mock.funcListChats = f
+	mmListChats.mock.funcListChatsOrigin = minimock.CallerInfo(1)
+	return mmListChats.mock
+}
+
+// When sets expectation for the AppPublicServiceServer.ListChats which will trigger the result defined by the following
+// Then helper
+func (mmListChats *mAppPublicServiceServerMockListChats) When(ctx context.Context, lp1 *mm_appv1alpha.ListChatsRequest) *AppPublicServiceServerMockListChatsExpectation {
+	if mmListChats.mock.funcListChats != nil {
+		mmListChats.mock.t.Fatalf("AppPublicServiceServerMock.ListChats mock is already set by Set")
+	}
+
+	expectation := &AppPublicServiceServerMockListChatsExpectation{
+		mock:               mmListChats.mock,
+		params:             &AppPublicServiceServerMockListChatsParams{ctx, lp1},
+		expectationOrigins: AppPublicServiceServerMockListChatsExpectationOrigins{origin: minimock.CallerInfo(1)},
+	}
+	mmListChats.expectations = append(mmListChats.expectations, expectation)
+	return expectation
+}
+
+// Then sets up AppPublicServiceServer.ListChats return parameters for the expectation previously defined by the When method
+func (e *AppPublicServiceServerMockListChatsExpectation) Then(lp2 *mm_appv1alpha.ListChatsResponse, err error) *AppPublicServiceServerMock {
+	e.results = &AppPublicServiceServerMockListChatsResults{lp2, err}
+	return e.mock
+}
+
+// Times sets number of times AppPublicServiceServer.ListChats should be invoked
+func (mmListChats *mAppPublicServiceServerMockListChats) Times(n uint64) *mAppPublicServiceServerMockListChats {
+	if n == 0 {
+		mmListChats.mock.t.Fatalf("Times of AppPublicServiceServerMock.ListChats mock can not be zero")
+	}
+	mm_atomic.StoreUint64(&mmListChats.expectedInvocations, n)
+	mmListChats.expectedInvocationsOrigin = minimock.CallerInfo(1)
+	return mmListChats
+}
+
+func (mmListChats *mAppPublicServiceServerMockListChats) invocationsDone() bool {
+	if len(mmListChats.expectations) == 0 && mmListChats.defaultExpectation == nil && mmListChats.mock.funcListChats == nil {
+		return true
+	}
+
+	totalInvocations := mm_atomic.LoadUint64(&mmListChats.mock.afterListChatsCounter)
+	expectedInvocations := mm_atomic.LoadUint64(&mmListChats.expectedInvocations)
+
+	return totalInvocations > 0 && (expectedInvocations == 0 || expectedInvocations == totalInvocations)
+}
+
+// ListChats implements mm_appv1alpha.AppPublicServiceServer
+func (mmListChats *AppPublicServiceServerMock) ListChats(ctx context.Context, lp1 *mm_appv1alpha.ListChatsRequest) (lp2 *mm_appv1alpha.ListChatsResponse, err error) {
+	mm_atomic.AddUint64(&mmListChats.beforeListChatsCounter, 1)
+	defer mm_atomic.AddUint64(&mmListChats.afterListChatsCounter, 1)
+
+	mmListChats.t.Helper()
+
+	if mmListChats.inspectFuncListChats != nil {
+		mmListChats.inspectFuncListChats(ctx, lp1)
+	}
+
+	mm_params := AppPublicServiceServerMockListChatsParams{ctx, lp1}
+
+	// Record call args
+	mmListChats.ListChatsMock.mutex.Lock()
+	mmListChats.ListChatsMock.callArgs = append(mmListChats.ListChatsMock.callArgs, &mm_params)
+	mmListChats.ListChatsMock.mutex.Unlock()
+
+	for _, e := range mmListChats.ListChatsMock.expectations {
+		if minimock.Equal(*e.params, mm_params) {
+			mm_atomic.AddUint64(&e.Counter, 1)
+			return e.results.lp2, e.results.err
+		}
+	}
+
+	if mmListChats.ListChatsMock.defaultExpectation != nil {
+		mm_atomic.AddUint64(&mmListChats.ListChatsMock.defaultExpectation.Counter, 1)
+		mm_want := mmListChats.ListChatsMock.defaultExpectation.params
+		mm_want_ptrs := mmListChats.ListChatsMock.defaultExpectation.paramPtrs
+
+		mm_got := AppPublicServiceServerMockListChatsParams{ctx, lp1}
+
+		if mm_want_ptrs != nil {
+
+			if mm_want_ptrs.ctx != nil && !minimock.Equal(*mm_want_ptrs.ctx, mm_got.ctx) {
+				mmListChats.t.Errorf("AppPublicServiceServerMock.ListChats got unexpected parameter ctx, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmListChats.ListChatsMock.defaultExpectation.expectationOrigins.originCtx, *mm_want_ptrs.ctx, mm_got.ctx, minimock.Diff(*mm_want_ptrs.ctx, mm_got.ctx))
+			}
+
+			if mm_want_ptrs.lp1 != nil && !minimock.Equal(*mm_want_ptrs.lp1, mm_got.lp1) {
+				mmListChats.t.Errorf("AppPublicServiceServerMock.ListChats got unexpected parameter lp1, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmListChats.ListChatsMock.defaultExpectation.expectationOrigins.originLp1, *mm_want_ptrs.lp1, mm_got.lp1, minimock.Diff(*mm_want_ptrs.lp1, mm_got.lp1))
+			}
+
+		} else if mm_want != nil && !minimock.Equal(*mm_want, mm_got) {
+			mmListChats.t.Errorf("AppPublicServiceServerMock.ListChats got unexpected parameters, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+				mmListChats.ListChatsMock.defaultExpectation.expectationOrigins.origin, *mm_want, mm_got, minimock.Diff(*mm_want, mm_got))
+		}
+
+		mm_results := mmListChats.ListChatsMock.defaultExpectation.results
+		if mm_results == nil {
+			mmListChats.t.Fatal("No results are set for the AppPublicServiceServerMock.ListChats")
+		}
+		return (*mm_results).lp2, (*mm_results).err
+	}
+	if mmListChats.funcListChats != nil {
+		return mmListChats.funcListChats(ctx, lp1)
+	}
+	mmListChats.t.Fatalf("Unexpected call to AppPublicServiceServerMock.ListChats. %v %v", ctx, lp1)
+	return
+}
+
+// ListChatsAfterCounter returns a count of finished AppPublicServiceServerMock.ListChats invocations
+func (mmListChats *AppPublicServiceServerMock) ListChatsAfterCounter() uint64 {
+	return mm_atomic.LoadUint64(&mmListChats.afterListChatsCounter)
+}
+
+// ListChatsBeforeCounter returns a count of AppPublicServiceServerMock.ListChats invocations
+func (mmListChats *AppPublicServiceServerMock) ListChatsBeforeCounter() uint64 {
+	return mm_atomic.LoadUint64(&mmListChats.beforeListChatsCounter)
+}
+
+// Calls returns a list of arguments used in each call to AppPublicServiceServerMock.ListChats.
+// The list is in the same order as the calls were made (i.e. recent calls have a higher index)
+func (mmListChats *mAppPublicServiceServerMockListChats) Calls() []*AppPublicServiceServerMockListChatsParams {
+	mmListChats.mutex.RLock()
+
+	argCopy := make([]*AppPublicServiceServerMockListChatsParams, len(mmListChats.callArgs))
+	copy(argCopy, mmListChats.callArgs)
+
+	mmListChats.mutex.RUnlock()
+
+	return argCopy
+}
+
+// MinimockListChatsDone returns true if the count of the ListChats invocations corresponds
+// the number of defined expectations
+func (m *AppPublicServiceServerMock) MinimockListChatsDone() bool {
+	if m.ListChatsMock.optional {
+		// Optional methods provide '0 or more' call count restriction.
+		return true
+	}
+
+	for _, e := range m.ListChatsMock.expectations {
+		if mm_atomic.LoadUint64(&e.Counter) < 1 {
+			return false
+		}
+	}
+
+	return m.ListChatsMock.invocationsDone()
+}
+
+// MinimockListChatsInspect logs each unmet expectation
+func (m *AppPublicServiceServerMock) MinimockListChatsInspect() {
+	for _, e := range m.ListChatsMock.expectations {
+		if mm_atomic.LoadUint64(&e.Counter) < 1 {
+			m.t.Errorf("Expected call to AppPublicServiceServerMock.ListChats at\n%s with params: %#v", e.expectationOrigins.origin, *e.params)
+		}
+	}
+
+	afterListChatsCounter := mm_atomic.LoadUint64(&m.afterListChatsCounter)
+	// if default expectation was set then invocations count should be greater than zero
+	if m.ListChatsMock.defaultExpectation != nil && afterListChatsCounter < 1 {
+		if m.ListChatsMock.defaultExpectation.params == nil {
+			m.t.Errorf("Expected call to AppPublicServiceServerMock.ListChats at\n%s", m.ListChatsMock.defaultExpectation.returnOrigin)
+		} else {
+			m.t.Errorf("Expected call to AppPublicServiceServerMock.ListChats at\n%s with params: %#v", m.ListChatsMock.defaultExpectation.expectationOrigins.origin, *m.ListChatsMock.defaultExpectation.params)
+		}
+	}
+	// if func was set then invocations count should be greater than zero
+	if m.funcListChats != nil && afterListChatsCounter < 1 {
+		m.t.Errorf("Expected call to AppPublicServiceServerMock.ListChats at\n%s", m.funcListChatsOrigin)
+	}
+
+	if !m.ListChatsMock.invocationsDone() && afterListChatsCounter > 0 {
+		m.t.Errorf("Expected %d calls to AppPublicServiceServerMock.ListChats at\n%s but found %d calls",
+			mm_atomic.LoadUint64(&m.ListChatsMock.expectedInvocations), m.ListChatsMock.expectedInvocationsOrigin, afterListChatsCounter)
 	}
 }
 
@@ -5346,6 +6768,349 @@ func (m *AppPublicServiceServerMock) MinimockUpdateAppInspect() {
 	}
 }
 
+type mAppPublicServiceServerMockUpdateChat struct {
+	optional           bool
+	mock               *AppPublicServiceServerMock
+	defaultExpectation *AppPublicServiceServerMockUpdateChatExpectation
+	expectations       []*AppPublicServiceServerMockUpdateChatExpectation
+
+	callArgs []*AppPublicServiceServerMockUpdateChatParams
+	mutex    sync.RWMutex
+
+	expectedInvocations       uint64
+	expectedInvocationsOrigin string
+}
+
+// AppPublicServiceServerMockUpdateChatExpectation specifies expectation struct of the AppPublicServiceServer.UpdateChat
+type AppPublicServiceServerMockUpdateChatExpectation struct {
+	mock               *AppPublicServiceServerMock
+	params             *AppPublicServiceServerMockUpdateChatParams
+	paramPtrs          *AppPublicServiceServerMockUpdateChatParamPtrs
+	expectationOrigins AppPublicServiceServerMockUpdateChatExpectationOrigins
+	results            *AppPublicServiceServerMockUpdateChatResults
+	returnOrigin       string
+	Counter            uint64
+}
+
+// AppPublicServiceServerMockUpdateChatParams contains parameters of the AppPublicServiceServer.UpdateChat
+type AppPublicServiceServerMockUpdateChatParams struct {
+	ctx context.Context
+	up1 *mm_appv1alpha.UpdateChatRequest
+}
+
+// AppPublicServiceServerMockUpdateChatParamPtrs contains pointers to parameters of the AppPublicServiceServer.UpdateChat
+type AppPublicServiceServerMockUpdateChatParamPtrs struct {
+	ctx *context.Context
+	up1 **mm_appv1alpha.UpdateChatRequest
+}
+
+// AppPublicServiceServerMockUpdateChatResults contains results of the AppPublicServiceServer.UpdateChat
+type AppPublicServiceServerMockUpdateChatResults struct {
+	up2 *mm_appv1alpha.UpdateChatResponse
+	err error
+}
+
+// AppPublicServiceServerMockUpdateChatOrigins contains origins of expectations of the AppPublicServiceServer.UpdateChat
+type AppPublicServiceServerMockUpdateChatExpectationOrigins struct {
+	origin    string
+	originCtx string
+	originUp1 string
+}
+
+// Marks this method to be optional. The default behavior of any method with Return() is '1 or more', meaning
+// the test will fail minimock's automatic final call check if the mocked method was not called at least once.
+// Optional() makes method check to work in '0 or more' mode.
+// It is NOT RECOMMENDED to use this option unless you really need it, as default behaviour helps to
+// catch the problems when the expected method call is totally skipped during test run.
+func (mmUpdateChat *mAppPublicServiceServerMockUpdateChat) Optional() *mAppPublicServiceServerMockUpdateChat {
+	mmUpdateChat.optional = true
+	return mmUpdateChat
+}
+
+// Expect sets up expected params for AppPublicServiceServer.UpdateChat
+func (mmUpdateChat *mAppPublicServiceServerMockUpdateChat) Expect(ctx context.Context, up1 *mm_appv1alpha.UpdateChatRequest) *mAppPublicServiceServerMockUpdateChat {
+	if mmUpdateChat.mock.funcUpdateChat != nil {
+		mmUpdateChat.mock.t.Fatalf("AppPublicServiceServerMock.UpdateChat mock is already set by Set")
+	}
+
+	if mmUpdateChat.defaultExpectation == nil {
+		mmUpdateChat.defaultExpectation = &AppPublicServiceServerMockUpdateChatExpectation{}
+	}
+
+	if mmUpdateChat.defaultExpectation.paramPtrs != nil {
+		mmUpdateChat.mock.t.Fatalf("AppPublicServiceServerMock.UpdateChat mock is already set by ExpectParams functions")
+	}
+
+	mmUpdateChat.defaultExpectation.params = &AppPublicServiceServerMockUpdateChatParams{ctx, up1}
+	mmUpdateChat.defaultExpectation.expectationOrigins.origin = minimock.CallerInfo(1)
+	for _, e := range mmUpdateChat.expectations {
+		if minimock.Equal(e.params, mmUpdateChat.defaultExpectation.params) {
+			mmUpdateChat.mock.t.Fatalf("Expectation set by When has same params: %#v", *mmUpdateChat.defaultExpectation.params)
+		}
+	}
+
+	return mmUpdateChat
+}
+
+// ExpectCtxParam1 sets up expected param ctx for AppPublicServiceServer.UpdateChat
+func (mmUpdateChat *mAppPublicServiceServerMockUpdateChat) ExpectCtxParam1(ctx context.Context) *mAppPublicServiceServerMockUpdateChat {
+	if mmUpdateChat.mock.funcUpdateChat != nil {
+		mmUpdateChat.mock.t.Fatalf("AppPublicServiceServerMock.UpdateChat mock is already set by Set")
+	}
+
+	if mmUpdateChat.defaultExpectation == nil {
+		mmUpdateChat.defaultExpectation = &AppPublicServiceServerMockUpdateChatExpectation{}
+	}
+
+	if mmUpdateChat.defaultExpectation.params != nil {
+		mmUpdateChat.mock.t.Fatalf("AppPublicServiceServerMock.UpdateChat mock is already set by Expect")
+	}
+
+	if mmUpdateChat.defaultExpectation.paramPtrs == nil {
+		mmUpdateChat.defaultExpectation.paramPtrs = &AppPublicServiceServerMockUpdateChatParamPtrs{}
+	}
+	mmUpdateChat.defaultExpectation.paramPtrs.ctx = &ctx
+	mmUpdateChat.defaultExpectation.expectationOrigins.originCtx = minimock.CallerInfo(1)
+
+	return mmUpdateChat
+}
+
+// ExpectUp1Param2 sets up expected param up1 for AppPublicServiceServer.UpdateChat
+func (mmUpdateChat *mAppPublicServiceServerMockUpdateChat) ExpectUp1Param2(up1 *mm_appv1alpha.UpdateChatRequest) *mAppPublicServiceServerMockUpdateChat {
+	if mmUpdateChat.mock.funcUpdateChat != nil {
+		mmUpdateChat.mock.t.Fatalf("AppPublicServiceServerMock.UpdateChat mock is already set by Set")
+	}
+
+	if mmUpdateChat.defaultExpectation == nil {
+		mmUpdateChat.defaultExpectation = &AppPublicServiceServerMockUpdateChatExpectation{}
+	}
+
+	if mmUpdateChat.defaultExpectation.params != nil {
+		mmUpdateChat.mock.t.Fatalf("AppPublicServiceServerMock.UpdateChat mock is already set by Expect")
+	}
+
+	if mmUpdateChat.defaultExpectation.paramPtrs == nil {
+		mmUpdateChat.defaultExpectation.paramPtrs = &AppPublicServiceServerMockUpdateChatParamPtrs{}
+	}
+	mmUpdateChat.defaultExpectation.paramPtrs.up1 = &up1
+	mmUpdateChat.defaultExpectation.expectationOrigins.originUp1 = minimock.CallerInfo(1)
+
+	return mmUpdateChat
+}
+
+// Inspect accepts an inspector function that has same arguments as the AppPublicServiceServer.UpdateChat
+func (mmUpdateChat *mAppPublicServiceServerMockUpdateChat) Inspect(f func(ctx context.Context, up1 *mm_appv1alpha.UpdateChatRequest)) *mAppPublicServiceServerMockUpdateChat {
+	if mmUpdateChat.mock.inspectFuncUpdateChat != nil {
+		mmUpdateChat.mock.t.Fatalf("Inspect function is already set for AppPublicServiceServerMock.UpdateChat")
+	}
+
+	mmUpdateChat.mock.inspectFuncUpdateChat = f
+
+	return mmUpdateChat
+}
+
+// Return sets up results that will be returned by AppPublicServiceServer.UpdateChat
+func (mmUpdateChat *mAppPublicServiceServerMockUpdateChat) Return(up2 *mm_appv1alpha.UpdateChatResponse, err error) *AppPublicServiceServerMock {
+	if mmUpdateChat.mock.funcUpdateChat != nil {
+		mmUpdateChat.mock.t.Fatalf("AppPublicServiceServerMock.UpdateChat mock is already set by Set")
+	}
+
+	if mmUpdateChat.defaultExpectation == nil {
+		mmUpdateChat.defaultExpectation = &AppPublicServiceServerMockUpdateChatExpectation{mock: mmUpdateChat.mock}
+	}
+	mmUpdateChat.defaultExpectation.results = &AppPublicServiceServerMockUpdateChatResults{up2, err}
+	mmUpdateChat.defaultExpectation.returnOrigin = minimock.CallerInfo(1)
+	return mmUpdateChat.mock
+}
+
+// Set uses given function f to mock the AppPublicServiceServer.UpdateChat method
+func (mmUpdateChat *mAppPublicServiceServerMockUpdateChat) Set(f func(ctx context.Context, up1 *mm_appv1alpha.UpdateChatRequest) (up2 *mm_appv1alpha.UpdateChatResponse, err error)) *AppPublicServiceServerMock {
+	if mmUpdateChat.defaultExpectation != nil {
+		mmUpdateChat.mock.t.Fatalf("Default expectation is already set for the AppPublicServiceServer.UpdateChat method")
+	}
+
+	if len(mmUpdateChat.expectations) > 0 {
+		mmUpdateChat.mock.t.Fatalf("Some expectations are already set for the AppPublicServiceServer.UpdateChat method")
+	}
+
+	mmUpdateChat.mock.funcUpdateChat = f
+	mmUpdateChat.mock.funcUpdateChatOrigin = minimock.CallerInfo(1)
+	return mmUpdateChat.mock
+}
+
+// When sets expectation for the AppPublicServiceServer.UpdateChat which will trigger the result defined by the following
+// Then helper
+func (mmUpdateChat *mAppPublicServiceServerMockUpdateChat) When(ctx context.Context, up1 *mm_appv1alpha.UpdateChatRequest) *AppPublicServiceServerMockUpdateChatExpectation {
+	if mmUpdateChat.mock.funcUpdateChat != nil {
+		mmUpdateChat.mock.t.Fatalf("AppPublicServiceServerMock.UpdateChat mock is already set by Set")
+	}
+
+	expectation := &AppPublicServiceServerMockUpdateChatExpectation{
+		mock:               mmUpdateChat.mock,
+		params:             &AppPublicServiceServerMockUpdateChatParams{ctx, up1},
+		expectationOrigins: AppPublicServiceServerMockUpdateChatExpectationOrigins{origin: minimock.CallerInfo(1)},
+	}
+	mmUpdateChat.expectations = append(mmUpdateChat.expectations, expectation)
+	return expectation
+}
+
+// Then sets up AppPublicServiceServer.UpdateChat return parameters for the expectation previously defined by the When method
+func (e *AppPublicServiceServerMockUpdateChatExpectation) Then(up2 *mm_appv1alpha.UpdateChatResponse, err error) *AppPublicServiceServerMock {
+	e.results = &AppPublicServiceServerMockUpdateChatResults{up2, err}
+	return e.mock
+}
+
+// Times sets number of times AppPublicServiceServer.UpdateChat should be invoked
+func (mmUpdateChat *mAppPublicServiceServerMockUpdateChat) Times(n uint64) *mAppPublicServiceServerMockUpdateChat {
+	if n == 0 {
+		mmUpdateChat.mock.t.Fatalf("Times of AppPublicServiceServerMock.UpdateChat mock can not be zero")
+	}
+	mm_atomic.StoreUint64(&mmUpdateChat.expectedInvocations, n)
+	mmUpdateChat.expectedInvocationsOrigin = minimock.CallerInfo(1)
+	return mmUpdateChat
+}
+
+func (mmUpdateChat *mAppPublicServiceServerMockUpdateChat) invocationsDone() bool {
+	if len(mmUpdateChat.expectations) == 0 && mmUpdateChat.defaultExpectation == nil && mmUpdateChat.mock.funcUpdateChat == nil {
+		return true
+	}
+
+	totalInvocations := mm_atomic.LoadUint64(&mmUpdateChat.mock.afterUpdateChatCounter)
+	expectedInvocations := mm_atomic.LoadUint64(&mmUpdateChat.expectedInvocations)
+
+	return totalInvocations > 0 && (expectedInvocations == 0 || expectedInvocations == totalInvocations)
+}
+
+// UpdateChat implements mm_appv1alpha.AppPublicServiceServer
+func (mmUpdateChat *AppPublicServiceServerMock) UpdateChat(ctx context.Context, up1 *mm_appv1alpha.UpdateChatRequest) (up2 *mm_appv1alpha.UpdateChatResponse, err error) {
+	mm_atomic.AddUint64(&mmUpdateChat.beforeUpdateChatCounter, 1)
+	defer mm_atomic.AddUint64(&mmUpdateChat.afterUpdateChatCounter, 1)
+
+	mmUpdateChat.t.Helper()
+
+	if mmUpdateChat.inspectFuncUpdateChat != nil {
+		mmUpdateChat.inspectFuncUpdateChat(ctx, up1)
+	}
+
+	mm_params := AppPublicServiceServerMockUpdateChatParams{ctx, up1}
+
+	// Record call args
+	mmUpdateChat.UpdateChatMock.mutex.Lock()
+	mmUpdateChat.UpdateChatMock.callArgs = append(mmUpdateChat.UpdateChatMock.callArgs, &mm_params)
+	mmUpdateChat.UpdateChatMock.mutex.Unlock()
+
+	for _, e := range mmUpdateChat.UpdateChatMock.expectations {
+		if minimock.Equal(*e.params, mm_params) {
+			mm_atomic.AddUint64(&e.Counter, 1)
+			return e.results.up2, e.results.err
+		}
+	}
+
+	if mmUpdateChat.UpdateChatMock.defaultExpectation != nil {
+		mm_atomic.AddUint64(&mmUpdateChat.UpdateChatMock.defaultExpectation.Counter, 1)
+		mm_want := mmUpdateChat.UpdateChatMock.defaultExpectation.params
+		mm_want_ptrs := mmUpdateChat.UpdateChatMock.defaultExpectation.paramPtrs
+
+		mm_got := AppPublicServiceServerMockUpdateChatParams{ctx, up1}
+
+		if mm_want_ptrs != nil {
+
+			if mm_want_ptrs.ctx != nil && !minimock.Equal(*mm_want_ptrs.ctx, mm_got.ctx) {
+				mmUpdateChat.t.Errorf("AppPublicServiceServerMock.UpdateChat got unexpected parameter ctx, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmUpdateChat.UpdateChatMock.defaultExpectation.expectationOrigins.originCtx, *mm_want_ptrs.ctx, mm_got.ctx, minimock.Diff(*mm_want_ptrs.ctx, mm_got.ctx))
+			}
+
+			if mm_want_ptrs.up1 != nil && !minimock.Equal(*mm_want_ptrs.up1, mm_got.up1) {
+				mmUpdateChat.t.Errorf("AppPublicServiceServerMock.UpdateChat got unexpected parameter up1, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmUpdateChat.UpdateChatMock.defaultExpectation.expectationOrigins.originUp1, *mm_want_ptrs.up1, mm_got.up1, minimock.Diff(*mm_want_ptrs.up1, mm_got.up1))
+			}
+
+		} else if mm_want != nil && !minimock.Equal(*mm_want, mm_got) {
+			mmUpdateChat.t.Errorf("AppPublicServiceServerMock.UpdateChat got unexpected parameters, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+				mmUpdateChat.UpdateChatMock.defaultExpectation.expectationOrigins.origin, *mm_want, mm_got, minimock.Diff(*mm_want, mm_got))
+		}
+
+		mm_results := mmUpdateChat.UpdateChatMock.defaultExpectation.results
+		if mm_results == nil {
+			mmUpdateChat.t.Fatal("No results are set for the AppPublicServiceServerMock.UpdateChat")
+		}
+		return (*mm_results).up2, (*mm_results).err
+	}
+	if mmUpdateChat.funcUpdateChat != nil {
+		return mmUpdateChat.funcUpdateChat(ctx, up1)
+	}
+	mmUpdateChat.t.Fatalf("Unexpected call to AppPublicServiceServerMock.UpdateChat. %v %v", ctx, up1)
+	return
+}
+
+// UpdateChatAfterCounter returns a count of finished AppPublicServiceServerMock.UpdateChat invocations
+func (mmUpdateChat *AppPublicServiceServerMock) UpdateChatAfterCounter() uint64 {
+	return mm_atomic.LoadUint64(&mmUpdateChat.afterUpdateChatCounter)
+}
+
+// UpdateChatBeforeCounter returns a count of AppPublicServiceServerMock.UpdateChat invocations
+func (mmUpdateChat *AppPublicServiceServerMock) UpdateChatBeforeCounter() uint64 {
+	return mm_atomic.LoadUint64(&mmUpdateChat.beforeUpdateChatCounter)
+}
+
+// Calls returns a list of arguments used in each call to AppPublicServiceServerMock.UpdateChat.
+// The list is in the same order as the calls were made (i.e. recent calls have a higher index)
+func (mmUpdateChat *mAppPublicServiceServerMockUpdateChat) Calls() []*AppPublicServiceServerMockUpdateChatParams {
+	mmUpdateChat.mutex.RLock()
+
+	argCopy := make([]*AppPublicServiceServerMockUpdateChatParams, len(mmUpdateChat.callArgs))
+	copy(argCopy, mmUpdateChat.callArgs)
+
+	mmUpdateChat.mutex.RUnlock()
+
+	return argCopy
+}
+
+// MinimockUpdateChatDone returns true if the count of the UpdateChat invocations corresponds
+// the number of defined expectations
+func (m *AppPublicServiceServerMock) MinimockUpdateChatDone() bool {
+	if m.UpdateChatMock.optional {
+		// Optional methods provide '0 or more' call count restriction.
+		return true
+	}
+
+	for _, e := range m.UpdateChatMock.expectations {
+		if mm_atomic.LoadUint64(&e.Counter) < 1 {
+			return false
+		}
+	}
+
+	return m.UpdateChatMock.invocationsDone()
+}
+
+// MinimockUpdateChatInspect logs each unmet expectation
+func (m *AppPublicServiceServerMock) MinimockUpdateChatInspect() {
+	for _, e := range m.UpdateChatMock.expectations {
+		if mm_atomic.LoadUint64(&e.Counter) < 1 {
+			m.t.Errorf("Expected call to AppPublicServiceServerMock.UpdateChat at\n%s with params: %#v", e.expectationOrigins.origin, *e.params)
+		}
+	}
+
+	afterUpdateChatCounter := mm_atomic.LoadUint64(&m.afterUpdateChatCounter)
+	// if default expectation was set then invocations count should be greater than zero
+	if m.UpdateChatMock.defaultExpectation != nil && afterUpdateChatCounter < 1 {
+		if m.UpdateChatMock.defaultExpectation.params == nil {
+			m.t.Errorf("Expected call to AppPublicServiceServerMock.UpdateChat at\n%s", m.UpdateChatMock.defaultExpectation.returnOrigin)
+		} else {
+			m.t.Errorf("Expected call to AppPublicServiceServerMock.UpdateChat at\n%s with params: %#v", m.UpdateChatMock.defaultExpectation.expectationOrigins.origin, *m.UpdateChatMock.defaultExpectation.params)
+		}
+	}
+	// if func was set then invocations count should be greater than zero
+	if m.funcUpdateChat != nil && afterUpdateChatCounter < 1 {
+		m.t.Errorf("Expected call to AppPublicServiceServerMock.UpdateChat at\n%s", m.funcUpdateChatOrigin)
+	}
+
+	if !m.UpdateChatMock.invocationsDone() && afterUpdateChatCounter > 0 {
+		m.t.Errorf("Expected %d calls to AppPublicServiceServerMock.UpdateChat at\n%s but found %d calls",
+			mm_atomic.LoadUint64(&m.UpdateChatMock.expectedInvocations), m.UpdateChatMock.expectedInvocationsOrigin, afterUpdateChatCounter)
+	}
+}
+
 type mAppPublicServiceServerMockUpdateConversation struct {
 	optional           bool
 	mock               *AppPublicServiceServerMock
@@ -6040,11 +7805,15 @@ func (m *AppPublicServiceServerMock) MinimockFinish() {
 
 			m.MinimockCreateAppInspect()
 
+			m.MinimockCreateChatInspect()
+
 			m.MinimockCreateConversationInspect()
 
 			m.MinimockCreateMessageInspect()
 
 			m.MinimockDeleteAppInspect()
+
+			m.MinimockDeleteChatInspect()
 
 			m.MinimockDeleteConversationInspect()
 
@@ -6053,6 +7822,10 @@ func (m *AppPublicServiceServerMock) MinimockFinish() {
 			m.MinimockGetPlaygroundConversationInspect()
 
 			m.MinimockListAppsInspect()
+
+			m.MinimockListChatMessagesInspect()
+
+			m.MinimockListChatsInspect()
 
 			m.MinimockListConversationsInspect()
 
@@ -6065,6 +7838,8 @@ func (m *AppPublicServiceServerMock) MinimockFinish() {
 			m.MinimockRestartPlaygroundConversationInspect()
 
 			m.MinimockUpdateAppInspect()
+
+			m.MinimockUpdateChatInspect()
 
 			m.MinimockUpdateConversationInspect()
 
@@ -6094,19 +7869,24 @@ func (m *AppPublicServiceServerMock) minimockDone() bool {
 	return done &&
 		m.MinimockChatDone() &&
 		m.MinimockCreateAppDone() &&
+		m.MinimockCreateChatDone() &&
 		m.MinimockCreateConversationDone() &&
 		m.MinimockCreateMessageDone() &&
 		m.MinimockDeleteAppDone() &&
+		m.MinimockDeleteChatDone() &&
 		m.MinimockDeleteConversationDone() &&
 		m.MinimockDeleteMessageDone() &&
 		m.MinimockGetPlaygroundConversationDone() &&
 		m.MinimockListAppsDone() &&
+		m.MinimockListChatMessagesDone() &&
+		m.MinimockListChatsDone() &&
 		m.MinimockListConversationsDone() &&
 		m.MinimockListMessagesDone() &&
 		m.MinimockLivenessDone() &&
 		m.MinimockReadinessDone() &&
 		m.MinimockRestartPlaygroundConversationDone() &&
 		m.MinimockUpdateAppDone() &&
+		m.MinimockUpdateChatDone() &&
 		m.MinimockUpdateConversationDone() &&
 		m.MinimockUpdateMessageDone()
 }

--- a/pkg/service/integration.go
+++ b/pkg/service/integration.go
@@ -149,17 +149,6 @@ func (s *service) componentDefinitionToIntegration(
 	integration.SetupSchema = setup.GetStructValue()
 	schemaFields := integration.SetupSchema.GetFields()
 
-	//nolint:staticcheck
-	// This is deprecated and only maintained for backwards compatibility.
-	// TODO jvallesm: remove when Integration Milestone 2 (OAuth) is rolled
-	// out.
-	integration.Schemas = []*pb.Integration_SetupSchema{
-		{
-			Method: pb.Connection_METHOD_DICTIONARY,
-			Schema: setup.GetStructValue(),
-		},
-	}
-
 	supportsOAuth, err := s.component.SupportsOAuth(uuid.FromStringOrNil(integration.Uid))
 	if err != nil {
 		return nil, fmt.Errorf("checking OAuth support: %w", err)


### PR DESCRIPTION
Because

- The `schemas` field was added under the wrong assumption that the
  integration schemas would differ across connection methods (OAuth vs
  key-value).
- After deprecating this field and providing an alternative
`setupSchema`
  field, all the clients for the deprecated one have been removed.
  Therefore, removing the deprecated field won't break any client.

This commit

- Removes the deprecated `schemas` field.
