### PR TITLE
feat(minio): add service name and version to MinIO requests

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -46,6 +46,7 @@ jobs:
           push: true
           build-args: |
             SERVICE_NAME=pipeline-backend
+            SERVICE_VERSION=${{ github.sha }}
           tags: instill/pipeline-backend:latest-amd64
           cache-from: type=registry,ref=instill/pipeline-backend:buildcache
           cache-to: type=registry,ref=instill/pipeline-backend:buildcache,mode=max
@@ -70,6 +71,7 @@ jobs:
           push: true
           build-args: |
             SERVICE_NAME=pipeline-backend
+            SERVICE_VERSION=${{steps.set_version.outputs.no_v_tag}}
           tags: instill/pipeline-backend:${{steps.set_version.outputs.no_v_tag}}-amd64
           cache-from: type=registry,ref=instill/pipeline-backend:buildcache
           cache-to: type=registry,ref=instill/pipeline-backend:buildcache,mode=max
@@ -114,6 +116,7 @@ jobs:
           push: true
           build-args: |
             SERVICE_NAME=pipeline-backend
+            SERVICE_VERSION=${{ github.sha }}
           tags: instill/pipeline-backend:latest-arm64
           cache-from: type=registry,ref=instill/pipeline-backend:buildcache
           cache-to: type=registry,ref=instill/pipeline-backend:buildcache,mode=max
@@ -138,6 +141,7 @@ jobs:
           push: true
           build-args: |
             SERVICE_NAME=pipeline-backend
+            SERVICE_VERSION=${{steps.set_version.outputs.no_v_tag}}
           tags: instill/pipeline-backend:${{steps.set_version.outputs.no_v_tag}}-arm64
           cache-from: type=registry,ref=instill/pipeline-backend:buildcache
           cache-to: type=registry,ref=instill/pipeline-backend:buildcache,mode=max

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -67,6 +67,7 @@ jobs:
           load: true
           build-args: |
             SERVICE_NAME=pipeline-backend
+            SERVICE_VERSION=${{ github.sha }}
           tags: instill/pipeline-backend:latest
 
       - name: Checkout repo (instill-core)

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,11 +43,34 @@ COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 
-ARG SERVICE_NAME TARGETOS TARGETARCH
-RUN --mount=target=. --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg GOOS=$TARGETOS GOARCH=$TARGETARCH go build -tags=ocr,onnx -o /${SERVICE_NAME} ./cmd/main
-RUN --mount=target=. --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /${SERVICE_NAME}-worker ./cmd/worker
-RUN --mount=target=. --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /${SERVICE_NAME}-migrate ./cmd/migration
-RUN --mount=target=. --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /${SERVICE_NAME}-init ./cmd/init
+ARG SERVICE_NAME SERVICE_VERSION TARGETOS TARGETARCH
+RUN --mount=target=. \
+    --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg \
+    GOOS=$TARGETOS GOARCH=$TARGETARCH \
+    go build -ldflags "-X main.version=${SERVICE_VERSION} -X main.serviceName=${SERVICE_NAME}" \
+    -tags=ocr,onnx -o /${SERVICE_NAME} ./cmd/main
+
+RUN --mount=target=. \
+    --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg \
+    GOOS=$TARGETOS GOARCH=$TARGETARCH \
+    go build -ldflags "-X main.version=${SERVICE_VERSION} -X main.serviceName=${SERVICE_NAME}-worker" \
+    -tags=ocr,onnx -o /${SERVICE_NAME}-worker ./cmd/worker
+
+RUN --mount=target=. \
+    --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg \
+    GOOS=$TARGETOS GOARCH=$TARGETARCH \
+    go build -ldflags "-X main.version=${SERVICE_VERSION} -X main.serviceName=${SERVICE_NAME}-migrate" \
+    -tags=ocr,onnx -o /${SERVICE_NAME}-migrate ./cmd/migration
+
+RUN --mount=target=. \
+    --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg \
+    GOOS=$TARGETOS GOARCH=$TARGETARCH \
+    go build -ldflags "-X main.version=${SERVICE_VERSION} -X main.serviceName=${SERVICE_NAME}-init" \
+    -tags=ocr,onnx -o /${SERVICE_NAME}-init ./cmd/init
 
 FROM debian:bullseye-slim
 

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250203091356-2b4937e1c3a2
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
-	github.com/instill-ai/x v0.6.0-alpha.0.20250212192855-6af31ff7cc27
+	github.com/instill-ai/x v0.6.0-alpha.0.20250213104218-8000506aa455
 	github.com/itchyny/gojq v0.12.14
 	github.com/jackc/pgconn v1.14.3
 	github.com/jackc/pgx/v5 v5.5.5

--- a/go.sum
+++ b/go.sum
@@ -946,8 +946,8 @@ github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250203091356-2b4937e1c3a2 h1:
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250203091356-2b4937e1c3a2/go.mod h1:fusT92ceR5+GVn1LT5mT4XcOq1DlemBjpb6JpodLLdc=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a/go.mod h1:EpX3Yr661uWULtZf5UnJHfr5rw2PDyX8ku4Kx0UtYFw=
-github.com/instill-ai/x v0.6.0-alpha.0.20250212192855-6af31ff7cc27 h1:5MwjakOj/G1iP7NwUBS7WCKvnAeI72mhgqq/abfuV+0=
-github.com/instill-ai/x v0.6.0-alpha.0.20250212192855-6af31ff7cc27/go.mod h1:4oSOcDRtho+uLswiPvty5sF5OxiiprUh8KCOiFdKyPw=
+github.com/instill-ai/x v0.6.0-alpha.0.20250213104218-8000506aa455 h1:hMkl7Csrasx0c8tMG/2cRF6CtA2W32DM9NGtmo051L4=
+github.com/instill-ai/x v0.6.0-alpha.0.20250213104218-8000506aa455/go.mod h1:4oSOcDRtho+uLswiPvty5sF5OxiiprUh8KCOiFdKyPw=
 github.com/intel/goresctrl v0.2.0/go.mod h1:+CZdzouYFn5EsxgqAQTEzMfwKwuc0fVdMrT9FCCAVRQ=
 github.com/itchyny/gojq v0.12.14 h1:6k8vVtsrhQSYgSGg827AD+PVVaB1NLXEdX+dda2oZCc=
 github.com/itchyny/gojq v0.12.14/go.mod h1:y1G7oO7XkcR1LPZO59KyoCRy08T3j9vDYRV0GgYSS+s=


### PR DESCRIPTION
Because

- We want to identify the service that is performing a MinIO action.

This commit

- Adds client information (app name and version) to the MinIO requests according to instill-ai/x/pull/37.
