### PR TITLE
chore(component,collection): fix component schema

### DIFF
--- a/pkg/component/generic/collection/v0/README.mdx
+++ b/pkg/component/generic/collection/v0/README.mdx
@@ -44,8 +44,8 @@ Append values to create or extend an array, or add key-value pairs to an object.
 | Input | ID | Type | Description |
 | :--- | :--- | :--- | :--- |
 | Task ID (required) | `task` | string | `TASK_APPEND` |
-| Data (required) | `data` | any | The input data. If it's an array, the value will be appended. If it's an object, the key-value pairs from value will be added. If it's a primitive type (string, number, boolean), it will be converted to a single-element array before appending. |
-| Value (required) | `value` | any | The value to append. For arrays: the value will be appended as a new element. For objects: if value is an object, its key-value pairs will be added to the input object. For primitives: value will be appended to create/extend an array. |
+| Data (required) | `data` | * | The input data. If it's an array, the value will be appended. If it's an object, the key-value pairs from value will be added. If it's a primitive type (string, number, boolean), it will be converted to a single-element array before appending. |
+| Value (required) | `value` | * | The value to append. For arrays: the value will be appended as a new element. For objects: if value is an object, its key-value pairs will be added to the input object. For primitives: value will be appended to create/extend an array. |
 </div>
 
 
@@ -57,7 +57,7 @@ Append values to create or extend an array, or add key-value pairs to an object.
 
 | Output | ID | Type | Description |
 | :--- | :--- | :--- | :--- |
-| Data | `data` | any | The resulting data structure after the append operation. Will be either an array (if input was array or primitive) or an object (if input was object). Examples: [1,2,3], \{'name':'John', 'age':25\}, or ['hello','world']. |
+| Data | `data` | * | The resulting data structure after the append operation. Will be either an array (if input was array or primitive) or an object (if input was object). Examples: [1,2,3], \{'name':'John', 'age':25\}, or ['hello','world']. |
 </div>
 
 
@@ -70,9 +70,9 @@ Assign a value to a specific path in a data structure.
 | Input | ID | Type | Description |
 | :--- | :--- | :--- | :--- |
 | Task ID (required) | `task` | string | `TASK_ASSIGN` |
-| Data (required) | `data` | any | The input data structure to modify. Can be an array, object, or primitive value. |
+| Data (required) | `data` | * | The input data structure to modify. Can be an array, object, or primitive value. |
 | Path (required) | `path` | string | The path where to assign the value. Use dot notation for nested objects and [n] for array indices. Examples: 'users.[0].name', '.[0].key', 'metadata.tags.[2]'. |
-| Value (required) | `value` | any | The value to assign at the specified path. Can be any type (string, number, boolean, array, or object). |
+| Value (required) | `value` | * | The value to assign at the specified path. Can be any type (string, number, boolean, array, or object). |
 </div>
 
 
@@ -84,7 +84,7 @@ Assign a value to a specific path in a data structure.
 
 | Output | ID | Type | Description |
 | :--- | :--- | :--- | :--- |
-| Data | `data` | any | The resulting data structure after the assign operation. |
+| Data | `data` | * | The resulting data structure after the assign operation. |
 </div>
 
 
@@ -97,7 +97,7 @@ Concatenate multiple arrays or merge multiple objects into a single collection.
 | Input | ID | Type | Description |
 | :--- | :--- | :--- | :--- |
 | Task ID (required) | `task` | string | `TASK_CONCAT` |
-| Data (required) | `data` | array | An array of arrays or objects to be concatenated/merged. For arrays: [[1, 2], [3, 4]] becomes [1, 2, 3, 4]. For objects: [\{'a': 1\}, \{'b': 2\}] becomes \{'a': 1, 'b': 2\}. Later values override earlier ones for objects. |
+| Data (required) | `data` | array[*] | An array of arrays or objects to be concatenated/merged. For arrays: [[1, 2], [3, 4]] becomes [1, 2, 3, 4]. For objects: [\{'a': 1\}, \{'b': 2\}] becomes \{'a': 1, 'b': 2\}. Later values override earlier ones for objects. |
 </div>
 
 
