### PR TITLE
feat(memory): remove recipe from in-process memory

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -518,7 +518,6 @@ func main() {
 	lw.RegisterActivity(cw.InitComponentsActivity)
 	lw.RegisterActivity(cw.SendStartedEventActivity)
 	lw.RegisterActivity(cw.LoadRecipeActivity)
-	lw.RegisterActivity(cw.LoadDAGDataActivity)
 	lw.RegisterActivity(cw.PostTriggerActivity)
 	lw.RegisterActivity(cw.ClosePipelineActivity)
 	lw.RegisterActivity(cw.IncreasePipelineTriggerCountActivity)

--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -517,7 +517,6 @@ func main() {
 	lw.RegisterActivity(cw.PostIteratorActivity)
 	lw.RegisterActivity(cw.InitComponentsActivity)
 	lw.RegisterActivity(cw.SendStartedEventActivity)
-	lw.RegisterActivity(cw.LoadRecipeActivity)
 	lw.RegisterActivity(cw.PostTriggerActivity)
 	lw.RegisterActivity(cw.ClosePipelineActivity)
 	lw.RegisterActivity(cw.IncreasePipelineTriggerCountActivity)

--- a/pkg/memory/memory.go
+++ b/pkg/memory/memory.go
@@ -86,8 +86,6 @@ type WorkflowMemory interface {
 	IsStreaming() bool
 
 	GetBatchSize() int
-	SetRecipe(*datamodel.Recipe)
-	GetRecipe() *datamodel.Recipe
 }
 
 type ComponentStatus struct {
@@ -105,7 +103,6 @@ type workflowMemory struct {
 	mu        sync.Mutex
 	id        string
 	data      []format.Value
-	recipe    *datamodel.Recipe
 	streaming bool
 
 	publishWFStatus func(_ context.Context, topic string, _ pubsub.Event) error
@@ -211,7 +208,6 @@ func (ms *memoryStore) NewWorkflowMemory(ctx context.Context, workflowID string,
 		mu:              sync.Mutex{},
 		id:              workflowID,
 		data:            wfmData,
-		recipe:          r,
 		publishWFStatus: ms.SendWorkflowStatusEvent,
 	})
 
@@ -445,14 +441,6 @@ func (wfm *workflowMemory) Get(ctx context.Context, batchIdx int, p string) (mem
 
 func (wfm *workflowMemory) GetBatchSize() int {
 	return len(wfm.data)
-}
-
-func (wfm *workflowMemory) SetRecipe(r *datamodel.Recipe) {
-	wfm.recipe = r
-}
-
-func (wfm *workflowMemory) GetRecipe() *datamodel.Recipe {
-	return wfm.recipe
 }
 
 func (wfm *workflowMemory) getComponentEventData(_ context.Context, batchIdx int, componentID string) ComponentEventData {

--- a/pkg/recipe/dag.go
+++ b/pkg/recipe/dag.go
@@ -336,21 +336,17 @@ func FindReferenceParent(input string) []string {
 	return upstreams
 }
 
-func GenerateTraces(ctx context.Context, wfm memory.WorkflowMemory, full bool) (map[string]*pb.Trace, error) {
-
+func GenerateTraces(ctx context.Context, compIDs []string, wfm memory.WorkflowMemory, full bool) (map[string]*pb.Trace, error) {
 	trace := map[string]*pb.Trace{}
 
 	batchSize := wfm.GetBatchSize()
-
-	for compID := range wfm.GetRecipe().Component {
-
+	for _, compID := range compIDs {
 		inputs := make([]*structpb.Struct, batchSize)
 		outputs := make([]*structpb.Struct, batchSize)
 		errors := make([]*structpb.Struct, batchSize)
 		traceStatuses := make([]pb.Trace_Status, batchSize)
 
 		for dataIdx := range batchSize {
-
 			completed, err := wfm.GetComponentStatus(ctx, dataIdx, compID, memory.ComponentStatusCompleted)
 			if err != nil {
 				continue

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"slices"
 	"strings"
 	"sync"
@@ -1770,7 +1771,8 @@ func (s *service) triggerPipeline(
 		return nil, nil, err
 	}
 
-	return s.getOutputsAndMetadata(ctx, triggerParams.pipelineTriggerID, returnTraces)
+	compIDs := slices.Collect(maps.Keys(triggerParams.recipe.Component))
+	return s.getOutputsAndMetadata(ctx, triggerParams.pipelineTriggerID, compIDs, returnTraces)
 }
 
 type triggerParams struct {
@@ -1883,15 +1885,13 @@ func (s *service) triggerAsyncPipeline(ctx context.Context, params triggerParams
 
 }
 
-func (s *service) getOutputsAndMetadata(ctx context.Context, pipelineTriggerID string, returnTraces bool) ([]*structpb.Struct, *pipelinepb.TriggerMetadata, error) {
-
+func (s *service) getOutputsAndMetadata(ctx context.Context, pipelineTriggerID string, compIDs []string, returnTraces bool) ([]*structpb.Struct, *pipelinepb.TriggerMetadata, error) {
 	wfm, err := s.memory.GetWorkflowMemory(ctx, pipelineTriggerID)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	pipelineOutputs := make([]*structpb.Struct, wfm.GetBatchSize())
-
 	for idx := range wfm.GetBatchSize() {
 		output, err := wfm.Get(ctx, idx, constant.SegOutput)
 		if err != nil {
@@ -1906,7 +1906,7 @@ func (s *service) getOutputsAndMetadata(ctx context.Context, pipelineTriggerID s
 
 	var metadata *pipelinepb.TriggerMetadata
 
-	traces, err := recipe.GenerateTraces(ctx, wfm, returnTraces)
+	traces, err := recipe.GenerateTraces(ctx, compIDs, wfm, returnTraces)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -2254,13 +2254,18 @@ func (s *service) getOperationFromWorkflowInfo(ctx context.Context, workflowExec
 
 	switch workflowExecutionInfo.Status {
 	case enums.WORKFLOW_EXECUTION_STATUS_COMPLETED:
-
 		pipelineTriggerID := workflowExecutionInfo.Execution.WorkflowId
 		defer func() {
 			_ = s.memory.PurgeWorkflowMemory(ctx, pipelineTriggerID)
 		}()
 
-		outputs, metadata, err := s.getOutputsAndMetadata(ctx, pipelineTriggerID, true)
+		recipe, err := s.fetchRecipeSnapshot(ctx, pipelineTriggerID)
+		if err != nil {
+			return nil, fmt.Errorf("fetching recipe snapshot: %w", err)
+		}
+
+		compIDs := slices.Collect(maps.Keys(recipe.Component))
+		outputs, metadata, err := s.getOutputsAndMetadata(ctx, pipelineTriggerID, compIDs, true)
 		if err != nil {
 			return nil, err
 		}
@@ -2305,4 +2310,37 @@ func (s *service) getOperationFromWorkflowInfo(ctx context.Context, workflowExec
 
 	operation.Name = fmt.Sprintf("operations/%s", workflowExecutionInfo.Execution.WorkflowId)
 	return &operation, nil
+}
+
+func (s *service) fetchRecipeSnapshot(ctx context.Context, pipelineTriggerID string) (*datamodel.Recipe, error) {
+	// TODO [INS-7438] fetching the component IDs should be achievable through
+	// the component runs in the repository. However, the iterator execution
+	// isn't being stored as a component run and its child components are
+	// storing component runs instead.
+	pipelineRun, err := s.repository.GetPipelineRunByUID(ctx, uuid.FromStringOrNil(pipelineTriggerID))
+	if err != nil {
+		return nil, fmt.Errorf("fetching pipeline run: %w", err)
+	}
+
+	if len(pipelineRun.RecipeSnapshot) < 1 {
+		return nil, fmt.Errorf("pipeline run contains no recipe")
+	}
+	refID := pipelineRun.RecipeSnapshot[0].Name
+
+	_, userUID := resourcex.GetRequesterUIDAndUserUID(ctx)
+	fileContents, err := s.minioClient.WithLogger(s.log).GetFilesByPaths(ctx, userUID, []string{refID})
+	if err != nil {
+		return nil, fmt.Errorf("downloading recipe: %w", err)
+	}
+
+	if len(fileContents) < 1 {
+		return nil, fmt.Errorf("recipe snapshot is empty")
+	}
+
+	recipe := new(datamodel.Recipe)
+	if err = json.Unmarshal(fileContents[0].Content, recipe); err != nil {
+		return nil, fmt.Errorf("unmarshalling recipe: %w", err)
+	}
+
+	return recipe, nil
 }

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -1733,7 +1733,6 @@ func (s *service) triggerPipeline(
 		workflowOptions,
 		"TriggerPipelineWorkflow",
 		&worker.TriggerPipelineWorkflowParam{
-			TriggerFromAPI: true,
 			SystemVariables: recipe.SystemVariables{
 				PipelineTriggerID:    triggerParams.pipelineTriggerID,
 				PipelineID:           triggerParams.pipelineID,
@@ -1834,9 +1833,8 @@ func (s *service) triggerAsyncPipeline(ctx context.Context, params triggerParams
 				HeaderAuthorization:  resource.GetRequestSingleHeader(ctx, "authorization"),
 				ExpiryRule:           params.expiryRule,
 			},
-			Mode:           mgmtpb.Mode_MODE_ASYNC,
-			TriggerFromAPI: true,
-			WorkerUID:      s.workerUID,
+			Mode:      mgmtpb.Mode_MODE_ASYNC,
+			WorkerUID: s.workerUID,
 		})
 	if err != nil {
 		logger.Error(fmt.Sprintf("unable to execute workflow: %s", err.Error()))

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -1748,6 +1748,7 @@ func (s *service) triggerPipeline(
 			},
 			Mode:      mgmtpb.Mode_MODE_SYNC,
 			WorkerUID: s.workerUID,
+			Recipe:    triggerParams.recipe,
 		})
 	if err != nil {
 		logger.Error(fmt.Sprintf("unable to execute workflow: %s", err.Error()))
@@ -1782,6 +1783,7 @@ type triggerParams struct {
 	requesterUID       uuid.UUID
 	userUID            uuid.UUID
 	expiryRule         minio.ExpiryRule
+	recipe             *datamodel.Recipe
 }
 
 func (s *service) triggerAsyncPipeline(ctx context.Context, params triggerParams) (*longrunningpb.Operation, error) {
@@ -1835,6 +1837,7 @@ func (s *service) triggerAsyncPipeline(ctx context.Context, params triggerParams
 			},
 			Mode:      mgmtpb.Mode_MODE_ASYNC,
 			WorkerUID: s.workerUID,
+			Recipe:    params.recipe,
 		})
 	if err != nil {
 		logger.Error(fmt.Sprintf("unable to execute workflow: %s", err.Error()))
@@ -2043,6 +2046,7 @@ func (s *service) TriggerNamespacePipelineByID(ctx context.Context, ns resource.
 		requesterUID:      requesterUID,
 		userUID:           userUID,
 		expiryRule:        expiryRule,
+		recipe:            dbPipeline.Recipe,
 	}, returnTraces)
 	if err != nil {
 		return nil, nil, err
@@ -2099,6 +2103,7 @@ func (s *service) TriggerAsyncNamespacePipelineByID(ctx context.Context, ns reso
 		requesterUID:      requesterUID,
 		userUID:           userUID,
 		expiryRule:        expiryRule,
+		recipe:            dbPipeline.Recipe,
 	})
 	if err != nil {
 		return nil, err
@@ -2163,6 +2168,7 @@ func (s *service) TriggerNamespacePipelineReleaseByID(ctx context.Context, ns re
 		requesterUID:       requesterUID,
 		userUID:            userUID,
 		expiryRule:         expiryRule,
+		recipe:             dbPipelineRelease.Recipe,
 	}, returnTraces)
 	if err != nil {
 		return nil, nil, err
@@ -2226,6 +2232,7 @@ func (s *service) TriggerAsyncNamespacePipelineReleaseByID(ctx context.Context, 
 		requesterUID:       requesterUID,
 		userUID:            userUID,
 		expiryRule:         expiryRule,
+		recipe:             dbPipelineRelease.Recipe,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/service/webhook.go
+++ b/pkg/service/webhook.go
@@ -188,6 +188,7 @@ func (s *service) DispatchPipelineWebhookEvent(ctx context.Context, params Dispa
 					requesterUID:      loadPipelineResult.ns.NsUID,
 					pipelineTriggerID: pipelineTriggerID.String(),
 					expiryRule:        expiryRule,
+					recipe:            loadPipelineResult.recipe,
 				})
 				if err != nil {
 					return DispatchPipelineWebhookEventResult{}, err
@@ -215,6 +216,7 @@ func (s *service) DispatchPipelineWebhookEvent(ctx context.Context, params Dispa
 					requesterUID:       loadPipelineResult.ns.NsUID,
 					pipelineTriggerID:  pipelineTriggerID.String(),
 					expiryRule:         expiryRule,
+					recipe:             loadPipelineResult.recipe,
 				})
 			}
 		}

--- a/pkg/worker/main.go
+++ b/pkg/worker/main.go
@@ -34,7 +34,6 @@ type Worker interface {
 	OutputActivity(context.Context, *ComponentActivityParam) error
 	PreIteratorActivity(context.Context, *PreIteratorActivityParam) ([]ChildPipelineTriggerParams, error)
 	PostIteratorActivity(context.Context, *PostIteratorActivityParam) error
-	LoadRecipeActivity(context.Context, *LoadRecipeActivityParam) error
 	InitComponentsActivity(context.Context, *InitComponentsActivityParam) error
 	SendStartedEventActivity(_ context.Context, workflowID string) error
 	PostTriggerActivity(context.Context, *PostTriggerActivityParam) error

--- a/pkg/worker/main.go
+++ b/pkg/worker/main.go
@@ -33,7 +33,6 @@ type Worker interface {
 	ComponentActivity(context.Context, *ComponentActivityParam) error
 	OutputActivity(context.Context, *ComponentActivityParam) error
 	PreIteratorActivity(context.Context, *PreIteratorActivityParam) ([]ChildPipelineTriggerParams, error)
-	LoadDAGDataActivity(_ context.Context, workflowID string) (*LoadDAGDataActivityResult, error)
 	PostIteratorActivity(context.Context, *PostIteratorActivityParam) error
 	LoadRecipeActivity(context.Context, *LoadRecipeActivityParam) error
 	InitComponentsActivity(context.Context, *InitComponentsActivityParam) error

--- a/pkg/worker/main.go
+++ b/pkg/worker/main.go
@@ -9,6 +9,7 @@ import (
 	"go.temporal.io/sdk/workflow"
 	"go.uber.org/zap"
 
+	"github.com/instill-ai/pipeline-backend/pkg/datamodel"
 	"github.com/instill-ai/pipeline-backend/pkg/external"
 	"github.com/instill-ai/pipeline-backend/pkg/logger"
 	"github.com/instill-ai/pipeline-backend/pkg/memory"
@@ -35,7 +36,7 @@ type Worker interface {
 	PreIteratorActivity(context.Context, *PreIteratorActivityParam) (*PreIteratorActivityResult, error)
 	LoadDAGDataActivity(_ context.Context, workflowID string) (*LoadDAGDataActivityResult, error)
 	PostIteratorActivity(context.Context, *PostIteratorActivityParam) error
-	LoadRecipeActivity(context.Context, *LoadRecipeActivityParam) error
+	LoadRecipeActivity(context.Context, *LoadRecipeActivityParam) (*datamodel.Recipe, error)
 	InitComponentsActivity(context.Context, *InitComponentsActivityParam) error
 	SendStartedEventActivity(_ context.Context, workflowID string) error
 	PostTriggerActivity(context.Context, *PostTriggerActivityParam) error
@@ -45,7 +46,7 @@ type Worker interface {
 	UpdatePipelineRunActivity(context.Context, *UpdatePipelineRunActivityParam) error
 	UpsertComponentRunActivity(context.Context, *UpsertComponentRunActivityParam) error
 	UploadOutputsToMinIOActivity(context.Context, *MinIOUploadMetadata) error
-	UploadRecipeToMinIOActivity(context.Context, *MinIOUploadMetadata) error
+	UploadRecipeToMinIOActivity(context.Context, UploadRecipeToMinIOParam) error
 	UploadComponentInputsActivity(context.Context, *ComponentActivityParam) error
 	UploadComponentOutputsActivity(context.Context, *ComponentActivityParam) error
 }

--- a/pkg/worker/main.go
+++ b/pkg/worker/main.go
@@ -32,7 +32,7 @@ type Worker interface {
 
 	ComponentActivity(context.Context, *ComponentActivityParam) error
 	OutputActivity(context.Context, *ComponentActivityParam) error
-	PreIteratorActivity(context.Context, *PreIteratorActivityParam) (*PreIteratorActivityResult, error)
+	PreIteratorActivity(context.Context, *PreIteratorActivityParam) ([]ChildPipelineTriggerParams, error)
 	LoadDAGDataActivity(_ context.Context, workflowID string) (*LoadDAGDataActivityResult, error)
 	PostIteratorActivity(context.Context, *PostIteratorActivityParam) error
 	LoadRecipeActivity(context.Context, *LoadRecipeActivityParam) error

--- a/pkg/worker/main.go
+++ b/pkg/worker/main.go
@@ -9,7 +9,6 @@ import (
 	"go.temporal.io/sdk/workflow"
 	"go.uber.org/zap"
 
-	"github.com/instill-ai/pipeline-backend/pkg/datamodel"
 	"github.com/instill-ai/pipeline-backend/pkg/external"
 	"github.com/instill-ai/pipeline-backend/pkg/logger"
 	"github.com/instill-ai/pipeline-backend/pkg/memory"
@@ -36,7 +35,7 @@ type Worker interface {
 	PreIteratorActivity(context.Context, *PreIteratorActivityParam) (*PreIteratorActivityResult, error)
 	LoadDAGDataActivity(_ context.Context, workflowID string) (*LoadDAGDataActivityResult, error)
 	PostIteratorActivity(context.Context, *PostIteratorActivityParam) error
-	LoadRecipeActivity(context.Context, *LoadRecipeActivityParam) (*datamodel.Recipe, error)
+	LoadRecipeActivity(context.Context, *LoadRecipeActivityParam) error
 	InitComponentsActivity(context.Context, *InitComponentsActivityParam) error
 	SendStartedEventActivity(_ context.Context, workflowID string) error
 	PostTriggerActivity(context.Context, *PostTriggerActivityParam) error

--- a/pkg/worker/workflow.go
+++ b/pkg/worker/workflow.go
@@ -247,13 +247,7 @@ func (w *worker) TriggerPipelineWorkflow(ctx workflow.Context, param *TriggerPip
 		}
 	}
 
-	dagData := new(LoadDAGDataActivityResult)
-	err := workflow.ExecuteActivity(ctx, w.LoadDAGDataActivity, workflowID).Get(ctx, dagData)
-	if err != nil {
-		logger.Error("Failed to load DAG", zap.Error(err))
-	}
-
-	dag, err := recipe.GenerateDAG(dagData.Recipe.Component)
+	dag, err := recipe.GenerateDAG(param.Recipe.Component)
 	if err != nil {
 		return err
 	}
@@ -938,23 +932,6 @@ func (w *worker) PostIteratorActivity(ctx context.Context, param *PostIteratorAc
 	return nil
 }
 
-func (w *worker) LoadDAGDataActivity(ctx context.Context, workflowID string) (*LoadDAGDataActivityResult, error) {
-
-	logger, _ := logger.GetZapLogger(ctx)
-	logger.Info("LoadDAGDataActivity started")
-
-	wfm, err := w.memoryStore.GetWorkflowMemory(ctx, workflowID)
-	if err != nil {
-		return nil, err
-	}
-
-	logger.Info("LoadDAGDataActivity completed")
-	return &LoadDAGDataActivityResult{
-		Recipe:    wfm.GetRecipe(),
-		BatchSize: wfm.GetBatchSize(),
-	}, nil
-}
-
 // preTriggerErr returns a function that handles errors that happen during the
 // trigger workflow setup, i.e., before the components start to be executed.
 // If the trigger is streamed, it will send an event to halt the execution.
@@ -1489,7 +1466,6 @@ const (
 	outputActivityErrorType       = "OutputActivityError"
 	preIteratorActivityErrorType  = "PreIteratorActivityError"
 	postIteratorActivityErrorType = "PostIteratorActivityError"
-	loadDAGDataActivityErrorType  = "LoadDAGDataActivityError"
 	postTriggerActivityErrorType  = "PostTriggerActivityError"
 )
 


### PR DESCRIPTION
Because

- The pipeline information that's loaded as in-process memory during trigger execution prevents us from scaling workers independently.

This commit

- Removes the pipeline recipe snapshot from the in-process memory. Recipes shouldn't be larger than the Temporal history constraints.
- This is achieved by passing the recipe as a parameter to the trigger workflow. This parameter is propagated to the activities that consume this information, so they don't need to fetch the recipe from the workflow memory anymore.
