### PR TITLE
feat(recipe): separate the template and the rendered value for input and setup

### DIFF
--- a/pkg/memory/memory.go
+++ b/pkg/memory/memory.go
@@ -46,6 +46,11 @@ const (
 )
 
 const (
+	// Templates originate from the recipe and are used to render the actual
+	// input or setup data.
+	ComponentDataInputTemplate ComponentDataType = "input-template"
+	ComponentDataSetupTemplate ComponentDataType = "setup-template"
+
 	ComponentDataInput   ComponentDataType = "input"
 	ComponentDataOutput  ComponentDataType = "output"
 	ComponentDataElement ComponentDataType = "element"
@@ -258,9 +263,11 @@ func (wfm *workflowMemory) InitComponent(ctx context.Context, batchIdx int, comp
 
 	compMemory := data.Map{
 
-		string(ComponentDataInput):  data.Map{},
-		string(ComponentDataOutput): data.Map{},
-		string(ComponentDataSetup):  data.Map{},
+		string(ComponentDataInputTemplate): data.Map{},
+		string(ComponentDataSetupTemplate): data.Map{},
+		string(ComponentDataInput):         data.Map{},
+		string(ComponentDataOutput):        data.Map{},
+		string(ComponentDataSetup):         data.Map{},
 		string(ComponentDataError): data.Map{
 			"message": data.NewString(""),
 		},

--- a/pkg/worker/io.go
+++ b/pkg/worker/io.go
@@ -29,7 +29,7 @@ func NewSetupReader(wfm memory.WorkflowMemory, compID string, conditionMap map[i
 
 func (i *setupReader) Read(ctx context.Context) (setups []*structpb.Struct, err error) {
 	for idx := range len(i.conditionMap) {
-		setupTemplate, err := i.wfm.GetComponentData(ctx, i.conditionMap[idx], i.compID, memory.ComponentDataSetup)
+		setupTemplate, err := i.wfm.GetComponentData(ctx, i.conditionMap[idx], i.compID, memory.ComponentDataSetupTemplate)
 		if err != nil {
 			return nil, err
 		}
@@ -68,7 +68,7 @@ func NewInputReader(wfm memory.WorkflowMemory, compID string, originalIdx int, b
 // structpb is not suitable for handling binary data and will be phased out gradually.
 func (i *inputReader) read(ctx context.Context) (inputVal format.Value, err error) {
 
-	inputTemplate, err := i.wfm.GetComponentData(ctx, i.originalIdx, i.compID, memory.ComponentDataInput)
+	inputTemplate, err := i.wfm.GetComponentData(ctx, i.originalIdx, i.compID, memory.ComponentDataInputTemplate)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/worker/workflow.go
+++ b/pkg/worker/workflow.go
@@ -991,10 +991,10 @@ func (w *worker) PreIteratorActivity(ctx context.Context, param *PreIteratorActi
 				childWFM.InitComponent(ctx, e, compID)
 
 				inputVal = setIteratorIndex(inputVal, param.Index, rangeIndex)
-				if err := childWFM.SetComponentData(ctx, e, compID, memory.ComponentDataInput, inputVal); err != nil {
+				if err := childWFM.SetComponentData(ctx, e, compID, memory.ComponentDataInputTemplate, inputVal); err != nil {
 					return nil, componentActivityError(ctx, wfm, err, preIteratorActivityErrorType, param.ID)
 				}
-				if err := childWFM.SetComponentData(ctx, e, compID, memory.ComponentDataSetup, setupVal); err != nil {
+				if err := childWFM.SetComponentData(ctx, e, compID, memory.ComponentDataSetupTemplate, setupVal); err != nil {
 					return nil, componentActivityError(ctx, wfm, err, preIteratorActivityErrorType, param.ID)
 				}
 			}
@@ -1287,7 +1287,7 @@ func (w *worker) InitComponentsActivity(ctx context.Context, param *InitComponen
 			if err != nil {
 				return handleErr(fmt.Errorf("initializing pipeline input memory: %w", err))
 			}
-			if err := wfm.SetComponentData(ctx, idx, compID, memory.ComponentDataInput, inputVal); err != nil {
+			if err := wfm.SetComponentData(ctx, idx, compID, memory.ComponentDataInputTemplate, inputVal); err != nil {
 				return handleErr(fmt.Errorf("initializing pipeline input memory: %w", err))
 			}
 
@@ -1295,7 +1295,7 @@ func (w *worker) InitComponentsActivity(ctx context.Context, param *InitComponen
 			if err != nil {
 				return handleErr(fmt.Errorf("initializing pipeline setup memory: %w", err))
 			}
-			if err := wfm.SetComponentData(ctx, idx, compID, memory.ComponentDataSetup, setupVal); err != nil {
+			if err := wfm.SetComponentData(ctx, idx, compID, memory.ComponentDataSetupTemplate, setupVal); err != nil {
 				return handleErr(fmt.Errorf("initializing pipeline setup memory: %w", err))
 			}
 		}


### PR DESCRIPTION
Because

- We want to preserve the original template for the input and setup sections in the recipe.

This commit

- Separates the template from the rendered values for input and setup.