### PR TITLE
ci(github): use ARM runner to speed up the image build process

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -6,8 +6,8 @@ on:
     types: [published]
 
 jobs:
-  docker-hub:
-    runs-on: ubuntu-latest
+  build-amd64:
+    runs-on: ubuntu-24.04
     steps:
       - name: Maximize build space
         uses: easimon/maximize-build-space@master
@@ -18,11 +18,6 @@ jobs:
 
       - name: Restart docker
         run: sudo service docker restart
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
 
       - uses: actions/checkout@v3
         with:
@@ -42,16 +37,16 @@ jobs:
           username: dropletbot
           password: ${{ secrets.botDockerHubPassword }}
 
-      - name: Build and push (latest)
+      - name: Build and push amd64 (latest)
         if: github.ref == 'refs/heads/main'
         uses: docker/build-push-action@v3
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           context: .
           push: true
           build-args: |
             SERVICE_NAME=pipeline-backend
-          tags: instill/pipeline-backend:latest
+          tags: instill/pipeline-backend:latest-amd64
           cache-from: type=registry,ref=instill/pipeline-backend:buildcache
           cache-to: type=registry,ref=instill/pipeline-backend:buildcache,mode=max
 
@@ -66,15 +61,118 @@ jobs:
             core.setOutput('tag', tag)
             core.setOutput('no_v_tag', no_v_tag)
 
-      - name: Build and push (release)
+      - name: Build and push amd64 (release)
         if: github.event_name == 'release'
         uses: docker/build-push-action@v3
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           context: .
           push: true
           build-args: |
             SERVICE_NAME=pipeline-backend
-          tags: instill/pipeline-backend:${{steps.set_version.outputs.no_v_tag}}
+          tags: instill/pipeline-backend:${{steps.set_version.outputs.no_v_tag}}-amd64
           cache-from: type=registry,ref=instill/pipeline-backend:buildcache
           cache-to: type=registry,ref=instill/pipeline-backend:buildcache,mode=max
+
+  build-arm64:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@master
+        with:
+          overprovision-lvm: "true"
+          remove-dotnet: "true"
+          build-mount-path: "/var/lib/docker/"
+
+      - name: Restart docker
+        run: sudo service docker restart
+
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.botGitHubToken }}
+
+      - name: Load .env file
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .env
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: dropletbot
+          password: ${{ secrets.botDockerHubPassword }}
+
+      - name: Build and push arm64 (latest)
+        if: github.ref == 'refs/heads/main'
+        uses: docker/build-push-action@v3
+        with:
+          platforms: linux/arm64
+          context: .
+          push: true
+          build-args: |
+            SERVICE_NAME=pipeline-backend
+          tags: instill/pipeline-backend:latest-arm64
+          cache-from: type=registry,ref=instill/pipeline-backend:buildcache
+          cache-to: type=registry,ref=instill/pipeline-backend:buildcache,mode=max
+
+      - name: Set Versions
+        if: github.event_name == 'release'
+        uses: actions/github-script@v6
+        id: set_version
+        with:
+          script: |
+            const tag = '${{ github.ref_name }}'
+            const no_v_tag = tag.replace('v', '')
+            core.setOutput('tag', tag)
+            core.setOutput('no_v_tag', no_v_tag)
+
+      - name: Build and push arm64 (release)
+        if: github.event_name == 'release'
+        uses: docker/build-push-action@v3
+        with:
+          platforms: linux/arm64
+          context: .
+          push: true
+          build-args: |
+            SERVICE_NAME=pipeline-backend
+          tags: instill/pipeline-backend:${{steps.set_version.outputs.no_v_tag}}-arm64
+          cache-from: type=registry,ref=instill/pipeline-backend:buildcache
+          cache-to: type=registry,ref=instill/pipeline-backend:buildcache,mode=max
+
+  merge-manifests:
+    needs: [build-amd64, build-arm64]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: dropletbot
+          password: ${{ secrets.botDockerHubPassword }}
+
+      - name: Create and push multi-arch manifest (latest)
+        if: github.ref == 'refs/heads/main'
+        run: |
+          docker buildx imagetools create -t instill/pipeline-backend:latest \
+            instill/pipeline-backend:latest-amd64 \
+            instill/pipeline-backend:latest-arm64
+
+      - name: Set Versions
+        if: github.event_name == 'release'
+        uses: actions/github-script@v6
+        id: set_version
+        with:
+          script: |
+            const tag = '${{ github.ref_name }}'
+            const no_v_tag = tag.replace('v', '')
+            core.setOutput('tag', tag)
+            core.setOutput('no_v_tag', no_v_tag)
+
+      - name: Create and push multi-arch manifest (release)
+        if: github.event_name == 'release'
+        run: |
+          docker buildx imagetools create -t instill/pipeline-backend:${{steps.set_version.outputs.no_v_tag}} \
+            instill/pipeline-backend:${{steps.set_version.outputs.no_v_tag}}-amd64 \
+            instill/pipeline-backend:${{steps.set_version.outputs.no_v_tag}}-arm64


### PR DESCRIPTION
Because

- Originally, we used QEMU for cross-compiling images, but it was slow and unstable.

This commit

- Uses an ARM runner to speed up the image build process.
