### PR TITLE
feat(data): add support for default value in `instill` Go tag

### DIFF
--- a/pkg/component/ai/anthropic/v0/io.go
+++ b/pkg/component/ai/anthropic/v0/io.go
@@ -2,14 +2,14 @@ package anthropic
 
 type MessagesInput struct {
 	ChatHistory  []ChatMessage `instill:"chat-history"`
-	MaxNewTokens int           `instill:"max-new-tokens"`
+	MaxNewTokens int           `instill:"max-new-tokens,default=50"`
 	ModelName    string        `instill:"model-name"`
 	Prompt       string        `instill:"prompt"`
 	PromptImages []string      `instill:"prompt-images"`
 	Seed         int           `instill:"seed"`
-	SystemMsg    string        `instill:"system-message"`
-	Temperature  float32       `instill:"temperature"`
-	TopK         int           `instill:"top-k"`
+	SystemMsg    string        `instill:"system-message,default=You are a helpful assistant."`
+	Temperature  float32       `instill:"temperature,default=0.7"`
+	TopK         int           `instill:"top-k,default=10"`
 }
 
 type ChatMessage struct {

--- a/pkg/component/ai/mistralai/v0/io.go
+++ b/pkg/component/ai/mistralai/v0/io.go
@@ -4,6 +4,7 @@ type ChatMessage struct {
 	Role    string              `instill:"role"`
 	Content []MultiModalContent `instill:"content"`
 }
+
 type URL struct {
 	URL string `instill:"url"`
 }
@@ -16,15 +17,15 @@ type MultiModalContent struct {
 
 type TextGenerationInput struct {
 	ChatHistory  []ChatMessage `instill:"chat-history"`
-	MaxNewTokens int           `instill:"max-new-tokens"`
+	MaxNewTokens int           `instill:"max-new-tokens,default=50"`
 	ModelName    string        `instill:"model-name"`
 	Prompt       string        `instill:"prompt"`
 	PromptImages []string      `instill:"prompt-images"`
 	Seed         int           `instill:"seed"`
-	SystemMsg    string        `instill:"system-message"`
-	Temperature  float64       `instill:"temperature"`
-	TopK         int           `instill:"top-k"`
-	TopP         float64       `instill:"top-p"`
+	SystemMsg    string        `instill:"system-message,default=You are a helpful assistant."`
+	Temperature  float64       `instill:"temperature,default=0.7"`
+	TopK         int           `instill:"top-k,default=10"`
+	TopP         float64       `instill:"top-p,default=0.5"`
 	Safe         bool          `instill:"safe"`
 }
 

--- a/pkg/component/ai/openai/v0/io.go
+++ b/pkg/component/ai/openai/v0/io.go
@@ -10,13 +10,13 @@ type taskTextGenerationInput struct {
 	ChatHistory      []*textMessage             `instill:"chat-history"`
 	Model            string                     `instill:"model"`
 	SystemMessage    *string                    `instill:"system-message"`
-	Temperature      *float32                   `instill:"temperature"`
-	TopP             *float32                   `instill:"top-p"`
-	N                *int                       `instill:"n"`
+	Temperature      *float32                   `instill:"temperature,default=1"`
+	TopP             *float32                   `instill:"top-p,default=1"`
+	N                *int                       `instill:"n,default=1"`
 	Stop             *string                    `instill:"stop"`
 	MaxTokens        *int                       `instill:"max-tokens"`
-	PresencePenalty  *float32                   `instill:"presence-penalty"`
-	FrequencyPenalty *float32                   `instill:"frequency-penalty"`
+	PresencePenalty  *float32                   `instill:"presence-penalty,default=0"`
+	FrequencyPenalty *float32                   `instill:"frequency-penalty,default=0"`
 	ResponseFormat   *responseFormatInputStruct `instill:"response-format"`
 }
 
@@ -55,7 +55,7 @@ type taskSpeechRecognitionInput struct {
 	Audio       format.Audio `instill:"audio"`
 	Model       string       `instill:"model"`
 	Prompt      *string      `instill:"prompt"`
-	Temperature *float32     `instill:"temperature"`
+	Temperature *float32     `instill:"temperature,default=0"`
 	Language    *string      `instill:"language"`
 }
 
@@ -66,10 +66,10 @@ type taskSpeechRecognitionOutput struct {
 
 type taskTextToSpeechInput struct {
 	Text           string   `instill:"text"`
-	Model          string   `instill:"model"`
-	Voice          string   `instill:"voice"`
-	ResponseFormat *string  `instill:"response-format"`
-	Speed          *float32 `instill:"speed"`
+	Model          string   `instill:"model,default=tts-1"`
+	Voice          string   `instill:"voice,default=alloy"`
+	ResponseFormat *string  `instill:"response-format,default=mp3"`
+	Speed          *float32 `instill:"speed,default=1"`
 }
 
 type taskTextToSpeechOutput struct {
@@ -79,10 +79,10 @@ type taskTextToSpeechOutput struct {
 type taskTextToImageInput struct {
 	Prompt  string  `instill:"prompt"`
 	Model   string  `instill:"model"`
-	N       *int    `instill:"n"`
-	Quality *string `instill:"quality"`
-	Size    *string `instill:"size"`
-	Style   *string `instill:"style"`
+	N       *int    `instill:"n,default=1"`
+	Quality *string `instill:"quality,default=standard"`
+	Size    *string `instill:"size,default=1024x1024"`
+	Style   *string `instill:"style,default=vivid"`
 }
 
 type taskTextToImageOutput struct {

--- a/pkg/component/ai/perplexityai/v0/io.go
+++ b/pkg/component/ai/perplexityai/v0/io.go
@@ -42,13 +42,13 @@ type Content struct {
 // Parameter contains the input parameter.
 type Parameter struct {
 	// MaxTokens is the maximum number of tokens to generate.
-	MaxTokens int `instill:"max-tokens"`
+	MaxTokens int `instill:"max-tokens,default=50"`
 	// Temperature is the temperature of the model.
-	Temperature float64 `instill:"temperature"`
+	Temperature float64 `instill:"temperature,default=0.2"`
 	// TopP is the top-p value of the model.
-	TopP float64 `instill:"top-p"`
+	TopP float64 `instill:"top-p,default=0.9"`
 	// Stream is whether to stream the output.
-	Stream bool `instill:"stream"`
+	Stream bool `instill:"stream,default=false"`
 	// SearchDomainFilter gives the list of domains,
 	// limit the citations used by the online model to URLs from the specified
 	// domains. Currently limited to only 3 domains for whitelisting and
@@ -59,17 +59,17 @@ type Parameter struct {
 	// - does not apply to images. Values include `month`, `week`, `day`, `hour`."
 	SearchRecencyFilter string `instill:"search-recency-filter"`
 	// TopK is the top-k value of the model.
-	TopK int `instill:"top-k"`
+	TopK int `instill:"top-k,default=0"`
 	// PresencePenalty is a value between -2.0 and 2.0. Positive values penalize new
 	// tokens based on whether they appear in the text so far, increasing the
 	// model's likelihood to talk about new topics. Incompatible with
 	// `frequency_penalty`.
-	PresencePenalty float64 `instill:"presence-penalty"`
+	PresencePenalty float64 `instill:"presence-penalty,default=0"`
 	// FrequencyPenalty is a multiplicative penalty greater than 0. Values greater
 	// than 1.0 penalize new tokens based on their existing frequency in the text so
 	// far, decreasing the model's likelihood to repeat the same line verbatim. A
 	// value of 1.0 means no penalty. Incompatible with `presence_penalty`.
-	FrequencyPenalty float64 `instill:"frequency-penalty"`
+	FrequencyPenalty float64 `instill:"frequency-penalty,default=1"`
 }
 
 // TextChatOutput is the output for the TASK_CHAT task.

--- a/pkg/component/application/github/v0/io.go
+++ b/pkg/component/application/github/v0/io.go
@@ -66,9 +66,9 @@ type getPullRequestOutput struct {
 
 type listIssuesInput struct {
 	RepoInfo
-	State         string `instill:"state"`
-	Sort          string `instill:"sort"`
-	Direction     string `instill:"direction"`
+	State         string `instill:"state,default=open"`
+	Sort          string `instill:"sort,default=created"`
+	Direction     string `instill:"direction,default=desc"`
 	Since         string `instill:"since"`
 	NoPullRequest bool   `instill:"no-pull-request"`
 	PageOptions
@@ -81,9 +81,9 @@ type listIssuesOutput struct {
 type listPullRequestsInput struct {
 	RepoInfo
 	PageOptions
-	State     string `instill:"state"`
-	Sort      string `instill:"sort"`
-	Direction string `instill:"direction"`
+	State     string `instill:"state,default=open"`
+	Sort      string `instill:"sort,default=created"`
+	Direction string `instill:"direction,default=desc"`
 }
 
 type listPullRequestsOutput struct {
@@ -92,10 +92,10 @@ type listPullRequestsOutput struct {
 
 type listReviewCommentsInput struct {
 	RepoInfo
-	PRNumber  int    `instill:"pr-number"`
-	Sort      string `instill:"sort"`
-	Direction string `instill:"direction"`
-	Since     string `instill:"since"`
+	PRNumber  int    `instill:"pr-number,default=0"`
+	Sort      string `instill:"sort,default=created"`
+	Direction string `instill:"direction,default=desc"`
+	Since     string `instill:"since,default=2021-01-01"`
 	PageOptions
 }
 

--- a/pkg/component/application/leadiq/v0/io.go
+++ b/pkg/component/application/leadiq/v0/io.go
@@ -12,7 +12,7 @@ type FindProspectsInput struct {
 	// Company is the company information to find prospects for.
 	Company Company `instill:"company"`
 	// Limit is the maximum number of prospects to return.
-	Limit int `instill:"limit"`
+	Limit int `instill:"limit,default=10"`
 	// FilterBy is the filter to apply to the prospects.
 	FilterBy FilterBy `instill:"filter-by"`
 }

--- a/pkg/component/data/googlesheets/v0/config/tasks.json
+++ b/pkg/component/data/googlesheets/v0/config/tasks.json
@@ -417,6 +417,7 @@
           "description": "The starting row number to retrieve (1-based index).",
           "instillFormat": "number",
           "minimum": 1,
+          "default": 2,
           "title": "Start Row",
           "type": "integer",
           "instillUIOrder": 0

--- a/pkg/component/data/googlesheets/v0/io.go
+++ b/pkg/component/data/googlesheets/v0/io.go
@@ -81,7 +81,7 @@ type taskDeleteSpreadsheetColumnOutput struct {
 type taskListRowsInput struct {
 	SharedLink string `instill:"shared-link"`
 	SheetName  string `instill:"sheet-name"`
-	StartRow   *int   `instill:"start-row"`
+	StartRow   *int   `instill:"start-row,default=2"`
 	EndRow     *int   `instill:"end-row"`
 }
 

--- a/pkg/component/generic/collection/v0/io.go
+++ b/pkg/component/generic/collection/v0/io.go
@@ -49,7 +49,7 @@ type intersectionOutput struct {
 
 type splitInput struct {
 	Data format.Value `instill:"data"`
-	Size int          `instill:"size"`
+	Size int          `instill:"size,default=1"`
 }
 
 type splitOutput struct {

--- a/pkg/component/operator/audio/v0/io.go
+++ b/pkg/component/operator/audio/v0/io.go
@@ -11,8 +11,8 @@ type segmentData struct {
 
 type detectActivityInput struct {
 	Audio              format.Audio `instill:"audio"`
-	MinSilenceDuration int          `instill:"min-silence-duration"`
-	SpeechPad          int          `instill:"speech-pad"`
+	MinSilenceDuration int          `instill:"min-silence-duration,default=100"`
+	SpeechPad          int          `instill:"speech-pad,default=30"`
 }
 
 type detectActivityOutput struct {

--- a/pkg/component/operator/document/v0/io.go
+++ b/pkg/component/operator/document/v0/io.go
@@ -4,10 +4,10 @@ import "github.com/instill-ai/pipeline-backend/pkg/data/format"
 
 type ConvertDocumentToMarkdownInput struct {
 	Document            format.Document `instill:"document"`
-	DisplayImageTag     bool            `instill:"display-image-tag"`
+	DisplayImageTag     bool            `instill:"display-image-tag,default=false"`
 	Filename            string          `instill:"filename"`
-	DisplayAllPageImage bool            `instill:"display-all-page-image"`
-	Resolution          int             `instill:"resolution"`
+	DisplayAllPageImage bool            `instill:"display-all-page-image,default=false"`
+	Resolution          int             `instill:"resolution,default=300"`
 }
 
 type ConvertDocumentToMarkdownOutput struct {
@@ -22,7 +22,7 @@ type ConvertDocumentToMarkdownOutput struct {
 type ConvertDocumentToImagesInput struct {
 	Document   format.Document `instill:"document"`
 	Filename   string          `instill:"filename"`
-	Resolution int             `instill:"resolution"`
+	Resolution int             `instill:"resolution,default=300"`
 }
 
 type ConvertDocumentToImagesOutput struct {

--- a/pkg/data/struct_test.go
+++ b/pkg/data/struct_test.go
@@ -194,6 +194,57 @@ func TestUnmarshal(t *testing.T) {
 		c.Assert(result.NullField, qt.IsNil)
 	})
 
+	c.Run("Default value", func(c *qt.C) {
+		type TestStruct struct {
+			StringField   format.String  `instill:"string-field,default=hello"`
+			NumberField   format.Number  `instill:"number-field,default=42"`
+			BooleanField  format.Boolean `instill:"boolean-field,default=true"`
+			IntField      int            `instill:"int-field,default=123"`
+			UintField     uint           `instill:"uint-field,default=456"`
+			FloatField    float64        `instill:"float-field,default=3.14"`
+			BoolField     bool           `instill:"bool-field,default=true"`
+			StrField      string         `instill:"string-field,default=world"`
+			IntPtrField   *int           `instill:"int-ptr-field,default=123"`
+			UintPtrField  *uint          `instill:"uint-ptr-field,default=456"`
+			FloatPtrField *float64       `instill:"float-ptr-field,default=3.14"`
+			BoolPtrField  *bool          `instill:"bool-ptr-field,default=true"`
+			StrPtrField   *string        `instill:"string-ptr-field,default=world"`
+		}
+
+		input := Map{}
+		var result TestStruct
+		err := unmarshaler.Unmarshal(context.Background(), input, &result)
+
+		c.Assert(err, qt.IsNil)
+
+		// Test format.Value types
+		c.Assert(result.StringField.String(), qt.Equals, "hello")
+		c.Assert(result.NumberField.Float64(), qt.Equals, 42.0)
+		c.Assert(result.BooleanField.Boolean(), qt.Equals, true)
+
+		// Test primitive types
+		c.Assert(result.IntField, qt.Equals, 123)
+		c.Assert(result.UintField, qt.Equals, uint(456))
+		c.Assert(result.FloatField, qt.Equals, 3.14)
+		c.Assert(result.BoolField, qt.Equals, true)
+		c.Assert(result.StrField, qt.Equals, "world")
+
+		// Test pointer primitive types
+		c.Assert(*result.IntPtrField, qt.Equals, 123)
+		c.Assert(*result.UintPtrField, qt.Equals, uint(456))
+		c.Assert(*result.FloatPtrField, qt.Equals, 3.14)
+		c.Assert(*result.BoolPtrField, qt.Equals, true)
+		c.Assert(*result.StrPtrField, qt.Equals, "world")
+
+		// Test invalid default values
+		type InvalidStruct struct {
+			BadInt *int `instill:"bad-int,default=not-a-number"`
+		}
+		var invalid InvalidStruct
+		err = unmarshaler.Unmarshal(context.Background(), Map{}, &invalid)
+		c.Assert(err, qt.ErrorMatches, "error setting default value for field bad-int:.*")
+	})
+
 	c.Run("Error cases", func(c *qt.C) {
 		c.Run("Non-pointer input", func(c *qt.C) {
 			var s struct{}

--- a/pkg/data/struct_test.go
+++ b/pkg/data/struct_test.go
@@ -245,6 +245,49 @@ func TestUnmarshal(t *testing.T) {
 		c.Assert(err, qt.ErrorMatches, "error setting default value for field bad-int:.*")
 	})
 
+	c.Run("Without default value", func(c *qt.C) {
+		type TestStruct struct {
+			StringField   format.String  `instill:"string-field"`
+			NumberField   format.Number  `instill:"number-field"`
+			BooleanField  format.Boolean `instill:"boolean-field"`
+			IntField      int            `instill:"int-field"`
+			UintField     uint           `instill:"uint-field"`
+			FloatField    float64        `instill:"float-field"`
+			BoolField     bool           `instill:"bool-field"`
+			StrField      string         `instill:"str-field"`
+			IntPtrField   *int           `instill:"int-ptr-field"`
+			UintPtrField  *uint          `instill:"uint-ptr-field"`
+			FloatPtrField *float64       `instill:"float-ptr-field"`
+			BoolPtrField  *bool          `instill:"bool-ptr-field"`
+			StrPtrField   *string        `instill:"str-ptr-field"`
+		}
+
+		input := Map{}
+		var result TestStruct
+		err := unmarshaler.Unmarshal(context.Background(), input, &result)
+
+		c.Assert(err, qt.IsNil)
+
+		// Test format.Value types have zero values
+		c.Assert(result.StringField, qt.IsNil)
+		c.Assert(result.NumberField, qt.IsNil)
+		c.Assert(result.BooleanField, qt.IsNil)
+
+		// Test primitive types have zero values
+		c.Assert(result.IntField, qt.Equals, 0)
+		c.Assert(result.UintField, qt.Equals, uint(0))
+		c.Assert(result.FloatField, qt.Equals, 0.0)
+		c.Assert(result.BoolField, qt.Equals, false)
+		c.Assert(result.StrField, qt.Equals, "")
+
+		// Test pointer primitive types are nil
+		c.Assert(result.IntPtrField, qt.IsNil)
+		c.Assert(result.UintPtrField, qt.IsNil)
+		c.Assert(result.FloatPtrField, qt.IsNil)
+		c.Assert(result.BoolPtrField, qt.IsNil)
+		c.Assert(result.StrPtrField, qt.IsNil)
+	})
+
 	c.Run("Error cases", func(c *qt.C) {
 		c.Run("Non-pointer input", func(c *qt.C) {
 			var s struct{}

--- a/pkg/worker/io.go
+++ b/pkg/worker/io.go
@@ -2,11 +2,9 @@ package worker
 
 import (
 	"context"
-	"fmt"
 
 	"google.golang.org/protobuf/types/known/structpb"
 
-	"github.com/instill-ai/pipeline-backend/pkg/component/base"
 	"github.com/instill-ai/pipeline-backend/pkg/data"
 	"github.com/instill-ai/pipeline-backend/pkg/data/format"
 	"github.com/instill-ai/pipeline-backend/pkg/external"
@@ -54,16 +52,14 @@ type inputReader struct {
 	wfm           memory.WorkflowMemory
 	originalIdx   int
 	binaryFetcher external.BinaryFetcher
-	execution     base.IExecution
 }
 
-func NewInputReader(wfm memory.WorkflowMemory, compID string, originalIdx int, binaryFetcher external.BinaryFetcher, execution base.IExecution) *inputReader {
+func NewInputReader(wfm memory.WorkflowMemory, compID string, originalIdx int, binaryFetcher external.BinaryFetcher) *inputReader {
 	return &inputReader{
 		compID:        compID,
 		wfm:           wfm,
 		originalIdx:   originalIdx,
 		binaryFetcher: binaryFetcher,
-		execution:     execution,
 	}
 }
 
@@ -114,10 +110,6 @@ func (i *inputReader) ReadData(ctx context.Context, input any) (err error) {
 	unmarshaler := data.NewUnmarshaler(i.binaryFetcher)
 	if err := unmarshaler.Unmarshal(ctx, inputVal, input); err != nil {
 		return err
-	}
-
-	if err := i.execution.FillInDefaultValues(input); err != nil {
-		return fmt.Errorf("filling default values: %w", err)
 	}
 
 	return nil

--- a/pkg/worker/workflow.go
+++ b/pkg/worker/workflow.go
@@ -585,7 +585,7 @@ func (w *worker) ComponentActivity(ctx context.Context, param *ComponentActivity
 	jobs := make([]*componentbase.Job, len(conditionMap))
 	for idx, originalIdx := range conditionMap {
 		jobs[idx] = &componentbase.Job{
-			Input:  NewInputReader(wfm, param.ID, originalIdx, w.binaryFetcher, execution),
+			Input:  NewInputReader(wfm, param.ID, originalIdx, w.binaryFetcher),
 			Output: NewOutputWriter(wfm, param.ID, originalIdx, wfm.IsStreaming()),
 			Error:  NewErrorHandler(wfm, param.ID, originalIdx),
 		}


### PR DESCRIPTION
Because

- Users may not always provide required data, we can set default values for certain fields when not provided.

This commit

- Adds support for default values in the instill Go tag.

Note

- The current tag requires manual maintenance. In the future, io.go will be auto-generated by compogen based on the tasks.json file, and default values will also be auto-generated.