### PR TITLE
feat(pipeline): add blob expiration time to run logs

### DIFF
--- a/cmd/migration/main.go
+++ b/cmd/migration/main.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"os"
 
 	"github.com/golang-migrate/migrate/v4"
+	"go.uber.org/zap"
 
 	_ "github.com/golang-migrate/migrate/v4/database/postgres"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
@@ -13,7 +15,14 @@ import (
 	"github.com/instill-ai/pipeline-backend/config"
 	"github.com/instill-ai/pipeline-backend/pkg/db/migration"
 	"github.com/instill-ai/pipeline-backend/pkg/db/migration/convert/legacy"
+	"github.com/instill-ai/pipeline-backend/pkg/external"
+	"github.com/instill-ai/pipeline-backend/pkg/logger"
+	"github.com/instill-ai/pipeline-backend/pkg/service"
+
+	database "github.com/instill-ai/pipeline-backend/pkg/db"
 )
+
+var log *zap.Logger
 
 func checkExist(databaseConfig config.DatabaseConfig) error {
 	db, err := sql.Open(
@@ -28,22 +37,21 @@ func checkExist(databaseConfig config.DatabaseConfig) error {
 	)
 
 	if err != nil {
-		panic(err)
+		return fmt.Errorf("opening database connection: %w", err)
 	}
 
 	defer db.Close()
 
-	// Open() may just validate its arguments without creating a connection to the database.
-	// To verify that the data source name is valid, call Ping().
+	// Open() may just validate its arguments without creating a connection to
+	// the database. To verify that the data source name is valid, call Ping().
 	if err = db.Ping(); err != nil {
-		panic(err)
+		return fmt.Errorf("pinging database: %w", err)
 	}
 
 	var rows *sql.Rows
 	rows, err = db.Query(fmt.Sprintf("SELECT datname FROM pg_catalog.pg_database WHERE lower(datname) = lower('%s');", databaseConfig.Name))
-
 	if err != nil {
-		panic(err)
+		return fmt.Errorf("executing database name query: %w", err)
 	}
 
 	dbExist := false
@@ -51,23 +59,23 @@ func checkExist(databaseConfig config.DatabaseConfig) error {
 	for rows.Next() {
 		var databaseName string
 		if err := rows.Scan(&databaseName); err != nil {
-			panic(err)
+			return fmt.Errorf("scanning database name from row: %w", err)
 		}
 
 		if databaseConfig.Name == databaseName {
 			dbExist = true
-			fmt.Printf("Database %s exist\n", databaseName)
+			log.With(zap.String("name", databaseName)).Info("Database exists")
 		}
 	}
 
 	if err := rows.Err(); err != nil {
-		panic(err)
+		return fmt.Errorf("scanning rows: %w", err)
 	}
 
 	if !dbExist {
-		fmt.Printf("Create database %s\n", databaseConfig.Name)
+		log.With(zap.String("name", databaseConfig.Name)).Info("Create database")
 		if _, err := db.Exec(fmt.Sprintf("CREATE DATABASE %s;", databaseConfig.Name)); err != nil {
-			return err
+			return fmt.Errorf("creating database: %w", err)
 		}
 	}
 
@@ -75,16 +83,16 @@ func checkExist(databaseConfig config.DatabaseConfig) error {
 }
 
 func main() {
-	migrateFolder, _ := os.Getwd()
+	ctx := context.Background()
+	log, _ = logger.GetZapLogger(ctx)
 
 	if err := config.Init(config.ParseConfigFlag()); err != nil {
-		panic(err)
+		log.With(zap.Error(err)).Fatal("Loading configuration")
 	}
 
 	databaseConfig := config.Config.Database
-
 	if err := checkExist(databaseConfig); err != nil {
-		panic(err)
+		log.With(zap.Error(err)).Fatal("Checking database existence")
 	}
 
 	dsn := fmt.Sprintf("postgres://%s:%s@%s:%d/%s?%s",
@@ -96,59 +104,105 @@ func main() {
 		"sslmode=disable",
 	)
 
-	m, err := migrate.New(fmt.Sprintf("file:///%s/pkg/db/migration", migrateFolder), dsn)
+	codeMigrator, cleanup := initCodeMigrator(ctx)
+	defer cleanup()
 
+	if err := runMigration(dsn, databaseConfig.Version, codeMigrator.Migrate); err != nil {
+		log.With(zap.Error(err)).Fatal("Running migration")
+	}
+}
+
+func runMigration(
+	dsn string,
+	expectedVersion uint,
+	execCode func(version uint) error,
+) error {
+	migrateFolder, err := os.Getwd()
 	if err != nil {
-		panic(err)
+		return fmt.Errorf("accessing base path: %w", err)
+	}
+
+	m, err := migrate.New(fmt.Sprintf("file:///%s/pkg/db/migration", migrateFolder), dsn)
+	if err != nil {
+		return fmt.Errorf("creating migration: %w", err)
 	}
 
 	curVersion, dirty, err := m.Version()
-
 	if err != nil && curVersion != 0 {
-		panic(err)
+		return fmt.Errorf("getting current version: %w", err)
 	}
 
-	expectedVersion := databaseConfig.Version
+	log.With(
+		zap.Uint("expectedVersion", expectedVersion),
+		zap.Uint("currentVersion", curVersion),
+		zap.Bool("dirty", dirty),
+	).Info("Running migration")
 
-	fmt.Printf("Expected migration version is %d\n", expectedVersion)
-	fmt.Printf("The current schema version is %d, and dirty flag is %t\n", curVersion, dirty)
 	if dirty {
-		panic("The database has dirty flag, please fix it")
+		return fmt.Errorf("database is dirty, please fix it")
 	}
 
 	step := curVersion
 	for {
 		if expectedVersion <= step {
-			fmt.Printf("Migration to version %d complete\n", expectedVersion)
+			log.With(zap.Uint("expectedVersion", expectedVersion)).Info("Migration completed")
 			break
 		}
 
 		switch step {
 		case 5:
 			if err := legacy.MigratePipelineRecipeUp000006(); err != nil {
-				panic(err)
+				return fmt.Errorf("running legacy step 6: %w", err)
 			}
 		case 6:
 			if err := legacy.MigratePipelineRecipeUp000007(); err != nil {
-				panic(err)
+				return fmt.Errorf("running legacy step 7: %w", err)
 			}
 		case 11:
 			if err := legacy.MigratePipelineRecipeUp000012(); err != nil {
-				panic(err)
+				return fmt.Errorf("running legacy step 12: %w", err)
 			}
 		}
 
-		fmt.Printf("Step up to version %d\n", step+1)
+		log.With(zap.Uint("step", step+1)).Info("Step up")
 		if err := m.Steps(1); err != nil {
-			panic(err)
+			return fmt.Errorf("stepping up: %w", err)
 		}
 
 		if step, _, err = m.Version(); err != nil {
-			panic(err)
+			return fmt.Errorf("getting new version: %w", err)
 		}
 
-		if err := migration.Migrate(step); err != nil {
-			panic(err)
+		if err := execCode(step); err != nil {
+			return fmt.Errorf("running associated code: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func initCodeMigrator(ctx context.Context) (cm *migration.CodeMigrator, cleanup func()) {
+	l, _ := logger.GetZapLogger(ctx)
+	cleanups := make([]func(), 0)
+
+	rh := service.NewRetentionHandler()
+	mgmtPrivateServiceClient, mgmtPrivateServiceClientConn := external.InitMgmtPrivateServiceClient(ctx)
+	if mgmtPrivateServiceClientConn != nil {
+		cleanups = append(cleanups, func() { _ = mgmtPrivateServiceClientConn.Close() })
+	}
+
+	db := database.GetConnection().WithContext(ctx)
+	cleanups = append(cleanups, func() { database.Close(db) })
+	codeMigrator := &migration.CodeMigrator{
+		Logger:                   l,
+		DB:                       db,
+		RetentionHandler:         rh,
+		MGMTPrivateServiceClient: mgmtPrivateServiceClient,
+	}
+
+	return codeMigrator, func() {
+		for _, cleanup := range cleanups {
+			cleanup()
 		}
 	}
 }

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -26,7 +26,7 @@ database:
   host: pg-sql
   port: 5432
   name: pipeline
-  version: 38
+  version: 39
   timezone: Etc/UTC
   pool:
     idleconnections: 5

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/h2non/filetype v1.1.3
 	github.com/iancoleman/strcase v0.3.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241129105617-c2c298e76498
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241213145904-c3d8111872b5
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
 	github.com/instill-ai/x v0.5.0-alpha.0.20241213094923-890bb310fcb2
 	github.com/itchyny/gojq v0.12.14

--- a/go.sum
+++ b/go.sum
@@ -1285,8 +1285,8 @@ github.com/influxdata/influxdb-client-go/v2 v2.12.3 h1:28nRlNMRIV4QbtIUvxhWqaxn0
 github.com/influxdata/influxdb-client-go/v2 v2.12.3/go.mod h1:IrrLUbCjjfkmRuaCiGQg4m2GbkaeJDcuWoxiWdQEbA0=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241129105617-c2c298e76498 h1:JYRfk/m+960jEScE1NPQM+xh+ScR4cHNMg/tCFwQbpI=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241129105617-c2c298e76498/go.mod h1:rf0UY7VpEgpaLudYEcjx5rnbuwlBaaLyD4FQmWLtgAY=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241213145904-c3d8111872b5 h1:5338ZeuB/C50P8aUOUKstjBSAQaWqmrdrAK2i9AbWk8=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20241213145904-c3d8111872b5/go.mod h1:rf0UY7VpEgpaLudYEcjx5rnbuwlBaaLyD4FQmWLtgAY=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a/go.mod h1:EpX3Yr661uWULtZf5UnJHfr5rw2PDyX8ku4Kx0UtYFw=
 github.com/instill-ai/x v0.5.0-alpha.0.20241213094923-890bb310fcb2 h1:JHQpGbLn8ViRH3WNdOEt+smFkyhDJCs6U6hDbJ9suHA=

--- a/pkg/component/internal/mock/artifact_public_service_client_mock.gen.go
+++ b/pkg/component/internal/mock/artifact_public_service_client_mock.gen.go
@@ -102,6 +102,13 @@ type ArtifactPublicServiceClientMock struct {
 	beforeLivenessCounter uint64
 	LivenessMock          mArtifactPublicServiceClientMockLiveness
 
+	funcMoveFileToCatalog          func(ctx context.Context, in *mm_artifactv1alpha.MoveFileToCatalogRequest, opts ...grpc.CallOption) (mp1 *mm_artifactv1alpha.MoveFileToCatalogResponse, err error)
+	funcMoveFileToCatalogOrigin    string
+	inspectFuncMoveFileToCatalog   func(ctx context.Context, in *mm_artifactv1alpha.MoveFileToCatalogRequest, opts ...grpc.CallOption)
+	afterMoveFileToCatalogCounter  uint64
+	beforeMoveFileToCatalogCounter uint64
+	MoveFileToCatalogMock          mArtifactPublicServiceClientMockMoveFileToCatalog
+
 	funcProcessCatalogFiles          func(ctx context.Context, in *mm_artifactv1alpha.ProcessCatalogFilesRequest, opts ...grpc.CallOption) (pp1 *mm_artifactv1alpha.ProcessCatalogFilesResponse, err error)
 	funcProcessCatalogFilesOrigin    string
 	inspectFuncProcessCatalogFiles   func(ctx context.Context, in *mm_artifactv1alpha.ProcessCatalogFilesRequest, opts ...grpc.CallOption)
@@ -209,6 +216,9 @@ func NewArtifactPublicServiceClientMock(t minimock.Tester) *ArtifactPublicServic
 
 	m.LivenessMock = mArtifactPublicServiceClientMockLiveness{mock: m}
 	m.LivenessMock.callArgs = []*ArtifactPublicServiceClientMockLivenessParams{}
+
+	m.MoveFileToCatalogMock = mArtifactPublicServiceClientMockMoveFileToCatalog{mock: m}
+	m.MoveFileToCatalogMock.callArgs = []*ArtifactPublicServiceClientMockMoveFileToCatalogParams{}
 
 	m.ProcessCatalogFilesMock = mArtifactPublicServiceClientMockProcessCatalogFiles{mock: m}
 	m.ProcessCatalogFilesMock.callArgs = []*ArtifactPublicServiceClientMockProcessCatalogFilesParams{}
@@ -4730,6 +4740,380 @@ func (m *ArtifactPublicServiceClientMock) MinimockLivenessInspect() {
 	}
 }
 
+type mArtifactPublicServiceClientMockMoveFileToCatalog struct {
+	optional           bool
+	mock               *ArtifactPublicServiceClientMock
+	defaultExpectation *ArtifactPublicServiceClientMockMoveFileToCatalogExpectation
+	expectations       []*ArtifactPublicServiceClientMockMoveFileToCatalogExpectation
+
+	callArgs []*ArtifactPublicServiceClientMockMoveFileToCatalogParams
+	mutex    sync.RWMutex
+
+	expectedInvocations       uint64
+	expectedInvocationsOrigin string
+}
+
+// ArtifactPublicServiceClientMockMoveFileToCatalogExpectation specifies expectation struct of the ArtifactPublicServiceClient.MoveFileToCatalog
+type ArtifactPublicServiceClientMockMoveFileToCatalogExpectation struct {
+	mock               *ArtifactPublicServiceClientMock
+	params             *ArtifactPublicServiceClientMockMoveFileToCatalogParams
+	paramPtrs          *ArtifactPublicServiceClientMockMoveFileToCatalogParamPtrs
+	expectationOrigins ArtifactPublicServiceClientMockMoveFileToCatalogExpectationOrigins
+	results            *ArtifactPublicServiceClientMockMoveFileToCatalogResults
+	returnOrigin       string
+	Counter            uint64
+}
+
+// ArtifactPublicServiceClientMockMoveFileToCatalogParams contains parameters of the ArtifactPublicServiceClient.MoveFileToCatalog
+type ArtifactPublicServiceClientMockMoveFileToCatalogParams struct {
+	ctx  context.Context
+	in   *mm_artifactv1alpha.MoveFileToCatalogRequest
+	opts []grpc.CallOption
+}
+
+// ArtifactPublicServiceClientMockMoveFileToCatalogParamPtrs contains pointers to parameters of the ArtifactPublicServiceClient.MoveFileToCatalog
+type ArtifactPublicServiceClientMockMoveFileToCatalogParamPtrs struct {
+	ctx  *context.Context
+	in   **mm_artifactv1alpha.MoveFileToCatalogRequest
+	opts *[]grpc.CallOption
+}
+
+// ArtifactPublicServiceClientMockMoveFileToCatalogResults contains results of the ArtifactPublicServiceClient.MoveFileToCatalog
+type ArtifactPublicServiceClientMockMoveFileToCatalogResults struct {
+	mp1 *mm_artifactv1alpha.MoveFileToCatalogResponse
+	err error
+}
+
+// ArtifactPublicServiceClientMockMoveFileToCatalogOrigins contains origins of expectations of the ArtifactPublicServiceClient.MoveFileToCatalog
+type ArtifactPublicServiceClientMockMoveFileToCatalogExpectationOrigins struct {
+	origin     string
+	originCtx  string
+	originIn   string
+	originOpts string
+}
+
+// Marks this method to be optional. The default behavior of any method with Return() is '1 or more', meaning
+// the test will fail minimock's automatic final call check if the mocked method was not called at least once.
+// Optional() makes method check to work in '0 or more' mode.
+// It is NOT RECOMMENDED to use this option unless you really need it, as default behaviour helps to
+// catch the problems when the expected method call is totally skipped during test run.
+func (mmMoveFileToCatalog *mArtifactPublicServiceClientMockMoveFileToCatalog) Optional() *mArtifactPublicServiceClientMockMoveFileToCatalog {
+	mmMoveFileToCatalog.optional = true
+	return mmMoveFileToCatalog
+}
+
+// Expect sets up expected params for ArtifactPublicServiceClient.MoveFileToCatalog
+func (mmMoveFileToCatalog *mArtifactPublicServiceClientMockMoveFileToCatalog) Expect(ctx context.Context, in *mm_artifactv1alpha.MoveFileToCatalogRequest, opts ...grpc.CallOption) *mArtifactPublicServiceClientMockMoveFileToCatalog {
+	if mmMoveFileToCatalog.mock.funcMoveFileToCatalog != nil {
+		mmMoveFileToCatalog.mock.t.Fatalf("ArtifactPublicServiceClientMock.MoveFileToCatalog mock is already set by Set")
+	}
+
+	if mmMoveFileToCatalog.defaultExpectation == nil {
+		mmMoveFileToCatalog.defaultExpectation = &ArtifactPublicServiceClientMockMoveFileToCatalogExpectation{}
+	}
+
+	if mmMoveFileToCatalog.defaultExpectation.paramPtrs != nil {
+		mmMoveFileToCatalog.mock.t.Fatalf("ArtifactPublicServiceClientMock.MoveFileToCatalog mock is already set by ExpectParams functions")
+	}
+
+	mmMoveFileToCatalog.defaultExpectation.params = &ArtifactPublicServiceClientMockMoveFileToCatalogParams{ctx, in, opts}
+	mmMoveFileToCatalog.defaultExpectation.expectationOrigins.origin = minimock.CallerInfo(1)
+	for _, e := range mmMoveFileToCatalog.expectations {
+		if minimock.Equal(e.params, mmMoveFileToCatalog.defaultExpectation.params) {
+			mmMoveFileToCatalog.mock.t.Fatalf("Expectation set by When has same params: %#v", *mmMoveFileToCatalog.defaultExpectation.params)
+		}
+	}
+
+	return mmMoveFileToCatalog
+}
+
+// ExpectCtxParam1 sets up expected param ctx for ArtifactPublicServiceClient.MoveFileToCatalog
+func (mmMoveFileToCatalog *mArtifactPublicServiceClientMockMoveFileToCatalog) ExpectCtxParam1(ctx context.Context) *mArtifactPublicServiceClientMockMoveFileToCatalog {
+	if mmMoveFileToCatalog.mock.funcMoveFileToCatalog != nil {
+		mmMoveFileToCatalog.mock.t.Fatalf("ArtifactPublicServiceClientMock.MoveFileToCatalog mock is already set by Set")
+	}
+
+	if mmMoveFileToCatalog.defaultExpectation == nil {
+		mmMoveFileToCatalog.defaultExpectation = &ArtifactPublicServiceClientMockMoveFileToCatalogExpectation{}
+	}
+
+	if mmMoveFileToCatalog.defaultExpectation.params != nil {
+		mmMoveFileToCatalog.mock.t.Fatalf("ArtifactPublicServiceClientMock.MoveFileToCatalog mock is already set by Expect")
+	}
+
+	if mmMoveFileToCatalog.defaultExpectation.paramPtrs == nil {
+		mmMoveFileToCatalog.defaultExpectation.paramPtrs = &ArtifactPublicServiceClientMockMoveFileToCatalogParamPtrs{}
+	}
+	mmMoveFileToCatalog.defaultExpectation.paramPtrs.ctx = &ctx
+	mmMoveFileToCatalog.defaultExpectation.expectationOrigins.originCtx = minimock.CallerInfo(1)
+
+	return mmMoveFileToCatalog
+}
+
+// ExpectInParam2 sets up expected param in for ArtifactPublicServiceClient.MoveFileToCatalog
+func (mmMoveFileToCatalog *mArtifactPublicServiceClientMockMoveFileToCatalog) ExpectInParam2(in *mm_artifactv1alpha.MoveFileToCatalogRequest) *mArtifactPublicServiceClientMockMoveFileToCatalog {
+	if mmMoveFileToCatalog.mock.funcMoveFileToCatalog != nil {
+		mmMoveFileToCatalog.mock.t.Fatalf("ArtifactPublicServiceClientMock.MoveFileToCatalog mock is already set by Set")
+	}
+
+	if mmMoveFileToCatalog.defaultExpectation == nil {
+		mmMoveFileToCatalog.defaultExpectation = &ArtifactPublicServiceClientMockMoveFileToCatalogExpectation{}
+	}
+
+	if mmMoveFileToCatalog.defaultExpectation.params != nil {
+		mmMoveFileToCatalog.mock.t.Fatalf("ArtifactPublicServiceClientMock.MoveFileToCatalog mock is already set by Expect")
+	}
+
+	if mmMoveFileToCatalog.defaultExpectation.paramPtrs == nil {
+		mmMoveFileToCatalog.defaultExpectation.paramPtrs = &ArtifactPublicServiceClientMockMoveFileToCatalogParamPtrs{}
+	}
+	mmMoveFileToCatalog.defaultExpectation.paramPtrs.in = &in
+	mmMoveFileToCatalog.defaultExpectation.expectationOrigins.originIn = minimock.CallerInfo(1)
+
+	return mmMoveFileToCatalog
+}
+
+// ExpectOptsParam3 sets up expected param opts for ArtifactPublicServiceClient.MoveFileToCatalog
+func (mmMoveFileToCatalog *mArtifactPublicServiceClientMockMoveFileToCatalog) ExpectOptsParam3(opts ...grpc.CallOption) *mArtifactPublicServiceClientMockMoveFileToCatalog {
+	if mmMoveFileToCatalog.mock.funcMoveFileToCatalog != nil {
+		mmMoveFileToCatalog.mock.t.Fatalf("ArtifactPublicServiceClientMock.MoveFileToCatalog mock is already set by Set")
+	}
+
+	if mmMoveFileToCatalog.defaultExpectation == nil {
+		mmMoveFileToCatalog.defaultExpectation = &ArtifactPublicServiceClientMockMoveFileToCatalogExpectation{}
+	}
+
+	if mmMoveFileToCatalog.defaultExpectation.params != nil {
+		mmMoveFileToCatalog.mock.t.Fatalf("ArtifactPublicServiceClientMock.MoveFileToCatalog mock is already set by Expect")
+	}
+
+	if mmMoveFileToCatalog.defaultExpectation.paramPtrs == nil {
+		mmMoveFileToCatalog.defaultExpectation.paramPtrs = &ArtifactPublicServiceClientMockMoveFileToCatalogParamPtrs{}
+	}
+	mmMoveFileToCatalog.defaultExpectation.paramPtrs.opts = &opts
+	mmMoveFileToCatalog.defaultExpectation.expectationOrigins.originOpts = minimock.CallerInfo(1)
+
+	return mmMoveFileToCatalog
+}
+
+// Inspect accepts an inspector function that has same arguments as the ArtifactPublicServiceClient.MoveFileToCatalog
+func (mmMoveFileToCatalog *mArtifactPublicServiceClientMockMoveFileToCatalog) Inspect(f func(ctx context.Context, in *mm_artifactv1alpha.MoveFileToCatalogRequest, opts ...grpc.CallOption)) *mArtifactPublicServiceClientMockMoveFileToCatalog {
+	if mmMoveFileToCatalog.mock.inspectFuncMoveFileToCatalog != nil {
+		mmMoveFileToCatalog.mock.t.Fatalf("Inspect function is already set for ArtifactPublicServiceClientMock.MoveFileToCatalog")
+	}
+
+	mmMoveFileToCatalog.mock.inspectFuncMoveFileToCatalog = f
+
+	return mmMoveFileToCatalog
+}
+
+// Return sets up results that will be returned by ArtifactPublicServiceClient.MoveFileToCatalog
+func (mmMoveFileToCatalog *mArtifactPublicServiceClientMockMoveFileToCatalog) Return(mp1 *mm_artifactv1alpha.MoveFileToCatalogResponse, err error) *ArtifactPublicServiceClientMock {
+	if mmMoveFileToCatalog.mock.funcMoveFileToCatalog != nil {
+		mmMoveFileToCatalog.mock.t.Fatalf("ArtifactPublicServiceClientMock.MoveFileToCatalog mock is already set by Set")
+	}
+
+	if mmMoveFileToCatalog.defaultExpectation == nil {
+		mmMoveFileToCatalog.defaultExpectation = &ArtifactPublicServiceClientMockMoveFileToCatalogExpectation{mock: mmMoveFileToCatalog.mock}
+	}
+	mmMoveFileToCatalog.defaultExpectation.results = &ArtifactPublicServiceClientMockMoveFileToCatalogResults{mp1, err}
+	mmMoveFileToCatalog.defaultExpectation.returnOrigin = minimock.CallerInfo(1)
+	return mmMoveFileToCatalog.mock
+}
+
+// Set uses given function f to mock the ArtifactPublicServiceClient.MoveFileToCatalog method
+func (mmMoveFileToCatalog *mArtifactPublicServiceClientMockMoveFileToCatalog) Set(f func(ctx context.Context, in *mm_artifactv1alpha.MoveFileToCatalogRequest, opts ...grpc.CallOption) (mp1 *mm_artifactv1alpha.MoveFileToCatalogResponse, err error)) *ArtifactPublicServiceClientMock {
+	if mmMoveFileToCatalog.defaultExpectation != nil {
+		mmMoveFileToCatalog.mock.t.Fatalf("Default expectation is already set for the ArtifactPublicServiceClient.MoveFileToCatalog method")
+	}
+
+	if len(mmMoveFileToCatalog.expectations) > 0 {
+		mmMoveFileToCatalog.mock.t.Fatalf("Some expectations are already set for the ArtifactPublicServiceClient.MoveFileToCatalog method")
+	}
+
+	mmMoveFileToCatalog.mock.funcMoveFileToCatalog = f
+	mmMoveFileToCatalog.mock.funcMoveFileToCatalogOrigin = minimock.CallerInfo(1)
+	return mmMoveFileToCatalog.mock
+}
+
+// When sets expectation for the ArtifactPublicServiceClient.MoveFileToCatalog which will trigger the result defined by the following
+// Then helper
+func (mmMoveFileToCatalog *mArtifactPublicServiceClientMockMoveFileToCatalog) When(ctx context.Context, in *mm_artifactv1alpha.MoveFileToCatalogRequest, opts ...grpc.CallOption) *ArtifactPublicServiceClientMockMoveFileToCatalogExpectation {
+	if mmMoveFileToCatalog.mock.funcMoveFileToCatalog != nil {
+		mmMoveFileToCatalog.mock.t.Fatalf("ArtifactPublicServiceClientMock.MoveFileToCatalog mock is already set by Set")
+	}
+
+	expectation := &ArtifactPublicServiceClientMockMoveFileToCatalogExpectation{
+		mock:               mmMoveFileToCatalog.mock,
+		params:             &ArtifactPublicServiceClientMockMoveFileToCatalogParams{ctx, in, opts},
+		expectationOrigins: ArtifactPublicServiceClientMockMoveFileToCatalogExpectationOrigins{origin: minimock.CallerInfo(1)},
+	}
+	mmMoveFileToCatalog.expectations = append(mmMoveFileToCatalog.expectations, expectation)
+	return expectation
+}
+
+// Then sets up ArtifactPublicServiceClient.MoveFileToCatalog return parameters for the expectation previously defined by the When method
+func (e *ArtifactPublicServiceClientMockMoveFileToCatalogExpectation) Then(mp1 *mm_artifactv1alpha.MoveFileToCatalogResponse, err error) *ArtifactPublicServiceClientMock {
+	e.results = &ArtifactPublicServiceClientMockMoveFileToCatalogResults{mp1, err}
+	return e.mock
+}
+
+// Times sets number of times ArtifactPublicServiceClient.MoveFileToCatalog should be invoked
+func (mmMoveFileToCatalog *mArtifactPublicServiceClientMockMoveFileToCatalog) Times(n uint64) *mArtifactPublicServiceClientMockMoveFileToCatalog {
+	if n == 0 {
+		mmMoveFileToCatalog.mock.t.Fatalf("Times of ArtifactPublicServiceClientMock.MoveFileToCatalog mock can not be zero")
+	}
+	mm_atomic.StoreUint64(&mmMoveFileToCatalog.expectedInvocations, n)
+	mmMoveFileToCatalog.expectedInvocationsOrigin = minimock.CallerInfo(1)
+	return mmMoveFileToCatalog
+}
+
+func (mmMoveFileToCatalog *mArtifactPublicServiceClientMockMoveFileToCatalog) invocationsDone() bool {
+	if len(mmMoveFileToCatalog.expectations) == 0 && mmMoveFileToCatalog.defaultExpectation == nil && mmMoveFileToCatalog.mock.funcMoveFileToCatalog == nil {
+		return true
+	}
+
+	totalInvocations := mm_atomic.LoadUint64(&mmMoveFileToCatalog.mock.afterMoveFileToCatalogCounter)
+	expectedInvocations := mm_atomic.LoadUint64(&mmMoveFileToCatalog.expectedInvocations)
+
+	return totalInvocations > 0 && (expectedInvocations == 0 || expectedInvocations == totalInvocations)
+}
+
+// MoveFileToCatalog implements mm_artifactv1alpha.ArtifactPublicServiceClient
+func (mmMoveFileToCatalog *ArtifactPublicServiceClientMock) MoveFileToCatalog(ctx context.Context, in *mm_artifactv1alpha.MoveFileToCatalogRequest, opts ...grpc.CallOption) (mp1 *mm_artifactv1alpha.MoveFileToCatalogResponse, err error) {
+	mm_atomic.AddUint64(&mmMoveFileToCatalog.beforeMoveFileToCatalogCounter, 1)
+	defer mm_atomic.AddUint64(&mmMoveFileToCatalog.afterMoveFileToCatalogCounter, 1)
+
+	mmMoveFileToCatalog.t.Helper()
+
+	if mmMoveFileToCatalog.inspectFuncMoveFileToCatalog != nil {
+		mmMoveFileToCatalog.inspectFuncMoveFileToCatalog(ctx, in, opts...)
+	}
+
+	mm_params := ArtifactPublicServiceClientMockMoveFileToCatalogParams{ctx, in, opts}
+
+	// Record call args
+	mmMoveFileToCatalog.MoveFileToCatalogMock.mutex.Lock()
+	mmMoveFileToCatalog.MoveFileToCatalogMock.callArgs = append(mmMoveFileToCatalog.MoveFileToCatalogMock.callArgs, &mm_params)
+	mmMoveFileToCatalog.MoveFileToCatalogMock.mutex.Unlock()
+
+	for _, e := range mmMoveFileToCatalog.MoveFileToCatalogMock.expectations {
+		if minimock.Equal(*e.params, mm_params) {
+			mm_atomic.AddUint64(&e.Counter, 1)
+			return e.results.mp1, e.results.err
+		}
+	}
+
+	if mmMoveFileToCatalog.MoveFileToCatalogMock.defaultExpectation != nil {
+		mm_atomic.AddUint64(&mmMoveFileToCatalog.MoveFileToCatalogMock.defaultExpectation.Counter, 1)
+		mm_want := mmMoveFileToCatalog.MoveFileToCatalogMock.defaultExpectation.params
+		mm_want_ptrs := mmMoveFileToCatalog.MoveFileToCatalogMock.defaultExpectation.paramPtrs
+
+		mm_got := ArtifactPublicServiceClientMockMoveFileToCatalogParams{ctx, in, opts}
+
+		if mm_want_ptrs != nil {
+
+			if mm_want_ptrs.ctx != nil && !minimock.Equal(*mm_want_ptrs.ctx, mm_got.ctx) {
+				mmMoveFileToCatalog.t.Errorf("ArtifactPublicServiceClientMock.MoveFileToCatalog got unexpected parameter ctx, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmMoveFileToCatalog.MoveFileToCatalogMock.defaultExpectation.expectationOrigins.originCtx, *mm_want_ptrs.ctx, mm_got.ctx, minimock.Diff(*mm_want_ptrs.ctx, mm_got.ctx))
+			}
+
+			if mm_want_ptrs.in != nil && !minimock.Equal(*mm_want_ptrs.in, mm_got.in) {
+				mmMoveFileToCatalog.t.Errorf("ArtifactPublicServiceClientMock.MoveFileToCatalog got unexpected parameter in, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmMoveFileToCatalog.MoveFileToCatalogMock.defaultExpectation.expectationOrigins.originIn, *mm_want_ptrs.in, mm_got.in, minimock.Diff(*mm_want_ptrs.in, mm_got.in))
+			}
+
+			if mm_want_ptrs.opts != nil && !minimock.Equal(*mm_want_ptrs.opts, mm_got.opts) {
+				mmMoveFileToCatalog.t.Errorf("ArtifactPublicServiceClientMock.MoveFileToCatalog got unexpected parameter opts, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmMoveFileToCatalog.MoveFileToCatalogMock.defaultExpectation.expectationOrigins.originOpts, *mm_want_ptrs.opts, mm_got.opts, minimock.Diff(*mm_want_ptrs.opts, mm_got.opts))
+			}
+
+		} else if mm_want != nil && !minimock.Equal(*mm_want, mm_got) {
+			mmMoveFileToCatalog.t.Errorf("ArtifactPublicServiceClientMock.MoveFileToCatalog got unexpected parameters, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+				mmMoveFileToCatalog.MoveFileToCatalogMock.defaultExpectation.expectationOrigins.origin, *mm_want, mm_got, minimock.Diff(*mm_want, mm_got))
+		}
+
+		mm_results := mmMoveFileToCatalog.MoveFileToCatalogMock.defaultExpectation.results
+		if mm_results == nil {
+			mmMoveFileToCatalog.t.Fatal("No results are set for the ArtifactPublicServiceClientMock.MoveFileToCatalog")
+		}
+		return (*mm_results).mp1, (*mm_results).err
+	}
+	if mmMoveFileToCatalog.funcMoveFileToCatalog != nil {
+		return mmMoveFileToCatalog.funcMoveFileToCatalog(ctx, in, opts...)
+	}
+	mmMoveFileToCatalog.t.Fatalf("Unexpected call to ArtifactPublicServiceClientMock.MoveFileToCatalog. %v %v %v", ctx, in, opts)
+	return
+}
+
+// MoveFileToCatalogAfterCounter returns a count of finished ArtifactPublicServiceClientMock.MoveFileToCatalog invocations
+func (mmMoveFileToCatalog *ArtifactPublicServiceClientMock) MoveFileToCatalogAfterCounter() uint64 {
+	return mm_atomic.LoadUint64(&mmMoveFileToCatalog.afterMoveFileToCatalogCounter)
+}
+
+// MoveFileToCatalogBeforeCounter returns a count of ArtifactPublicServiceClientMock.MoveFileToCatalog invocations
+func (mmMoveFileToCatalog *ArtifactPublicServiceClientMock) MoveFileToCatalogBeforeCounter() uint64 {
+	return mm_atomic.LoadUint64(&mmMoveFileToCatalog.beforeMoveFileToCatalogCounter)
+}
+
+// Calls returns a list of arguments used in each call to ArtifactPublicServiceClientMock.MoveFileToCatalog.
+// The list is in the same order as the calls were made (i.e. recent calls have a higher index)
+func (mmMoveFileToCatalog *mArtifactPublicServiceClientMockMoveFileToCatalog) Calls() []*ArtifactPublicServiceClientMockMoveFileToCatalogParams {
+	mmMoveFileToCatalog.mutex.RLock()
+
+	argCopy := make([]*ArtifactPublicServiceClientMockMoveFileToCatalogParams, len(mmMoveFileToCatalog.callArgs))
+	copy(argCopy, mmMoveFileToCatalog.callArgs)
+
+	mmMoveFileToCatalog.mutex.RUnlock()
+
+	return argCopy
+}
+
+// MinimockMoveFileToCatalogDone returns true if the count of the MoveFileToCatalog invocations corresponds
+// the number of defined expectations
+func (m *ArtifactPublicServiceClientMock) MinimockMoveFileToCatalogDone() bool {
+	if m.MoveFileToCatalogMock.optional {
+		// Optional methods provide '0 or more' call count restriction.
+		return true
+	}
+
+	for _, e := range m.MoveFileToCatalogMock.expectations {
+		if mm_atomic.LoadUint64(&e.Counter) < 1 {
+			return false
+		}
+	}
+
+	return m.MoveFileToCatalogMock.invocationsDone()
+}
+
+// MinimockMoveFileToCatalogInspect logs each unmet expectation
+func (m *ArtifactPublicServiceClientMock) MinimockMoveFileToCatalogInspect() {
+	for _, e := range m.MoveFileToCatalogMock.expectations {
+		if mm_atomic.LoadUint64(&e.Counter) < 1 {
+			m.t.Errorf("Expected call to ArtifactPublicServiceClientMock.MoveFileToCatalog at\n%s with params: %#v", e.expectationOrigins.origin, *e.params)
+		}
+	}
+
+	afterMoveFileToCatalogCounter := mm_atomic.LoadUint64(&m.afterMoveFileToCatalogCounter)
+	// if default expectation was set then invocations count should be greater than zero
+	if m.MoveFileToCatalogMock.defaultExpectation != nil && afterMoveFileToCatalogCounter < 1 {
+		if m.MoveFileToCatalogMock.defaultExpectation.params == nil {
+			m.t.Errorf("Expected call to ArtifactPublicServiceClientMock.MoveFileToCatalog at\n%s", m.MoveFileToCatalogMock.defaultExpectation.returnOrigin)
+		} else {
+			m.t.Errorf("Expected call to ArtifactPublicServiceClientMock.MoveFileToCatalog at\n%s with params: %#v", m.MoveFileToCatalogMock.defaultExpectation.expectationOrigins.origin, *m.MoveFileToCatalogMock.defaultExpectation.params)
+		}
+	}
+	// if func was set then invocations count should be greater than zero
+	if m.funcMoveFileToCatalog != nil && afterMoveFileToCatalogCounter < 1 {
+		m.t.Errorf("Expected call to ArtifactPublicServiceClientMock.MoveFileToCatalog at\n%s", m.funcMoveFileToCatalogOrigin)
+	}
+
+	if !m.MoveFileToCatalogMock.invocationsDone() && afterMoveFileToCatalogCounter > 0 {
+		m.t.Errorf("Expected %d calls to ArtifactPublicServiceClientMock.MoveFileToCatalog at\n%s but found %d calls",
+			mm_atomic.LoadUint64(&m.MoveFileToCatalogMock.expectedInvocations), m.MoveFileToCatalogMock.expectedInvocationsOrigin, afterMoveFileToCatalogCounter)
+	}
+}
+
 type mArtifactPublicServiceClientMockProcessCatalogFiles struct {
 	optional           bool
 	mock               *ArtifactPublicServiceClientMock
@@ -8124,6 +8508,8 @@ func (m *ArtifactPublicServiceClientMock) MinimockFinish() {
 
 			m.MinimockLivenessInspect()
 
+			m.MinimockMoveFileToCatalogInspect()
+
 			m.MinimockProcessCatalogFilesInspect()
 
 			m.MinimockQuestionAnsweringInspect()
@@ -8176,6 +8562,7 @@ func (m *ArtifactPublicServiceClientMock) minimockDone() bool {
 		m.MinimockListCatalogsDone() &&
 		m.MinimockListChunksDone() &&
 		m.MinimockLivenessDone() &&
+		m.MinimockMoveFileToCatalogDone() &&
 		m.MinimockProcessCatalogFilesDone() &&
 		m.MinimockQuestionAnsweringDone() &&
 		m.MinimockReadinessDone() &&

--- a/pkg/component/internal/mock/artifact_public_service_server_mock.gen.go
+++ b/pkg/component/internal/mock/artifact_public_service_server_mock.gen.go
@@ -101,6 +101,13 @@ type ArtifactPublicServiceServerMock struct {
 	beforeLivenessCounter uint64
 	LivenessMock          mArtifactPublicServiceServerMockLiveness
 
+	funcMoveFileToCatalog          func(ctx context.Context, mp1 *mm_artifactv1alpha.MoveFileToCatalogRequest) (mp2 *mm_artifactv1alpha.MoveFileToCatalogResponse, err error)
+	funcMoveFileToCatalogOrigin    string
+	inspectFuncMoveFileToCatalog   func(ctx context.Context, mp1 *mm_artifactv1alpha.MoveFileToCatalogRequest)
+	afterMoveFileToCatalogCounter  uint64
+	beforeMoveFileToCatalogCounter uint64
+	MoveFileToCatalogMock          mArtifactPublicServiceServerMockMoveFileToCatalog
+
 	funcProcessCatalogFiles          func(ctx context.Context, pp1 *mm_artifactv1alpha.ProcessCatalogFilesRequest) (pp2 *mm_artifactv1alpha.ProcessCatalogFilesResponse, err error)
 	funcProcessCatalogFilesOrigin    string
 	inspectFuncProcessCatalogFiles   func(ctx context.Context, pp1 *mm_artifactv1alpha.ProcessCatalogFilesRequest)
@@ -208,6 +215,9 @@ func NewArtifactPublicServiceServerMock(t minimock.Tester) *ArtifactPublicServic
 
 	m.LivenessMock = mArtifactPublicServiceServerMockLiveness{mock: m}
 	m.LivenessMock.callArgs = []*ArtifactPublicServiceServerMockLivenessParams{}
+
+	m.MoveFileToCatalogMock = mArtifactPublicServiceServerMockMoveFileToCatalog{mock: m}
+	m.MoveFileToCatalogMock.callArgs = []*ArtifactPublicServiceServerMockMoveFileToCatalogParams{}
 
 	m.ProcessCatalogFilesMock = mArtifactPublicServiceServerMockProcessCatalogFiles{mock: m}
 	m.ProcessCatalogFilesMock.callArgs = []*ArtifactPublicServiceServerMockProcessCatalogFilesParams{}
@@ -4357,6 +4367,349 @@ func (m *ArtifactPublicServiceServerMock) MinimockLivenessInspect() {
 	}
 }
 
+type mArtifactPublicServiceServerMockMoveFileToCatalog struct {
+	optional           bool
+	mock               *ArtifactPublicServiceServerMock
+	defaultExpectation *ArtifactPublicServiceServerMockMoveFileToCatalogExpectation
+	expectations       []*ArtifactPublicServiceServerMockMoveFileToCatalogExpectation
+
+	callArgs []*ArtifactPublicServiceServerMockMoveFileToCatalogParams
+	mutex    sync.RWMutex
+
+	expectedInvocations       uint64
+	expectedInvocationsOrigin string
+}
+
+// ArtifactPublicServiceServerMockMoveFileToCatalogExpectation specifies expectation struct of the ArtifactPublicServiceServer.MoveFileToCatalog
+type ArtifactPublicServiceServerMockMoveFileToCatalogExpectation struct {
+	mock               *ArtifactPublicServiceServerMock
+	params             *ArtifactPublicServiceServerMockMoveFileToCatalogParams
+	paramPtrs          *ArtifactPublicServiceServerMockMoveFileToCatalogParamPtrs
+	expectationOrigins ArtifactPublicServiceServerMockMoveFileToCatalogExpectationOrigins
+	results            *ArtifactPublicServiceServerMockMoveFileToCatalogResults
+	returnOrigin       string
+	Counter            uint64
+}
+
+// ArtifactPublicServiceServerMockMoveFileToCatalogParams contains parameters of the ArtifactPublicServiceServer.MoveFileToCatalog
+type ArtifactPublicServiceServerMockMoveFileToCatalogParams struct {
+	ctx context.Context
+	mp1 *mm_artifactv1alpha.MoveFileToCatalogRequest
+}
+
+// ArtifactPublicServiceServerMockMoveFileToCatalogParamPtrs contains pointers to parameters of the ArtifactPublicServiceServer.MoveFileToCatalog
+type ArtifactPublicServiceServerMockMoveFileToCatalogParamPtrs struct {
+	ctx *context.Context
+	mp1 **mm_artifactv1alpha.MoveFileToCatalogRequest
+}
+
+// ArtifactPublicServiceServerMockMoveFileToCatalogResults contains results of the ArtifactPublicServiceServer.MoveFileToCatalog
+type ArtifactPublicServiceServerMockMoveFileToCatalogResults struct {
+	mp2 *mm_artifactv1alpha.MoveFileToCatalogResponse
+	err error
+}
+
+// ArtifactPublicServiceServerMockMoveFileToCatalogOrigins contains origins of expectations of the ArtifactPublicServiceServer.MoveFileToCatalog
+type ArtifactPublicServiceServerMockMoveFileToCatalogExpectationOrigins struct {
+	origin    string
+	originCtx string
+	originMp1 string
+}
+
+// Marks this method to be optional. The default behavior of any method with Return() is '1 or more', meaning
+// the test will fail minimock's automatic final call check if the mocked method was not called at least once.
+// Optional() makes method check to work in '0 or more' mode.
+// It is NOT RECOMMENDED to use this option unless you really need it, as default behaviour helps to
+// catch the problems when the expected method call is totally skipped during test run.
+func (mmMoveFileToCatalog *mArtifactPublicServiceServerMockMoveFileToCatalog) Optional() *mArtifactPublicServiceServerMockMoveFileToCatalog {
+	mmMoveFileToCatalog.optional = true
+	return mmMoveFileToCatalog
+}
+
+// Expect sets up expected params for ArtifactPublicServiceServer.MoveFileToCatalog
+func (mmMoveFileToCatalog *mArtifactPublicServiceServerMockMoveFileToCatalog) Expect(ctx context.Context, mp1 *mm_artifactv1alpha.MoveFileToCatalogRequest) *mArtifactPublicServiceServerMockMoveFileToCatalog {
+	if mmMoveFileToCatalog.mock.funcMoveFileToCatalog != nil {
+		mmMoveFileToCatalog.mock.t.Fatalf("ArtifactPublicServiceServerMock.MoveFileToCatalog mock is already set by Set")
+	}
+
+	if mmMoveFileToCatalog.defaultExpectation == nil {
+		mmMoveFileToCatalog.defaultExpectation = &ArtifactPublicServiceServerMockMoveFileToCatalogExpectation{}
+	}
+
+	if mmMoveFileToCatalog.defaultExpectation.paramPtrs != nil {
+		mmMoveFileToCatalog.mock.t.Fatalf("ArtifactPublicServiceServerMock.MoveFileToCatalog mock is already set by ExpectParams functions")
+	}
+
+	mmMoveFileToCatalog.defaultExpectation.params = &ArtifactPublicServiceServerMockMoveFileToCatalogParams{ctx, mp1}
+	mmMoveFileToCatalog.defaultExpectation.expectationOrigins.origin = minimock.CallerInfo(1)
+	for _, e := range mmMoveFileToCatalog.expectations {
+		if minimock.Equal(e.params, mmMoveFileToCatalog.defaultExpectation.params) {
+			mmMoveFileToCatalog.mock.t.Fatalf("Expectation set by When has same params: %#v", *mmMoveFileToCatalog.defaultExpectation.params)
+		}
+	}
+
+	return mmMoveFileToCatalog
+}
+
+// ExpectCtxParam1 sets up expected param ctx for ArtifactPublicServiceServer.MoveFileToCatalog
+func (mmMoveFileToCatalog *mArtifactPublicServiceServerMockMoveFileToCatalog) ExpectCtxParam1(ctx context.Context) *mArtifactPublicServiceServerMockMoveFileToCatalog {
+	if mmMoveFileToCatalog.mock.funcMoveFileToCatalog != nil {
+		mmMoveFileToCatalog.mock.t.Fatalf("ArtifactPublicServiceServerMock.MoveFileToCatalog mock is already set by Set")
+	}
+
+	if mmMoveFileToCatalog.defaultExpectation == nil {
+		mmMoveFileToCatalog.defaultExpectation = &ArtifactPublicServiceServerMockMoveFileToCatalogExpectation{}
+	}
+
+	if mmMoveFileToCatalog.defaultExpectation.params != nil {
+		mmMoveFileToCatalog.mock.t.Fatalf("ArtifactPublicServiceServerMock.MoveFileToCatalog mock is already set by Expect")
+	}
+
+	if mmMoveFileToCatalog.defaultExpectation.paramPtrs == nil {
+		mmMoveFileToCatalog.defaultExpectation.paramPtrs = &ArtifactPublicServiceServerMockMoveFileToCatalogParamPtrs{}
+	}
+	mmMoveFileToCatalog.defaultExpectation.paramPtrs.ctx = &ctx
+	mmMoveFileToCatalog.defaultExpectation.expectationOrigins.originCtx = minimock.CallerInfo(1)
+
+	return mmMoveFileToCatalog
+}
+
+// ExpectMp1Param2 sets up expected param mp1 for ArtifactPublicServiceServer.MoveFileToCatalog
+func (mmMoveFileToCatalog *mArtifactPublicServiceServerMockMoveFileToCatalog) ExpectMp1Param2(mp1 *mm_artifactv1alpha.MoveFileToCatalogRequest) *mArtifactPublicServiceServerMockMoveFileToCatalog {
+	if mmMoveFileToCatalog.mock.funcMoveFileToCatalog != nil {
+		mmMoveFileToCatalog.mock.t.Fatalf("ArtifactPublicServiceServerMock.MoveFileToCatalog mock is already set by Set")
+	}
+
+	if mmMoveFileToCatalog.defaultExpectation == nil {
+		mmMoveFileToCatalog.defaultExpectation = &ArtifactPublicServiceServerMockMoveFileToCatalogExpectation{}
+	}
+
+	if mmMoveFileToCatalog.defaultExpectation.params != nil {
+		mmMoveFileToCatalog.mock.t.Fatalf("ArtifactPublicServiceServerMock.MoveFileToCatalog mock is already set by Expect")
+	}
+
+	if mmMoveFileToCatalog.defaultExpectation.paramPtrs == nil {
+		mmMoveFileToCatalog.defaultExpectation.paramPtrs = &ArtifactPublicServiceServerMockMoveFileToCatalogParamPtrs{}
+	}
+	mmMoveFileToCatalog.defaultExpectation.paramPtrs.mp1 = &mp1
+	mmMoveFileToCatalog.defaultExpectation.expectationOrigins.originMp1 = minimock.CallerInfo(1)
+
+	return mmMoveFileToCatalog
+}
+
+// Inspect accepts an inspector function that has same arguments as the ArtifactPublicServiceServer.MoveFileToCatalog
+func (mmMoveFileToCatalog *mArtifactPublicServiceServerMockMoveFileToCatalog) Inspect(f func(ctx context.Context, mp1 *mm_artifactv1alpha.MoveFileToCatalogRequest)) *mArtifactPublicServiceServerMockMoveFileToCatalog {
+	if mmMoveFileToCatalog.mock.inspectFuncMoveFileToCatalog != nil {
+		mmMoveFileToCatalog.mock.t.Fatalf("Inspect function is already set for ArtifactPublicServiceServerMock.MoveFileToCatalog")
+	}
+
+	mmMoveFileToCatalog.mock.inspectFuncMoveFileToCatalog = f
+
+	return mmMoveFileToCatalog
+}
+
+// Return sets up results that will be returned by ArtifactPublicServiceServer.MoveFileToCatalog
+func (mmMoveFileToCatalog *mArtifactPublicServiceServerMockMoveFileToCatalog) Return(mp2 *mm_artifactv1alpha.MoveFileToCatalogResponse, err error) *ArtifactPublicServiceServerMock {
+	if mmMoveFileToCatalog.mock.funcMoveFileToCatalog != nil {
+		mmMoveFileToCatalog.mock.t.Fatalf("ArtifactPublicServiceServerMock.MoveFileToCatalog mock is already set by Set")
+	}
+
+	if mmMoveFileToCatalog.defaultExpectation == nil {
+		mmMoveFileToCatalog.defaultExpectation = &ArtifactPublicServiceServerMockMoveFileToCatalogExpectation{mock: mmMoveFileToCatalog.mock}
+	}
+	mmMoveFileToCatalog.defaultExpectation.results = &ArtifactPublicServiceServerMockMoveFileToCatalogResults{mp2, err}
+	mmMoveFileToCatalog.defaultExpectation.returnOrigin = minimock.CallerInfo(1)
+	return mmMoveFileToCatalog.mock
+}
+
+// Set uses given function f to mock the ArtifactPublicServiceServer.MoveFileToCatalog method
+func (mmMoveFileToCatalog *mArtifactPublicServiceServerMockMoveFileToCatalog) Set(f func(ctx context.Context, mp1 *mm_artifactv1alpha.MoveFileToCatalogRequest) (mp2 *mm_artifactv1alpha.MoveFileToCatalogResponse, err error)) *ArtifactPublicServiceServerMock {
+	if mmMoveFileToCatalog.defaultExpectation != nil {
+		mmMoveFileToCatalog.mock.t.Fatalf("Default expectation is already set for the ArtifactPublicServiceServer.MoveFileToCatalog method")
+	}
+
+	if len(mmMoveFileToCatalog.expectations) > 0 {
+		mmMoveFileToCatalog.mock.t.Fatalf("Some expectations are already set for the ArtifactPublicServiceServer.MoveFileToCatalog method")
+	}
+
+	mmMoveFileToCatalog.mock.funcMoveFileToCatalog = f
+	mmMoveFileToCatalog.mock.funcMoveFileToCatalogOrigin = minimock.CallerInfo(1)
+	return mmMoveFileToCatalog.mock
+}
+
+// When sets expectation for the ArtifactPublicServiceServer.MoveFileToCatalog which will trigger the result defined by the following
+// Then helper
+func (mmMoveFileToCatalog *mArtifactPublicServiceServerMockMoveFileToCatalog) When(ctx context.Context, mp1 *mm_artifactv1alpha.MoveFileToCatalogRequest) *ArtifactPublicServiceServerMockMoveFileToCatalogExpectation {
+	if mmMoveFileToCatalog.mock.funcMoveFileToCatalog != nil {
+		mmMoveFileToCatalog.mock.t.Fatalf("ArtifactPublicServiceServerMock.MoveFileToCatalog mock is already set by Set")
+	}
+
+	expectation := &ArtifactPublicServiceServerMockMoveFileToCatalogExpectation{
+		mock:               mmMoveFileToCatalog.mock,
+		params:             &ArtifactPublicServiceServerMockMoveFileToCatalogParams{ctx, mp1},
+		expectationOrigins: ArtifactPublicServiceServerMockMoveFileToCatalogExpectationOrigins{origin: minimock.CallerInfo(1)},
+	}
+	mmMoveFileToCatalog.expectations = append(mmMoveFileToCatalog.expectations, expectation)
+	return expectation
+}
+
+// Then sets up ArtifactPublicServiceServer.MoveFileToCatalog return parameters for the expectation previously defined by the When method
+func (e *ArtifactPublicServiceServerMockMoveFileToCatalogExpectation) Then(mp2 *mm_artifactv1alpha.MoveFileToCatalogResponse, err error) *ArtifactPublicServiceServerMock {
+	e.results = &ArtifactPublicServiceServerMockMoveFileToCatalogResults{mp2, err}
+	return e.mock
+}
+
+// Times sets number of times ArtifactPublicServiceServer.MoveFileToCatalog should be invoked
+func (mmMoveFileToCatalog *mArtifactPublicServiceServerMockMoveFileToCatalog) Times(n uint64) *mArtifactPublicServiceServerMockMoveFileToCatalog {
+	if n == 0 {
+		mmMoveFileToCatalog.mock.t.Fatalf("Times of ArtifactPublicServiceServerMock.MoveFileToCatalog mock can not be zero")
+	}
+	mm_atomic.StoreUint64(&mmMoveFileToCatalog.expectedInvocations, n)
+	mmMoveFileToCatalog.expectedInvocationsOrigin = minimock.CallerInfo(1)
+	return mmMoveFileToCatalog
+}
+
+func (mmMoveFileToCatalog *mArtifactPublicServiceServerMockMoveFileToCatalog) invocationsDone() bool {
+	if len(mmMoveFileToCatalog.expectations) == 0 && mmMoveFileToCatalog.defaultExpectation == nil && mmMoveFileToCatalog.mock.funcMoveFileToCatalog == nil {
+		return true
+	}
+
+	totalInvocations := mm_atomic.LoadUint64(&mmMoveFileToCatalog.mock.afterMoveFileToCatalogCounter)
+	expectedInvocations := mm_atomic.LoadUint64(&mmMoveFileToCatalog.expectedInvocations)
+
+	return totalInvocations > 0 && (expectedInvocations == 0 || expectedInvocations == totalInvocations)
+}
+
+// MoveFileToCatalog implements mm_artifactv1alpha.ArtifactPublicServiceServer
+func (mmMoveFileToCatalog *ArtifactPublicServiceServerMock) MoveFileToCatalog(ctx context.Context, mp1 *mm_artifactv1alpha.MoveFileToCatalogRequest) (mp2 *mm_artifactv1alpha.MoveFileToCatalogResponse, err error) {
+	mm_atomic.AddUint64(&mmMoveFileToCatalog.beforeMoveFileToCatalogCounter, 1)
+	defer mm_atomic.AddUint64(&mmMoveFileToCatalog.afterMoveFileToCatalogCounter, 1)
+
+	mmMoveFileToCatalog.t.Helper()
+
+	if mmMoveFileToCatalog.inspectFuncMoveFileToCatalog != nil {
+		mmMoveFileToCatalog.inspectFuncMoveFileToCatalog(ctx, mp1)
+	}
+
+	mm_params := ArtifactPublicServiceServerMockMoveFileToCatalogParams{ctx, mp1}
+
+	// Record call args
+	mmMoveFileToCatalog.MoveFileToCatalogMock.mutex.Lock()
+	mmMoveFileToCatalog.MoveFileToCatalogMock.callArgs = append(mmMoveFileToCatalog.MoveFileToCatalogMock.callArgs, &mm_params)
+	mmMoveFileToCatalog.MoveFileToCatalogMock.mutex.Unlock()
+
+	for _, e := range mmMoveFileToCatalog.MoveFileToCatalogMock.expectations {
+		if minimock.Equal(*e.params, mm_params) {
+			mm_atomic.AddUint64(&e.Counter, 1)
+			return e.results.mp2, e.results.err
+		}
+	}
+
+	if mmMoveFileToCatalog.MoveFileToCatalogMock.defaultExpectation != nil {
+		mm_atomic.AddUint64(&mmMoveFileToCatalog.MoveFileToCatalogMock.defaultExpectation.Counter, 1)
+		mm_want := mmMoveFileToCatalog.MoveFileToCatalogMock.defaultExpectation.params
+		mm_want_ptrs := mmMoveFileToCatalog.MoveFileToCatalogMock.defaultExpectation.paramPtrs
+
+		mm_got := ArtifactPublicServiceServerMockMoveFileToCatalogParams{ctx, mp1}
+
+		if mm_want_ptrs != nil {
+
+			if mm_want_ptrs.ctx != nil && !minimock.Equal(*mm_want_ptrs.ctx, mm_got.ctx) {
+				mmMoveFileToCatalog.t.Errorf("ArtifactPublicServiceServerMock.MoveFileToCatalog got unexpected parameter ctx, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmMoveFileToCatalog.MoveFileToCatalogMock.defaultExpectation.expectationOrigins.originCtx, *mm_want_ptrs.ctx, mm_got.ctx, minimock.Diff(*mm_want_ptrs.ctx, mm_got.ctx))
+			}
+
+			if mm_want_ptrs.mp1 != nil && !minimock.Equal(*mm_want_ptrs.mp1, mm_got.mp1) {
+				mmMoveFileToCatalog.t.Errorf("ArtifactPublicServiceServerMock.MoveFileToCatalog got unexpected parameter mp1, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmMoveFileToCatalog.MoveFileToCatalogMock.defaultExpectation.expectationOrigins.originMp1, *mm_want_ptrs.mp1, mm_got.mp1, minimock.Diff(*mm_want_ptrs.mp1, mm_got.mp1))
+			}
+
+		} else if mm_want != nil && !minimock.Equal(*mm_want, mm_got) {
+			mmMoveFileToCatalog.t.Errorf("ArtifactPublicServiceServerMock.MoveFileToCatalog got unexpected parameters, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+				mmMoveFileToCatalog.MoveFileToCatalogMock.defaultExpectation.expectationOrigins.origin, *mm_want, mm_got, minimock.Diff(*mm_want, mm_got))
+		}
+
+		mm_results := mmMoveFileToCatalog.MoveFileToCatalogMock.defaultExpectation.results
+		if mm_results == nil {
+			mmMoveFileToCatalog.t.Fatal("No results are set for the ArtifactPublicServiceServerMock.MoveFileToCatalog")
+		}
+		return (*mm_results).mp2, (*mm_results).err
+	}
+	if mmMoveFileToCatalog.funcMoveFileToCatalog != nil {
+		return mmMoveFileToCatalog.funcMoveFileToCatalog(ctx, mp1)
+	}
+	mmMoveFileToCatalog.t.Fatalf("Unexpected call to ArtifactPublicServiceServerMock.MoveFileToCatalog. %v %v", ctx, mp1)
+	return
+}
+
+// MoveFileToCatalogAfterCounter returns a count of finished ArtifactPublicServiceServerMock.MoveFileToCatalog invocations
+func (mmMoveFileToCatalog *ArtifactPublicServiceServerMock) MoveFileToCatalogAfterCounter() uint64 {
+	return mm_atomic.LoadUint64(&mmMoveFileToCatalog.afterMoveFileToCatalogCounter)
+}
+
+// MoveFileToCatalogBeforeCounter returns a count of ArtifactPublicServiceServerMock.MoveFileToCatalog invocations
+func (mmMoveFileToCatalog *ArtifactPublicServiceServerMock) MoveFileToCatalogBeforeCounter() uint64 {
+	return mm_atomic.LoadUint64(&mmMoveFileToCatalog.beforeMoveFileToCatalogCounter)
+}
+
+// Calls returns a list of arguments used in each call to ArtifactPublicServiceServerMock.MoveFileToCatalog.
+// The list is in the same order as the calls were made (i.e. recent calls have a higher index)
+func (mmMoveFileToCatalog *mArtifactPublicServiceServerMockMoveFileToCatalog) Calls() []*ArtifactPublicServiceServerMockMoveFileToCatalogParams {
+	mmMoveFileToCatalog.mutex.RLock()
+
+	argCopy := make([]*ArtifactPublicServiceServerMockMoveFileToCatalogParams, len(mmMoveFileToCatalog.callArgs))
+	copy(argCopy, mmMoveFileToCatalog.callArgs)
+
+	mmMoveFileToCatalog.mutex.RUnlock()
+
+	return argCopy
+}
+
+// MinimockMoveFileToCatalogDone returns true if the count of the MoveFileToCatalog invocations corresponds
+// the number of defined expectations
+func (m *ArtifactPublicServiceServerMock) MinimockMoveFileToCatalogDone() bool {
+	if m.MoveFileToCatalogMock.optional {
+		// Optional methods provide '0 or more' call count restriction.
+		return true
+	}
+
+	for _, e := range m.MoveFileToCatalogMock.expectations {
+		if mm_atomic.LoadUint64(&e.Counter) < 1 {
+			return false
+		}
+	}
+
+	return m.MoveFileToCatalogMock.invocationsDone()
+}
+
+// MinimockMoveFileToCatalogInspect logs each unmet expectation
+func (m *ArtifactPublicServiceServerMock) MinimockMoveFileToCatalogInspect() {
+	for _, e := range m.MoveFileToCatalogMock.expectations {
+		if mm_atomic.LoadUint64(&e.Counter) < 1 {
+			m.t.Errorf("Expected call to ArtifactPublicServiceServerMock.MoveFileToCatalog at\n%s with params: %#v", e.expectationOrigins.origin, *e.params)
+		}
+	}
+
+	afterMoveFileToCatalogCounter := mm_atomic.LoadUint64(&m.afterMoveFileToCatalogCounter)
+	// if default expectation was set then invocations count should be greater than zero
+	if m.MoveFileToCatalogMock.defaultExpectation != nil && afterMoveFileToCatalogCounter < 1 {
+		if m.MoveFileToCatalogMock.defaultExpectation.params == nil {
+			m.t.Errorf("Expected call to ArtifactPublicServiceServerMock.MoveFileToCatalog at\n%s", m.MoveFileToCatalogMock.defaultExpectation.returnOrigin)
+		} else {
+			m.t.Errorf("Expected call to ArtifactPublicServiceServerMock.MoveFileToCatalog at\n%s with params: %#v", m.MoveFileToCatalogMock.defaultExpectation.expectationOrigins.origin, *m.MoveFileToCatalogMock.defaultExpectation.params)
+		}
+	}
+	// if func was set then invocations count should be greater than zero
+	if m.funcMoveFileToCatalog != nil && afterMoveFileToCatalogCounter < 1 {
+		m.t.Errorf("Expected call to ArtifactPublicServiceServerMock.MoveFileToCatalog at\n%s", m.funcMoveFileToCatalogOrigin)
+	}
+
+	if !m.MoveFileToCatalogMock.invocationsDone() && afterMoveFileToCatalogCounter > 0 {
+		m.t.Errorf("Expected %d calls to ArtifactPublicServiceServerMock.MoveFileToCatalog at\n%s but found %d calls",
+			mm_atomic.LoadUint64(&m.MoveFileToCatalogMock.expectedInvocations), m.MoveFileToCatalogMock.expectedInvocationsOrigin, afterMoveFileToCatalogCounter)
+	}
+}
+
 type mArtifactPublicServiceServerMockProcessCatalogFiles struct {
 	optional           bool
 	mock               *ArtifactPublicServiceServerMock
@@ -7472,6 +7825,8 @@ func (m *ArtifactPublicServiceServerMock) MinimockFinish() {
 
 			m.MinimockLivenessInspect()
 
+			m.MinimockMoveFileToCatalogInspect()
+
 			m.MinimockProcessCatalogFilesInspect()
 
 			m.MinimockQuestionAnsweringInspect()
@@ -7524,6 +7879,7 @@ func (m *ArtifactPublicServiceServerMock) minimockDone() bool {
 		m.MinimockListCatalogsDone() &&
 		m.MinimockListChunksDone() &&
 		m.MinimockLivenessDone() &&
+		m.MinimockMoveFileToCatalogDone() &&
 		m.MinimockProcessCatalogFilesDone() &&
 		m.MinimockQuestionAnsweringDone() &&
 		m.MinimockReadinessDone() &&

--- a/pkg/datamodel/runlogging.go
+++ b/pkg/datamodel/runlogging.go
@@ -64,33 +64,36 @@ func (j *JSONB) Scan(value interface{}) error {
 
 // PipelineRun represents the metadata and execution details for each pipeline run.
 type PipelineRun struct {
-	PipelineTriggerUID uuid.UUID      `gorm:"primaryKey" json:"pipeline-trigger-uid"`                                        // Unique identifier for each run
-	PipelineUID        uuid.UUID      `gorm:"type:uuid;index" json:"pipeline-uid"`                                           // Pipeline unique ID used in the run
-	Pipeline           Pipeline       `gorm:"foreignKey:PipelineUID;references:UID"`                                         // Pipeline instance referenced in the run
-	PipelineVersion    string         `gorm:"type:varchar(255)" json:"pipeline-version"`                                     // Pipeline version used in the run
-	Status             RunStatus      `gorm:"type:valid_trigger_status;index" json:"status"`                                 // Current status of the run (e.g., Running, Completed, Failed)
-	Source             RunSource      `gorm:"type:valid_trigger_source" json:"source"`                                       // Origin of the run (e.g., Web click, API)
-	TotalDuration      null.Int       `gorm:"type:bigint" json:"total-duration"`                                             // Time taken to complete the run in nanoseconds
-	RunnerUID          uuid.UUID      `gorm:"type:uuid" json:"runner-uid"`                                                   // Identity of the user who initiated the run
-	RequesterUID       uuid.UUID      `gorm:"type:uuid" json:"requester-uid"`                                                // Namespace used for the run, which is the requester
-	Inputs             JSONB          `gorm:"type:jsonb" json:"inputs"`                                                      // Input files for the run
-	Outputs            JSONB          `gorm:"type:jsonb" json:"outputs"`                                                     // Output files from the run
-	RecipeSnapshot     JSONB          `gorm:"type:jsonb" json:"recipe-snapshot"`                                             // Snapshot of the pipeline recipe used for this run
-	StartedTime        time.Time      `gorm:"type:timestamp with time zone;index" json:"started-time,omitempty"`             // Time when the run started execution
-	CompletedTime      null.Time      `gorm:"type:timestamp with time zone;index" json:"completed-time,omitempty"`           // Time when the run completed
-	Error              null.String    `gorm:"type:text" json:"error-msg"`                                                    // Error message if the run failed
-	Components         []ComponentRun `gorm:"foreignKey:PipelineTriggerUID;references:PipelineTriggerUID" json:"components"` // Execution details for each component in the pipeline
+	PipelineTriggerUID     uuid.UUID `gorm:"primaryKey" json:"pipeline-trigger-uid"`                                   // Unique identifier for each run
+	PipelineUID            uuid.UUID `gorm:"type:uuid;index" json:"pipeline-uid"`                                      // Pipeline unique ID used in the run
+	Pipeline               Pipeline  `gorm:"foreignKey:PipelineUID;references:UID"`                                    // Pipeline instance referenced in the run
+	PipelineVersion        string    `gorm:"type:varchar(255)" json:"pipeline-version"`                                // Pipeline version used in the run
+	Status                 RunStatus `gorm:"type:valid_trigger_status;index" json:"status"`                            // Current status of the run (e.g., Running, Completed, Failed)
+	Source                 RunSource `gorm:"type:valid_trigger_source" json:"source"`                                  // Origin of the run (e.g., Web click, API)
+	TotalDuration          null.Int  `gorm:"type:bigint" json:"total-duration"`                                        // Time taken to complete the run in nanoseconds
+	RunnerUID              uuid.UUID `gorm:"type:uuid" json:"runner-uid"`                                              // Identity of the user who initiated the run
+	RequesterUID           uuid.UUID `gorm:"type:uuid" json:"requester-uid"`                                           // Namespace used for the run, which is the requester
+	Inputs                 JSONB     `gorm:"type:jsonb" json:"inputs"`                                                 // Input files for the run
+	Outputs                JSONB     `gorm:"type:jsonb" json:"outputs"`                                                // Output files from the run
+	RecipeSnapshot         JSONB     `gorm:"type:jsonb" json:"recipe-snapshot"`                                        // Snapshot of the pipeline recipe used for this run
+	StartedTime            time.Time `gorm:"type:timestamp with time zone;index" json:"started-time,omitempty"`        // Time when the run started execution
+	CompletedTime          null.Time `gorm:"type:timestamp with time zone;index" json:"completed-time,omitempty"`      // Time when the run completed
+	BlobDataExpirationTime null.Time `gorm:"type:timestamp with time zone" json:"blob-data-expiration-time,omitempty"` // Time when the blob data (e.g. input or recipe) will expire.
+
+	Error      null.String    `gorm:"type:text" json:"error-msg"`                                                    // Error message if the run failed
+	Components []ComponentRun `gorm:"foreignKey:PipelineTriggerUID;references:PipelineTriggerUID" json:"components"` // Execution details for each component in the pipeline
 }
 
 // ComponentRun represents the execution details of a single component within a pipeline run.
 type ComponentRun struct {
-	PipelineTriggerUID uuid.UUID   `gorm:"type:uuid;primaryKey;index" json:"pipeline-trigger-uid"`    // Links to the parent PipelineRun
-	ComponentID        string      `gorm:"type:varchar(255);primaryKey" json:"component-id"`          // Unique identifier for each pipeline component
-	Status             RunStatus   `gorm:"type:varchar(50);index" json:"status"`                      // Completion status of the component (e.g., Completed, Errored)
-	TotalDuration      null.Int    `gorm:"type:bigint" json:"total-duration"`                         // Time taken to execute the component in nanoseconds
-	StartedTime        time.Time   `gorm:"type:timestamp with time zone;index" json:"started-time"`   // Time when the component started execution
-	CompletedTime      null.Time   `gorm:"type:timestamp with time zone;index" json:"completed-time"` // Time when the component finished execution
-	Error              null.String `gorm:"type:text" json:"error-msg"`                                // Error message if the component failed
-	Inputs             JSONB       `gorm:"type:jsonb" json:"inputs"`                                  // Input files for the component
-	Outputs            JSONB       `gorm:"type:jsonb" json:"outputs"`                                 // Output files from the component
+	PipelineTriggerUID     uuid.UUID   `gorm:"type:uuid;primaryKey;index" json:"pipeline-trigger-uid"`                   // Links to the parent PipelineRun
+	ComponentID            string      `gorm:"type:varchar(255);primaryKey" json:"component-id"`                         // Unique identifier for each pipeline component
+	Status                 RunStatus   `gorm:"type:varchar(50);index" json:"status"`                                     // Completion status of the component (e.g., Completed, Errored)
+	TotalDuration          null.Int    `gorm:"type:bigint" json:"total-duration"`                                        // Time taken to execute the component in nanoseconds
+	StartedTime            time.Time   `gorm:"type:timestamp with time zone;index" json:"started-time"`                  // Time when the component started execution
+	CompletedTime          null.Time   `gorm:"type:timestamp with time zone;index" json:"completed-time"`                // Time when the component finished execution
+	BlobDataExpirationTime null.Time   `gorm:"type:timestamp with time zone" json:"blob-data-expiration-time,omitempty"` // Time when the blob data (e.g. input or recipe) will expire.
+	Error                  null.String `gorm:"type:text" json:"error-msg"`                                               // Error message if the component failed
+	Inputs                 JSONB       `gorm:"type:jsonb" json:"inputs"`                                                 // Input files for the component
+	Outputs                JSONB       `gorm:"type:jsonb" json:"outputs"`                                                // Output files from the component
 }

--- a/pkg/db/migration/000039_add_pipeline_run_expiration_time.down.sql
+++ b/pkg/db/migration/000039_add_pipeline_run_expiration_time.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE component_run DROP COLUMN IF EXISTS blob_data_expiration_time;
+ALTER TABLE pipeline_run DROP COLUMN IF EXISTS blob_data_expiration_time;
+
+COMMIT;

--- a/pkg/db/migration/000039_add_pipeline_run_expiration_time.up.sql
+++ b/pkg/db/migration/000039_add_pipeline_run_expiration_time.up.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE pipeline_run ADD COLUMN IF NOT EXISTS blob_data_expiration_time TIMESTAMPTZ;
+ALTER TABLE component_run ADD COLUMN IF NOT EXISTS blob_data_expiration_time TIMESTAMPTZ;
+
+COMMIT;

--- a/pkg/db/migration/convert/convert000039/convert.go
+++ b/pkg/db/migration/convert/convert000039/convert.go
@@ -1,0 +1,87 @@
+package convert000039
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+
+	"github.com/gofrs/uuid"
+	"github.com/instill-ai/pipeline-backend/pkg/datamodel"
+	"github.com/instill-ai/pipeline-backend/pkg/db/migration/convert"
+	"github.com/instill-ai/pipeline-backend/pkg/service"
+)
+
+const batchSize = 100
+
+// AddExpirationDateToRuns ...
+type AddExpirationDateToRuns struct {
+	convert.Basic
+	RetentionHandler service.MetadataRetentionHandler
+}
+
+// Migrate ...
+func (c *AddExpirationDateToRuns) Migrate() error {
+	return c.migratePipelineAndComponentRuns()
+}
+
+type pipelineRun struct {
+	RequesterUID uuid.UUID `gorm:"type:uuid;primary_key;<-:create"`
+}
+
+func (pipelineRun) TableName() string {
+	return "pipeline_run"
+}
+
+func (c *AddExpirationDateToRuns) migratePipelineAndComponentRuns() error {
+	c.DB = c.DB.Debug()
+
+	pipelineRuns := make([]*pipelineRun, 0, batchSize)
+	return c.DB.Distinct("requester_uid").FindInBatches(&pipelineRuns, batchSize, func(tx *gorm.DB, _ int) error {
+		for _, pr := range pipelineRuns {
+			log := c.Logger.With(zap.String("requesterUID", pr.RequesterUID.String()))
+
+			expiryRule, err := c.RetentionHandler.GetExpiryRuleByNamespace(context.Background(), pr.RequesterUID)
+			if err != nil {
+				log.Error("Failed to fetch expiry rule", zap.Error(err))
+				return fmt.Errorf("fetching expiry rule: %w", err)
+			}
+
+			if expiryRule.ExpirationDays <= 0 {
+				// Infinite expiration, blob expiration time should be NULL.
+				continue
+			}
+
+			// No record with primary key specified, so the update will be done
+			// in batch.
+			err = c.DB.Model(&datamodel.PipelineRun{}).
+				Where("blob_data_expiration_time IS ?", nil).
+				Where("requester_uid = ?", pr.RequesterUID).
+				Update(
+					"blob_data_expiration_time",
+					gorm.Expr("started_time + make_interval(days => ?)", expiryRule.ExpirationDays),
+				).Error
+			if err != nil {
+				log.Error("Failed to update pipeline runs", zap.Error(err))
+				return fmt.Errorf("updating pipeline runs: %w", err)
+			}
+
+			err = c.DB.Exec(
+				`UPDATE "component_run"
+					SET "blob_data_expiration_time"=component_run.started_time + make_interval(days => ?)
+					FROM "pipeline_run"
+					WHERE component_run.blob_data_expiration_time IS NULL
+					AND pipeline_run.requester_uid = ?`,
+				expiryRule.ExpirationDays,
+				pr.RequesterUID,
+			).Error
+			if err != nil {
+				log.Error("Failed to update component runs", zap.Error(err))
+				return fmt.Errorf("updating component runs: %w", err)
+			}
+		}
+
+		return nil
+	}).Error
+}

--- a/pkg/service/pipelinerun.go
+++ b/pkg/service/pipelinerun.go
@@ -416,7 +416,16 @@ func (s *service) uploadPipelineRunInputsToMinio(ctx context.Context, param uplo
 		URL:  url,
 	}}
 
-	err = s.repository.UpdatePipelineRun(ctx, param.pipelineTriggerID, &datamodel.PipelineRun{Inputs: inputs})
+	pipelineRunUpdate := &datamodel.PipelineRun{
+		Inputs: inputs,
+	}
+
+	if param.expiryRule.ExpirationDays > 0 {
+		blobExpiration := time.Now().UTC().AddDate(0, 0, param.expiryRule.ExpirationDays)
+		pipelineRunUpdate.BlobDataExpirationTime = null.TimeFrom(blobExpiration)
+	}
+
+	err = s.repository.UpdatePipelineRun(ctx, param.pipelineTriggerID, pipelineRunUpdate)
 	if err != nil {
 		logger.Error("save pipeline run input data", zap.Error(err))
 		return err

--- a/pkg/service/utils.go
+++ b/pkg/service/utils.go
@@ -140,6 +140,9 @@ func (s *service) convertPipelineRunToPB(run datamodel.PipelineRun) (*pipelinepb
 	if run.CompletedTime.Valid {
 		result.CompleteTime = timestamppb.New(run.CompletedTime.Time)
 	}
+	if run.BlobDataExpirationTime.Valid {
+		result.BlobDataExpirationTime = timestamppb.New(run.BlobDataExpirationTime.Time)
+	}
 
 	return result, nil
 }
@@ -159,6 +162,9 @@ func (s *service) convertComponentRunToPB(run datamodel.ComponentRun) (*pipeline
 	}
 	if run.CompletedTime.Valid {
 		result.CompleteTime = timestamppb.New(run.CompletedTime.Time)
+	}
+	if run.BlobDataExpirationTime.Valid {
+		result.BlobDataExpirationTime = timestamppb.New(run.BlobDataExpirationTime.Time)
 	}
 
 	for _, fileReference := range run.Inputs {

--- a/pkg/worker/workflow.go
+++ b/pkg/worker/workflow.go
@@ -119,10 +119,6 @@ type PostTriggerActivityParam struct {
 	SystemVariables recipe.SystemVariables
 }
 
-type UpsertPipelineRunActivityParam struct {
-	PipelineRun *datamodel.PipelineRun
-}
-
 type UpdatePipelineRunActivityParam struct {
 	PipelineTriggerID string
 	PipelineRun       *datamodel.PipelineRun


### PR DESCRIPTION
Because

- When the blob data associated to a pipeline / component run expires, the backend will stop serving it. It will be useful to both backend and clients to know that the data isn't there because it expired (instead of because an error occurred).

This commit

- Adds a field with the blob data expiration data to the run entities.

