### PR TITLE
feat(recipe): support `required` attribute for variable

### DIFF
--- a/pkg/datamodel/datamodel.go
+++ b/pkg/datamodel/datamodel.go
@@ -278,6 +278,7 @@ type Variable struct {
 	Listen         []string `json:"listen,omitempty" yaml:"listen,omitempty"`
 	Default        any      `json:"default,omitempty" yaml:"default,omitempty"`
 	InstillUIOrder int32    `json:"instillUiOrder,omitempty" yaml:"instill-ui-order,omitempty"`
+	Required       bool     `json:"required,omitempty" yaml:"required,omitempty"`
 }
 
 type Output struct {

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -916,8 +916,14 @@ func (s *service) preTriggerPipeline(ctx context.Context, ns resource.Namespace,
 			}
 
 			if v == nil {
+				// If the field is required but no value is provided, return an error.
+				if r.Variable[k].Required {
+					return fmt.Errorf("missing required variable: %s", k)
+				}
+
 				// If the field has no value and no default value is specified,
-				// represent it as null, we treat null as missing value
+				// represent it as null. A null value indicates that the field
+				// is missing and should be handled as such by components.
 				if d, ok := defaultValueMap[k]; !ok || d == nil {
 					variable[k] = data.NewNull()
 					continue


### PR DESCRIPTION
Because

- we want users to explicitly define which variables are required.

This commit

- adds support for the required attribute in variables.