### PR TITLE
feat(vdp): skip google drive for cloud version

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,13 @@ import (
 	miniox "github.com/instill-ai/x/minio"
 )
 
+const (
+	EditionLocalCE      = "local-ce:dev"
+	EditionCloudDev     = "cloud:dev"
+	EditionCloudStaging = "cloud:staging"
+	EditionCloudProd    = "cloud:prod"
+)
+
 // Config - Global variable to export
 var Config AppConfig
 

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -770,6 +770,9 @@ func (r *repository) ListComponentDefinitionUIDs(_ context.Context, p ListCompon
 	if config.Config.Server.Edition == "local-ce:dev" {
 		skipComponentsInCE := []string{"instill-app"}
 		queryBuilder = queryBuilder.Where("id NOT IN (?)", skipComponentsInCE)
+	} else {
+		skipComponentsInCloud := []string{"google-drive"}
+		queryBuilder = queryBuilder.Where("id NOT IN (?)", skipComponentsInCloud)
 	}
 
 	queryBuilder.Count(&totalSize)

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -767,11 +767,13 @@ func (r *repository) ListComponentDefinitionUIDs(_ context.Context, p ListCompon
 		Where(where, whereArgs...).
 		Where("is_visible IS TRUE")
 
-	if config.Config.Server.Edition == "local-ce:dev" {
+
+	// TODO: refactor it with store.go in ins-7031
+	if config.Config.Server.Edition == config.EditionLocalCE {
 		skipComponentsInCE := []string{"instill-app"}
 		queryBuilder = queryBuilder.Where("id NOT IN (?)", skipComponentsInCE)
-	} else {
-		skipComponentsInCloud := []string{"google-drive"}
+	} else if config.Config.Server.Edition == config.EditionCloudStaging || config.Config.Server.Edition == config.EditionCloudProd {
+		skipComponentsInCloud := []string{"google-drive", "google-sheets"}
 		queryBuilder = queryBuilder.Where("id NOT IN (?)", skipComponentsInCloud)
 	}
 


### PR DESCRIPTION
Because

- we want to hide google drive in cloud before we get drive.readonly scope from Google

This commit

- hide google drive in cloud version
