### PR TITLE
feat(component,data,base): enhance component features

### DIFF
--- a/pkg/component/base/execution.go
+++ b/pkg/component/base/execution.go
@@ -25,6 +25,7 @@ type IExecution interface {
 	GetComponent() IComponent
 	GetComponentID() string
 	UsesInstillCredentials() bool
+	FillInDefaultValues(input any) error
 
 	Execute(context.Context, []*Job) error
 }

--- a/pkg/worker/io.go
+++ b/pkg/worker/io.go
@@ -2,9 +2,11 @@ package worker
 
 import (
 	"context"
+	"fmt"
 
 	"google.golang.org/protobuf/types/known/structpb"
 
+	"github.com/instill-ai/pipeline-backend/pkg/component/base"
 	"github.com/instill-ai/pipeline-backend/pkg/data"
 	"github.com/instill-ai/pipeline-backend/pkg/data/format"
 	"github.com/instill-ai/pipeline-backend/pkg/external"
@@ -52,14 +54,16 @@ type inputReader struct {
 	wfm           memory.WorkflowMemory
 	originalIdx   int
 	binaryFetcher external.BinaryFetcher
+	execution     base.IExecution
 }
 
-func NewInputReader(wfm memory.WorkflowMemory, compID string, originalIdx int, binaryFetcher external.BinaryFetcher) *inputReader {
+func NewInputReader(wfm memory.WorkflowMemory, compID string, originalIdx int, binaryFetcher external.BinaryFetcher, execution base.IExecution) *inputReader {
 	return &inputReader{
 		compID:        compID,
 		wfm:           wfm,
 		originalIdx:   originalIdx,
 		binaryFetcher: binaryFetcher,
+		execution:     execution,
 	}
 }
 
@@ -106,8 +110,17 @@ func (i *inputReader) ReadData(ctx context.Context, input any) (err error) {
 	if err != nil {
 		return err
 	}
+
 	unmarshaler := data.NewUnmarshaler(i.binaryFetcher)
-	return unmarshaler.Unmarshal(ctx, inputVal, input)
+	if err := unmarshaler.Unmarshal(ctx, inputVal, input); err != nil {
+		return err
+	}
+
+	if err := i.execution.FillInDefaultValues(input); err != nil {
+		return fmt.Errorf("filling default values: %w", err)
+	}
+
+	return nil
 }
 
 type outputWriter struct {

--- a/pkg/worker/workflow.go
+++ b/pkg/worker/workflow.go
@@ -585,7 +585,7 @@ func (w *worker) ComponentActivity(ctx context.Context, param *ComponentActivity
 	jobs := make([]*componentbase.Job, len(conditionMap))
 	for idx, originalIdx := range conditionMap {
 		jobs[idx] = &componentbase.Job{
-			Input:  NewInputReader(wfm, param.ID, originalIdx, w.binaryFetcher),
+			Input:  NewInputReader(wfm, param.ID, originalIdx, w.binaryFetcher, execution),
 			Output: NewOutputWriter(wfm, param.ID, originalIdx, wfm.IsStreaming()),
 			Error:  NewErrorHandler(wfm, param.ID, originalIdx),
 		}


### PR DESCRIPTION
Because

- the current component initialisation with JSON Schema misses key features

This commit

- add compositional struct support
- support default value injection
- add support for JSON Schema `allOf` for multiple `$ref` used in an object (flattened into the object properties)
```
{
  "type": "object",
  "allOf": [
    { "$ref": "#/definitions/address" },
    { "$ref": "#/definitions/person" }
  ],
  "properties": {
    "customField": { "type": "string" }
  },
  "required": ["customField"]
}
```
