### PR TITLE
feat(minio): add client info and user header to artifact binary fetcher

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250203091356-2b4937e1c3a2
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a
-	github.com/instill-ai/x v0.6.0-alpha.0.20250217111826-ae24d382e703
+	github.com/instill-ai/x v0.6.0-alpha.0.20250220064016-87c34501e6cd
 	github.com/itchyny/gojq v0.12.14
 	github.com/jackc/pgconn v1.14.3
 	github.com/jackc/pgx/v5 v5.5.5

--- a/go.sum
+++ b/go.sum
@@ -946,8 +946,8 @@ github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250203091356-2b4937e1c3a2 h1:
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250203091356-2b4937e1c3a2/go.mod h1:fusT92ceR5+GVn1LT5mT4XcOq1DlemBjpb6JpodLLdc=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a h1:gmy8BcCFDZQan40c/D3f62DwTYtlCwi0VrSax+pKffw=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20240123081026-6c78d9a5197a/go.mod h1:EpX3Yr661uWULtZf5UnJHfr5rw2PDyX8ku4Kx0UtYFw=
-github.com/instill-ai/x v0.6.0-alpha.0.20250217111826-ae24d382e703 h1:K+V5ADMPM9K0qeXyPh2ZC6a1zl3rbnn4iG0tBQjIZzA=
-github.com/instill-ai/x v0.6.0-alpha.0.20250217111826-ae24d382e703/go.mod h1:4oSOcDRtho+uLswiPvty5sF5OxiiprUh8KCOiFdKyPw=
+github.com/instill-ai/x v0.6.0-alpha.0.20250220064016-87c34501e6cd h1:NThz1N8tPcZ/MfbeZH570SRAIVAz50PffA619CjbEWc=
+github.com/instill-ai/x v0.6.0-alpha.0.20250220064016-87c34501e6cd/go.mod h1:4oSOcDRtho+uLswiPvty5sF5OxiiprUh8KCOiFdKyPw=
 github.com/intel/goresctrl v0.2.0/go.mod h1:+CZdzouYFn5EsxgqAQTEzMfwKwuc0fVdMrT9FCCAVRQ=
 github.com/itchyny/gojq v0.12.14 h1:6k8vVtsrhQSYgSGg827AD+PVVaB1NLXEdX+dda2oZCc=
 github.com/itchyny/gojq v0.12.14/go.mod h1:y1G7oO7XkcR1LPZO59KyoCRy08T3j9vDYRV0GgYSS+s=

--- a/pkg/service/main.go
+++ b/pkg/service/main.go
@@ -18,12 +18,12 @@ import (
 	"github.com/instill-ai/pipeline-backend/pkg/memory"
 	"github.com/instill-ai/pipeline-backend/pkg/repository"
 	"github.com/instill-ai/pipeline-backend/pkg/resource"
+	"github.com/instill-ai/x/minio"
 
 	componentstore "github.com/instill-ai/pipeline-backend/pkg/component/store"
 	artifactpb "github.com/instill-ai/protogen-go/artifact/artifact/v1alpha"
 	mgmtpb "github.com/instill-ai/protogen-go/core/mgmt/v1beta"
 	pb "github.com/instill-ai/protogen-go/pipeline/pipeline/v1beta"
-	miniox "github.com/instill-ai/x/minio"
 )
 
 // Service interface
