### PR TITLE
feat(connection): add lookup connection endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/h2non/filetype v1.1.3
 	github.com/iancoleman/strcase v0.3.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241129102337-37e5db84ca7f
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241129105617-c2c298e76498
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.5.0-alpha.0.20241119141833-e4a78ca87792
 	github.com/itchyny/gojq v0.12.14

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/h2non/filetype v1.1.3
 	github.com/iancoleman/strcase v0.3.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241129072738-55710ccd25ba
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241129102337-37e5db84ca7f
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.5.0-alpha.0.20241119141833-e4a78ca87792
 	github.com/itchyny/gojq v0.12.14

--- a/go.sum
+++ b/go.sum
@@ -1281,8 +1281,8 @@ github.com/influxdata/influxdb-client-go/v2 v2.12.3 h1:28nRlNMRIV4QbtIUvxhWqaxn0
 github.com/influxdata/influxdb-client-go/v2 v2.12.3/go.mod h1:IrrLUbCjjfkmRuaCiGQg4m2GbkaeJDcuWoxiWdQEbA0=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241129072738-55710ccd25ba h1:JrRwf/Wn2fgyp5DDcCyVT7rtBVcbo4GcQPs9YDlCPsc=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241129072738-55710ccd25ba/go.mod h1:rf0UY7VpEgpaLudYEcjx5rnbuwlBaaLyD4FQmWLtgAY=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241129102337-37e5db84ca7f h1:Cd7DieUBJEAUGgRB/lFmmXQp6wIPX9DOgwmMWecNZLw=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241129102337-37e5db84ca7f/go.mod h1:rf0UY7VpEgpaLudYEcjx5rnbuwlBaaLyD4FQmWLtgAY=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a/go.mod h1:EpX3Yr661uWULtZf5UnJHfr5rw2PDyX8ku4Kx0UtYFw=
 github.com/instill-ai/x v0.5.0-alpha.0.20241119141833-e4a78ca87792 h1:b4lhXcFJ/kGGC1RErtItoI57paf9WXBCVpaPIAApldY=

--- a/go.sum
+++ b/go.sum
@@ -1281,8 +1281,8 @@ github.com/influxdata/influxdb-client-go/v2 v2.12.3 h1:28nRlNMRIV4QbtIUvxhWqaxn0
 github.com/influxdata/influxdb-client-go/v2 v2.12.3/go.mod h1:IrrLUbCjjfkmRuaCiGQg4m2GbkaeJDcuWoxiWdQEbA0=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241129102337-37e5db84ca7f h1:Cd7DieUBJEAUGgRB/lFmmXQp6wIPX9DOgwmMWecNZLw=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241129102337-37e5db84ca7f/go.mod h1:rf0UY7VpEgpaLudYEcjx5rnbuwlBaaLyD4FQmWLtgAY=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241129105617-c2c298e76498 h1:JYRfk/m+960jEScE1NPQM+xh+ScR4cHNMg/tCFwQbpI=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241129105617-c2c298e76498/go.mod h1:rf0UY7VpEgpaLudYEcjx5rnbuwlBaaLyD4FQmWLtgAY=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a/go.mod h1:EpX3Yr661uWULtZf5UnJHfr5rw2PDyX8ku4Kx0UtYFw=
 github.com/instill-ai/x v0.5.0-alpha.0.20241119141833-e4a78ca87792 h1:b4lhXcFJ/kGGC1RErtItoI57paf9WXBCVpaPIAApldY=

