### PR TITLE
ci(docker): fix Dockerifle building docling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,25 @@ FROM debian:bullseye-slim
 
 # Install Python, create virtual environment, install pdfplumber and Docling
 RUN apt update && \
-    apt install -y curl wget xz-utils python3 python3-venv poppler-utils wv unrtf tidy tesseract-ocr libtesseract-dev libreoffice libsoxr-dev chromium qpdf && \
+    apt install -y \
+    build-essential \
+    curl \
+    wget \
+    xz-utils \
+    python3 \
+    python3-venv \
+    python3-dev \
+    libgeos++-dev \
+    poppler-utils \
+    wv \
+    unrtf \
+    tidy \
+    tesseract-ocr \
+    libtesseract-dev \
+    libreoffice \
+    libsoxr-dev \
+    chromium \
+    qpdf && \
     python3 -m venv /opt/venv && \
     /opt/venv/bin/pip install pdfplumber mistral-common tokenizers && \
     rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,10 +73,8 @@ RUN apt update && \
     chromium \
     qpdf && \
     python3 -m venv /opt/venv && \
-    /opt/venv/bin/pip install pdfplumber mistral-common tokenizers && \
+    /opt/venv/bin/pip install pdfplumber mistral-common tokenizers docling && \
     rm -rf /var/lib/apt/lists/*
-
-RUN /opt/venv/bin/pip install docling
 
 # Copy FFmpeg from build stage
 COPY --from=build --chown=nobody:nogroup /usr/local/bin/ffmpeg /usr/local/bin/ffmpeg

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -11,7 +11,23 @@ ARG TARGETOS TARGETARCH K6_VERSION XK6_VERSION XK6_SQL_VERSION XK6_SQL_POSTGRES_
 
 # Install Python, create virtual environment, install pdfplumber and Docling
 RUN apt update && \
-    apt install -y xz-utils python3 python3-venv poppler-utils wv unrtf tidy tesseract-ocr libtesseract-dev libreoffice libsoxr-dev chromium qpdf && \
+    apt install -y \
+    build-essential \
+    xz-utils \
+    python3 \
+    python3-venv \
+    python3-dev \
+    libgeos++-dev \
+    poppler-utils \
+    wv \
+    unrtf \
+    tidy \
+    tesseract-ocr \
+    libtesseract-dev \
+    libreoffice \
+    libsoxr-dev \
+    chromium \
+    qpdf && \
     python3 -m venv /opt/venv && \
     /opt/venv/bin/pip install pdfplumber mistral-common tokenizers docling && \
     rm -rf /var/lib/apt/lists/*
@@ -52,9 +68,9 @@ RUN --mount=target=. --mount=type=cache,target=/root/.cache/go-build --mount=typ
 # k6
 RUN --mount=target=. --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg GOOS=$TARGETOS GOARCH=$TARGETARCH go install go.k6.io/xk6/cmd/xk6@v${XK6_VERSION}
 RUN --mount=target=. --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg GOOS=$TARGETOS GOARCH=$TARGETARCH xk6 build v${K6_VERSION} \
-  --with github.com/grafana/xk6-sql@v${XK6_SQL_VERSION} \
-  --with github.com/grafana/xk6-sql-driver-postgres@v${XK6_SQL_POSTGRES_VERSION} \
-  --output /usr/bin/k6
+    --with github.com/grafana/xk6-sql@v${XK6_SQL_VERSION} \
+    --with github.com/grafana/xk6-sql-driver-postgres@v${XK6_SQL_POSTGRES_VERSION} \
+    --output /usr/bin/k6
 
 # -- set up Go
 

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,6 @@ rm: ## Remove all running containers
 build-dev: ## Build dev docker image
 	@docker build \
 		--build-arg SERVICE_NAME=${SERVICE_NAME} \
-		--build-arg GOLANG_VERSION=${GOLANG_VERSION} \
 		--build-arg K6_VERSION=${K6_VERSION} \
 		--build-arg XK6_VERSION=${XK6_VERSION} \
 		--build-arg XK6_SQL_VERSION=${XK6_SQL_VERSION} \
@@ -55,7 +54,6 @@ build-dev: ## Build dev docker image
 .PHONY: build-latest
 build-latest: ## Build latest docker image
 	@docker build \
-		--build-arg GOLANG_VERSION=${GOLANG_VERSION} \
 		--build-arg SERVICE_NAME=${SERVICE_NAME} \
 		-t instill/pipeline-backend:latest .
 


### PR DESCRIPTION
Because

- `pip install docling` will compile dependencies (e.g., shapely) for `aarch64` platform, which requires further development libraries

This commit

- remove `GOLANG_VERSION` in Makefile `build-dev` and `build-latest` target as we now hardcode Go version in Dockerfile
- add the missing dependent packages:
  - build-essential
  - python3-dev
  - libgeos++-dev