@@ -107,7 +107,7 @@ type service struct {
 	mgmtPrivateServiceClient     mgmtpb.MgmtPrivateServiceClient
 	aclClient                    acl.ACLClientInterface
 	converter                    Converter
-	minioClient                  miniox.MinioI
+	minioClient                  minio.Client
 	memory                       memory.MemoryStore
 	log                          *zap.Logger
 	workerUID                    uuid.UUID
@@ -126,7 +126,7 @@ func NewService(
 	converter Converter,
 	mgmtPublicServiceClient mgmtpb.MgmtPublicServiceClient,
 	mgmtPrivateServiceClient mgmtpb.MgmtPrivateServiceClient,
-	minioClient miniox.MinioI,
+	minioClient minio.Client,
 	componentStore *componentstore.Store,
 	memory memory.MemoryStore,
 	workerUID uuid.UUID,

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -37,7 +37,7 @@ import (
 	"github.com/instill-ai/pipeline-backend/pkg/utils"
 	"github.com/instill-ai/pipeline-backend/pkg/worker"
 	"github.com/instill-ai/x/errmsg"
-	miniox "github.com/instill-ai/x/minio"
+	"github.com/instill-ai/x/minio"
 
 	errdomain "github.com/instill-ai/pipeline-backend/pkg/errors"
 	mgmtpb "github.com/instill-ai/protogen-go/core/mgmt/v1beta"
@@ -853,7 +853,7 @@ func (s *service) preTriggerPipeline(
 	r *datamodel.Recipe,
 	pipelineTriggerID string,
 	pipelineData []*pipelinepb.TriggerData,
-	expiryRule miniox.ExpiryRule,
+	expiryRule minio.ExpiryRule,
 ) error {
 	batchSize := len(pipelineData)
 	if batchSize > constant.MaxBatchSize {
@@ -1782,7 +1782,7 @@ type triggerParams struct {
 	pipelineTriggerID  string
 	requesterUID       uuid.UUID
 	userUID            uuid.UUID
-	expiryRule         miniox.ExpiryRule
+	expiryRule         minio.ExpiryRule
 }
 
 func (s *service) triggerAsyncPipeline(ctx context.Context, params triggerParams) (*longrunningpb.Operation, error) {

--- a/pkg/service/pipeline_test.go
+++ b/pkg/service/pipeline_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/instill-ai/pipeline-backend/pkg/mock"
 	"github.com/instill-ai/pipeline-backend/pkg/repository"
 	"github.com/instill-ai/pipeline-backend/pkg/resource"
-	miniox "github.com/instill-ai/x/minio"
+	"github.com/instill-ai/x/minio"
 
 	componentstore "github.com/instill-ai/pipeline-backend/pkg/component/store"
 	artifactpb "github.com/instill-ai/protogen-go/artifact/artifact/v1alpha"
@@ -131,7 +131,7 @@ type serviceConfig struct {
 	converter                    Converter
 	mgmtPublicServiceClient      mgmtpb.MgmtPublicServiceClient
 	mgmtPrivateServiceClient     mgmtpb.MgmtPrivateServiceClient
-	minioClient                  miniox.MinioI
+	minioClient                  minio.Client
 	componentStore               *componentstore.Store
 	memory                       memory.MemoryStore
 	workerUID                    uuid.UUID

--- a/pkg/worker/main.go
+++ b/pkg/worker/main.go
@@ -14,12 +14,12 @@ import (
 	"github.com/instill-ai/pipeline-backend/pkg/memory"
 	"github.com/instill-ai/pipeline-backend/pkg/recipe"
 	"github.com/instill-ai/pipeline-backend/pkg/repository"
+	"github.com/instill-ai/x/minio"
 
 	"github.com/instill-ai/pipeline-backend/pkg/component/generic/scheduler/v0"
 	componentstore "github.com/instill-ai/pipeline-backend/pkg/component/store"
 	artifactpb "github.com/instill-ai/protogen-go/artifact/artifact/v1alpha"
 	pb "github.com/instill-ai/protogen-go/pipeline/pipeline/v1beta"
-	miniox "github.com/instill-ai/x/minio"
 )
 
 // TaskQueue is the Temporal task queue name for pipeline-backend
@@ -56,7 +56,7 @@ type WorkerConfig struct {
 	RedisClient                  *redis.Client
 	InfluxDBWriteClient          api.WriteAPI
 	Component                    *componentstore.Store
-	MinioClient                  miniox.MinioI
+	MinioClient                  minio.Client
 	MemoryStore                  memory.MemoryStore
 	WorkerUID                    uuid.UUID
 	ArtifactPublicServiceClient  artifactpb.ArtifactPublicServiceClient
@@ -71,7 +71,7 @@ type worker struct {
 	redisClient                  *redis.Client
 	influxDBWriteClient          api.WriteAPI
 	component                    *componentstore.Store
-	minioClient                  miniox.MinioI
+	minioClient                  minio.Client
 	log                          *zap.Logger
 	memoryStore                  memory.MemoryStore
 	workerUID                    uuid.UUID


### PR DESCRIPTION
Because

- The artifact binary fetcher interacted with MinIO without providing the app and user information that we need for the audit logs.

This commit

- Uses the latest version of `x/minio` to provide such information.