--- a/integration-test/proto/vdp/pipeline/v1beta/integration.proto
+++ b/integration-test/proto/vdp/pipeline/v1beta/integration.proto
@@ -311,7 +311,7 @@ message GetIntegrationResponse {
 // connection by UID.
 message LookUpConnectionAdminRequest {
   // Connection UID.
-  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  string uid = 1 [(google.api.field_behavior) = REQUIRED];
   // View allows clients to specify the desired view in the response. It
   // defaults to `VIEW_BASIC`.
   optional View view = 2 [(google.api.field_behavior) = OPTIONAL];

--- a/pkg/component/internal/mock/artifact_public_service_client_mock.gen.go
+++ b/pkg/component/internal/mock/artifact_public_service_client_mock.gen.go
@@ -123,6 +123,20 @@ type ArtifactPublicServiceClientMock struct {
 	beforeReadinessCounter uint64
 	ReadinessMock          mArtifactPublicServiceClientMockReadiness
 
+	funcSearchChunks          func(ctx context.Context, in *mm_artifactv1alpha.SearchChunksRequest, opts ...grpc.CallOption) (sp1 *mm_artifactv1alpha.SearchChunksResponse, err error)
+	funcSearchChunksOrigin    string
+	inspectFuncSearchChunks   func(ctx context.Context, in *mm_artifactv1alpha.SearchChunksRequest, opts ...grpc.CallOption)
+	afterSearchChunksCounter  uint64
+	beforeSearchChunksCounter uint64
+	SearchChunksMock          mArtifactPublicServiceClientMockSearchChunks
+
+	funcSearchSourceFiles          func(ctx context.Context, in *mm_artifactv1alpha.SearchSourceFilesRequest, opts ...grpc.CallOption) (sp1 *mm_artifactv1alpha.SearchSourceFilesResponse, err error)
+	funcSearchSourceFilesOrigin    string
+	inspectFuncSearchSourceFiles   func(ctx context.Context, in *mm_artifactv1alpha.SearchSourceFilesRequest, opts ...grpc.CallOption)
+	afterSearchSourceFilesCounter  uint64
+	beforeSearchSourceFilesCounter uint64
+	SearchSourceFilesMock          mArtifactPublicServiceClientMockSearchSourceFiles
+
 	funcSimilarityChunksSearch          func(ctx context.Context, in *mm_artifactv1alpha.SimilarityChunksSearchRequest, opts ...grpc.CallOption) (sp1 *mm_artifactv1alpha.SimilarityChunksSearchResponse, err error)
 	funcSimilarityChunksSearchOrigin    string
 	inspectFuncSimilarityChunksSearch   func(ctx context.Context, in *mm_artifactv1alpha.SimilarityChunksSearchRequest, opts ...grpc.CallOption)
@@ -204,6 +218,12 @@ func NewArtifactPublicServiceClientMock(t minimock.Tester) *ArtifactPublicServic
 
 	m.ReadinessMock = mArtifactPublicServiceClientMockReadiness{mock: m}
 	m.ReadinessMock.callArgs = []*ArtifactPublicServiceClientMockReadinessParams{}
+
+	m.SearchChunksMock = mArtifactPublicServiceClientMockSearchChunks{mock: m}
+	m.SearchChunksMock.callArgs = []*ArtifactPublicServiceClientMockSearchChunksParams{}
+
+	m.SearchSourceFilesMock = mArtifactPublicServiceClientMockSearchSourceFiles{mock: m}
+	m.SearchSourceFilesMock.callArgs = []*ArtifactPublicServiceClientMockSearchSourceFilesParams{}
 
 	m.SimilarityChunksSearchMock = mArtifactPublicServiceClientMockSimilarityChunksSearch{mock: m}
 	m.SimilarityChunksSearchMock.callArgs = []*ArtifactPublicServiceClientMockSimilarityChunksSearchParams{}
@@ -5832,6 +5852,754 @@ func (m *ArtifactPublicServiceClientMock) MinimockReadinessInspect() {
 	}
 }
 
+type mArtifactPublicServiceClientMockSearchChunks struct {
+	optional           bool
+	mock               *ArtifactPublicServiceClientMock
+	defaultExpectation *ArtifactPublicServiceClientMockSearchChunksExpectation
+	expectations       []*ArtifactPublicServiceClientMockSearchChunksExpectation
+
+	callArgs []*ArtifactPublicServiceClientMockSearchChunksParams
+	mutex    sync.RWMutex
+
+	expectedInvocations       uint64
+	expectedInvocationsOrigin string
+}
+
+// ArtifactPublicServiceClientMockSearchChunksExpectation specifies expectation struct of the ArtifactPublicServiceClient.SearchChunks
+type ArtifactPublicServiceClientMockSearchChunksExpectation struct {
+	mock               *ArtifactPublicServiceClientMock
+	params             *ArtifactPublicServiceClientMockSearchChunksParams
+	paramPtrs          *ArtifactPublicServiceClientMockSearchChunksParamPtrs
+	expectationOrigins ArtifactPublicServiceClientMockSearchChunksExpectationOrigins
+	results            *ArtifactPublicServiceClientMockSearchChunksResults
+	returnOrigin       string
+	Counter            uint64
+}
+
+// ArtifactPublicServiceClientMockSearchChunksParams contains parameters of the ArtifactPublicServiceClient.SearchChunks
+type ArtifactPublicServiceClientMockSearchChunksParams struct {
+	ctx  context.Context
+	in   *mm_artifactv1alpha.SearchChunksRequest
+	opts []grpc.CallOption
+}
+
+// ArtifactPublicServiceClientMockSearchChunksParamPtrs contains pointers to parameters of the ArtifactPublicServiceClient.SearchChunks
+type ArtifactPublicServiceClientMockSearchChunksParamPtrs struct {
+	ctx  *context.Context
+	in   **mm_artifactv1alpha.SearchChunksRequest
+	opts *[]grpc.CallOption
+}
+
+// ArtifactPublicServiceClientMockSearchChunksResults contains results of the ArtifactPublicServiceClient.SearchChunks
+type ArtifactPublicServiceClientMockSearchChunksResults struct {
+	sp1 *mm_artifactv1alpha.SearchChunksResponse
+	err error
+}
+
+// ArtifactPublicServiceClientMockSearchChunksOrigins contains origins of expectations of the ArtifactPublicServiceClient.SearchChunks
+type ArtifactPublicServiceClientMockSearchChunksExpectationOrigins struct {
+	origin     string
+	originCtx  string
+	originIn   string
+	originOpts string
+}
+
+// Marks this method to be optional. The default behavior of any method with Return() is '1 or more', meaning
+// the test will fail minimock's automatic final call check if the mocked method was not called at least once.
+// Optional() makes method check to work in '0 or more' mode.
+// It is NOT RECOMMENDED to use this option unless you really need it, as default behaviour helps to
+// catch the problems when the expected method call is totally skipped during test run.
+func (mmSearchChunks *mArtifactPublicServiceClientMockSearchChunks) Optional() *mArtifactPublicServiceClientMockSearchChunks {
+	mmSearchChunks.optional = true
+	return mmSearchChunks
+}
+
+// Expect sets up expected params for ArtifactPublicServiceClient.SearchChunks
+func (mmSearchChunks *mArtifactPublicServiceClientMockSearchChunks) Expect(ctx context.Context, in *mm_artifactv1alpha.SearchChunksRequest, opts ...grpc.CallOption) *mArtifactPublicServiceClientMockSearchChunks {
+	if mmSearchChunks.mock.funcSearchChunks != nil {
+		mmSearchChunks.mock.t.Fatalf("ArtifactPublicServiceClientMock.SearchChunks mock is already set by Set")
+	}
+
+	if mmSearchChunks.defaultExpectation == nil {
+		mmSearchChunks.defaultExpectation = &ArtifactPublicServiceClientMockSearchChunksExpectation{}
+	}
+
+	if mmSearchChunks.defaultExpectation.paramPtrs != nil {
+		mmSearchChunks.mock.t.Fatalf("ArtifactPublicServiceClientMock.SearchChunks mock is already set by ExpectParams functions")
+	}
+
+	mmSearchChunks.defaultExpectation.params = &ArtifactPublicServiceClientMockSearchChunksParams{ctx, in, opts}
+	mmSearchChunks.defaultExpectation.expectationOrigins.origin = minimock.CallerInfo(1)
+	for _, e := range mmSearchChunks.expectations {
+		if minimock.Equal(e.params, mmSearchChunks.defaultExpectation.params) {
+			mmSearchChunks.mock.t.Fatalf("Expectation set by When has same params: %#v", *mmSearchChunks.defaultExpectation.params)
+		}
+	}
+
+	return mmSearchChunks
+}
+
+// ExpectCtxParam1 sets up expected param ctx for ArtifactPublicServiceClient.SearchChunks
+func (mmSearchChunks *mArtifactPublicServiceClientMockSearchChunks) ExpectCtxParam1(ctx context.Context) *mArtifactPublicServiceClientMockSearchChunks {
+	if mmSearchChunks.mock.funcSearchChunks != nil {
+		mmSearchChunks.mock.t.Fatalf("ArtifactPublicServiceClientMock.SearchChunks mock is already set by Set")
+	}
+
+	if mmSearchChunks.defaultExpectation == nil {
+		mmSearchChunks.defaultExpectation = &ArtifactPublicServiceClientMockSearchChunksExpectation{}
+	}
+
+	if mmSearchChunks.defaultExpectation.params != nil {
+		mmSearchChunks.mock.t.Fatalf("ArtifactPublicServiceClientMock.SearchChunks mock is already set by Expect")
+	}
+
+	if mmSearchChunks.defaultExpectation.paramPtrs == nil {
+		mmSearchChunks.defaultExpectation.paramPtrs = &ArtifactPublicServiceClientMockSearchChunksParamPtrs{}
+	}
+	mmSearchChunks.defaultExpectation.paramPtrs.ctx = &ctx
+	mmSearchChunks.defaultExpectation.expectationOrigins.originCtx = minimock.CallerInfo(1)
+
+	return mmSearchChunks
+}
+
+// ExpectInParam2 sets up expected param in for ArtifactPublicServiceClient.SearchChunks
+func (mmSearchChunks *mArtifactPublicServiceClientMockSearchChunks) ExpectInParam2(in *mm_artifactv1alpha.SearchChunksRequest) *mArtifactPublicServiceClientMockSearchChunks {
+	if mmSearchChunks.mock.funcSearchChunks != nil {
+		mmSearchChunks.mock.t.Fatalf("ArtifactPublicServiceClientMock.SearchChunks mock is already set by Set")
+	}
+
+	if mmSearchChunks.defaultExpectation == nil {
+		mmSearchChunks.defaultExpectation = &ArtifactPublicServiceClientMockSearchChunksExpectation{}
+	}
+
+	if mmSearchChunks.defaultExpectation.params != nil {
+		mmSearchChunks.mock.t.Fatalf("ArtifactPublicServiceClientMock.SearchChunks mock is already set by Expect")
+	}
+
+	if mmSearchChunks.defaultExpectation.paramPtrs == nil {
+		mmSearchChunks.defaultExpectation.paramPtrs = &ArtifactPublicServiceClientMockSearchChunksParamPtrs{}
+	}
+	mmSearchChunks.defaultExpectation.paramPtrs.in = &in
+	mmSearchChunks.defaultExpectation.expectationOrigins.originIn = minimock.CallerInfo(1)
+
+	return mmSearchChunks
+}
+
+// ExpectOptsParam3 sets up expected param opts for ArtifactPublicServiceClient.SearchChunks
+func (mmSearchChunks *mArtifactPublicServiceClientMockSearchChunks) ExpectOptsParam3(opts ...grpc.CallOption) *mArtifactPublicServiceClientMockSearchChunks {
+	if mmSearchChunks.mock.funcSearchChunks != nil {
+		mmSearchChunks.mock.t.Fatalf("ArtifactPublicServiceClientMock.SearchChunks mock is already set by Set")
+	}
+
+	if mmSearchChunks.defaultExpectation == nil {
+		mmSearchChunks.defaultExpectation = &ArtifactPublicServiceClientMockSearchChunksExpectation{}
+	}
+
+	if mmSearchChunks.defaultExpectation.params != nil {
+		mmSearchChunks.mock.t.Fatalf("ArtifactPublicServiceClientMock.SearchChunks mock is already set by Expect")
+	}
+
+	if mmSearchChunks.defaultExpectation.paramPtrs == nil {
+		mmSearchChunks.defaultExpectation.paramPtrs = &ArtifactPublicServiceClientMockSearchChunksParamPtrs{}
+	}
+	mmSearchChunks.defaultExpectation.paramPtrs.opts = &opts
+	mmSearchChunks.defaultExpectation.expectationOrigins.originOpts = minimock.CallerInfo(1)
+
+	return mmSearchChunks
+}
+
+// Inspect accepts an inspector function that has same arguments as the ArtifactPublicServiceClient.SearchChunks
+func (mmSearchChunks *mArtifactPublicServiceClientMockSearchChunks) Inspect(f func(ctx context.Context, in *mm_artifactv1alpha.SearchChunksRequest, opts ...grpc.CallOption)) *mArtifactPublicServiceClientMockSearchChunks {
+	if mmSearchChunks.mock.inspectFuncSearchChunks != nil {
+		mmSearchChunks.mock.t.Fatalf("Inspect function is already set for ArtifactPublicServiceClientMock.SearchChunks")
+	}
+
+	mmSearchChunks.mock.inspectFuncSearchChunks = f
+
+	return mmSearchChunks
+}
+
+// Return sets up results that will be returned by ArtifactPublicServiceClient.SearchChunks
+func (mmSearchChunks *mArtifactPublicServiceClientMockSearchChunks) Return(sp1 *mm_artifactv1alpha.SearchChunksResponse, err error) *ArtifactPublicServiceClientMock {
+	if mmSearchChunks.mock.funcSearchChunks != nil {
+		mmSearchChunks.mock.t.Fatalf("ArtifactPublicServiceClientMock.SearchChunks mock is already set by Set")
+	}
+
+	if mmSearchChunks.defaultExpectation == nil {
+		mmSearchChunks.defaultExpectation = &ArtifactPublicServiceClientMockSearchChunksExpectation{mock: mmSearchChunks.mock}
+	}
+	mmSearchChunks.defaultExpectation.results = &ArtifactPublicServiceClientMockSearchChunksResults{sp1, err}
+	mmSearchChunks.defaultExpectation.returnOrigin = minimock.CallerInfo(1)
+	return mmSearchChunks.mock
+}
+
+// Set uses given function f to mock the ArtifactPublicServiceClient.SearchChunks method
+func (mmSearchChunks *mArtifactPublicServiceClientMockSearchChunks) Set(f func(ctx context.Context, in *mm_artifactv1alpha.SearchChunksRequest, opts ...grpc.CallOption) (sp1 *mm_artifactv1alpha.SearchChunksResponse, err error)) *ArtifactPublicServiceClientMock {
+	if mmSearchChunks.defaultExpectation != nil {
+		mmSearchChunks.mock.t.Fatalf("Default expectation is already set for the ArtifactPublicServiceClient.SearchChunks method")
+	}
+
+	if len(mmSearchChunks.expectations) > 0 {
+		mmSearchChunks.mock.t.Fatalf("Some expectations are already set for the ArtifactPublicServiceClient.SearchChunks method")
+	}
+
+	mmSearchChunks.mock.funcSearchChunks = f
+	mmSearchChunks.mock.funcSearchChunksOrigin = minimock.CallerInfo(1)
+	return mmSearchChunks.mock
+}
+
+// When sets expectation for the ArtifactPublicServiceClient.SearchChunks which will trigger the result defined by the following
+// Then helper
+func (mmSearchChunks *mArtifactPublicServiceClientMockSearchChunks) When(ctx context.Context, in *mm_artifactv1alpha.SearchChunksRequest, opts ...grpc.CallOption) *ArtifactPublicServiceClientMockSearchChunksExpectation {
+	if mmSearchChunks.mock.funcSearchChunks != nil {
+		mmSearchChunks.mock.t.Fatalf("ArtifactPublicServiceClientMock.SearchChunks mock is already set by Set")
+	}
+
+	expectation := &ArtifactPublicServiceClientMockSearchChunksExpectation{
+		mock:               mmSearchChunks.mock,
+		params:             &ArtifactPublicServiceClientMockSearchChunksParams{ctx, in, opts},
+		expectationOrigins: ArtifactPublicServiceClientMockSearchChunksExpectationOrigins{origin: minimock.CallerInfo(1)},
+	}
+	mmSearchChunks.expectations = append(mmSearchChunks.expectations, expectation)
+	return expectation
+}
+
+// Then sets up ArtifactPublicServiceClient.SearchChunks return parameters for the expectation previously defined by the When method
+func (e *ArtifactPublicServiceClientMockSearchChunksExpectation) Then(sp1 *mm_artifactv1alpha.SearchChunksResponse, err error) *ArtifactPublicServiceClientMock {
+	e.results = &ArtifactPublicServiceClientMockSearchChunksResults{sp1, err}
+	return e.mock
+}
+
+// Times sets number of times ArtifactPublicServiceClient.SearchChunks should be invoked
+func (mmSearchChunks *mArtifactPublicServiceClientMockSearchChunks) Times(n uint64) *mArtifactPublicServiceClientMockSearchChunks {
+	if n == 0 {
+		mmSearchChunks.mock.t.Fatalf("Times of ArtifactPublicServiceClientMock.SearchChunks mock can not be zero")
+	}
+	mm_atomic.StoreUint64(&mmSearchChunks.expectedInvocations, n)
+	mmSearchChunks.expectedInvocationsOrigin = minimock.CallerInfo(1)
+	return mmSearchChunks
+}
+
+func (mmSearchChunks *mArtifactPublicServiceClientMockSearchChunks) invocationsDone() bool {
+	if len(mmSearchChunks.expectations) == 0 && mmSearchChunks.defaultExpectation == nil && mmSearchChunks.mock.funcSearchChunks == nil {
+		return true
+	}
+
+	totalInvocations := mm_atomic.LoadUint64(&mmSearchChunks.mock.afterSearchChunksCounter)
+	expectedInvocations := mm_atomic.LoadUint64(&mmSearchChunks.expectedInvocations)
+
+	return totalInvocations > 0 && (expectedInvocations == 0 || expectedInvocations == totalInvocations)
+}
+
+// SearchChunks implements mm_artifactv1alpha.ArtifactPublicServiceClient
+func (mmSearchChunks *ArtifactPublicServiceClientMock) SearchChunks(ctx context.Context, in *mm_artifactv1alpha.SearchChunksRequest, opts ...grpc.CallOption) (sp1 *mm_artifactv1alpha.SearchChunksResponse, err error) {
+	mm_atomic.AddUint64(&mmSearchChunks.beforeSearchChunksCounter, 1)
+	defer mm_atomic.AddUint64(&mmSearchChunks.afterSearchChunksCounter, 1)
+
+	mmSearchChunks.t.Helper()
+
+	if mmSearchChunks.inspectFuncSearchChunks != nil {
+		mmSearchChunks.inspectFuncSearchChunks(ctx, in, opts...)
+	}
+
+	mm_params := ArtifactPublicServiceClientMockSearchChunksParams{ctx, in, opts}
+
+	// Record call args
+	mmSearchChunks.SearchChunksMock.mutex.Lock()
+	mmSearchChunks.SearchChunksMock.callArgs = append(mmSearchChunks.SearchChunksMock.callArgs, &mm_params)
+	mmSearchChunks.SearchChunksMock.mutex.Unlock()
+
+	for _, e := range mmSearchChunks.SearchChunksMock.expectations {
+		if minimock.Equal(*e.params, mm_params) {
+			mm_atomic.AddUint64(&e.Counter, 1)
+			return e.results.sp1, e.results.err
+		}
+	}
+
+	if mmSearchChunks.SearchChunksMock.defaultExpectation != nil {
+		mm_atomic.AddUint64(&mmSearchChunks.SearchChunksMock.defaultExpectation.Counter, 1)
+		mm_want := mmSearchChunks.SearchChunksMock.defaultExpectation.params
+		mm_want_ptrs := mmSearchChunks.SearchChunksMock.defaultExpectation.paramPtrs
+
+		mm_got := ArtifactPublicServiceClientMockSearchChunksParams{ctx, in, opts}
+
+		if mm_want_ptrs != nil {
+
+			if mm_want_ptrs.ctx != nil && !minimock.Equal(*mm_want_ptrs.ctx, mm_got.ctx) {
+				mmSearchChunks.t.Errorf("ArtifactPublicServiceClientMock.SearchChunks got unexpected parameter ctx, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmSearchChunks.SearchChunksMock.defaultExpectation.expectationOrigins.originCtx, *mm_want_ptrs.ctx, mm_got.ctx, minimock.Diff(*mm_want_ptrs.ctx, mm_got.ctx))
+			}
+
+			if mm_want_ptrs.in != nil && !minimock.Equal(*mm_want_ptrs.in, mm_got.in) {
+				mmSearchChunks.t.Errorf("ArtifactPublicServiceClientMock.SearchChunks got unexpected parameter in, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmSearchChunks.SearchChunksMock.defaultExpectation.expectationOrigins.originIn, *mm_want_ptrs.in, mm_got.in, minimock.Diff(*mm_want_ptrs.in, mm_got.in))
+			}
+
+			if mm_want_ptrs.opts != nil && !minimock.Equal(*mm_want_ptrs.opts, mm_got.opts) {
+				mmSearchChunks.t.Errorf("ArtifactPublicServiceClientMock.SearchChunks got unexpected parameter opts, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmSearchChunks.SearchChunksMock.defaultExpectation.expectationOrigins.originOpts, *mm_want_ptrs.opts, mm_got.opts, minimock.Diff(*mm_want_ptrs.opts, mm_got.opts))
+			}
+
+		} else if mm_want != nil && !minimock.Equal(*mm_want, mm_got) {
+			mmSearchChunks.t.Errorf("ArtifactPublicServiceClientMock.SearchChunks got unexpected parameters, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+				mmSearchChunks.SearchChunksMock.defaultExpectation.expectationOrigins.origin, *mm_want, mm_got, minimock.Diff(*mm_want, mm_got))
+		}
+
+		mm_results := mmSearchChunks.SearchChunksMock.defaultExpectation.results
+		if mm_results == nil {
+			mmSearchChunks.t.Fatal("No results are set for the ArtifactPublicServiceClientMock.SearchChunks")
+		}
+		return (*mm_results).sp1, (*mm_results).err
+	}
+	if mmSearchChunks.funcSearchChunks != nil {
+		return mmSearchChunks.funcSearchChunks(ctx, in, opts...)
+	}
+	mmSearchChunks.t.Fatalf("Unexpected call to ArtifactPublicServiceClientMock.SearchChunks. %v %v %v", ctx, in, opts)
+	return
+}
+
+// SearchChunksAfterCounter returns a count of finished ArtifactPublicServiceClientMock.SearchChunks invocations
+func (mmSearchChunks *ArtifactPublicServiceClientMock) SearchChunksAfterCounter() uint64 {
+	return mm_atomic.LoadUint64(&mmSearchChunks.afterSearchChunksCounter)
+}
+
+// SearchChunksBeforeCounter returns a count of ArtifactPublicServiceClientMock.SearchChunks invocations
+func (mmSearchChunks *ArtifactPublicServiceClientMock) SearchChunksBeforeCounter() uint64 {
+	return mm_atomic.LoadUint64(&mmSearchChunks.beforeSearchChunksCounter)
+}
+
+// Calls returns a list of arguments used in each call to ArtifactPublicServiceClientMock.SearchChunks.
+// The list is in the same order as the calls were made (i.e. recent calls have a higher index)
+func (mmSearchChunks *mArtifactPublicServiceClientMockSearchChunks) Calls() []*ArtifactPublicServiceClientMockSearchChunksParams {
+	mmSearchChunks.mutex.RLock()
+
+	argCopy := make([]*ArtifactPublicServiceClientMockSearchChunksParams, len(mmSearchChunks.callArgs))
+	copy(argCopy, mmSearchChunks.callArgs)
+
+	mmSearchChunks.mutex.RUnlock()
+
+	return argCopy
+}
+
+// MinimockSearchChunksDone returns true if the count of the SearchChunks invocations corresponds
+// the number of defined expectations
+func (m *ArtifactPublicServiceClientMock) MinimockSearchChunksDone() bool {
+	if m.SearchChunksMock.optional {
+		// Optional methods provide '0 or more' call count restriction.
+		return true
+	}
+
+	for _, e := range m.SearchChunksMock.expectations {
+		if mm_atomic.LoadUint64(&e.Counter) < 1 {
+			return false
+		}
+	}
+
+	return m.SearchChunksMock.invocationsDone()
+}
+
+// MinimockSearchChunksInspect logs each unmet expectation
+func (m *ArtifactPublicServiceClientMock) MinimockSearchChunksInspect() {
+	for _, e := range m.SearchChunksMock.expectations {
+		if mm_atomic.LoadUint64(&e.Counter) < 1 {
+			m.t.Errorf("Expected call to ArtifactPublicServiceClientMock.SearchChunks at\n%s with params: %#v", e.expectationOrigins.origin, *e.params)
+		}
+	}
+
+	afterSearchChunksCounter := mm_atomic.LoadUint64(&m.afterSearchChunksCounter)
+	// if default expectation was set then invocations count should be greater than zero
+	if m.SearchChunksMock.defaultExpectation != nil && afterSearchChunksCounter < 1 {
+		if m.SearchChunksMock.defaultExpectation.params == nil {
+			m.t.Errorf("Expected call to ArtifactPublicServiceClientMock.SearchChunks at\n%s", m.SearchChunksMock.defaultExpectation.returnOrigin)
+		} else {
+			m.t.Errorf("Expected call to ArtifactPublicServiceClientMock.SearchChunks at\n%s with params: %#v", m.SearchChunksMock.defaultExpectation.expectationOrigins.origin, *m.SearchChunksMock.defaultExpectation.params)
+		}
+	}
+	// if func was set then invocations count should be greater than zero
+	if m.funcSearchChunks != nil && afterSearchChunksCounter < 1 {
+		m.t.Errorf("Expected call to ArtifactPublicServiceClientMock.SearchChunks at\n%s", m.funcSearchChunksOrigin)
+	}
+
+	if !m.SearchChunksMock.invocationsDone() && afterSearchChunksCounter > 0 {
+		m.t.Errorf("Expected %d calls to ArtifactPublicServiceClientMock.SearchChunks at\n%s but found %d calls",
+			mm_atomic.LoadUint64(&m.SearchChunksMock.expectedInvocations), m.SearchChunksMock.expectedInvocationsOrigin, afterSearchChunksCounter)
+	}
+}
+
+type mArtifactPublicServiceClientMockSearchSourceFiles struct {
+	optional           bool
+	mock               *ArtifactPublicServiceClientMock
+	defaultExpectation *ArtifactPublicServiceClientMockSearchSourceFilesExpectation
+	expectations       []*ArtifactPublicServiceClientMockSearchSourceFilesExpectation
+
+	callArgs []*ArtifactPublicServiceClientMockSearchSourceFilesParams
+	mutex    sync.RWMutex
+
+	expectedInvocations       uint64
+	expectedInvocationsOrigin string
+}
+
+// ArtifactPublicServiceClientMockSearchSourceFilesExpectation specifies expectation struct of the ArtifactPublicServiceClient.SearchSourceFiles
+type ArtifactPublicServiceClientMockSearchSourceFilesExpectation struct {
+	mock               *ArtifactPublicServiceClientMock
+	params             *ArtifactPublicServiceClientMockSearchSourceFilesParams
+	paramPtrs          *ArtifactPublicServiceClientMockSearchSourceFilesParamPtrs
+	expectationOrigins ArtifactPublicServiceClientMockSearchSourceFilesExpectationOrigins
+	results            *ArtifactPublicServiceClientMockSearchSourceFilesResults
+	returnOrigin       string
+	Counter            uint64
+}
+
+// ArtifactPublicServiceClientMockSearchSourceFilesParams contains parameters of the ArtifactPublicServiceClient.SearchSourceFiles
+type ArtifactPublicServiceClientMockSearchSourceFilesParams struct {
+	ctx  context.Context
+	in   *mm_artifactv1alpha.SearchSourceFilesRequest
+	opts []grpc.CallOption
+}
+
+// ArtifactPublicServiceClientMockSearchSourceFilesParamPtrs contains pointers to parameters of the ArtifactPublicServiceClient.SearchSourceFiles
+type ArtifactPublicServiceClientMockSearchSourceFilesParamPtrs struct {
+	ctx  *context.Context
+	in   **mm_artifactv1alpha.SearchSourceFilesRequest
+	opts *[]grpc.CallOption
+}
+
+// ArtifactPublicServiceClientMockSearchSourceFilesResults contains results of the ArtifactPublicServiceClient.SearchSourceFiles
+type ArtifactPublicServiceClientMockSearchSourceFilesResults struct {
+	sp1 *mm_artifactv1alpha.SearchSourceFilesResponse
+	err error
+}
+
+// ArtifactPublicServiceClientMockSearchSourceFilesOrigins contains origins of expectations of the ArtifactPublicServiceClient.SearchSourceFiles
+type ArtifactPublicServiceClientMockSearchSourceFilesExpectationOrigins struct {
+	origin     string
+	originCtx  string
+	originIn   string
+	originOpts string
+}
+
+// Marks this method to be optional. The default behavior of any method with Return() is '1 or more', meaning
+// the test will fail minimock's automatic final call check if the mocked method was not called at least once.
+// Optional() makes method check to work in '0 or more' mode.
+// It is NOT RECOMMENDED to use this option unless you really need it, as default behaviour helps to
+// catch the problems when the expected method call is totally skipped during test run.
+func (mmSearchSourceFiles *mArtifactPublicServiceClientMockSearchSourceFiles) Optional() *mArtifactPublicServiceClientMockSearchSourceFiles {
+	mmSearchSourceFiles.optional = true
+	return mmSearchSourceFiles
+}
+
+// Expect sets up expected params for ArtifactPublicServiceClient.SearchSourceFiles
+func (mmSearchSourceFiles *mArtifactPublicServiceClientMockSearchSourceFiles) Expect(ctx context.Context, in *mm_artifactv1alpha.SearchSourceFilesRequest, opts ...grpc.CallOption) *mArtifactPublicServiceClientMockSearchSourceFiles {
+	if mmSearchSourceFiles.mock.funcSearchSourceFiles != nil {
+		mmSearchSourceFiles.mock.t.Fatalf("ArtifactPublicServiceClientMock.SearchSourceFiles mock is already set by Set")
+	}
+
+	if mmSearchSourceFiles.defaultExpectation == nil {
+		mmSearchSourceFiles.defaultExpectation = &ArtifactPublicServiceClientMockSearchSourceFilesExpectation{}
+	}
+
+	if mmSearchSourceFiles.defaultExpectation.paramPtrs != nil {
+		mmSearchSourceFiles.mock.t.Fatalf("ArtifactPublicServiceClientMock.SearchSourceFiles mock is already set by ExpectParams functions")
+	}
+
+	mmSearchSourceFiles.defaultExpectation.params = &ArtifactPublicServiceClientMockSearchSourceFilesParams{ctx, in, opts}
+	mmSearchSourceFiles.defaultExpectation.expectationOrigins.origin = minimock.CallerInfo(1)
+	for _, e := range mmSearchSourceFiles.expectations {
+		if minimock.Equal(e.params, mmSearchSourceFiles.defaultExpectation.params) {
+			mmSearchSourceFiles.mock.t.Fatalf("Expectation set by When has same params: %#v", *mmSearchSourceFiles.defaultExpectation.params)
+		}
+	}
+
+	return mmSearchSourceFiles
+}
+
+// ExpectCtxParam1 sets up expected param ctx for ArtifactPublicServiceClient.SearchSourceFiles
+func (mmSearchSourceFiles *mArtifactPublicServiceClientMockSearchSourceFiles) ExpectCtxParam1(ctx context.Context) *mArtifactPublicServiceClientMockSearchSourceFiles {
+	if mmSearchSourceFiles.mock.funcSearchSourceFiles != nil {
+		mmSearchSourceFiles.mock.t.Fatalf("ArtifactPublicServiceClientMock.SearchSourceFiles mock is already set by Set")
+	}
+
+	if mmSearchSourceFiles.defaultExpectation == nil {
+		mmSearchSourceFiles.defaultExpectation = &ArtifactPublicServiceClientMockSearchSourceFilesExpectation{}
+	}
+
+	if mmSearchSourceFiles.defaultExpectation.params != nil {
+		mmSearchSourceFiles.mock.t.Fatalf("ArtifactPublicServiceClientMock.SearchSourceFiles mock is already set by Expect")
+	}
+
+	if mmSearchSourceFiles.defaultExpectation.paramPtrs == nil {
+		mmSearchSourceFiles.defaultExpectation.paramPtrs = &ArtifactPublicServiceClientMockSearchSourceFilesParamPtrs{}
+	}
+	mmSearchSourceFiles.defaultExpectation.paramPtrs.ctx = &ctx
+	mmSearchSourceFiles.defaultExpectation.expectationOrigins.originCtx = minimock.CallerInfo(1)
+
+	return mmSearchSourceFiles
+}
+
+// ExpectInParam2 sets up expected param in for ArtifactPublicServiceClient.SearchSourceFiles
+func (mmSearchSourceFiles *mArtifactPublicServiceClientMockSearchSourceFiles) ExpectInParam2(in *mm_artifactv1alpha.SearchSourceFilesRequest) *mArtifactPublicServiceClientMockSearchSourceFiles {
+	if mmSearchSourceFiles.mock.funcSearchSourceFiles != nil {
+		mmSearchSourceFiles.mock.t.Fatalf("ArtifactPublicServiceClientMock.SearchSourceFiles mock is already set by Set")
+	}
+
+	if mmSearchSourceFiles.defaultExpectation == nil {
+		mmSearchSourceFiles.defaultExpectation = &ArtifactPublicServiceClientMockSearchSourceFilesExpectation{}
+	}
+
+	if mmSearchSourceFiles.defaultExpectation.params != nil {
+		mmSearchSourceFiles.mock.t.Fatalf("ArtifactPublicServiceClientMock.SearchSourceFiles mock is already set by Expect")
+	}
+
+	if mmSearchSourceFiles.defaultExpectation.paramPtrs == nil {
+		mmSearchSourceFiles.defaultExpectation.paramPtrs = &ArtifactPublicServiceClientMockSearchSourceFilesParamPtrs{}
+	}
+	mmSearchSourceFiles.defaultExpectation.paramPtrs.in = &in
+	mmSearchSourceFiles.defaultExpectation.expectationOrigins.originIn = minimock.CallerInfo(1)
+
+	return mmSearchSourceFiles
+}
+
+// ExpectOptsParam3 sets up expected param opts for ArtifactPublicServiceClient.SearchSourceFiles
+func (mmSearchSourceFiles *mArtifactPublicServiceClientMockSearchSourceFiles) ExpectOptsParam3(opts ...grpc.CallOption) *mArtifactPublicServiceClientMockSearchSourceFiles {
+	if mmSearchSourceFiles.mock.funcSearchSourceFiles != nil {
+		mmSearchSourceFiles.mock.t.Fatalf("ArtifactPublicServiceClientMock.SearchSourceFiles mock is already set by Set")
+	}
+
+	if mmSearchSourceFiles.defaultExpectation == nil {
+		mmSearchSourceFiles.defaultExpectation = &ArtifactPublicServiceClientMockSearchSourceFilesExpectation{}
+	}
+
+	if mmSearchSourceFiles.defaultExpectation.params != nil {
+		mmSearchSourceFiles.mock.t.Fatalf("ArtifactPublicServiceClientMock.SearchSourceFiles mock is already set by Expect")
+	}
+
+	if mmSearchSourceFiles.defaultExpectation.paramPtrs == nil {
+		mmSearchSourceFiles.defaultExpectation.paramPtrs = &ArtifactPublicServiceClientMockSearchSourceFilesParamPtrs{}
+	}
+	mmSearchSourceFiles.defaultExpectation.paramPtrs.opts = &opts
+	mmSearchSourceFiles.defaultExpectation.expectationOrigins.originOpts = minimock.CallerInfo(1)
+
+	return mmSearchSourceFiles
+}
+
+// Inspect accepts an inspector function that has same arguments as the ArtifactPublicServiceClient.SearchSourceFiles
+func (mmSearchSourceFiles *mArtifactPublicServiceClientMockSearchSourceFiles) Inspect(f func(ctx context.Context, in *mm_artifactv1alpha.SearchSourceFilesRequest, opts ...grpc.CallOption)) *mArtifactPublicServiceClientMockSearchSourceFiles {
+	if mmSearchSourceFiles.mock.inspectFuncSearchSourceFiles != nil {
+		mmSearchSourceFiles.mock.t.Fatalf("Inspect function is already set for ArtifactPublicServiceClientMock.SearchSourceFiles")
+	}
+
+	mmSearchSourceFiles.mock.inspectFuncSearchSourceFiles = f
+
+	return mmSearchSourceFiles
+}
+
+// Return sets up results that will be returned by ArtifactPublicServiceClient.SearchSourceFiles
+func (mmSearchSourceFiles *mArtifactPublicServiceClientMockSearchSourceFiles) Return(sp1 *mm_artifactv1alpha.SearchSourceFilesResponse, err error) *ArtifactPublicServiceClientMock {
+	if mmSearchSourceFiles.mock.funcSearchSourceFiles != nil {
+		mmSearchSourceFiles.mock.t.Fatalf("ArtifactPublicServiceClientMock.SearchSourceFiles mock is already set by Set")
+	}
+
+	if mmSearchSourceFiles.defaultExpectation == nil {
+		mmSearchSourceFiles.defaultExpectation = &ArtifactPublicServiceClientMockSearchSourceFilesExpectation{mock: mmSearchSourceFiles.mock}
+	}
+	mmSearchSourceFiles.defaultExpectation.results = &ArtifactPublicServiceClientMockSearchSourceFilesResults{sp1, err}
+	mmSearchSourceFiles.defaultExpectation.returnOrigin = minimock.CallerInfo(1)
+	return mmSearchSourceFiles.mock
+}
+
+// Set uses given function f to mock the ArtifactPublicServiceClient.SearchSourceFiles method
+func (mmSearchSourceFiles *mArtifactPublicServiceClientMockSearchSourceFiles) Set(f func(ctx context.Context, in *mm_artifactv1alpha.SearchSourceFilesRequest, opts ...grpc.CallOption) (sp1 *mm_artifactv1alpha.SearchSourceFilesResponse, err error)) *ArtifactPublicServiceClientMock {
+	if mmSearchSourceFiles.defaultExpectation != nil {
+		mmSearchSourceFiles.mock.t.Fatalf("Default expectation is already set for the ArtifactPublicServiceClient.SearchSourceFiles method")
+	}
+
+	if len(mmSearchSourceFiles.expectations) > 0 {
+		mmSearchSourceFiles.mock.t.Fatalf("Some expectations are already set for the ArtifactPublicServiceClient.SearchSourceFiles method")
+	}
+
+	mmSearchSourceFiles.mock.funcSearchSourceFiles = f
+	mmSearchSourceFiles.mock.funcSearchSourceFilesOrigin = minimock.CallerInfo(1)
+	return mmSearchSourceFiles.mock
+}
+
+// When sets expectation for the ArtifactPublicServiceClient.SearchSourceFiles which will trigger the result defined by the following
+// Then helper
+func (mmSearchSourceFiles *mArtifactPublicServiceClientMockSearchSourceFiles) When(ctx context.Context, in *mm_artifactv1alpha.SearchSourceFilesRequest, opts ...grpc.CallOption) *ArtifactPublicServiceClientMockSearchSourceFilesExpectation {
+	if mmSearchSourceFiles.mock.funcSearchSourceFiles != nil {
+		mmSearchSourceFiles.mock.t.Fatalf("ArtifactPublicServiceClientMock.SearchSourceFiles mock is already set by Set")
+	}
+
+	expectation := &ArtifactPublicServiceClientMockSearchSourceFilesExpectation{
+		mock:               mmSearchSourceFiles.mock,
+		params:             &ArtifactPublicServiceClientMockSearchSourceFilesParams{ctx, in, opts},
+		expectationOrigins: ArtifactPublicServiceClientMockSearchSourceFilesExpectationOrigins{origin: minimock.CallerInfo(1)},
+	}
+	mmSearchSourceFiles.expectations = append(mmSearchSourceFiles.expectations, expectation)
+	return expectation
+}
+
+// Then sets up ArtifactPublicServiceClient.SearchSourceFiles return parameters for the expectation previously defined by the When method
+func (e *ArtifactPublicServiceClientMockSearchSourceFilesExpectation) Then(sp1 *mm_artifactv1alpha.SearchSourceFilesResponse, err error) *ArtifactPublicServiceClientMock {
+	e.results = &ArtifactPublicServiceClientMockSearchSourceFilesResults{sp1, err}
+	return e.mock
+}
+
+// Times sets number of times ArtifactPublicServiceClient.SearchSourceFiles should be invoked
+func (mmSearchSourceFiles *mArtifactPublicServiceClientMockSearchSourceFiles) Times(n uint64) *mArtifactPublicServiceClientMockSearchSourceFiles {
+	if n == 0 {
+		mmSearchSourceFiles.mock.t.Fatalf("Times of ArtifactPublicServiceClientMock.SearchSourceFiles mock can not be zero")
+	}
+	mm_atomic.StoreUint64(&mmSearchSourceFiles.expectedInvocations, n)
+	mmSearchSourceFiles.expectedInvocationsOrigin = minimock.CallerInfo(1)
+	return mmSearchSourceFiles
+}
+
+func (mmSearchSourceFiles *mArtifactPublicServiceClientMockSearchSourceFiles) invocationsDone() bool {
+	if len(mmSearchSourceFiles.expectations) == 0 && mmSearchSourceFiles.defaultExpectation == nil && mmSearchSourceFiles.mock.funcSearchSourceFiles == nil {
+		return true
+	}
+
+	totalInvocations := mm_atomic.LoadUint64(&mmSearchSourceFiles.mock.afterSearchSourceFilesCounter)
+	expectedInvocations := mm_atomic.LoadUint64(&mmSearchSourceFiles.expectedInvocations)
+
+	return totalInvocations > 0 && (expectedInvocations == 0 || expectedInvocations == totalInvocations)
+}
+
+// SearchSourceFiles implements mm_artifactv1alpha.ArtifactPublicServiceClient
+func (mmSearchSourceFiles *ArtifactPublicServiceClientMock) SearchSourceFiles(ctx context.Context, in *mm_artifactv1alpha.SearchSourceFilesRequest, opts ...grpc.CallOption) (sp1 *mm_artifactv1alpha.SearchSourceFilesResponse, err error) {
+	mm_atomic.AddUint64(&mmSearchSourceFiles.beforeSearchSourceFilesCounter, 1)
+	defer mm_atomic.AddUint64(&mmSearchSourceFiles.afterSearchSourceFilesCounter, 1)
+
+	mmSearchSourceFiles.t.Helper()
+
+	if mmSearchSourceFiles.inspectFuncSearchSourceFiles != nil {
+		mmSearchSourceFiles.inspectFuncSearchSourceFiles(ctx, in, opts...)
+	}
+
+	mm_params := ArtifactPublicServiceClientMockSearchSourceFilesParams{ctx, in, opts}
+
+	// Record call args
+	mmSearchSourceFiles.SearchSourceFilesMock.mutex.Lock()
+	mmSearchSourceFiles.SearchSourceFilesMock.callArgs = append(mmSearchSourceFiles.SearchSourceFilesMock.callArgs, &mm_params)
+	mmSearchSourceFiles.SearchSourceFilesMock.mutex.Unlock()
+
+	for _, e := range mmSearchSourceFiles.SearchSourceFilesMock.expectations {
+		if minimock.Equal(*e.params, mm_params) {
+			mm_atomic.AddUint64(&e.Counter, 1)
+			return e.results.sp1, e.results.err
+		}
+	}
+
+	if mmSearchSourceFiles.SearchSourceFilesMock.defaultExpectation != nil {
+		mm_atomic.AddUint64(&mmSearchSourceFiles.SearchSourceFilesMock.defaultExpectation.Counter, 1)
+		mm_want := mmSearchSourceFiles.SearchSourceFilesMock.defaultExpectation.params
+		mm_want_ptrs := mmSearchSourceFiles.SearchSourceFilesMock.defaultExpectation.paramPtrs
+
+		mm_got := ArtifactPublicServiceClientMockSearchSourceFilesParams{ctx, in, opts}
+
+		if mm_want_ptrs != nil {
+
+			if mm_want_ptrs.ctx != nil && !minimock.Equal(*mm_want_ptrs.ctx, mm_got.ctx) {
+				mmSearchSourceFiles.t.Errorf("ArtifactPublicServiceClientMock.SearchSourceFiles got unexpected parameter ctx, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmSearchSourceFiles.SearchSourceFilesMock.defaultExpectation.expectationOrigins.originCtx, *mm_want_ptrs.ctx, mm_got.ctx, minimock.Diff(*mm_want_ptrs.ctx, mm_got.ctx))
+			}
+
+			if mm_want_ptrs.in != nil && !minimock.Equal(*mm_want_ptrs.in, mm_got.in) {
+				mmSearchSourceFiles.t.Errorf("ArtifactPublicServiceClientMock.SearchSourceFiles got unexpected parameter in, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmSearchSourceFiles.SearchSourceFilesMock.defaultExpectation.expectationOrigins.originIn, *mm_want_ptrs.in, mm_got.in, minimock.Diff(*mm_want_ptrs.in, mm_got.in))
+			}
+
+			if mm_want_ptrs.opts != nil && !minimock.Equal(*mm_want_ptrs.opts, mm_got.opts) {
+				mmSearchSourceFiles.t.Errorf("ArtifactPublicServiceClientMock.SearchSourceFiles got unexpected parameter opts, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmSearchSourceFiles.SearchSourceFilesMock.defaultExpectation.expectationOrigins.originOpts, *mm_want_ptrs.opts, mm_got.opts, minimock.Diff(*mm_want_ptrs.opts, mm_got.opts))
+			}
+
+		} else if mm_want != nil && !minimock.Equal(*mm_want, mm_got) {
+			mmSearchSourceFiles.t.Errorf("ArtifactPublicServiceClientMock.SearchSourceFiles got unexpected parameters, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+				mmSearchSourceFiles.SearchSourceFilesMock.defaultExpectation.expectationOrigins.origin, *mm_want, mm_got, minimock.Diff(*mm_want, mm_got))
+		}
+
+		mm_results := mmSearchSourceFiles.SearchSourceFilesMock.defaultExpectation.results
+		if mm_results == nil {
+			mmSearchSourceFiles.t.Fatal("No results are set for the ArtifactPublicServiceClientMock.SearchSourceFiles")
+		}
+		return (*mm_results).sp1, (*mm_results).err
+	}
+	if mmSearchSourceFiles.funcSearchSourceFiles != nil {
+		return mmSearchSourceFiles.funcSearchSourceFiles(ctx, in, opts...)
+	}
+	mmSearchSourceFiles.t.Fatalf("Unexpected call to ArtifactPublicServiceClientMock.SearchSourceFiles. %v %v %v", ctx, in, opts)
+	return
+}
+
+// SearchSourceFilesAfterCounter returns a count of finished ArtifactPublicServiceClientMock.SearchSourceFiles invocations
+func (mmSearchSourceFiles *ArtifactPublicServiceClientMock) SearchSourceFilesAfterCounter() uint64 {
+	return mm_atomic.LoadUint64(&mmSearchSourceFiles.afterSearchSourceFilesCounter)
+}
+
+// SearchSourceFilesBeforeCounter returns a count of ArtifactPublicServiceClientMock.SearchSourceFiles invocations
+func (mmSearchSourceFiles *ArtifactPublicServiceClientMock) SearchSourceFilesBeforeCounter() uint64 {
+	return mm_atomic.LoadUint64(&mmSearchSourceFiles.beforeSearchSourceFilesCounter)
+}
+
+// Calls returns a list of arguments used in each call to ArtifactPublicServiceClientMock.SearchSourceFiles.
+// The list is in the same order as the calls were made (i.e. recent calls have a higher index)
+func (mmSearchSourceFiles *mArtifactPublicServiceClientMockSearchSourceFiles) Calls() []*ArtifactPublicServiceClientMockSearchSourceFilesParams {
+	mmSearchSourceFiles.mutex.RLock()
+
+	argCopy := make([]*ArtifactPublicServiceClientMockSearchSourceFilesParams, len(mmSearchSourceFiles.callArgs))
+	copy(argCopy, mmSearchSourceFiles.callArgs)
+
+	mmSearchSourceFiles.mutex.RUnlock()
+
+	return argCopy
+}
+
+// MinimockSearchSourceFilesDone returns true if the count of the SearchSourceFiles invocations corresponds
+// the number of defined expectations
+func (m *ArtifactPublicServiceClientMock) MinimockSearchSourceFilesDone() bool {
+	if m.SearchSourceFilesMock.optional {
+		// Optional methods provide '0 or more' call count restriction.
+		return true
+	}
+
+	for _, e := range m.SearchSourceFilesMock.expectations {
+		if mm_atomic.LoadUint64(&e.Counter) < 1 {
+			return false
+		}
+	}
+
+	return m.SearchSourceFilesMock.invocationsDone()
+}
+
+// MinimockSearchSourceFilesInspect logs each unmet expectation
+func (m *ArtifactPublicServiceClientMock) MinimockSearchSourceFilesInspect() {
+	for _, e := range m.SearchSourceFilesMock.expectations {
+		if mm_atomic.LoadUint64(&e.Counter) < 1 {
+			m.t.Errorf("Expected call to ArtifactPublicServiceClientMock.SearchSourceFiles at\n%s with params: %#v", e.expectationOrigins.origin, *e.params)
+		}
+	}
+
+	afterSearchSourceFilesCounter := mm_atomic.LoadUint64(&m.afterSearchSourceFilesCounter)
+	// if default expectation was set then invocations count should be greater than zero
+	if m.SearchSourceFilesMock.defaultExpectation != nil && afterSearchSourceFilesCounter < 1 {
+		if m.SearchSourceFilesMock.defaultExpectation.params == nil {
+			m.t.Errorf("Expected call to ArtifactPublicServiceClientMock.SearchSourceFiles at\n%s", m.SearchSourceFilesMock.defaultExpectation.returnOrigin)
+		} else {
+			m.t.Errorf("Expected call to ArtifactPublicServiceClientMock.SearchSourceFiles at\n%s with params: %#v", m.SearchSourceFilesMock.defaultExpectation.expectationOrigins.origin, *m.SearchSourceFilesMock.defaultExpectation.params)
+		}
+	}
+	// if func was set then invocations count should be greater than zero
+	if m.funcSearchSourceFiles != nil && afterSearchSourceFilesCounter < 1 {
+		m.t.Errorf("Expected call to ArtifactPublicServiceClientMock.SearchSourceFiles at\n%s", m.funcSearchSourceFilesOrigin)
+	}
+
+	if !m.SearchSourceFilesMock.invocationsDone() && afterSearchSourceFilesCounter > 0 {
+		m.t.Errorf("Expected %d calls to ArtifactPublicServiceClientMock.SearchSourceFiles at\n%s but found %d calls",
+			mm_atomic.LoadUint64(&m.SearchSourceFilesMock.expectedInvocations), m.SearchSourceFilesMock.expectedInvocationsOrigin, afterSearchSourceFilesCounter)
+	}
+}
+
 type mArtifactPublicServiceClientMockSimilarityChunksSearch struct {
 	optional           bool
 	mock               *ArtifactPublicServiceClientMock
@@ -7362,6 +8130,10 @@ func (m *ArtifactPublicServiceClientMock) MinimockFinish() {
 
 			m.MinimockReadinessInspect()
 
+			m.MinimockSearchChunksInspect()
+
+			m.MinimockSearchSourceFilesInspect()
+
 			m.MinimockSimilarityChunksSearchInspect()
 
 			m.MinimockUpdateCatalogInspect()
@@ -7407,6 +8179,8 @@ func (m *ArtifactPublicServiceClientMock) minimockDone() bool {
 		m.MinimockProcessCatalogFilesDone() &&
 		m.MinimockQuestionAnsweringDone() &&
 		m.MinimockReadinessDone() &&
+		m.MinimockSearchChunksDone() &&
+		m.MinimockSearchSourceFilesDone() &&
 		m.MinimockSimilarityChunksSearchDone() &&
 		m.MinimockUpdateCatalogDone() &&
 		m.MinimockUpdateChunkDone() &&

--- a/pkg/component/internal/mock/artifact_public_service_server_mock.gen.go
+++ b/pkg/component/internal/mock/artifact_public_service_server_mock.gen.go
@@ -122,6 +122,20 @@ type ArtifactPublicServiceServerMock struct {
 	beforeReadinessCounter uint64
 	ReadinessMock          mArtifactPublicServiceServerMockReadiness
 
+	funcSearchChunks          func(ctx context.Context, sp1 *mm_artifactv1alpha.SearchChunksRequest) (sp2 *mm_artifactv1alpha.SearchChunksResponse, err error)
+	funcSearchChunksOrigin    string
+	inspectFuncSearchChunks   func(ctx context.Context, sp1 *mm_artifactv1alpha.SearchChunksRequest)
+	afterSearchChunksCounter  uint64
+	beforeSearchChunksCounter uint64
+	SearchChunksMock          mArtifactPublicServiceServerMockSearchChunks
+
+	funcSearchSourceFiles          func(ctx context.Context, sp1 *mm_artifactv1alpha.SearchSourceFilesRequest) (sp2 *mm_artifactv1alpha.SearchSourceFilesResponse, err error)
+	funcSearchSourceFilesOrigin    string
+	inspectFuncSearchSourceFiles   func(ctx context.Context, sp1 *mm_artifactv1alpha.SearchSourceFilesRequest)
+	afterSearchSourceFilesCounter  uint64
+	beforeSearchSourceFilesCounter uint64
+	SearchSourceFilesMock          mArtifactPublicServiceServerMockSearchSourceFiles
+
 	funcSimilarityChunksSearch          func(ctx context.Context, sp1 *mm_artifactv1alpha.SimilarityChunksSearchRequest) (sp2 *mm_artifactv1alpha.SimilarityChunksSearchResponse, err error)
 	funcSimilarityChunksSearchOrigin    string
 	inspectFuncSimilarityChunksSearch   func(ctx context.Context, sp1 *mm_artifactv1alpha.SimilarityChunksSearchRequest)
@@ -203,6 +217,12 @@ func NewArtifactPublicServiceServerMock(t minimock.Tester) *ArtifactPublicServic
 
 	m.ReadinessMock = mArtifactPublicServiceServerMockReadiness{mock: m}
 	m.ReadinessMock.callArgs = []*ArtifactPublicServiceServerMockReadinessParams{}
+
+	m.SearchChunksMock = mArtifactPublicServiceServerMockSearchChunks{mock: m}
+	m.SearchChunksMock.callArgs = []*ArtifactPublicServiceServerMockSearchChunksParams{}
+
+	m.SearchSourceFilesMock = mArtifactPublicServiceServerMockSearchSourceFiles{mock: m}
+	m.SearchSourceFilesMock.callArgs = []*ArtifactPublicServiceServerMockSearchSourceFilesParams{}
 
 	m.SimilarityChunksSearchMock = mArtifactPublicServiceServerMockSimilarityChunksSearch{mock: m}
 	m.SimilarityChunksSearchMock.callArgs = []*ArtifactPublicServiceServerMockSimilarityChunksSearchParams{}
@@ -5366,6 +5386,692 @@ func (m *ArtifactPublicServiceServerMock) MinimockReadinessInspect() {
 	}
 }
 
+type mArtifactPublicServiceServerMockSearchChunks struct {
+	optional           bool
+	mock               *ArtifactPublicServiceServerMock
+	defaultExpectation *ArtifactPublicServiceServerMockSearchChunksExpectation
+	expectations       []*ArtifactPublicServiceServerMockSearchChunksExpectation
+
+	callArgs []*ArtifactPublicServiceServerMockSearchChunksParams
+	mutex    sync.RWMutex
+
+	expectedInvocations       uint64
+	expectedInvocationsOrigin string
+}
+
+// ArtifactPublicServiceServerMockSearchChunksExpectation specifies expectation struct of the ArtifactPublicServiceServer.SearchChunks
+type ArtifactPublicServiceServerMockSearchChunksExpectation struct {
+	mock               *ArtifactPublicServiceServerMock
+	params             *ArtifactPublicServiceServerMockSearchChunksParams
+	paramPtrs          *ArtifactPublicServiceServerMockSearchChunksParamPtrs
+	expectationOrigins ArtifactPublicServiceServerMockSearchChunksExpectationOrigins
+	results            *ArtifactPublicServiceServerMockSearchChunksResults
+	returnOrigin       string
+	Counter            uint64
+}
+
+// ArtifactPublicServiceServerMockSearchChunksParams contains parameters of the ArtifactPublicServiceServer.SearchChunks
+type ArtifactPublicServiceServerMockSearchChunksParams struct {
+	ctx context.Context
+	sp1 *mm_artifactv1alpha.SearchChunksRequest
+}
+
+// ArtifactPublicServiceServerMockSearchChunksParamPtrs contains pointers to parameters of the ArtifactPublicServiceServer.SearchChunks
+type ArtifactPublicServiceServerMockSearchChunksParamPtrs struct {
+	ctx *context.Context
+	sp1 **mm_artifactv1alpha.SearchChunksRequest
+}
+
+// ArtifactPublicServiceServerMockSearchChunksResults contains results of the ArtifactPublicServiceServer.SearchChunks
+type ArtifactPublicServiceServerMockSearchChunksResults struct {
+	sp2 *mm_artifactv1alpha.SearchChunksResponse
+	err error
+}
+
+// ArtifactPublicServiceServerMockSearchChunksOrigins contains origins of expectations of the ArtifactPublicServiceServer.SearchChunks
+type ArtifactPublicServiceServerMockSearchChunksExpectationOrigins struct {
+	origin    string
+	originCtx string
+	originSp1 string
+}
+
+// Marks this method to be optional. The default behavior of any method with Return() is '1 or more', meaning
+// the test will fail minimock's automatic final call check if the mocked method was not called at least once.
+// Optional() makes method check to work in '0 or more' mode.
+// It is NOT RECOMMENDED to use this option unless you really need it, as default behaviour helps to
+// catch the problems when the expected method call is totally skipped during test run.
+func (mmSearchChunks *mArtifactPublicServiceServerMockSearchChunks) Optional() *mArtifactPublicServiceServerMockSearchChunks {
+	mmSearchChunks.optional = true
+	return mmSearchChunks
+}
+
+// Expect sets up expected params for ArtifactPublicServiceServer.SearchChunks
+func (mmSearchChunks *mArtifactPublicServiceServerMockSearchChunks) Expect(ctx context.Context, sp1 *mm_artifactv1alpha.SearchChunksRequest) *mArtifactPublicServiceServerMockSearchChunks {
+	if mmSearchChunks.mock.funcSearchChunks != nil {
+		mmSearchChunks.mock.t.Fatalf("ArtifactPublicServiceServerMock.SearchChunks mock is already set by Set")
+	}
+
+	if mmSearchChunks.defaultExpectation == nil {
+		mmSearchChunks.defaultExpectation = &ArtifactPublicServiceServerMockSearchChunksExpectation{}
+	}
+
+	if mmSearchChunks.defaultExpectation.paramPtrs != nil {
+		mmSearchChunks.mock.t.Fatalf("ArtifactPublicServiceServerMock.SearchChunks mock is already set by ExpectParams functions")
+	}
+
+	mmSearchChunks.defaultExpectation.params = &ArtifactPublicServiceServerMockSearchChunksParams{ctx, sp1}
+	mmSearchChunks.defaultExpectation.expectationOrigins.origin = minimock.CallerInfo(1)
+	for _, e := range mmSearchChunks.expectations {
+		if minimock.Equal(e.params, mmSearchChunks.defaultExpectation.params) {
+			mmSearchChunks.mock.t.Fatalf("Expectation set by When has same params: %#v", *mmSearchChunks.defaultExpectation.params)
+		}
+	}
+
+	return mmSearchChunks
+}
+
+// ExpectCtxParam1 sets up expected param ctx for ArtifactPublicServiceServer.SearchChunks
+func (mmSearchChunks *mArtifactPublicServiceServerMockSearchChunks) ExpectCtxParam1(ctx context.Context) *mArtifactPublicServiceServerMockSearchChunks {
+	if mmSearchChunks.mock.funcSearchChunks != nil {
+		mmSearchChunks.mock.t.Fatalf("ArtifactPublicServiceServerMock.SearchChunks mock is already set by Set")
+	}
+
+	if mmSearchChunks.defaultExpectation == nil {
+		mmSearchChunks.defaultExpectation = &ArtifactPublicServiceServerMockSearchChunksExpectation{}
+	}
+
+	if mmSearchChunks.defaultExpectation.params != nil {
+		mmSearchChunks.mock.t.Fatalf("ArtifactPublicServiceServerMock.SearchChunks mock is already set by Expect")
+	}
+
+	if mmSearchChunks.defaultExpectation.paramPtrs == nil {
+		mmSearchChunks.defaultExpectation.paramPtrs = &ArtifactPublicServiceServerMockSearchChunksParamPtrs{}
+	}
+	mmSearchChunks.defaultExpectation.paramPtrs.ctx = &ctx
+	mmSearchChunks.defaultExpectation.expectationOrigins.originCtx = minimock.CallerInfo(1)
+
+	return mmSearchChunks
+}
+
+// ExpectSp1Param2 sets up expected param sp1 for ArtifactPublicServiceServer.SearchChunks
+func (mmSearchChunks *mArtifactPublicServiceServerMockSearchChunks) ExpectSp1Param2(sp1 *mm_artifactv1alpha.SearchChunksRequest) *mArtifactPublicServiceServerMockSearchChunks {
+	if mmSearchChunks.mock.funcSearchChunks != nil {
+		mmSearchChunks.mock.t.Fatalf("ArtifactPublicServiceServerMock.SearchChunks mock is already set by Set")
+	}
+
+	if mmSearchChunks.defaultExpectation == nil {
+		mmSearchChunks.defaultExpectation = &ArtifactPublicServiceServerMockSearchChunksExpectation{}
+	}
+
+	if mmSearchChunks.defaultExpectation.params != nil {
+		mmSearchChunks.mock.t.Fatalf("ArtifactPublicServiceServerMock.SearchChunks mock is already set by Expect")
+	}
+
+	if mmSearchChunks.defaultExpectation.paramPtrs == nil {
+		mmSearchChunks.defaultExpectation.paramPtrs = &ArtifactPublicServiceServerMockSearchChunksParamPtrs{}
+	}
+	mmSearchChunks.defaultExpectation.paramPtrs.sp1 = &sp1
+	mmSearchChunks.defaultExpectation.expectationOrigins.originSp1 = minimock.CallerInfo(1)
+
+	return mmSearchChunks
+}
+
+// Inspect accepts an inspector function that has same arguments as the ArtifactPublicServiceServer.SearchChunks
+func (mmSearchChunks *mArtifactPublicServiceServerMockSearchChunks) Inspect(f func(ctx context.Context, sp1 *mm_artifactv1alpha.SearchChunksRequest)) *mArtifactPublicServiceServerMockSearchChunks {
+	if mmSearchChunks.mock.inspectFuncSearchChunks != nil {
+		mmSearchChunks.mock.t.Fatalf("Inspect function is already set for ArtifactPublicServiceServerMock.SearchChunks")
+	}
+
+	mmSearchChunks.mock.inspectFuncSearchChunks = f
+
+	return mmSearchChunks
+}
+
+// Return sets up results that will be returned by ArtifactPublicServiceServer.SearchChunks
+func (mmSearchChunks *mArtifactPublicServiceServerMockSearchChunks) Return(sp2 *mm_artifactv1alpha.SearchChunksResponse, err error) *ArtifactPublicServiceServerMock {
+	if mmSearchChunks.mock.funcSearchChunks != nil {
+		mmSearchChunks.mock.t.Fatalf("ArtifactPublicServiceServerMock.SearchChunks mock is already set by Set")
+	}
+
+	if mmSearchChunks.defaultExpectation == nil {
+		mmSearchChunks.defaultExpectation = &ArtifactPublicServiceServerMockSearchChunksExpectation{mock: mmSearchChunks.mock}
+	}
+	mmSearchChunks.defaultExpectation.results = &ArtifactPublicServiceServerMockSearchChunksResults{sp2, err}
+	mmSearchChunks.defaultExpectation.returnOrigin = minimock.CallerInfo(1)
+	return mmSearchChunks.mock
+}
+
+// Set uses given function f to mock the ArtifactPublicServiceServer.SearchChunks method
+func (mmSearchChunks *mArtifactPublicServiceServerMockSearchChunks) Set(f func(ctx context.Context, sp1 *mm_artifactv1alpha.SearchChunksRequest) (sp2 *mm_artifactv1alpha.SearchChunksResponse, err error)) *ArtifactPublicServiceServerMock {
+	if mmSearchChunks.defaultExpectation != nil {
+		mmSearchChunks.mock.t.Fatalf("Default expectation is already set for the ArtifactPublicServiceServer.SearchChunks method")
+	}
+
+	if len(mmSearchChunks.expectations) > 0 {
+		mmSearchChunks.mock.t.Fatalf("Some expectations are already set for the ArtifactPublicServiceServer.SearchChunks method")
+	}
+
+	mmSearchChunks.mock.funcSearchChunks = f
+	mmSearchChunks.mock.funcSearchChunksOrigin = minimock.CallerInfo(1)
+	return mmSearchChunks.mock
+}
+
+// When sets expectation for the ArtifactPublicServiceServer.SearchChunks which will trigger the result defined by the following
+// Then helper
+func (mmSearchChunks *mArtifactPublicServiceServerMockSearchChunks) When(ctx context.Context, sp1 *mm_artifactv1alpha.SearchChunksRequest) *ArtifactPublicServiceServerMockSearchChunksExpectation {
+	if mmSearchChunks.mock.funcSearchChunks != nil {
+		mmSearchChunks.mock.t.Fatalf("ArtifactPublicServiceServerMock.SearchChunks mock is already set by Set")
+	}
+
+	expectation := &ArtifactPublicServiceServerMockSearchChunksExpectation{
+		mock:               mmSearchChunks.mock,
+		params:             &ArtifactPublicServiceServerMockSearchChunksParams{ctx, sp1},
+		expectationOrigins: ArtifactPublicServiceServerMockSearchChunksExpectationOrigins{origin: minimock.CallerInfo(1)},
+	}
+	mmSearchChunks.expectations = append(mmSearchChunks.expectations, expectation)
+	return expectation
+}
+
+// Then sets up ArtifactPublicServiceServer.SearchChunks return parameters for the expectation previously defined by the When method
+func (e *ArtifactPublicServiceServerMockSearchChunksExpectation) Then(sp2 *mm_artifactv1alpha.SearchChunksResponse, err error) *ArtifactPublicServiceServerMock {
+	e.results = &ArtifactPublicServiceServerMockSearchChunksResults{sp2, err}
+	return e.mock
+}
+
+// Times sets number of times ArtifactPublicServiceServer.SearchChunks should be invoked
+func (mmSearchChunks *mArtifactPublicServiceServerMockSearchChunks) Times(n uint64) *mArtifactPublicServiceServerMockSearchChunks {
+	if n == 0 {
+		mmSearchChunks.mock.t.Fatalf("Times of ArtifactPublicServiceServerMock.SearchChunks mock can not be zero")
+	}
+	mm_atomic.StoreUint64(&mmSearchChunks.expectedInvocations, n)
+	mmSearchChunks.expectedInvocationsOrigin = minimock.CallerInfo(1)
+	return mmSearchChunks
+}
+
+func (mmSearchChunks *mArtifactPublicServiceServerMockSearchChunks) invocationsDone() bool {
+	if len(mmSearchChunks.expectations) == 0 && mmSearchChunks.defaultExpectation == nil && mmSearchChunks.mock.funcSearchChunks == nil {
+		return true
+	}
+
+	totalInvocations := mm_atomic.LoadUint64(&mmSearchChunks.mock.afterSearchChunksCounter)
+	expectedInvocations := mm_atomic.LoadUint64(&mmSearchChunks.expectedInvocations)
+
+	return totalInvocations > 0 && (expectedInvocations == 0 || expectedInvocations == totalInvocations)
+}
+
+// SearchChunks implements mm_artifactv1alpha.ArtifactPublicServiceServer
+func (mmSearchChunks *ArtifactPublicServiceServerMock) SearchChunks(ctx context.Context, sp1 *mm_artifactv1alpha.SearchChunksRequest) (sp2 *mm_artifactv1alpha.SearchChunksResponse, err error) {
+	mm_atomic.AddUint64(&mmSearchChunks.beforeSearchChunksCounter, 1)
+	defer mm_atomic.AddUint64(&mmSearchChunks.afterSearchChunksCounter, 1)
+
+	mmSearchChunks.t.Helper()
+
+	if mmSearchChunks.inspectFuncSearchChunks != nil {
+		mmSearchChunks.inspectFuncSearchChunks(ctx, sp1)
+	}
+
+	mm_params := ArtifactPublicServiceServerMockSearchChunksParams{ctx, sp1}
+
+	// Record call args
+	mmSearchChunks.SearchChunksMock.mutex.Lock()
+	mmSearchChunks.SearchChunksMock.callArgs = append(mmSearchChunks.SearchChunksMock.callArgs, &mm_params)
+	mmSearchChunks.SearchChunksMock.mutex.Unlock()
+
+	for _, e := range mmSearchChunks.SearchChunksMock.expectations {
+		if minimock.Equal(*e.params, mm_params) {
+			mm_atomic.AddUint64(&e.Counter, 1)
+			return e.results.sp2, e.results.err
+		}
+	}
+
+	if mmSearchChunks.SearchChunksMock.defaultExpectation != nil {
+		mm_atomic.AddUint64(&mmSearchChunks.SearchChunksMock.defaultExpectation.Counter, 1)
+		mm_want := mmSearchChunks.SearchChunksMock.defaultExpectation.params
+		mm_want_ptrs := mmSearchChunks.SearchChunksMock.defaultExpectation.paramPtrs
+
+		mm_got := ArtifactPublicServiceServerMockSearchChunksParams{ctx, sp1}
+
+		if mm_want_ptrs != nil {
+
+			if mm_want_ptrs.ctx != nil && !minimock.Equal(*mm_want_ptrs.ctx, mm_got.ctx) {
+				mmSearchChunks.t.Errorf("ArtifactPublicServiceServerMock.SearchChunks got unexpected parameter ctx, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmSearchChunks.SearchChunksMock.defaultExpectation.expectationOrigins.originCtx, *mm_want_ptrs.ctx, mm_got.ctx, minimock.Diff(*mm_want_ptrs.ctx, mm_got.ctx))
+			}
+
+			if mm_want_ptrs.sp1 != nil && !minimock.Equal(*mm_want_ptrs.sp1, mm_got.sp1) {
+				mmSearchChunks.t.Errorf("ArtifactPublicServiceServerMock.SearchChunks got unexpected parameter sp1, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmSearchChunks.SearchChunksMock.defaultExpectation.expectationOrigins.originSp1, *mm_want_ptrs.sp1, mm_got.sp1, minimock.Diff(*mm_want_ptrs.sp1, mm_got.sp1))
+			}
+
+		} else if mm_want != nil && !minimock.Equal(*mm_want, mm_got) {
+			mmSearchChunks.t.Errorf("ArtifactPublicServiceServerMock.SearchChunks got unexpected parameters, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+				mmSearchChunks.SearchChunksMock.defaultExpectation.expectationOrigins.origin, *mm_want, mm_got, minimock.Diff(*mm_want, mm_got))
+		}
+
+		mm_results := mmSearchChunks.SearchChunksMock.defaultExpectation.results
+		if mm_results == nil {
+			mmSearchChunks.t.Fatal("No results are set for the ArtifactPublicServiceServerMock.SearchChunks")
+		}
+		return (*mm_results).sp2, (*mm_results).err
+	}
+	if mmSearchChunks.funcSearchChunks != nil {
+		return mmSearchChunks.funcSearchChunks(ctx, sp1)
+	}
+	mmSearchChunks.t.Fatalf("Unexpected call to ArtifactPublicServiceServerMock.SearchChunks. %v %v", ctx, sp1)
+	return
+}
+
+// SearchChunksAfterCounter returns a count of finished ArtifactPublicServiceServerMock.SearchChunks invocations
+func (mmSearchChunks *ArtifactPublicServiceServerMock) SearchChunksAfterCounter() uint64 {
+	return mm_atomic.LoadUint64(&mmSearchChunks.afterSearchChunksCounter)
+}
+
+// SearchChunksBeforeCounter returns a count of ArtifactPublicServiceServerMock.SearchChunks invocations
+func (mmSearchChunks *ArtifactPublicServiceServerMock) SearchChunksBeforeCounter() uint64 {
+	return mm_atomic.LoadUint64(&mmSearchChunks.beforeSearchChunksCounter)
+}
+
+// Calls returns a list of arguments used in each call to ArtifactPublicServiceServerMock.SearchChunks.
+// The list is in the same order as the calls were made (i.e. recent calls have a higher index)
+func (mmSearchChunks *mArtifactPublicServiceServerMockSearchChunks) Calls() []*ArtifactPublicServiceServerMockSearchChunksParams {
+	mmSearchChunks.mutex.RLock()
+
+	argCopy := make([]*ArtifactPublicServiceServerMockSearchChunksParams, len(mmSearchChunks.callArgs))
+	copy(argCopy, mmSearchChunks.callArgs)
+
+	mmSearchChunks.mutex.RUnlock()
+
+	return argCopy
+}
+
+// MinimockSearchChunksDone returns true if the count of the SearchChunks invocations corresponds
+// the number of defined expectations
+func (m *ArtifactPublicServiceServerMock) MinimockSearchChunksDone() bool {
+	if m.SearchChunksMock.optional {
+		// Optional methods provide '0 or more' call count restriction.
+		return true
+	}
+
+	for _, e := range m.SearchChunksMock.expectations {
+		if mm_atomic.LoadUint64(&e.Counter) < 1 {
+			return false
+		}
+	}
+
+	return m.SearchChunksMock.invocationsDone()
+}
+
+// MinimockSearchChunksInspect logs each unmet expectation
+func (m *ArtifactPublicServiceServerMock) MinimockSearchChunksInspect() {
+	for _, e := range m.SearchChunksMock.expectations {
+		if mm_atomic.LoadUint64(&e.Counter) < 1 {
+			m.t.Errorf("Expected call to ArtifactPublicServiceServerMock.SearchChunks at\n%s with params: %#v", e.expectationOrigins.origin, *e.params)
+		}
+	}
+
+	afterSearchChunksCounter := mm_atomic.LoadUint64(&m.afterSearchChunksCounter)
+	// if default expectation was set then invocations count should be greater than zero
+	if m.SearchChunksMock.defaultExpectation != nil && afterSearchChunksCounter < 1 {
+		if m.SearchChunksMock.defaultExpectation.params == nil {
+			m.t.Errorf("Expected call to ArtifactPublicServiceServerMock.SearchChunks at\n%s", m.SearchChunksMock.defaultExpectation.returnOrigin)
+		} else {
+			m.t.Errorf("Expected call to ArtifactPublicServiceServerMock.SearchChunks at\n%s with params: %#v", m.SearchChunksMock.defaultExpectation.expectationOrigins.origin, *m.SearchChunksMock.defaultExpectation.params)
+		}
+	}
+	// if func was set then invocations count should be greater than zero
+	if m.funcSearchChunks != nil && afterSearchChunksCounter < 1 {
+		m.t.Errorf("Expected call to ArtifactPublicServiceServerMock.SearchChunks at\n%s", m.funcSearchChunksOrigin)
+	}
+
+	if !m.SearchChunksMock.invocationsDone() && afterSearchChunksCounter > 0 {
+		m.t.Errorf("Expected %d calls to ArtifactPublicServiceServerMock.SearchChunks at\n%s but found %d calls",
+			mm_atomic.LoadUint64(&m.SearchChunksMock.expectedInvocations), m.SearchChunksMock.expectedInvocationsOrigin, afterSearchChunksCounter)
+	}
+}
+
+type mArtifactPublicServiceServerMockSearchSourceFiles struct {
+	optional           bool
+	mock               *ArtifactPublicServiceServerMock
+	defaultExpectation *ArtifactPublicServiceServerMockSearchSourceFilesExpectation
+	expectations       []*ArtifactPublicServiceServerMockSearchSourceFilesExpectation
+
+	callArgs []*ArtifactPublicServiceServerMockSearchSourceFilesParams
+	mutex    sync.RWMutex
+
+	expectedInvocations       uint64
+	expectedInvocationsOrigin string
+}
+
+// ArtifactPublicServiceServerMockSearchSourceFilesExpectation specifies expectation struct of the ArtifactPublicServiceServer.SearchSourceFiles
+type ArtifactPublicServiceServerMockSearchSourceFilesExpectation struct {
+	mock               *ArtifactPublicServiceServerMock
+	params             *ArtifactPublicServiceServerMockSearchSourceFilesParams
+	paramPtrs          *ArtifactPublicServiceServerMockSearchSourceFilesParamPtrs
+	expectationOrigins ArtifactPublicServiceServerMockSearchSourceFilesExpectationOrigins
+	results            *ArtifactPublicServiceServerMockSearchSourceFilesResults
+	returnOrigin       string
+	Counter            uint64
+}
+
+// ArtifactPublicServiceServerMockSearchSourceFilesParams contains parameters of the ArtifactPublicServiceServer.SearchSourceFiles
+type ArtifactPublicServiceServerMockSearchSourceFilesParams struct {
+	ctx context.Context
+	sp1 *mm_artifactv1alpha.SearchSourceFilesRequest
+}
+
+// ArtifactPublicServiceServerMockSearchSourceFilesParamPtrs contains pointers to parameters of the ArtifactPublicServiceServer.SearchSourceFiles
+type ArtifactPublicServiceServerMockSearchSourceFilesParamPtrs struct {
+	ctx *context.Context
+	sp1 **mm_artifactv1alpha.SearchSourceFilesRequest
+}
+
+// ArtifactPublicServiceServerMockSearchSourceFilesResults contains results of the ArtifactPublicServiceServer.SearchSourceFiles
+type ArtifactPublicServiceServerMockSearchSourceFilesResults struct {
+	sp2 *mm_artifactv1alpha.SearchSourceFilesResponse
+	err error
+}
+
+// ArtifactPublicServiceServerMockSearchSourceFilesOrigins contains origins of expectations of the ArtifactPublicServiceServer.SearchSourceFiles
+type ArtifactPublicServiceServerMockSearchSourceFilesExpectationOrigins struct {
+	origin    string
+	originCtx string
+	originSp1 string
+}
+
+// Marks this method to be optional. The default behavior of any method with Return() is '1 or more', meaning
+// the test will fail minimock's automatic final call check if the mocked method was not called at least once.
+// Optional() makes method check to work in '0 or more' mode.
+// It is NOT RECOMMENDED to use this option unless you really need it, as default behaviour helps to
+// catch the problems when the expected method call is totally skipped during test run.
+func (mmSearchSourceFiles *mArtifactPublicServiceServerMockSearchSourceFiles) Optional() *mArtifactPublicServiceServerMockSearchSourceFiles {
+	mmSearchSourceFiles.optional = true
+	return mmSearchSourceFiles
+}
+
+// Expect sets up expected params for ArtifactPublicServiceServer.SearchSourceFiles
+func (mmSearchSourceFiles *mArtifactPublicServiceServerMockSearchSourceFiles) Expect(ctx context.Context, sp1 *mm_artifactv1alpha.SearchSourceFilesRequest) *mArtifactPublicServiceServerMockSearchSourceFiles {
+	if mmSearchSourceFiles.mock.funcSearchSourceFiles != nil {
+		mmSearchSourceFiles.mock.t.Fatalf("ArtifactPublicServiceServerMock.SearchSourceFiles mock is already set by Set")
+	}
+
+	if mmSearchSourceFiles.defaultExpectation == nil {
+		mmSearchSourceFiles.defaultExpectation = &ArtifactPublicServiceServerMockSearchSourceFilesExpectation{}
+	}
+
+	if mmSearchSourceFiles.defaultExpectation.paramPtrs != nil {
+		mmSearchSourceFiles.mock.t.Fatalf("ArtifactPublicServiceServerMock.SearchSourceFiles mock is already set by ExpectParams functions")
+	}
+
+	mmSearchSourceFiles.defaultExpectation.params = &ArtifactPublicServiceServerMockSearchSourceFilesParams{ctx, sp1}
+	mmSearchSourceFiles.defaultExpectation.expectationOrigins.origin = minimock.CallerInfo(1)
+	for _, e := range mmSearchSourceFiles.expectations {
+		if minimock.Equal(e.params, mmSearchSourceFiles.defaultExpectation.params) {
+			mmSearchSourceFiles.mock.t.Fatalf("Expectation set by When has same params: %#v", *mmSearchSourceFiles.defaultExpectation.params)
+		}
+	}
+
+	return mmSearchSourceFiles
+}
+
+// ExpectCtxParam1 sets up expected param ctx for ArtifactPublicServiceServer.SearchSourceFiles
+func (mmSearchSourceFiles *mArtifactPublicServiceServerMockSearchSourceFiles) ExpectCtxParam1(ctx context.Context) *mArtifactPublicServiceServerMockSearchSourceFiles {
+	if mmSearchSourceFiles.mock.funcSearchSourceFiles != nil {
+		mmSearchSourceFiles.mock.t.Fatalf("ArtifactPublicServiceServerMock.SearchSourceFiles mock is already set by Set")
+	}
+
+	if mmSearchSourceFiles.defaultExpectation == nil {
+		mmSearchSourceFiles.defaultExpectation = &ArtifactPublicServiceServerMockSearchSourceFilesExpectation{}
+	}
+
+	if mmSearchSourceFiles.defaultExpectation.params != nil {
+		mmSearchSourceFiles.mock.t.Fatalf("ArtifactPublicServiceServerMock.SearchSourceFiles mock is already set by Expect")
+	}
+
+	if mmSearchSourceFiles.defaultExpectation.paramPtrs == nil {
+		mmSearchSourceFiles.defaultExpectation.paramPtrs = &ArtifactPublicServiceServerMockSearchSourceFilesParamPtrs{}
+	}
+	mmSearchSourceFiles.defaultExpectation.paramPtrs.ctx = &ctx
+	mmSearchSourceFiles.defaultExpectation.expectationOrigins.originCtx = minimock.CallerInfo(1)
+
+	return mmSearchSourceFiles
+}
+
+// ExpectSp1Param2 sets up expected param sp1 for ArtifactPublicServiceServer.SearchSourceFiles
+func (mmSearchSourceFiles *mArtifactPublicServiceServerMockSearchSourceFiles) ExpectSp1Param2(sp1 *mm_artifactv1alpha.SearchSourceFilesRequest) *mArtifactPublicServiceServerMockSearchSourceFiles {
+	if mmSearchSourceFiles.mock.funcSearchSourceFiles != nil {
+		mmSearchSourceFiles.mock.t.Fatalf("ArtifactPublicServiceServerMock.SearchSourceFiles mock is already set by Set")
+	}
+
+	if mmSearchSourceFiles.defaultExpectation == nil {
+		mmSearchSourceFiles.defaultExpectation = &ArtifactPublicServiceServerMockSearchSourceFilesExpectation{}
+	}
+
+	if mmSearchSourceFiles.defaultExpectation.params != nil {
+		mmSearchSourceFiles.mock.t.Fatalf("ArtifactPublicServiceServerMock.SearchSourceFiles mock is already set by Expect")
+	}
+
+	if mmSearchSourceFiles.defaultExpectation.paramPtrs == nil {
+		mmSearchSourceFiles.defaultExpectation.paramPtrs = &ArtifactPublicServiceServerMockSearchSourceFilesParamPtrs{}
+	}
+	mmSearchSourceFiles.defaultExpectation.paramPtrs.sp1 = &sp1
+	mmSearchSourceFiles.defaultExpectation.expectationOrigins.originSp1 = minimock.CallerInfo(1)
+
+	return mmSearchSourceFiles
+}
+
+// Inspect accepts an inspector function that has same arguments as the ArtifactPublicServiceServer.SearchSourceFiles
+func (mmSearchSourceFiles *mArtifactPublicServiceServerMockSearchSourceFiles) Inspect(f func(ctx context.Context, sp1 *mm_artifactv1alpha.SearchSourceFilesRequest)) *mArtifactPublicServiceServerMockSearchSourceFiles {
+	if mmSearchSourceFiles.mock.inspectFuncSearchSourceFiles != nil {
+		mmSearchSourceFiles.mock.t.Fatalf("Inspect function is already set for ArtifactPublicServiceServerMock.SearchSourceFiles")
+	}
+
+	mmSearchSourceFiles.mock.inspectFuncSearchSourceFiles = f
+
+	return mmSearchSourceFiles
+}
+
+// Return sets up results that will be returned by ArtifactPublicServiceServer.SearchSourceFiles
+func (mmSearchSourceFiles *mArtifactPublicServiceServerMockSearchSourceFiles) Return(sp2 *mm_artifactv1alpha.SearchSourceFilesResponse, err error) *ArtifactPublicServiceServerMock {
+	if mmSearchSourceFiles.mock.funcSearchSourceFiles != nil {
+		mmSearchSourceFiles.mock.t.Fatalf("ArtifactPublicServiceServerMock.SearchSourceFiles mock is already set by Set")
+	}
+
+	if mmSearchSourceFiles.defaultExpectation == nil {
+		mmSearchSourceFiles.defaultExpectation = &ArtifactPublicServiceServerMockSearchSourceFilesExpectation{mock: mmSearchSourceFiles.mock}
+	}
+	mmSearchSourceFiles.defaultExpectation.results = &ArtifactPublicServiceServerMockSearchSourceFilesResults{sp2, err}
+	mmSearchSourceFiles.defaultExpectation.returnOrigin = minimock.CallerInfo(1)
+	return mmSearchSourceFiles.mock
+}
+
+// Set uses given function f to mock the ArtifactPublicServiceServer.SearchSourceFiles method
+func (mmSearchSourceFiles *mArtifactPublicServiceServerMockSearchSourceFiles) Set(f func(ctx context.Context, sp1 *mm_artifactv1alpha.SearchSourceFilesRequest) (sp2 *mm_artifactv1alpha.SearchSourceFilesResponse, err error)) *ArtifactPublicServiceServerMock {
+	if mmSearchSourceFiles.defaultExpectation != nil {
+		mmSearchSourceFiles.mock.t.Fatalf("Default expectation is already set for the ArtifactPublicServiceServer.SearchSourceFiles method")
+	}
+
+	if len(mmSearchSourceFiles.expectations) > 0 {
+		mmSearchSourceFiles.mock.t.Fatalf("Some expectations are already set for the ArtifactPublicServiceServer.SearchSourceFiles method")
+	}
+
+	mmSearchSourceFiles.mock.funcSearchSourceFiles = f
+	mmSearchSourceFiles.mock.funcSearchSourceFilesOrigin = minimock.CallerInfo(1)
+	return mmSearchSourceFiles.mock
+}
+
+// When sets expectation for the ArtifactPublicServiceServer.SearchSourceFiles which will trigger the result defined by the following
+// Then helper
+func (mmSearchSourceFiles *mArtifactPublicServiceServerMockSearchSourceFiles) When(ctx context.Context, sp1 *mm_artifactv1alpha.SearchSourceFilesRequest) *ArtifactPublicServiceServerMockSearchSourceFilesExpectation {
+	if mmSearchSourceFiles.mock.funcSearchSourceFiles != nil {
+		mmSearchSourceFiles.mock.t.Fatalf("ArtifactPublicServiceServerMock.SearchSourceFiles mock is already set by Set")
+	}
+
+	expectation := &ArtifactPublicServiceServerMockSearchSourceFilesExpectation{
+		mock:               mmSearchSourceFiles.mock,
+		params:             &ArtifactPublicServiceServerMockSearchSourceFilesParams{ctx, sp1},
+		expectationOrigins: ArtifactPublicServiceServerMockSearchSourceFilesExpectationOrigins{origin: minimock.CallerInfo(1)},
+	}
+	mmSearchSourceFiles.expectations = append(mmSearchSourceFiles.expectations, expectation)
+	return expectation
+}
+
+// Then sets up ArtifactPublicServiceServer.SearchSourceFiles return parameters for the expectation previously defined by the When method
+func (e *ArtifactPublicServiceServerMockSearchSourceFilesExpectation) Then(sp2 *mm_artifactv1alpha.SearchSourceFilesResponse, err error) *ArtifactPublicServiceServerMock {
+	e.results = &ArtifactPublicServiceServerMockSearchSourceFilesResults{sp2, err}
+	return e.mock
+}
+
+// Times sets number of times ArtifactPublicServiceServer.SearchSourceFiles should be invoked
+func (mmSearchSourceFiles *mArtifactPublicServiceServerMockSearchSourceFiles) Times(n uint64) *mArtifactPublicServiceServerMockSearchSourceFiles {
+	if n == 0 {
+		mmSearchSourceFiles.mock.t.Fatalf("Times of ArtifactPublicServiceServerMock.SearchSourceFiles mock can not be zero")
+	}
+	mm_atomic.StoreUint64(&mmSearchSourceFiles.expectedInvocations, n)
+	mmSearchSourceFiles.expectedInvocationsOrigin = minimock.CallerInfo(1)
+	return mmSearchSourceFiles
+}
+
+func (mmSearchSourceFiles *mArtifactPublicServiceServerMockSearchSourceFiles) invocationsDone() bool {
+	if len(mmSearchSourceFiles.expectations) == 0 && mmSearchSourceFiles.defaultExpectation == nil && mmSearchSourceFiles.mock.funcSearchSourceFiles == nil {
+		return true
+	}
+
+	totalInvocations := mm_atomic.LoadUint64(&mmSearchSourceFiles.mock.afterSearchSourceFilesCounter)
+	expectedInvocations := mm_atomic.LoadUint64(&mmSearchSourceFiles.expectedInvocations)
+
+	return totalInvocations > 0 && (expectedInvocations == 0 || expectedInvocations == totalInvocations)
+}
+
+// SearchSourceFiles implements mm_artifactv1alpha.ArtifactPublicServiceServer
+func (mmSearchSourceFiles *ArtifactPublicServiceServerMock) SearchSourceFiles(ctx context.Context, sp1 *mm_artifactv1alpha.SearchSourceFilesRequest) (sp2 *mm_artifactv1alpha.SearchSourceFilesResponse, err error) {
+	mm_atomic.AddUint64(&mmSearchSourceFiles.beforeSearchSourceFilesCounter, 1)
+	defer mm_atomic.AddUint64(&mmSearchSourceFiles.afterSearchSourceFilesCounter, 1)
+
+	mmSearchSourceFiles.t.Helper()
+
+	if mmSearchSourceFiles.inspectFuncSearchSourceFiles != nil {
+		mmSearchSourceFiles.inspectFuncSearchSourceFiles(ctx, sp1)
+	}
+
+	mm_params := ArtifactPublicServiceServerMockSearchSourceFilesParams{ctx, sp1}
+
+	// Record call args
+	mmSearchSourceFiles.SearchSourceFilesMock.mutex.Lock()
+	mmSearchSourceFiles.SearchSourceFilesMock.callArgs = append(mmSearchSourceFiles.SearchSourceFilesMock.callArgs, &mm_params)
+	mmSearchSourceFiles.SearchSourceFilesMock.mutex.Unlock()
+
+	for _, e := range mmSearchSourceFiles.SearchSourceFilesMock.expectations {
+		if minimock.Equal(*e.params, mm_params) {
+			mm_atomic.AddUint64(&e.Counter, 1)
+			return e.results.sp2, e.results.err
+		}
+	}
+
+	if mmSearchSourceFiles.SearchSourceFilesMock.defaultExpectation != nil {
+		mm_atomic.AddUint64(&mmSearchSourceFiles.SearchSourceFilesMock.defaultExpectation.Counter, 1)
+		mm_want := mmSearchSourceFiles.SearchSourceFilesMock.defaultExpectation.params
+		mm_want_ptrs := mmSearchSourceFiles.SearchSourceFilesMock.defaultExpectation.paramPtrs
+
+		mm_got := ArtifactPublicServiceServerMockSearchSourceFilesParams{ctx, sp1}
+
+		if mm_want_ptrs != nil {
+
+			if mm_want_ptrs.ctx != nil && !minimock.Equal(*mm_want_ptrs.ctx, mm_got.ctx) {
+				mmSearchSourceFiles.t.Errorf("ArtifactPublicServiceServerMock.SearchSourceFiles got unexpected parameter ctx, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmSearchSourceFiles.SearchSourceFilesMock.defaultExpectation.expectationOrigins.originCtx, *mm_want_ptrs.ctx, mm_got.ctx, minimock.Diff(*mm_want_ptrs.ctx, mm_got.ctx))
+			}
+
+			if mm_want_ptrs.sp1 != nil && !minimock.Equal(*mm_want_ptrs.sp1, mm_got.sp1) {
+				mmSearchSourceFiles.t.Errorf("ArtifactPublicServiceServerMock.SearchSourceFiles got unexpected parameter sp1, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmSearchSourceFiles.SearchSourceFilesMock.defaultExpectation.expectationOrigins.originSp1, *mm_want_ptrs.sp1, mm_got.sp1, minimock.Diff(*mm_want_ptrs.sp1, mm_got.sp1))
+			}
+
+		} else if mm_want != nil && !minimock.Equal(*mm_want, mm_got) {
+			mmSearchSourceFiles.t.Errorf("ArtifactPublicServiceServerMock.SearchSourceFiles got unexpected parameters, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+				mmSearchSourceFiles.SearchSourceFilesMock.defaultExpectation.expectationOrigins.origin, *mm_want, mm_got, minimock.Diff(*mm_want, mm_got))
+		}
+
+		mm_results := mmSearchSourceFiles.SearchSourceFilesMock.defaultExpectation.results
+		if mm_results == nil {
+			mmSearchSourceFiles.t.Fatal("No results are set for the ArtifactPublicServiceServerMock.SearchSourceFiles")
+		}
+		return (*mm_results).sp2, (*mm_results).err
+	}
+	if mmSearchSourceFiles.funcSearchSourceFiles != nil {
+		return mmSearchSourceFiles.funcSearchSourceFiles(ctx, sp1)
+	}
+	mmSearchSourceFiles.t.Fatalf("Unexpected call to ArtifactPublicServiceServerMock.SearchSourceFiles. %v %v", ctx, sp1)
+	return
+}
+
+// SearchSourceFilesAfterCounter returns a count of finished ArtifactPublicServiceServerMock.SearchSourceFiles invocations
+func (mmSearchSourceFiles *ArtifactPublicServiceServerMock) SearchSourceFilesAfterCounter() uint64 {
+	return mm_atomic.LoadUint64(&mmSearchSourceFiles.afterSearchSourceFilesCounter)
+}
+
+// SearchSourceFilesBeforeCounter returns a count of ArtifactPublicServiceServerMock.SearchSourceFiles invocations
+func (mmSearchSourceFiles *ArtifactPublicServiceServerMock) SearchSourceFilesBeforeCounter() uint64 {
+	return mm_atomic.LoadUint64(&mmSearchSourceFiles.beforeSearchSourceFilesCounter)
+}
+
+// Calls returns a list of arguments used in each call to ArtifactPublicServiceServerMock.SearchSourceFiles.
+// The list is in the same order as the calls were made (i.e. recent calls have a higher index)
+func (mmSearchSourceFiles *mArtifactPublicServiceServerMockSearchSourceFiles) Calls() []*ArtifactPublicServiceServerMockSearchSourceFilesParams {
+	mmSearchSourceFiles.mutex.RLock()
+
+	argCopy := make([]*ArtifactPublicServiceServerMockSearchSourceFilesParams, len(mmSearchSourceFiles.callArgs))
+	copy(argCopy, mmSearchSourceFiles.callArgs)
+
+	mmSearchSourceFiles.mutex.RUnlock()
+
+	return argCopy
+}
+
+// MinimockSearchSourceFilesDone returns true if the count of the SearchSourceFiles invocations corresponds
+// the number of defined expectations
+func (m *ArtifactPublicServiceServerMock) MinimockSearchSourceFilesDone() bool {
+	if m.SearchSourceFilesMock.optional {
+		// Optional methods provide '0 or more' call count restriction.
+		return true
+	}
+
+	for _, e := range m.SearchSourceFilesMock.expectations {
+		if mm_atomic.LoadUint64(&e.Counter) < 1 {
+			return false
+		}
+	}
+
+	return m.SearchSourceFilesMock.invocationsDone()
+}
+
+// MinimockSearchSourceFilesInspect logs each unmet expectation
+func (m *ArtifactPublicServiceServerMock) MinimockSearchSourceFilesInspect() {
+	for _, e := range m.SearchSourceFilesMock.expectations {
+		if mm_atomic.LoadUint64(&e.Counter) < 1 {
+			m.t.Errorf("Expected call to ArtifactPublicServiceServerMock.SearchSourceFiles at\n%s with params: %#v", e.expectationOrigins.origin, *e.params)
+		}
+	}
+
+	afterSearchSourceFilesCounter := mm_atomic.LoadUint64(&m.afterSearchSourceFilesCounter)
+	// if default expectation was set then invocations count should be greater than zero
+	if m.SearchSourceFilesMock.defaultExpectation != nil && afterSearchSourceFilesCounter < 1 {
+		if m.SearchSourceFilesMock.defaultExpectation.params == nil {
+			m.t.Errorf("Expected call to ArtifactPublicServiceServerMock.SearchSourceFiles at\n%s", m.SearchSourceFilesMock.defaultExpectation.returnOrigin)
+		} else {
+			m.t.Errorf("Expected call to ArtifactPublicServiceServerMock.SearchSourceFiles at\n%s with params: %#v", m.SearchSourceFilesMock.defaultExpectation.expectationOrigins.origin, *m.SearchSourceFilesMock.defaultExpectation.params)
+		}
+	}
+	// if func was set then invocations count should be greater than zero
+	if m.funcSearchSourceFiles != nil && afterSearchSourceFilesCounter < 1 {
+		m.t.Errorf("Expected call to ArtifactPublicServiceServerMock.SearchSourceFiles at\n%s", m.funcSearchSourceFilesOrigin)
+	}
+
+	if !m.SearchSourceFilesMock.invocationsDone() && afterSearchSourceFilesCounter > 0 {
+		m.t.Errorf("Expected %d calls to ArtifactPublicServiceServerMock.SearchSourceFiles at\n%s but found %d calls",
+			mm_atomic.LoadUint64(&m.SearchSourceFilesMock.expectedInvocations), m.SearchSourceFilesMock.expectedInvocationsOrigin, afterSearchSourceFilesCounter)
+	}
+}
+
 type mArtifactPublicServiceServerMockSimilarityChunksSearch struct {
 	optional           bool
 	mock               *ArtifactPublicServiceServerMock
@@ -6772,6 +7478,10 @@ func (m *ArtifactPublicServiceServerMock) MinimockFinish() {
 
 			m.MinimockReadinessInspect()
 
+			m.MinimockSearchChunksInspect()
+
+			m.MinimockSearchSourceFilesInspect()
+
 			m.MinimockSimilarityChunksSearchInspect()
 
 			m.MinimockUpdateCatalogInspect()
@@ -6817,6 +7527,8 @@ func (m *ArtifactPublicServiceServerMock) minimockDone() bool {
 		m.MinimockProcessCatalogFilesDone() &&
 		m.MinimockQuestionAnsweringDone() &&
 		m.MinimockReadinessDone() &&
+		m.MinimockSearchChunksDone() &&
+		m.MinimockSearchSourceFilesDone() &&
 		m.MinimockSimilarityChunksSearchDone() &&
 		m.MinimockUpdateCatalogDone() &&
 		m.MinimockUpdateChunkDone() &&

--- a/pkg/handler/integration.go
+++ b/pkg/handler/integration.go
@@ -270,3 +270,19 @@ func (h *PublicHandler) ListNamespaceConnections(ctx context.Context, req *pb.Li
 	)))
 	return resp, nil
 }
+
+// LookUpConnectionAdmin fetches a connection by UID.
+func (h *PrivateHandler) LookUpConnectionAdmin(ctx context.Context, req *pb.LookUpConnectionAdminRequest) (*pb.LookUpConnectionAdminResponse, error) {
+	view := pb.View_VIEW_BASIC
+	if req.GetView() != pb.View_VIEW_UNSPECIFIED {
+		view = req.GetView()
+	}
+
+	uid := uuid.FromStringOrNil(req.GetUid())
+	conn, err := h.service.GetConnectionByUIDAdmin(ctx, uid, view)
+	if err != nil {
+		return nil, err
+	}
+
+	return &pb.LookUpConnectionAdminResponse{Connection: conn}, nil
+}

--- a/pkg/mock/repository_mock.gen.go
+++ b/pkg/mock/repository_mock.gen.go
@@ -130,6 +130,13 @@ type RepositoryMock struct {
 	beforeDeletePipelineTagsCounter uint64
 	DeletePipelineTagsMock          mRepositoryMockDeletePipelineTags
 
+	funcGetConnectionByUID          func(ctx context.Context, u1 uuid.UUID) (cp1 *datamodel.Connection, err error)
+	funcGetConnectionByUIDOrigin    string
+	inspectFuncGetConnectionByUID   func(ctx context.Context, u1 uuid.UUID)
+	afterGetConnectionByUIDCounter  uint64
+	beforeGetConnectionByUIDCounter uint64
+	GetConnectionByUIDMock          mRepositoryMockGetConnectionByUID
+
 	funcGetDefinitionByUID          func(ctx context.Context, u1 uuid.UUID) (cp1 *datamodel.ComponentDefinition, err error)
 	funcGetDefinitionByUIDOrigin    string
 	inspectFuncGetDefinitionByUID   func(ctx context.Context, u1 uuid.UUID)
@@ -456,6 +463,9 @@ func NewRepositoryMock(t minimock.Tester) *RepositoryMock {
 
 	m.DeletePipelineTagsMock = mRepositoryMockDeletePipelineTags{mock: m}
 	m.DeletePipelineTagsMock.callArgs = []*RepositoryMockDeletePipelineTagsParams{}
+
+	m.GetConnectionByUIDMock = mRepositoryMockGetConnectionByUID{mock: m}
+	m.GetConnectionByUIDMock.callArgs = []*RepositoryMockGetConnectionByUIDParams{}
 
 	m.GetDefinitionByUIDMock = mRepositoryMockGetDefinitionByUID{mock: m}
 	m.GetDefinitionByUIDMock.callArgs = []*RepositoryMockGetDefinitionByUIDParams{}
@@ -6079,6 +6089,349 @@ func (m *RepositoryMock) MinimockDeletePipelineTagsInspect() {
 	if !m.DeletePipelineTagsMock.invocationsDone() && afterDeletePipelineTagsCounter > 0 {
 		m.t.Errorf("Expected %d calls to RepositoryMock.DeletePipelineTags at\n%s but found %d calls",
 			mm_atomic.LoadUint64(&m.DeletePipelineTagsMock.expectedInvocations), m.DeletePipelineTagsMock.expectedInvocationsOrigin, afterDeletePipelineTagsCounter)
+	}
+}
+
+type mRepositoryMockGetConnectionByUID struct {
+	optional           bool
+	mock               *RepositoryMock
+	defaultExpectation *RepositoryMockGetConnectionByUIDExpectation
+	expectations       []*RepositoryMockGetConnectionByUIDExpectation
+
+	callArgs []*RepositoryMockGetConnectionByUIDParams
+	mutex    sync.RWMutex
+
+	expectedInvocations       uint64
+	expectedInvocationsOrigin string
+}
+
+// RepositoryMockGetConnectionByUIDExpectation specifies expectation struct of the Repository.GetConnectionByUID
+type RepositoryMockGetConnectionByUIDExpectation struct {
+	mock               *RepositoryMock
+	params             *RepositoryMockGetConnectionByUIDParams
+	paramPtrs          *RepositoryMockGetConnectionByUIDParamPtrs
+	expectationOrigins RepositoryMockGetConnectionByUIDExpectationOrigins
+	results            *RepositoryMockGetConnectionByUIDResults
+	returnOrigin       string
+	Counter            uint64
+}
+
+// RepositoryMockGetConnectionByUIDParams contains parameters of the Repository.GetConnectionByUID
+type RepositoryMockGetConnectionByUIDParams struct {
+	ctx context.Context
+	u1  uuid.UUID
+}
+
+// RepositoryMockGetConnectionByUIDParamPtrs contains pointers to parameters of the Repository.GetConnectionByUID
+type RepositoryMockGetConnectionByUIDParamPtrs struct {
+	ctx *context.Context
+	u1  *uuid.UUID
+}
+
+// RepositoryMockGetConnectionByUIDResults contains results of the Repository.GetConnectionByUID
+type RepositoryMockGetConnectionByUIDResults struct {
+	cp1 *datamodel.Connection
+	err error
+}
+
+// RepositoryMockGetConnectionByUIDOrigins contains origins of expectations of the Repository.GetConnectionByUID
+type RepositoryMockGetConnectionByUIDExpectationOrigins struct {
+	origin    string
+	originCtx string
+	originU1  string
+}
+
+// Marks this method to be optional. The default behavior of any method with Return() is '1 or more', meaning
+// the test will fail minimock's automatic final call check if the mocked method was not called at least once.
+// Optional() makes method check to work in '0 or more' mode.
+// It is NOT RECOMMENDED to use this option unless you really need it, as default behaviour helps to
+// catch the problems when the expected method call is totally skipped during test run.
+func (mmGetConnectionByUID *mRepositoryMockGetConnectionByUID) Optional() *mRepositoryMockGetConnectionByUID {
+	mmGetConnectionByUID.optional = true
+	return mmGetConnectionByUID
+}
+
+// Expect sets up expected params for Repository.GetConnectionByUID
+func (mmGetConnectionByUID *mRepositoryMockGetConnectionByUID) Expect(ctx context.Context, u1 uuid.UUID) *mRepositoryMockGetConnectionByUID {
+	if mmGetConnectionByUID.mock.funcGetConnectionByUID != nil {
+		mmGetConnectionByUID.mock.t.Fatalf("RepositoryMock.GetConnectionByUID mock is already set by Set")
+	}
+
+	if mmGetConnectionByUID.defaultExpectation == nil {
+		mmGetConnectionByUID.defaultExpectation = &RepositoryMockGetConnectionByUIDExpectation{}
+	}
+
+	if mmGetConnectionByUID.defaultExpectation.paramPtrs != nil {
+		mmGetConnectionByUID.mock.t.Fatalf("RepositoryMock.GetConnectionByUID mock is already set by ExpectParams functions")
+	}
+
+	mmGetConnectionByUID.defaultExpectation.params = &RepositoryMockGetConnectionByUIDParams{ctx, u1}
+	mmGetConnectionByUID.defaultExpectation.expectationOrigins.origin = minimock.CallerInfo(1)
+	for _, e := range mmGetConnectionByUID.expectations {
+		if minimock.Equal(e.params, mmGetConnectionByUID.defaultExpectation.params) {
+			mmGetConnectionByUID.mock.t.Fatalf("Expectation set by When has same params: %#v", *mmGetConnectionByUID.defaultExpectation.params)
+		}
+	}
+
+	return mmGetConnectionByUID
+}
+
+// ExpectCtxParam1 sets up expected param ctx for Repository.GetConnectionByUID
+func (mmGetConnectionByUID *mRepositoryMockGetConnectionByUID) ExpectCtxParam1(ctx context.Context) *mRepositoryMockGetConnectionByUID {
+	if mmGetConnectionByUID.mock.funcGetConnectionByUID != nil {
+		mmGetConnectionByUID.mock.t.Fatalf("RepositoryMock.GetConnectionByUID mock is already set by Set")
+	}
+
+	if mmGetConnectionByUID.defaultExpectation == nil {
+		mmGetConnectionByUID.defaultExpectation = &RepositoryMockGetConnectionByUIDExpectation{}
+	}
+
+	if mmGetConnectionByUID.defaultExpectation.params != nil {
+		mmGetConnectionByUID.mock.t.Fatalf("RepositoryMock.GetConnectionByUID mock is already set by Expect")
+	}
+
+	if mmGetConnectionByUID.defaultExpectation.paramPtrs == nil {
+		mmGetConnectionByUID.defaultExpectation.paramPtrs = &RepositoryMockGetConnectionByUIDParamPtrs{}
+	}
+	mmGetConnectionByUID.defaultExpectation.paramPtrs.ctx = &ctx
+	mmGetConnectionByUID.defaultExpectation.expectationOrigins.originCtx = minimock.CallerInfo(1)
+
+	return mmGetConnectionByUID
+}
+
+// ExpectU1Param2 sets up expected param u1 for Repository.GetConnectionByUID
+func (mmGetConnectionByUID *mRepositoryMockGetConnectionByUID) ExpectU1Param2(u1 uuid.UUID) *mRepositoryMockGetConnectionByUID {
+	if mmGetConnectionByUID.mock.funcGetConnectionByUID != nil {
+		mmGetConnectionByUID.mock.t.Fatalf("RepositoryMock.GetConnectionByUID mock is already set by Set")
+	}
+
+	if mmGetConnectionByUID.defaultExpectation == nil {
+		mmGetConnectionByUID.defaultExpectation = &RepositoryMockGetConnectionByUIDExpectation{}
+	}
+
+	if mmGetConnectionByUID.defaultExpectation.params != nil {
+		mmGetConnectionByUID.mock.t.Fatalf("RepositoryMock.GetConnectionByUID mock is already set by Expect")
+	}
+
+	if mmGetConnectionByUID.defaultExpectation.paramPtrs == nil {
+		mmGetConnectionByUID.defaultExpectation.paramPtrs = &RepositoryMockGetConnectionByUIDParamPtrs{}
+	}
+	mmGetConnectionByUID.defaultExpectation.paramPtrs.u1 = &u1
+	mmGetConnectionByUID.defaultExpectation.expectationOrigins.originU1 = minimock.CallerInfo(1)
+
+	return mmGetConnectionByUID
+}
+
+// Inspect accepts an inspector function that has same arguments as the Repository.GetConnectionByUID
+func (mmGetConnectionByUID *mRepositoryMockGetConnectionByUID) Inspect(f func(ctx context.Context, u1 uuid.UUID)) *mRepositoryMockGetConnectionByUID {
+	if mmGetConnectionByUID.mock.inspectFuncGetConnectionByUID != nil {
+		mmGetConnectionByUID.mock.t.Fatalf("Inspect function is already set for RepositoryMock.GetConnectionByUID")
+	}
+
+	mmGetConnectionByUID.mock.inspectFuncGetConnectionByUID = f
+
+	return mmGetConnectionByUID
+}
+
+// Return sets up results that will be returned by Repository.GetConnectionByUID
+func (mmGetConnectionByUID *mRepositoryMockGetConnectionByUID) Return(cp1 *datamodel.Connection, err error) *RepositoryMock {
+	if mmGetConnectionByUID.mock.funcGetConnectionByUID != nil {
+		mmGetConnectionByUID.mock.t.Fatalf("RepositoryMock.GetConnectionByUID mock is already set by Set")
+	}
+
+	if mmGetConnectionByUID.defaultExpectation == nil {
+		mmGetConnectionByUID.defaultExpectation = &RepositoryMockGetConnectionByUIDExpectation{mock: mmGetConnectionByUID.mock}
+	}
+	mmGetConnectionByUID.defaultExpectation.results = &RepositoryMockGetConnectionByUIDResults{cp1, err}
+	mmGetConnectionByUID.defaultExpectation.returnOrigin = minimock.CallerInfo(1)
+	return mmGetConnectionByUID.mock
+}
+
+// Set uses given function f to mock the Repository.GetConnectionByUID method
+func (mmGetConnectionByUID *mRepositoryMockGetConnectionByUID) Set(f func(ctx context.Context, u1 uuid.UUID) (cp1 *datamodel.Connection, err error)) *RepositoryMock {
+	if mmGetConnectionByUID.defaultExpectation != nil {
+		mmGetConnectionByUID.mock.t.Fatalf("Default expectation is already set for the Repository.GetConnectionByUID method")
+	}
+
+	if len(mmGetConnectionByUID.expectations) > 0 {
+		mmGetConnectionByUID.mock.t.Fatalf("Some expectations are already set for the Repository.GetConnectionByUID method")
+	}
+
+	mmGetConnectionByUID.mock.funcGetConnectionByUID = f
+	mmGetConnectionByUID.mock.funcGetConnectionByUIDOrigin = minimock.CallerInfo(1)
+	return mmGetConnectionByUID.mock
+}
+
+// When sets expectation for the Repository.GetConnectionByUID which will trigger the result defined by the following
+// Then helper
+func (mmGetConnectionByUID *mRepositoryMockGetConnectionByUID) When(ctx context.Context, u1 uuid.UUID) *RepositoryMockGetConnectionByUIDExpectation {
+	if mmGetConnectionByUID.mock.funcGetConnectionByUID != nil {
+		mmGetConnectionByUID.mock.t.Fatalf("RepositoryMock.GetConnectionByUID mock is already set by Set")
+	}
+
+	expectation := &RepositoryMockGetConnectionByUIDExpectation{
+		mock:               mmGetConnectionByUID.mock,
+		params:             &RepositoryMockGetConnectionByUIDParams{ctx, u1},
+		expectationOrigins: RepositoryMockGetConnectionByUIDExpectationOrigins{origin: minimock.CallerInfo(1)},
+	}
+	mmGetConnectionByUID.expectations = append(mmGetConnectionByUID.expectations, expectation)
+	return expectation
+}
+
+// Then sets up Repository.GetConnectionByUID return parameters for the expectation previously defined by the When method
+func (e *RepositoryMockGetConnectionByUIDExpectation) Then(cp1 *datamodel.Connection, err error) *RepositoryMock {
+	e.results = &RepositoryMockGetConnectionByUIDResults{cp1, err}
+	return e.mock
+}
+
+// Times sets number of times Repository.GetConnectionByUID should be invoked
+func (mmGetConnectionByUID *mRepositoryMockGetConnectionByUID) Times(n uint64) *mRepositoryMockGetConnectionByUID {
+	if n == 0 {
+		mmGetConnectionByUID.mock.t.Fatalf("Times of RepositoryMock.GetConnectionByUID mock can not be zero")
+	}
+	mm_atomic.StoreUint64(&mmGetConnectionByUID.expectedInvocations, n)
+	mmGetConnectionByUID.expectedInvocationsOrigin = minimock.CallerInfo(1)
+	return mmGetConnectionByUID
+}
+
+func (mmGetConnectionByUID *mRepositoryMockGetConnectionByUID) invocationsDone() bool {
+	if len(mmGetConnectionByUID.expectations) == 0 && mmGetConnectionByUID.defaultExpectation == nil && mmGetConnectionByUID.mock.funcGetConnectionByUID == nil {
+		return true
+	}
+
+	totalInvocations := mm_atomic.LoadUint64(&mmGetConnectionByUID.mock.afterGetConnectionByUIDCounter)
+	expectedInvocations := mm_atomic.LoadUint64(&mmGetConnectionByUID.expectedInvocations)
+
+	return totalInvocations > 0 && (expectedInvocations == 0 || expectedInvocations == totalInvocations)
+}
+
+// GetConnectionByUID implements mm_repository.Repository
+func (mmGetConnectionByUID *RepositoryMock) GetConnectionByUID(ctx context.Context, u1 uuid.UUID) (cp1 *datamodel.Connection, err error) {
+	mm_atomic.AddUint64(&mmGetConnectionByUID.beforeGetConnectionByUIDCounter, 1)
+	defer mm_atomic.AddUint64(&mmGetConnectionByUID.afterGetConnectionByUIDCounter, 1)
+
+	mmGetConnectionByUID.t.Helper()
+
+	if mmGetConnectionByUID.inspectFuncGetConnectionByUID != nil {
+		mmGetConnectionByUID.inspectFuncGetConnectionByUID(ctx, u1)
+	}
+
+	mm_params := RepositoryMockGetConnectionByUIDParams{ctx, u1}
+
+	// Record call args
+	mmGetConnectionByUID.GetConnectionByUIDMock.mutex.Lock()
+	mmGetConnectionByUID.GetConnectionByUIDMock.callArgs = append(mmGetConnectionByUID.GetConnectionByUIDMock.callArgs, &mm_params)
+	mmGetConnectionByUID.GetConnectionByUIDMock.mutex.Unlock()
+
+	for _, e := range mmGetConnectionByUID.GetConnectionByUIDMock.expectations {
+		if minimock.Equal(*e.params, mm_params) {
+			mm_atomic.AddUint64(&e.Counter, 1)
+			return e.results.cp1, e.results.err
+		}
+	}
+
+	if mmGetConnectionByUID.GetConnectionByUIDMock.defaultExpectation != nil {
+		mm_atomic.AddUint64(&mmGetConnectionByUID.GetConnectionByUIDMock.defaultExpectation.Counter, 1)
+		mm_want := mmGetConnectionByUID.GetConnectionByUIDMock.defaultExpectation.params
+		mm_want_ptrs := mmGetConnectionByUID.GetConnectionByUIDMock.defaultExpectation.paramPtrs
+
+		mm_got := RepositoryMockGetConnectionByUIDParams{ctx, u1}
+
+		if mm_want_ptrs != nil {
+
+			if mm_want_ptrs.ctx != nil && !minimock.Equal(*mm_want_ptrs.ctx, mm_got.ctx) {
+				mmGetConnectionByUID.t.Errorf("RepositoryMock.GetConnectionByUID got unexpected parameter ctx, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmGetConnectionByUID.GetConnectionByUIDMock.defaultExpectation.expectationOrigins.originCtx, *mm_want_ptrs.ctx, mm_got.ctx, minimock.Diff(*mm_want_ptrs.ctx, mm_got.ctx))
+			}
+
+			if mm_want_ptrs.u1 != nil && !minimock.Equal(*mm_want_ptrs.u1, mm_got.u1) {
+				mmGetConnectionByUID.t.Errorf("RepositoryMock.GetConnectionByUID got unexpected parameter u1, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmGetConnectionByUID.GetConnectionByUIDMock.defaultExpectation.expectationOrigins.originU1, *mm_want_ptrs.u1, mm_got.u1, minimock.Diff(*mm_want_ptrs.u1, mm_got.u1))
+			}
+
+		} else if mm_want != nil && !minimock.Equal(*mm_want, mm_got) {
+			mmGetConnectionByUID.t.Errorf("RepositoryMock.GetConnectionByUID got unexpected parameters, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+				mmGetConnectionByUID.GetConnectionByUIDMock.defaultExpectation.expectationOrigins.origin, *mm_want, mm_got, minimock.Diff(*mm_want, mm_got))
+		}
+
+		mm_results := mmGetConnectionByUID.GetConnectionByUIDMock.defaultExpectation.results
+		if mm_results == nil {
+			mmGetConnectionByUID.t.Fatal("No results are set for the RepositoryMock.GetConnectionByUID")
+		}
+		return (*mm_results).cp1, (*mm_results).err
+	}
+	if mmGetConnectionByUID.funcGetConnectionByUID != nil {
+		return mmGetConnectionByUID.funcGetConnectionByUID(ctx, u1)
+	}
+	mmGetConnectionByUID.t.Fatalf("Unexpected call to RepositoryMock.GetConnectionByUID. %v %v", ctx, u1)
+	return
+}
+
+// GetConnectionByUIDAfterCounter returns a count of finished RepositoryMock.GetConnectionByUID invocations
+func (mmGetConnectionByUID *RepositoryMock) GetConnectionByUIDAfterCounter() uint64 {
+	return mm_atomic.LoadUint64(&mmGetConnectionByUID.afterGetConnectionByUIDCounter)
+}
+
+// GetConnectionByUIDBeforeCounter returns a count of RepositoryMock.GetConnectionByUID invocations
+func (mmGetConnectionByUID *RepositoryMock) GetConnectionByUIDBeforeCounter() uint64 {
+	return mm_atomic.LoadUint64(&mmGetConnectionByUID.beforeGetConnectionByUIDCounter)
+}
+
+// Calls returns a list of arguments used in each call to RepositoryMock.GetConnectionByUID.
+// The list is in the same order as the calls were made (i.e. recent calls have a higher index)
+func (mmGetConnectionByUID *mRepositoryMockGetConnectionByUID) Calls() []*RepositoryMockGetConnectionByUIDParams {
+	mmGetConnectionByUID.mutex.RLock()
+
+	argCopy := make([]*RepositoryMockGetConnectionByUIDParams, len(mmGetConnectionByUID.callArgs))
+	copy(argCopy, mmGetConnectionByUID.callArgs)
+
+	mmGetConnectionByUID.mutex.RUnlock()
+
+	return argCopy
+}
+
+// MinimockGetConnectionByUIDDone returns true if the count of the GetConnectionByUID invocations corresponds
+// the number of defined expectations
+func (m *RepositoryMock) MinimockGetConnectionByUIDDone() bool {
+	if m.GetConnectionByUIDMock.optional {
+		// Optional methods provide '0 or more' call count restriction.
+		return true
+	}
+
+	for _, e := range m.GetConnectionByUIDMock.expectations {
+		if mm_atomic.LoadUint64(&e.Counter) < 1 {
+			return false
+		}
+	}
+
+	return m.GetConnectionByUIDMock.invocationsDone()
+}
+
+// MinimockGetConnectionByUIDInspect logs each unmet expectation
+func (m *RepositoryMock) MinimockGetConnectionByUIDInspect() {
+	for _, e := range m.GetConnectionByUIDMock.expectations {
+		if mm_atomic.LoadUint64(&e.Counter) < 1 {
+			m.t.Errorf("Expected call to RepositoryMock.GetConnectionByUID at\n%s with params: %#v", e.expectationOrigins.origin, *e.params)
+		}
+	}
+
+	afterGetConnectionByUIDCounter := mm_atomic.LoadUint64(&m.afterGetConnectionByUIDCounter)
+	// if default expectation was set then invocations count should be greater than zero
+	if m.GetConnectionByUIDMock.defaultExpectation != nil && afterGetConnectionByUIDCounter < 1 {
+		if m.GetConnectionByUIDMock.defaultExpectation.params == nil {
+			m.t.Errorf("Expected call to RepositoryMock.GetConnectionByUID at\n%s", m.GetConnectionByUIDMock.defaultExpectation.returnOrigin)
+		} else {
+			m.t.Errorf("Expected call to RepositoryMock.GetConnectionByUID at\n%s with params: %#v", m.GetConnectionByUIDMock.defaultExpectation.expectationOrigins.origin, *m.GetConnectionByUIDMock.defaultExpectation.params)
+		}
+	}
+	// if func was set then invocations count should be greater than zero
+	if m.funcGetConnectionByUID != nil && afterGetConnectionByUIDCounter < 1 {
+		m.t.Errorf("Expected call to RepositoryMock.GetConnectionByUID at\n%s", m.funcGetConnectionByUIDOrigin)
+	}
+
+	if !m.GetConnectionByUIDMock.invocationsDone() && afterGetConnectionByUIDCounter > 0 {
+		m.t.Errorf("Expected %d calls to RepositoryMock.GetConnectionByUID at\n%s but found %d calls",
+			mm_atomic.LoadUint64(&m.GetConnectionByUIDMock.expectedInvocations), m.GetConnectionByUIDMock.expectedInvocationsOrigin, afterGetConnectionByUIDCounter)
 	}
 }
 
@@ -21668,6 +22021,8 @@ func (m *RepositoryMock) MinimockFinish() {
 
 			m.MinimockDeletePipelineTagsInspect()
 
+			m.MinimockGetConnectionByUIDInspect()
+
 			m.MinimockGetDefinitionByUIDInspect()
 
 			m.MinimockGetHubStatsInspect()
@@ -21783,6 +22138,7 @@ func (m *RepositoryMock) minimockDone() bool {
 		m.MinimockDeleteNamespaceSecretByIDDone() &&
 		m.MinimockDeletePipelineRunOnDone() &&
 		m.MinimockDeletePipelineTagsDone() &&
+		m.MinimockGetConnectionByUIDDone() &&
 		m.MinimockGetDefinitionByUIDDone() &&
 		m.MinimockGetHubStatsDone() &&
 		m.MinimockGetLatestNamespacePipelineReleaseDone() &&

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -80,6 +80,7 @@ type Repository interface {
 	UpdateNamespaceConnectionByUID(context.Context, uuid.UUID, *datamodel.Connection) (*datamodel.Connection, error)
 	DeleteNamespaceConnectionByID(_ context.Context, nsUID uuid.UUID, id string) error
 	GetNamespaceConnectionByID(_ context.Context, nsUID uuid.UUID, id string) (*datamodel.Connection, error)
+	GetConnectionByUID(context.Context, uuid.UUID) (*datamodel.Connection, error)
 	ListNamespaceConnections(context.Context, ListNamespaceConnectionsParams) (ConnectionList, error)
 	ListPipelineIDsByConnectionID(context.Context, ListPipelineIDsByConnectionIDParams) (PipelinesByConnectionList, error)
 
@@ -1388,6 +1389,18 @@ func (r *repository) GetNamespaceConnectionByID(ctx context.Context, nsUID uuid.
 	q := db.Preload("Integration").Where("namespace_uid = ? AND id = ?", nsUID, id)
 	conn := new(datamodel.Connection)
 	if err := q.First(&conn).Error; err != nil {
+		return nil, r.toDomainErr(err)
+	}
+
+	return conn, nil
+}
+
+func (r *repository) GetConnectionByUID(ctx context.Context, uid uuid.UUID) (*datamodel.Connection, error) {
+	db := r.db.WithContext(ctx)
+
+	q := db.Preload("Integration")
+	conn := new(datamodel.Connection)
+	if err := q.First(&conn, uid).Error; err != nil {
 		return nil, r.toDomainErr(err)
 	}
 

--- a/pkg/repository/repository_test.go
+++ b/pkg/repository/repository_test.go
@@ -732,7 +732,7 @@ func TestRepository_GetPaginatedPipelineRunsByRequester(t *testing.T) {
 		Source:             datamodel.RunSource(runpb.RunSource_RUN_SOURCE_API),
 		RunnerUID:          user1,
 		RequesterUID:       namespace1,
-		StartedTime:        now.Add(-1 * time.Hour),
+		StartedTime:        now.Add(-2 * time.Hour),
 		TotalDuration:      null.IntFrom(42),
 		Components:         nil,
 	}

--- a/pkg/service/integration.go
+++ b/pkg/service/integration.go
@@ -695,3 +695,17 @@ func (s *service) ListPipelineIDsByConnectionID(ctx context.Context, req *pb.Lis
 		TotalSize:     page.TotalSize,
 	}, nil
 }
+
+func (s *service) GetConnectionByUIDAdmin(ctx context.Context, uid uuid.UUID, view pb.View) (*pb.Connection, error) {
+	inDB, err := s.repository.GetConnectionByUID(ctx, uid)
+	if err != nil {
+		return nil, fmt.Errorf("fetching connection: %w", err)
+	}
+
+	ns, err := s.GetNamespaceByUID(ctx, inDB.NamespaceUID)
+	if err != nil {
+		return nil, fmt.Errorf("fetching namespace: %w", err)
+	}
+
+	return s.connectionToPB(inDB, ns.NsID, view)
+}

--- a/pkg/service/main.go
+++ b/pkg/service/main.go
@@ -87,6 +87,7 @@ type Service interface {
 	GetNamespaceConnection(context.Context, *pb.GetNamespaceConnectionRequest) (*pb.Connection, error)
 	ListNamespaceConnections(context.Context, *pb.ListNamespaceConnectionsRequest) (*pb.ListNamespaceConnectionsResponse, error)
 	ListPipelineIDsByConnectionID(context.Context, *pb.ListPipelineIDsByConnectionIDRequest) (*pb.ListPipelineIDsByConnectionIDResponse, error)
+	GetConnectionByUIDAdmin(context.Context, uuid.UUID, pb.View) (*pb.Connection, error)
 }
 
 // TriggerResult defines a new type to encapsulate the stream data

--- a/pkg/service/pipelinerun_test.go
+++ b/pkg/service/pipelinerun_test.go
@@ -561,7 +561,7 @@ func TestService_ListPipelineRunsByRequester(t *testing.T) {
 	c.Check(resp.TotalSize, qt.Equals, int32(1))
 	c.Check(resp.GetPipelineRuns(), qt.HasLen, 1)
 	c.Check(resp.GetPipelineRuns()[0].GetPipelineRunUid(), qt.Equals, pipelineRun.PipelineTriggerUID.String())
-	c.Check(resp.GetPipelineRuns()[0].GetNamespaceId(), qt.Equals, got.NamespaceID)
+	c.Check(resp.GetPipelineRuns()[0].GetPipelineNamespaceId(), qt.Equals, got.NamespaceID)
 
 	pipelineRun = &datamodel.PipelineRun{
 		PipelineTriggerUID: uuid.Must(uuid.NewV4()),

--- a/pkg/service/pipelinerun_test.go
+++ b/pkg/service/pipelinerun_test.go
@@ -177,19 +177,11 @@ func TestService_ListPipelineRuns(t *testing.T) {
 
 			repo := repository.NewRepository(tx, redisClient)
 
-			svc := NewService(
-				repo,
-				nil,
-				nil,
-				nil,
-				nil,
-				mgmtPrivateClient,
-				mockMinio,
-				nil,
-				nil,
-				uuid.UUID{},
-				nil,
-			)
+			svc := NewService(ServiceConfig{
+				Repository:               repo,
+				MgmtPrivateServiceClient: mgmtPrivateClient,
+				MinioClient:              mockMinio,
+			})
 
 			ctx := context.Background()
 
@@ -397,19 +389,12 @@ func TestService_ListPipelineRuns_OrgResource(t *testing.T) {
 
 			repo := repository.NewRepository(tx, redisClient)
 
-			svc := NewService(
-				repo,
-				redisClient,
-				nil,
-				nil,
-				nil,
-				mgmtPrivateClient,
-				mockMinio,
-				nil,
-				nil,
-				uuid.UUID{},
-				nil,
-			)
+			svc := NewService(ServiceConfig{
+				Repository:               repo,
+				RedisClient:              redisClient,
+				MgmtPrivateServiceClient: mgmtPrivateClient,
+				MinioClient:              mockMinio,
+			})
 
 			ctx := context.Background()
 
@@ -504,19 +489,11 @@ func TestService_ListPipelineRunsByRequester(t *testing.T) {
 
 	repo := repository.NewRepository(tx, redisClient)
 
-	svc := NewService(
-		repo,
-		nil,
-		nil,
-		nil,
-		nil,
-		mgmtPrivateClient,
-		mockMinio,
-		nil,
-		nil,
-		uuid.UUID{},
-		nil,
-	)
+	svc := NewService(ServiceConfig{
+		Repository:               repo,
+		MgmtPrivateServiceClient: mgmtPrivateClient,
+		MinioClient:              mockMinio,
+	})
 
 	ctx := context.Background()
 

--- a/pkg/service/utils.go
+++ b/pkg/service/utils.go
@@ -122,15 +122,14 @@ func (s *service) GetNamespaceByID(ctx context.Context, namespaceID string) (res
 // Helper methods
 func (s *service) convertPipelineRunToPB(run datamodel.PipelineRun) (*pipelinepb.PipelineRun, error) {
 	result := &pipelinepb.PipelineRun{
-		PipelineUid:     run.PipelineUID.String(),
-		PipelineId:      &run.Pipeline.ID,
-		NamespaceId:     run.Pipeline.NamespaceID,
-		PipelineRunUid:  run.PipelineTriggerUID.String(),
-		PipelineVersion: run.PipelineVersion,
-		Status:          runpb.RunStatus(run.Status),
-		Source:          runpb.RunSource(run.Source),
-		StartTime:       timestamppb.New(run.StartedTime),
-		Error:           run.Error.Ptr(),
+		PipelineId:          &run.Pipeline.ID,
+		PipelineNamespaceId: run.Pipeline.NamespaceID,
+		PipelineRunUid:      run.PipelineTriggerUID.String(),
+		PipelineVersion:     run.PipelineVersion,
+		Status:              runpb.RunStatus(run.Status),
+		Source:              runpb.RunSource(run.Source),
+		StartTime:           timestamppb.New(run.StartedTime),
+		Error:               run.Error.Ptr(),
 	}
 
 	if run.TotalDuration.Valid {


### PR DESCRIPTION
Because

- Agent configurations will store the UIDs of the connections needed to use
  in agent tools (UIDs are used to avoid breaking the config if the ID is
  updated by the namespace).

This commit

- Adds a private endpoint to fetch a connection by UID.

Part of INS-6933, branch name is wrong.
