### PR TITLE
chore(component): add event cards in component definition

### DIFF
--- a/pkg/component/application/github/v0/config/definition.json
+++ b/pkg/component/application/github/v0/config/definition.json
@@ -10,6 +10,9 @@
     "TASK_CREATE_ISSUE",
     "TASK_CREATE_WEBHOOK"
   ],
+  "availableEvents": [
+    "EVENT_STAR_CREATED"
+  ],
   "documentationUrl": "https://www.instill.tech/docs/component/application/github",
   "icon": "assets/github.svg",
   "id": "github",

--- a/pkg/component/application/github/v0/config/events.json
+++ b/pkg/component/application/github/v0/config/events.json
@@ -1,6 +1,6 @@
 {
   "EVENT_STAR_CREATED": {
-    "title": "Star Created Event",
+    "title": "Star Created",
     "description": "A star created event from GitHub",
     "configSchema": {
       "type": "object",

--- a/pkg/component/application/slack/v0/config/definition.json
+++ b/pkg/component/application/slack/v0/config/definition.json
@@ -3,6 +3,9 @@
     "TASK_READ_MESSAGE",
     "TASK_WRITE_MESSAGE"
   ],
+  "availableEvents": [
+    "EVENT_NEW_MESSAGE"
+  ],
   "custom": false,
   "documentationUrl": "https://www.instill.tech/docs/component/application/slack",
   "icon": "assets/slack.svg",

--- a/pkg/component/application/slack/v0/config/events.json
+++ b/pkg/component/application/slack/v0/config/events.json
@@ -1,6 +1,6 @@
 {
   "EVENT_NEW_MESSAGE": {
-    "title": "New Message Event",
+    "title": "New Message",
     "description": "A new message event from Slack.",
     "configSchema": {
       "type": "object",

--- a/pkg/component/generic/schedule/v0/config/definition.json
+++ b/pkg/component/generic/schedule/v0/config/definition.json
@@ -1,5 +1,8 @@
 {
   "availableTasks": [],
+  "availableEvents": [
+    "EVENT_CRON_JOB_TRIGGERED"
+  ],
   "documentationUrl": "https://www.instill.tech/docs/component/generic/schedule",
   "icon": "assets/schedule.svg",
   "id": "schedule",

--- a/pkg/component/generic/schedule/v0/config/events.json
+++ b/pkg/component/generic/schedule/v0/config/events.json
@@ -1,6 +1,6 @@
 {
   "EVENT_CRON_JOB_TRIGGERED": {
-    "title": "Cron Job Triggered Event",
+    "title": "Cron Job Triggered",
     "description": "An event triggered on a cron job",
     "configSchema": {
       "type": "object",


### PR DESCRIPTION
Because

- we have an event card data structure in our component definition response, but it hasn’t been implemented yet.

This commit

- implements event cards in the component definition.