### PR TITLE
chore(google-drive): document component is only available on CE

### DIFF
--- a/pkg/component/data/googledrive/v0/.compogen/intro.mdx
+++ b/pkg/component/data/googledrive/v0/.compogen/intro.mdx
@@ -1,0 +1,1 @@
+**Note**: This component is only available on **🔮 Instill Core**.

--- a/pkg/component/data/googledrive/v0/README.mdx
+++ b/pkg/component/data/googledrive/v0/README.mdx
@@ -10,6 +10,7 @@ It can carry out the following tasks:
 - [Read File](#read-file)
 - [Read Folder](#read-folder)
 
+**Note**: This component is only available on **🔮 Instill Core**.
 
 
 ## Release Stage

--- a/pkg/component/data/googledrive/v0/main.go
+++ b/pkg/component/data/googledrive/v0/main.go
@@ -1,4 +1,4 @@
-//go:generate compogen readme ./config ./README.mdx
+//go:generate compogen readme ./config ./README.mdx --extraContents intro=.compogen/intro.mdx
 package googledrive
 
 import (


### PR DESCRIPTION
Because

- When building the `instill.tech` docs, Google Drive was [included](https://github.com/instill-ai/instill.tech/pull/1279#discussion_r1886644507).
  - This is correct because CE versions can use this component (i.e. we shouldn't hide the doc), but might generate confusion for Cloud users.

This commit

- Specifies CE-only usage in `google-drive` component document.