@@ -109,7 +109,7 @@ Concatenate multiple arrays or merge multiple objects into a single collection.
 
 | Output | ID | Type | Description |
 | :--- | :--- | :--- | :--- |
-| Data | `data` | any | The resulting array or object after concat operation. |
+| Data | `data` | * | The resulting array or object after concat operation. |
 </div>
 
 
@@ -122,7 +122,7 @@ Find elements that exist in the first array or object but not in any of the othe
 | Input | ID | Type | Description |
 | :--- | :--- | :--- | :--- |
 | Task ID (required) | `task` | string | `TASK_DIFFERENCE` |
-| Data (required) | `data` | array | An array of arrays or objects to find the difference. The first element is compared against all subsequent elements. For example, given arrays [[1, 2, 3], [2, 3, 4], [3, 4, 5]], the result will be [1]. For objects, given [\{'a': 1, 'b': 2\}, \{'b': 2, 'c': 3\}], the result will be \{'a': 1\}. |
+| Data (required) | `data` | array[*] | An array of arrays or objects to find the difference. The first element is compared against all subsequent elements. For example, given arrays [[1, 2, 3], [2, 3, 4], [3, 4, 5]], the result will be [1]. For objects, given [\{'a': 1, 'b': 2\}, \{'b': 2, 'c': 3\}], the result will be \{'a': 1\}. |
 </div>
 
 
@@ -134,7 +134,7 @@ Find elements that exist in the first array or object but not in any of the othe
 
 | Output | ID | Type | Description |
 | :--- | :--- | :--- | :--- |
-| Data | `data` | any | The resulting array or object after the difference operation. |
+| Data | `data` | * | The resulting array or object after the difference operation. |
 </div>
 
 
@@ -147,7 +147,7 @@ Find common elements that exist in all input arrays or objects.
 | Input | ID | Type | Description |
 | :--- | :--- | :--- | :--- |
 | Task ID (required) | `task` | string | `TASK_INTERSECTION` |
-| Data (required) | `data` | array | An array of arrays or objects to find common elements. For arrays: given [[1, 2, 3], [2, 3, 4]], the result will be [2, 3]. For objects: given [\{'a': 1, 'b': 2\}, \{'b': 2, 'c': 3\}], the result will be \{'b': 2\}. |
+| Data (required) | `data` | array[*] | An array of arrays or objects to find common elements. For arrays: given [[1, 2, 3], [2, 3, 4]], the result will be [2, 3]. For objects: given [\{'a': 1, 'b': 2\}, \{'b': 2, 'c': 3\}], the result will be \{'b': 2\}. |
 </div>
 
 
@@ -159,7 +159,7 @@ Find common elements that exist in all input arrays or objects.
 
 | Output | ID | Type | Description |
 | :--- | :--- | :--- | :--- |
-| Data | `data` | any | The resulting array or object after the intersection operation. |
+| Data | `data` | * | The resulting array or object after the intersection operation. |
 </div>
 
 
@@ -172,7 +172,7 @@ Split arrays or objects into smaller chunks.
 | Input | ID | Type | Description |
 | :--- | :--- | :--- | :--- |
 | Task ID (required) | `task` | string | `TASK_SPLIT` |
-| Data (required) | `data` | any | The source data to be split. Can be: 1) An array to split into groups 2) An object to split by property count (keys are sorted alphabetically for consistent ordering) |
+| Data (required) | `data` | * | The source data to be split. Can be: 1) An array to split into groups 2) An object to split by property count (keys are sorted alphabetically for consistent ordering) |
 | Size (required) | `size` | integer | Number of elements per group |
 </div>
 
