### PR TITLE
fix(workflow): fix wrong component id in SchedulePipelineWorkflow

### DIFF
--- a/pkg/worker/workflow.go
+++ b/pkg/worker/workflow.go
@@ -1654,7 +1654,7 @@ func (w *worker) SchedulePipelineWorkflow(wfctx workflow.Context, param *schedul
 	}
 
 	_, err = w.pipelinePublicServiceClient.DispatchPipelineWebhookEvent(sCtx, &pb.DispatchPipelineWebhookEventRequest{
-		WebhookType: "schedule",
+		WebhookType: "scheduler",
 		Message:     structPayload,
 	})
 	if err != nil {


### PR DESCRIPTION
This commit

- fixes wrong component id in SchedulePipelineWorkflow
