### PR TITLE
chore(ollama): rename vdp to pipeline in doc

### DIFF
--- a/pkg/component/ai/ollama/v0/.compogen/setup-hosting.mdx
+++ b/pkg/component/ai/ollama/v0/.compogen/setup-hosting.mdx
@@ -10,4 +10,4 @@ To set up an Ollama instance on your local machine, follow the instructions belo
     - On Linux and macOS, open the terminal and type `ifconfig`.
     - On Windows, open the command prompt and type `ipconfig`.
 4. Suppose the IP address is `192.168.178.88`, then the Ollama hosting endpoint would be `192.168.178.88:11434`.
-5. Enjoy fast LLM inference on your local machine and integration with 💧 Instill VDP.
+5. Enjoy fast LLM inference on your local machine and integration with 💧 Instill Pipeline.

--- a/pkg/component/ai/ollama/v0/README.mdx
+++ b/pkg/component/ai/ollama/v0/README.mdx
@@ -130,7 +130,7 @@ To set up an Ollama instance on your local machine, follow the instructions belo
     - On Linux and macOS, open the terminal and type `ifconfig`.
     - On Windows, open the command prompt and type `ipconfig`.
 4. Suppose the IP address is `192.168.178.88`, then the Ollama hosting endpoint would be `192.168.178.88:11434`.
-5. Enjoy fast LLM inference on your local machine and integration with 💧 Instill VDP.
+5. Enjoy fast LLM inference on your local machine and integration with 💧 Instill Pipeline.
 
 ### Text Embeddings
 


### PR DESCRIPTION
This commit

- renames `vdp` to `pipeline` in doc.