@@ -185,7 +185,7 @@ Split arrays or objects into smaller chunks.
 
 | Output | ID | Type | Description |
 | :--- | :--- | :--- | :--- |
-| Data | `data` | array | The resulting array after splitting. For arrays: array of subarrays. For objects: array of smaller objects with alphabetically ordered keys |
+| Data | `data` | array[*] | The resulting array after splitting. For arrays: array of subarrays. For objects: array of smaller objects with alphabetically ordered keys |
 </div>
 
 
@@ -198,7 +198,7 @@ Find elements that exist in exactly one of the input arrays or objects, but not 
 | Input | ID | Type | Description |
 | :--- | :--- | :--- | :--- |
 | Task ID (required) | `task` | string | `TASK_SYMMETRIC_DIFFERENCE` |
-| Data (required) | `data` | array | An array of arrays or objects to find symmetric difference. For arrays: given [[1, 2], [2, 3]], the result will be [1, 3]. For objects: given [\{'a': 1, 'b': 2\}, \{'b': 2, 'c': 3\}], the result will be \{'a': 1, 'c': 3\}. |
+| Data (required) | `data` | array[*] | An array of arrays or objects to find symmetric difference. For arrays: given [[1, 2], [2, 3]], the result will be [1, 3]. For objects: given [\{'a': 1, 'b': 2\}, \{'b': 2, 'c': 3\}], the result will be \{'a': 1, 'c': 3\}. |
 </div>
 
 
@@ -210,7 +210,7 @@ Find elements that exist in exactly one of the input arrays or objects, but not 
 
 | Output | ID | Type | Description |
 | :--- | :--- | :--- | :--- |
-| Data | `data` | any | The resulting array or object after the symmetric difference operation. |
+| Data | `data` | * | The resulting array or object after the symmetric difference operation. |
 </div>
 
 
@@ -223,7 +223,7 @@ Find unique elements that exist in any of the input arrays or objects.
 | Input | ID | Type | Description |
 | :--- | :--- | :--- | :--- |
 | Task ID (required) | `task` | string | `TASK_UNION` |
-| Data (required) | `data` | array | An array of arrays or objects to find unique elements. For arrays: given [[1, 2], [2, 3]], the result will be [1, 2, 3]. For objects: given [\{'a': 1, 'b': 2\}, \{'b': 2, 'c': 3\}], the result will be \{'a': 1, 'b': 2, 'c': 3\}. |
+| Data (required) | `data` | array[*] | An array of arrays or objects to find unique elements. For arrays: given [[1, 2], [2, 3]], the result will be [1, 2, 3]. For objects: given [\{'a': 1, 'b': 2\}, \{'b': 2, 'c': 3\}], the result will be \{'a': 1, 'b': 2, 'c': 3\}. |
 </div>
 
 
@@ -235,7 +235,7 @@ Find unique elements that exist in any of the input arrays or objects.
 
 | Output | ID | Type | Description |
 | :--- | :--- | :--- | :--- |
-| Data | `data` | any | The resulting array or object after the union operation. |
+| Data | `data` | * | The resulting array or object after the union operation. |
 </div>
 
 

--- a/pkg/component/generic/collection/v0/config/tasks.json
+++ b/pkg/component/generic/collection/v0/config/tasks.json
@@ -21,9 +21,11 @@
             "reference",
             "template"
           ],
