### PR TITLE
feat(trigger): enable optional values for variables

### DIFF
--- a/pkg/recipe/dag.go
+++ b/pkg/recipe/dag.go
@@ -160,14 +160,6 @@ func (d *dag) TopologicalSort() ([]datamodel.ComponentMap, error) {
 	return ans, nil
 }
 
-func resolveReference(ctx context.Context, wfm memory.WorkflowMemory, batchIdx int, path string) (format.Value, error) {
-	v, err := wfm.Get(ctx, batchIdx, path)
-	if err != nil {
-		return nil, err
-	}
-	return v, err
-}
-
 func Render(ctx context.Context, template format.Value, batchIdx int, wfm memory.WorkflowMemory, allowUnresolved bool) (format.Value, error) {
 	if input, ok := template.(format.ReferenceString); ok {
 		s := input.String()
@@ -178,7 +170,7 @@ func Render(ctx context.Context, template format.Value, batchIdx int, wfm memory
 			if s == constant.SegSecret+"."+constant.GlobalSecretKey {
 				return data.NewString(componentbase.SecretKeyword), nil
 			}
-			val, err := resolveReference(ctx, wfm, batchIdx, s)
+			val, err := wfm.Get(ctx, batchIdx, s)
 			if err != nil {
 				if allowUnresolved {
 					return data.NewNull(), nil
@@ -207,7 +199,7 @@ func Render(ctx context.Context, template format.Value, batchIdx int, wfm memory
 			}
 
 			ref := strings.TrimSpace(s[2:endIdx])
-			v, err := resolveReference(ctx, wfm, batchIdx, ref)
+			v, err := wfm.Get(ctx, batchIdx, ref)
 			if err != nil {
 				if allowUnresolved {
 					return data.NewNull(), nil

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -889,8 +889,11 @@ func (s *service) preTriggerPipeline(ctx context.Context, ns resource.Namespace,
 			}
 
 			if v == nil {
+				// If the field has no value and no default value is specified,
+				// represent it as null, we treat null as missing value
 				if d, ok := defaultValueMap[k]; !ok || d == nil {
-					return fmt.Errorf("%w: missing or invalid value for %s field \"%s\"", errdomain.ErrInvalidArgument, formatMap[k], k)
+					variable[k] = data.NewNull()
+					continue
 				}
 			}
 


### PR DESCRIPTION
Because

- Variables might sometimes be optional to provide flexibility. We want pipeline variables to support optional values.

This commit

- Enables optional values for variables.