### PR TITLE
fix(ci): registry image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ RUN apt update && \
     /opt/venv/bin/pip install pdfplumber mistral-common tokenizers && \
     rm -rf /var/lib/apt/lists/*
 
-RUN /opt/venv/bin/pip install docling docling-core
+RUN /opt/venv/bin/pip install docling
 
 # Copy FFmpeg from build stage
 COPY --from=build --chown=nobody:nogroup /usr/local/bin/ffmpeg /usr/local/bin/ffmpeg

--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,7 @@ ENV ONNX_MODEL_FOLDER_PATH=/${SERVICE_NAME}/pkg/component/resources/onnx
 # artifacts.
 ENV DOCLING_ARTIFACTS_PATH=/${SERVICE_NAME}/pkg/component/resources/docling
 
-RUN echo "from docling.pipeline.standard_pdf_pipeline import StandardPdfPipeline\n" > import_artifacts.py
+RUN echo "from docling.pipeline.standard_pdf_pipeline import StandardPdfPipeline" > import_artifacts.py
 RUN echo "StandardPdfPipeline.download_models_hf(local_dir='${DOCLING_ARTIFACTS_PATH}')" >> import_artifacts.py
 RUN /opt/venv/bin/python import_artifacts.py
 RUN rm import_artifacts.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,8 +55,10 @@ FROM debian:bullseye-slim
 RUN apt update && \
     apt install -y curl wget xz-utils python3 python3-venv poppler-utils wv unrtf tidy tesseract-ocr libtesseract-dev libreoffice libsoxr-dev chromium qpdf && \
     python3 -m venv /opt/venv && \
-    /opt/venv/bin/pip install pdfplumber mistral-common tokenizers docling docling-core && \
+    /opt/venv/bin/pip install pdfplumber mistral-common tokenizers && \
     rm -rf /var/lib/apt/lists/*
+
+RUN /opt/venv/bin/pip install docling docling-core
 
 # Copy FFmpeg from build stage
 COPY --from=build --chown=nobody:nogroup /usr/local/bin/ffmpeg /usr/local/bin/ffmpeg

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -13,7 +13,7 @@ ARG TARGETOS TARGETARCH K6_VERSION XK6_VERSION XK6_SQL_VERSION XK6_SQL_POSTGRES_
 RUN apt update && \
     apt install -y xz-utils python3 python3-venv poppler-utils wv unrtf tidy tesseract-ocr libtesseract-dev libreoffice libsoxr-dev chromium qpdf && \
     python3 -m venv /opt/venv && \
-    /opt/venv/bin/pip install pdfplumber mistral-common tokenizers docling docling-core && \
+    /opt/venv/bin/pip install pdfplumber mistral-common tokenizers docling && \
     rm -rf /var/lib/apt/lists/*
 
 # Install FFmpeg Static Build

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -78,7 +78,7 @@ ENV ONNX_MODEL_FOLDER_PATH=/${SERVICE_NAME}/pkg/component/resources/onnx
 # artifacts.
 ENV DOCLING_ARTIFACTS_PATH=/${SERVICE_NAME}/pkg/component/resources/docling
 
-RUN echo "from docling.pipeline.standard_pdf_pipeline import StandardPdfPipeline\n" > import_artifacts.py
+RUN echo "from docling.pipeline.standard_pdf_pipeline import StandardPdfPipeline" > import_artifacts.py
 RUN echo "StandardPdfPipeline.download_models_hf(local_dir='${DOCLING_ARTIFACTS_PATH}')" >> import_artifacts.py
 RUN /opt/venv/bin/python import_artifacts.py
 RUN rm import_artifacts.py


### PR DESCRIPTION
Because

- Image build succeeded on the PR CI but fails on the `main` branch workflow.

This commit

- Splits the errored command to gather more information
- Adds some minor corrections to the Dockerfile