+          "type": "*",
           "title": "Data"
         },
         "value": {
+          "type": "*",
           "description": "The value to append. For arrays: the value will be appended as a new element. For objects: if value is an object, its key-value pairs will be added to the input object. For primitives: value will be appended to create/extend an array.",
           "instillAcceptFormats": [
             "*"
@@ -53,6 +55,7 @@
       "instillUIOrder": 0,
       "properties": {
         "data": {
+          "type": "*",
           "description": "The resulting data structure after the append operation. Will be either an array (if input was array or primitive) or an object (if input was object). Examples: [1,2,3], {'name':'John', 'age':25}, or ['hello','world'].",
           "instillEditOnNodeFields": [],
           "instillFormat": "*",
@@ -80,6 +83,7 @@
       "instillUIOrder": 0,
       "properties": {
         "data": {
+          "type": "*",
           "description": "The input data structure to modify. Can be an array, object, or primitive value.",
           "instillAcceptFormats": [
             "*"
@@ -108,6 +112,7 @@
           "title": "Path"
         },
         "value": {
+          "type": "*",
           "description": "The value to assign at the specified path. Can be any type (string, number, boolean, array, or object).",
           "instillAcceptFormats": [
             "*"
@@ -138,6 +143,7 @@
       "instillUIOrder": 0,
       "properties": {
         "data": {
+          "type": "*",
           "description": "The resulting data structure after the assign operation.",
           "instillEditOnNodeFields": [],
           "instillFormat": "*",
@@ -173,7 +179,9 @@
             "reference",
             "template"
           ],
-          "items": {},
+          "items": {
+            "type": "*"
+          },
           "title": "Data",
           "type": "array"
         }
@@ -196,6 +204,7 @@
           "instillEditOnNodeFields": [],
           "instillFormat": "*",
           "instillUIOrder": 0,
+          "type": "*",
           "title": "Data"
         }
       },
@@ -226,7 +235,9 @@
             "reference",
             "template"
           ],
-          "items": {},
+          "items": {
+            "type": "*"
+          },
           "required": [],
           "title": "Data",
           "type": "array"
@@ -246,6 +257,7 @@
       "instillUIOrder": 0,
       "properties": {
         "data": {
+          "type": "*",
           "description": "The resulting array or object after the difference operation.",
           "instillEditOnNodeFields": [],
           "instillFormat": "*",
@@ -281,7 +293,9 @@
             "reference",
             "template"
           ],
-          "items": {},
+          "items": {
+            "type": "*"
+          },
           "title": "Data",
           "type": "array"
         }
@@ -300,6 +314,7 @@
       "instillUIOrder": 0,
       "properties": {
         "data": {
+          "type": "*",
           "description": "The resulting array or object after the intersection operation.",
           "instillEditOnNodeFields": [],
           "instillFormat": "*",
@@ -321,6 +336,7 @@
       "instillUIOrder": 0,
       "properties": {
         "data": {
+          "type": "*",
           "description": "The source data to be split. Can be: 1) An array to split into groups 2) An object to split by property count (keys are sorted alphabetically for consistent ordering)",
           "instillAcceptFormats": [
             "*"
@@ -363,6 +379,9 @@
           "description": "The resulting array after splitting. For arrays: array of subarrays. For objects: array of smaller objects with alphabetically ordered keys",
           "instillFormat": "array:*",
           "instillUIOrder": 0,
+          "items": {
+            "type": "*"
+          },
           "title": "Data",
           "type": "array"
         }
@@ -395,7 +414,9 @@
             "reference",
             "template"
           ],
-          "items": {},
+          "items": {
+            "type": "*"
+          },
           "title": "Data",
           "type": "array"
         }
@@ -418,6 +439,7 @@
           "instillEditOnNodeFields": [],
           "instillFormat": "*",
           "instillUIOrder": 0,
+          "type": "*",
           "title": "Data"
         }
       },
@@ -449,7 +471,9 @@
             "reference",
             "template"
           ],
-          "items": {},
+          "items": {
+            "type": "*"
+          },
           "title": "Data",
           "type": "array"
         }
@@ -472,6 +496,7 @@
           "instillEditOnNodeFields": [],
           "instillFormat": "*",
           "instillUIOrder": 0,
+          "type": "*",
           "title": "Data"
         }
       },


### PR DESCRIPTION
Because

- all fields in the component schema require a `type`. Currently, we can use `*` as a temporary type. In the future, `type` will be retired, and only `format` will remain.

This commit

- fixes the component schema to comply with the current requirements.