### PR TITLE
chore(service): remove the unused code

### DIFF
--- a/pkg/service/main.go
+++ b/pkg/service/main.go
@@ -61,8 +61,6 @@ type Service interface {
 	TriggerNamespacePipelineByID(ctx context.Context, ns resource.Namespace, id string, data []*pb.TriggerData, pipelineTriggerID string, returnTraces bool) ([]*structpb.Struct, *pb.TriggerMetadata, error)
 	TriggerAsyncNamespacePipelineByID(ctx context.Context, ns resource.Namespace, id string, data []*pb.TriggerData, pipelineTriggerID string, returnTraces bool) (*longrunningpb.Operation, error)
 
-	CheckPipelineEventCode(ctx context.Context, ns resource.Namespace, id string, code string) (bool, error)
-	// HandleNamespacePipelineEventByID(ctx context.Context, ns resource.Namespace, id string, eventID string, data *structpb.Struct, pipelineTriggerID string) (*structpb.Struct, error)
 	DispatchPipelineWebhookEvent(ctx context.Context, params DispatchPipelineWebhookEventParams) (DispatchPipelineWebhookEventResult, error)
 
 	TriggerNamespacePipelineReleaseByID(ctx context.Context, ns resource.Namespace, pipelineUID uuid.UUID, id string, data []*pb.TriggerData, pipelineTriggerID string, returnTraces bool) ([]*structpb.Struct, *pb.TriggerMetadata, error)

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -1818,15 +1818,6 @@ func (s *service) checkTriggerPermission(ctx context.Context, pipeline *datamode
 	return nil
 }
 
-func (s *service) CheckPipelineEventCode(ctx context.Context, ns resource.Namespace, id string, code string) (bool, error) {
-	dbPipeline, err := s.repository.GetNamespacePipelineByID(ctx, ns.Permalink(), id, false, true)
-	if err != nil {
-		return false, errdomain.ErrNotFound
-	}
-
-	return dbPipeline.ShareCode == code, nil
-}
-
 func (s *service) TriggerNamespacePipelineByID(ctx context.Context, ns resource.Namespace, id string, data []*pipelinepb.TriggerData, pipelineTriggerID string, returnTraces bool) ([]*structpb.Struct, *pipelinepb.TriggerMetadata, error) {
 	ownerPermalink := ns.Permalink()
 


### PR DESCRIPTION
Because

- The old webhook-related code is deprecated.

This commit

- removes the unused code.