### PR TITLE
feat(trigger): use MinIO to store workflow memory

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -299,7 +299,7 @@ func main() {
 	workerUID, _ := uuid.NewV4()
 
 	pubsub := pubsub.NewRedisPubSub(redisClient)
-	ms := memory.NewMemoryStore(pubsub)
+	ms := memory.NewStore(pubsub)
 
 	repo := repository.NewRepository(db, redisClient)
 	service := service.NewService(

--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -299,7 +299,7 @@ func main() {
 	workerUID, _ := uuid.NewV4()
 
 	pubsub := pubsub.NewRedisPubSub(redisClient)
-	ms := memory.NewStore(pubsub)
+	ms := memory.NewStore(pubsub, minIOClient.WithLogger(logger))
 
 	repo := repository.NewRepository(db, redisClient)
 	service := service.NewService(
@@ -511,6 +511,7 @@ func main() {
 	w.RegisterWorkflow(cw.TriggerPipelineWorkflow)
 	w.RegisterWorkflow(cw.SchedulePipelineWorkflow)
 
+	lw.RegisterActivity(cw.LoadWorkflowMemory)
 	lw.RegisterActivity(cw.ComponentActivity)
 	lw.RegisterActivity(cw.OutputActivity)
 	lw.RegisterActivity(cw.PreIteratorActivity)

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250218192547-887cb37e3b6e
 	github.com/instill-ai/usage-client v0.3.0-alpha.0.20250313022849-49504d982f18
-	github.com/instill-ai/x v0.7.0-alpha.0.20250313022430-5aa78d8d09e0
+	github.com/instill-ai/x v0.7.0-alpha.0.20250319093842-bd27e04e1246
 	github.com/itchyny/gojq v0.12.14
 	github.com/jackc/pgconn v1.14.3
 	github.com/jackc/pgx/v5 v5.5.5

--- a/go.sum
+++ b/go.sum
@@ -946,8 +946,8 @@ github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250218192547-887cb37e3b6e h1:
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250218192547-887cb37e3b6e/go.mod h1:fusT92ceR5+GVn1LT5mT4XcOq1DlemBjpb6JpodLLdc=
 github.com/instill-ai/usage-client v0.3.0-alpha.0.20250313022849-49504d982f18 h1:RFdRDODY4qMTTIcKm4TBMpYhxDGFCql6HQ7oocA+WeQ=
 github.com/instill-ai/usage-client v0.3.0-alpha.0.20250313022849-49504d982f18/go.mod h1:/B+Irg9TYBlP+X79GZ+yvPxFvC+7fbRL7APNGiJlDSk=
-github.com/instill-ai/x v0.7.0-alpha.0.20250313022430-5aa78d8d09e0 h1:4Dg1+BH8L4QnKJGCVptXASveqVM0ezGfiOLSCDXx2eA=
-github.com/instill-ai/x v0.7.0-alpha.0.20250313022430-5aa78d8d09e0/go.mod h1:1U1QRbtHDmVPA0nEb06RZYRaEQ77C3XuF4DnOG9JmMs=
+github.com/instill-ai/x v0.7.0-alpha.0.20250319093842-bd27e04e1246 h1:GbeoQq5SC+/cR053ZGItfGHG6kBX+FrYlP89R6xNcrE=
+github.com/instill-ai/x v0.7.0-alpha.0.20250319093842-bd27e04e1246/go.mod h1:1U1QRbtHDmVPA0nEb06RZYRaEQ77C3XuF4DnOG9JmMs=
 github.com/intel/goresctrl v0.2.0/go.mod h1:+CZdzouYFn5EsxgqAQTEzMfwKwuc0fVdMrT9FCCAVRQ=
 github.com/itchyny/gojq v0.12.14 h1:6k8vVtsrhQSYgSGg827AD+PVVaB1NLXEdX+dda2oZCc=
 github.com/itchyny/gojq v0.12.14/go.mod h1:y1G7oO7XkcR1LPZO59KyoCRy08T3j9vDYRV0GgYSS+s=

--- a/pkg/data/encode.go
+++ b/pkg/data/encode.go
@@ -1,0 +1,65 @@
+package data
+
+import (
+	"bytes"
+	"encoding/gob"
+	"fmt"
+
+	"github.com/instill-ai/pipeline-backend/pkg/data/format"
+)
+
+// init registers the concrete format.Value types for the gob encoder and
+// decoder. On each end, this will tell the engine which concrete type is being
+// sent that implements the interface.
+func init() {
+	gob.Register(Array{})
+	gob.Register(Map{})
+
+	gob.Register(&audioData{})
+	gob.Register(&booleanData{})
+	gob.Register(&byteArrayData{})
+	gob.Register(&documentData{})
+	gob.Register(&fileData{})
+	gob.Register(&imageData{})
+	gob.Register(&nullData{})
+	gob.Register(&numberData{})
+	gob.Register(&stringData{})
+	gob.Register(&videoData{})
+}
+
+// Encode transforms any implementation of format.Value into its byte
+// representation, which can be later recovered respecting the concrete type
+// implementation.
+func Encode(v format.Value) ([]byte, error) {
+	var bb bytes.Buffer
+	enc := gob.NewEncoder(&bb)
+
+	// Encoding will fail unless the concrete type has been registered. All the
+	// format.Value implementations in this package should be registered in the
+	// init() function.
+
+	// A pointer to interface is passed so Encode sees (and hence sends) a
+	// value of interface type. If we passed v directly it would see the
+	// concrete type instead.
+	if err := enc.Encode(&v); err != nil {
+		return nil, fmt.Errorf("encoding gob: %w", err)
+	}
+
+	return bb.Bytes(), nil
+}
+
+// Decode transforms an encoded implementation of the format.Value interface
+// into an object that implements format.Value (and respects the original
+// type).
+func Decode(b []byte) (format.Value, error) {
+	var v format.Value
+	dec := gob.NewDecoder(bytes.NewBuffer(b))
+
+	// The decode function will fail unless the concrete type on the wire has
+	// been registered, which was done in the init() function.
+	if err := dec.Decode(&v); err != nil {
+		return nil, fmt.Errorf("decoding gob: %w", err)
+	}
+
+	return v, nil
+}

--- a/pkg/data/encode_test.go
+++ b/pkg/data/encode_test.go
@@ -1,0 +1,66 @@
+package data
+
+import (
+	"os"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/instill-ai/pipeline-backend/pkg/data/format"
+)
+
+func TestEncodeDecode(t *testing.T) {
+	c := qt.New(t)
+
+	// Fill data structure
+	data := Array(make([]format.Value, 1))
+
+	variable := Map{}
+	variable["true"] = NewBoolean(true)
+	variable["false"] = NewBoolean(true)
+	variable["number"] = NewNumberFromFloat(12.34)
+	variable["integer"] = NewNumberFromInteger(1234)
+	variable["null"] = NewNull()
+	variable["string"] = NewString("asdf")
+	variable["nested"] = Map{"string": NewString("ghjk")}
+	variable["bytes"] = NewByteArray([]byte(`1234`))
+
+	filename := "sample_640_426.jpeg"
+	img, err := os.ReadFile("testdata/" + filename)
+	c.Assert(err, qt.IsNil)
+
+	variable["file"], err = NewFileFromBytes([]byte(img), "", "")
+	c.Assert(err, qt.IsNil)
+
+	variable["img"], err = NewImageFromBytes([]byte(img), JPEG, filename)
+	c.Assert(err, qt.IsNil)
+
+	filename = "sample1.mp3"
+	audio, err := os.ReadFile("testdata/" + filename)
+	c.Assert(err, qt.IsNil)
+
+	variable["audio"], err = NewAudioFromBytes([]byte(audio), MP3, filename)
+	c.Assert(err, qt.IsNil)
+
+	filename = "sample_640_360.mp4"
+	vid, err := os.ReadFile("testdata/" + filename)
+	c.Assert(err, qt.IsNil)
+
+	variable["video"], err = NewVideoFromBytes([]byte(vid), MP4, filename)
+	c.Assert(err, qt.IsNil)
+
+	data[0] = variable
+	want, err := data.ToJSONValue()
+	c.Assert(err, qt.IsNil)
+
+	// Encode, decode and compare
+	b, err := Encode(data)
+	c.Assert(err, qt.IsNil)
+
+	v, err := Decode(b)
+	c.Assert(err, qt.IsNil)
+
+	got, err := v.ToJSONValue()
+	c.Assert(err, qt.IsNil)
+
+	c.Check(got, qt.ContentEquals, want)
+}

--- a/pkg/data/encode_test.go
+++ b/pkg/data/encode_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
 	"github.com/instill-ai/pipeline-backend/pkg/data/format"
 )
 

--- a/pkg/memory/memory.go
+++ b/pkg/memory/memory.go
@@ -13,7 +13,6 @@ import (
 	"github.com/instill-ai/pipeline-backend/pkg/data"
 	"github.com/instill-ai/pipeline-backend/pkg/data/format"
 	"github.com/instill-ai/pipeline-backend/pkg/data/path"
-	"github.com/instill-ai/pipeline-backend/pkg/datamodel"
 	"github.com/instill-ai/pipeline-backend/pkg/pubsub"
 )
 
@@ -61,7 +60,7 @@ const (
 )
 
 type MemoryStore interface {
-	NewWorkflowMemory(ctx context.Context, workflowID string, recipe *datamodel.Recipe, batchSize int) (workflow WorkflowMemory, err error)
+	NewWorkflowMemory(ctx context.Context, workflowID string, batchSize int) (workflow WorkflowMemory, err error)
 	GetWorkflowMemory(ctx context.Context, workflowID string) (workflow WorkflowMemory, err error)
 	PurgeWorkflowMemory(ctx context.Context, workflowID string) (err error)
 
@@ -191,7 +190,7 @@ func NewMemoryStore(pub pubsub.EventPublisher) MemoryStore {
 	}
 }
 
-func (ms *memoryStore) NewWorkflowMemory(ctx context.Context, workflowID string, r *datamodel.Recipe, batchSize int) (workflow WorkflowMemory, err error) {
+func (ms *memoryStore) NewWorkflowMemory(ctx context.Context, workflowID string, batchSize int) (workflow WorkflowMemory, err error) {
 	wfmData := make([]format.Value, batchSize)
 	for idx := range batchSize {
 		m := data.Map{

--- a/pkg/memory/store.go
+++ b/pkg/memory/store.go
@@ -1,0 +1,86 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/instill-ai/pipeline-backend/pkg/data"
+	"github.com/instill-ai/pipeline-backend/pkg/data/format"
+	"github.com/instill-ai/pipeline-backend/pkg/pubsub"
+)
+
+// Store is used to communicate the pipeline trigger information (inputs,
+// outputs, status) between processes (server, worker) during or after workflow
+// execution.
+type Store interface {
+	NewWorkflowMemory(_ context.Context, workflowID string, batchSize int) (WorkflowMemory, error)
+	GetWorkflowMemory(_ context.Context, workflowID string) (WorkflowMemory, error)
+	PurgeWorkflowMemory(_ context.Context, workflowID string) error
+
+	SendWorkflowStatusEvent(_ context.Context, workflowID string, event pubsub.Event) error
+}
+
+type store struct {
+	workflows sync.Map
+	publisher pubsub.EventPublisher
+}
+
+// NewStore returns an initialized memory stored.
+func NewStore(pub pubsub.EventPublisher) Store {
+	return &store{
+		workflows: sync.Map{},
+		publisher: pub,
+	}
+}
+
+func (s *store) NewWorkflowMemory(_ context.Context, workflowID string, batchSize int) (WorkflowMemory, error) {
+	wfmData := make([]format.Value, batchSize)
+	for idx := range batchSize {
+		m := data.Map{
+			string(PipelineVariable):   data.Map{},
+			string(PipelineSecret):     data.Map{},
+			string(PipelineConnection): data.Map{},
+			string(PipelineOutput):     data.Map{},
+		}
+
+		wfmData[idx] = m
+	}
+
+	s.workflows.Store(workflowID, &workflowMemory{
+		mu:              sync.Mutex{},
+		id:              workflowID,
+		data:            wfmData,
+		publishWFStatus: s.SendWorkflowStatusEvent,
+	})
+
+	wfm, ok := s.workflows.Load(workflowID)
+	if !ok {
+		return nil, fmt.Errorf("workflow memory not found")
+	}
+
+	return wfm.(WorkflowMemory), nil
+}
+
+func (s *store) GetWorkflowMemory(_ context.Context, workflowID string) (WorkflowMemory, error) {
+	wfm, ok := s.workflows.Load(workflowID)
+	if !ok {
+		return nil, fmt.Errorf("workflow memory not found")
+	}
+
+	return wfm.(WorkflowMemory), nil
+}
+
+func (s *store) PurgeWorkflowMemory(_ context.Context, workflowID string) error {
+	s.workflows.Delete(workflowID)
+	return nil
+}
+
+func (s *store) SendWorkflowStatusEvent(ctx context.Context, workflowID string, event pubsub.Event) error {
+	channel := pubsub.WorkflowStatusTopic(workflowID)
+	if err := s.publisher.PublishEvent(ctx, channel, event); err != nil {
+		return fmt.Errorf("publishing event: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/memory/store.go
+++ b/pkg/memory/store.go
@@ -20,11 +20,13 @@ type Store struct {
 	workflows sync.Map
 	publisher pubsub.EventPublisher
 
-	// This memory store implementation stores the workflow memory as a blob in
-	// MinIO. This is a first step in refactoring the pipeline trigger workflow
-	// that allows us to decouple the server and worker processes. We will
-	// further refactor this code to remove the communication through MinIO
-	// blobs.
+	// Due to the size of the workflow memory data, it needs to be persisted in
+	// MinIO (or another datastore) in order to be shared between different
+	// processes.
+	// TODO [INS-7456,INS-7457]: As we further refactor the workflow code, we
+	// might consider using an alternative datastore to remove duplication or
+	// not to hold data blobs in the memory, which would remove the need to
+	// commit and fetch the worfklow memory data.
 	minioClient minio.Client
 }
 

--- a/pkg/memory/store.go
+++ b/pkg/memory/store.go
@@ -111,7 +111,7 @@ func (s *Store) CommitWorkflowData(ctx context.Context, userUID uuid.UUID, wfm *
 		return fmt.Errorf("serializing workflow memory data: %w", err)
 	}
 
-	_, _, err = s.minioClient.UploadFileBytes(ctx, &minio.UploadFileBytesParam{
+	err = s.minioClient.UploadPrivateFileBytes(ctx, minio.UploadFileBytesParam{
 		UserUID:       userUID,
 		FilePath:      wfmFilePath(wfm.id),
 		FileBytes:     b,

--- a/pkg/memory/store.go
+++ b/pkg/memory/store.go
@@ -5,9 +5,12 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/gofrs/uuid"
+
 	"github.com/instill-ai/pipeline-backend/pkg/data"
 	"github.com/instill-ai/pipeline-backend/pkg/data/format"
 	"github.com/instill-ai/pipeline-backend/pkg/pubsub"
+	"github.com/instill-ai/x/minio"
 )
 
 // Store is used to communicate the pipeline trigger information (inputs,
@@ -16,13 +19,21 @@ import (
 type Store struct {
 	workflows sync.Map
 	publisher pubsub.EventPublisher
+
+	// This memory store implementation stores the workflow memory as a blob in
+	// MinIO. This is a first step in refactoring the pipeline trigger workflow
+	// that allows us to decouple the server and worker processes. We will
+	// further refactor this code to remove the communication through MinIO
+	// blobs.
+	minioClient minio.Client
 }
 
 // NewStore returns an initialized memory store.
-func NewStore(pub pubsub.EventPublisher) *Store {
+func NewStore(pub pubsub.EventPublisher, minioClient minio.Client) *Store {
 	return &Store{
-		workflows: sync.Map{},
-		publisher: pub,
+		workflows:   sync.Map{},
+		publisher:   pub,
+		minioClient: minioClient,
 	}
 }
 
@@ -75,4 +86,65 @@ func (s *Store) SendWorkflowStatusEvent(ctx context.Context, workflowID string, 
 	}
 
 	return nil
+}
+
+// WorkflowMemoryExpiryRuleTag will be used to automatically delete the
+// workflow memory blobs.
+const WorkflowMemoryExpiryRuleTag = "workflow-memory"
+
+// CommitWorkflowData persists the workflow memory data in a datastore.
+func (s *Store) CommitWorkflowData(ctx context.Context, userUID uuid.UUID, wfm *WorkflowMemory) error {
+	b, err := data.Encode(data.Array(wfm.data))
+	if err != nil {
+		return fmt.Errorf("serializing workflow memory data: %w", err)
+	}
+
+	_, _, err = s.minioClient.UploadFileBytes(ctx, &minio.UploadFileBytesParam{
+		UserUID:       userUID,
+		FilePath:      fmt.Sprintf("pipeline-runs/wfm/%s.json", wfm.id),
+		FileBytes:     b,
+		ExpiryRuleTag: WorkflowMemoryExpiryRuleTag,
+	})
+	if err != nil {
+		return fmt.Errorf("uploading workflow memory to MinIO: %w", err)
+	}
+
+	return nil
+}
+
+// FetchWorkflowMemory loads the workflow data into memory. This relies on
+// the workflow memory being stored via the CommitWorkflowData method,
+// and is used when separate processes want to share the workflow data.
+func (s *Store) FetchWorkflowMemory(ctx context.Context, userUID uuid.UUID, workflowID string) (*WorkflowMemory, error) {
+	objectName := fmt.Sprintf("pipeline-runs/wfm/%s.json", workflowID)
+	b, err := s.minioClient.GetFile(ctx, userUID, objectName)
+	if err != nil {
+		return nil, fmt.Errorf("downloading workflow memory from MinIO: %w", err)
+	}
+
+	v, err := data.Decode(b)
+	if err != nil {
+		return nil, fmt.Errorf("deserializing workflow memory data: %w", err)
+	}
+
+	wData, ok := v.(data.Array)
+	if !ok {
+		return nil, fmt.Errorf("workflow memory data should be an array")
+	}
+
+	var wfm *WorkflowMemory
+	if v, existsInMem := s.workflows.Load(workflowID); existsInMem {
+		wfm = v.(*WorkflowMemory)
+	} else {
+		wfm, err = s.NewWorkflowMemory(ctx, workflowID, len(wData))
+		if err != nil {
+			return nil, fmt.Errorf("creating workflow memory: %w", err)
+		}
+	}
+
+	wfm.mu.Lock()
+	defer wfm.mu.Unlock()
+	wfm.data = wData
+
+	return wfm, nil
 }

--- a/pkg/memory/workflow.go
+++ b/pkg/memory/workflow.go
@@ -81,12 +81,6 @@ type WorkflowMemory interface {
 	GetBatchSize() int
 }
 
-type ComponentStatus struct {
-	Started   bool `json:"started"`
-	Completed bool `json:"completed"`
-	Skipped   bool `json:"skipped"`
-}
-
 type workflowMemory struct {
 	mu        sync.Mutex
 	id        string

--- a/pkg/recipe/dag.go
+++ b/pkg/recipe/dag.go
@@ -155,7 +155,7 @@ func (d *dag) TopologicalSort() ([]datamodel.ComponentMap, error) {
 	return ans, nil
 }
 
-func Render(ctx context.Context, template format.Value, batchIdx int, wfm memory.WorkflowMemory, allowUnresolved bool) (format.Value, error) {
+func Render(ctx context.Context, template format.Value, batchIdx int, wfm *memory.WorkflowMemory, allowUnresolved bool) (format.Value, error) {
 	if input, ok := template.(format.ReferenceString); ok {
 		s := input.String()
 		if strings.HasPrefix(s, "${") && strings.HasSuffix(s, "}") && strings.Count(s, "${") == 1 {
@@ -336,7 +336,7 @@ func FindReferenceParent(input string) []string {
 	return upstreams
 }
 
-func GenerateTraces(ctx context.Context, compIDs []string, wfm memory.WorkflowMemory, full bool) (map[string]*pb.Trace, error) {
+func GenerateTraces(ctx context.Context, compIDs []string, wfm *memory.WorkflowMemory, full bool) (map[string]*pb.Trace, error) {
 	trace := map[string]*pb.Trace{}
 
 	batchSize := wfm.GetBatchSize()

--- a/pkg/service/convert.go
+++ b/pkg/service/convert.go
@@ -865,6 +865,7 @@ var supportedFormats = []string{
 	"video", "array:video",
 	"document", "array:document",
 	"file", "array:file",
+	"json",
 }
 
 // For fields without valid "format", we will fall back to using JSON format.

--- a/pkg/service/main.go
+++ b/pkg/service/main.go
@@ -108,7 +108,7 @@ type service struct {
 	aclClient                    acl.ACLClientInterface
 	converter                    Converter
 	minioClient                  minio.Client
-	memory                       memory.Store
+	memory                       *memory.Store
 	log                          *zap.Logger
 	workerUID                    uuid.UUID
 	retentionHandler             MetadataRetentionHandler
@@ -128,7 +128,7 @@ func NewService(
 	mgmtPrivateServiceClient mgmtpb.MgmtPrivateServiceClient,
 	minioClient minio.Client,
 	componentStore *componentstore.Store,
-	memory memory.Store,
+	memory *memory.Store,
 	workerUID uuid.UUID,
 	retentionHandler MetadataRetentionHandler,
 	binaryFetcher external.BinaryFetcher,

--- a/pkg/service/main.go
+++ b/pkg/service/main.go
@@ -108,7 +108,7 @@ type service struct {
 	aclClient                    acl.ACLClientInterface
 	converter                    Converter
 	minioClient                  minio.Client
-	memory                       memory.MemoryStore
+	memory                       memory.Store
 	log                          *zap.Logger
 	workerUID                    uuid.UUID
 	retentionHandler             MetadataRetentionHandler
@@ -128,7 +128,7 @@ func NewService(
 	mgmtPrivateServiceClient mgmtpb.MgmtPrivateServiceClient,
 	minioClient minio.Client,
 	componentStore *componentstore.Store,
-	memory memory.MemoryStore,
+	memory memory.Store,
 	workerUID uuid.UUID,
 	retentionHandler MetadataRetentionHandler,
 	binaryFetcher external.BinaryFetcher,

--- a/pkg/service/metadataretention.go
+++ b/pkg/service/metadataretention.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/gofrs/uuid"
 
+	"github.com/instill-ai/pipeline-backend/pkg/memory"
+
 	miniox "github.com/instill-ai/x/minio"
 )
 
@@ -29,6 +31,16 @@ func NewRetentionHandler() MetadataRetentionHandler {
 }
 
 var (
+	// WorkflowMemoryExpiryRule defines the expiration time for workflow memory
+	// blobs. This is the minimum expiration delay (1 day). Since processes
+	// creating a workflow memory blob are responsible of purging it after
+	// they're done with it, this is only a safeguard. By the time this
+	// expiration rule is applied, the blob should not exist.
+	WorkflowMemoryExpiryRule = miniox.ExpiryRule{
+		Tag:            memory.WorkflowMemoryExpiryRuleTag,
+		ExpirationDays: 1,
+	}
+
 	defaultExpiryRule = miniox.ExpiryRule{
 		Tag:            "default-expiry",
 		ExpirationDays: 3,
@@ -36,7 +48,7 @@ var (
 )
 
 func (h *metadataRetentionHandler) ListExpiryRules() []miniox.ExpiryRule {
-	return []miniox.ExpiryRule{defaultExpiryRule}
+	return []miniox.ExpiryRule{defaultExpiryRule, WorkflowMemoryExpiryRule}
 }
 
 func (h *metadataRetentionHandler) GetExpiryRuleByNamespace(_ context.Context, _ uuid.UUID) (miniox.ExpiryRule, error) {

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -923,7 +923,7 @@ func (s *service) preTriggerPipeline(
 		return fmt.Errorf("[Pipeline Trigger Data Error] %s", strings.Join(errors, "; "))
 	}
 
-	wfm, err := s.memory.NewWorkflowMemory(ctx, pipelineTriggerID, nil, len(pipelineData))
+	wfm, err := s.memory.NewWorkflowMemory(ctx, pipelineTriggerID, len(pipelineData))
 	if err != nil {
 		return err
 	}

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -1414,11 +1414,6 @@ func (s *service) preTriggerPipeline(
 		return fmt.Errorf("uploading pipeline run inputs to minio: %w", err)
 	}
 
-	isStreaming := resource.GetRequestSingleHeader(ctx, constant.HeaderAccept) == "text/event-stream"
-	if isStreaming {
-		wfm.EnableStreaming()
-	}
-
 	return nil
 }
 
@@ -1691,6 +1686,7 @@ func (s *service) triggerPipeline(
 		return nil, nil, err
 	}
 
+	isStreaming := resource.GetRequestSingleHeader(ctx, constant.HeaderAccept) == "text/event-stream"
 	we, err := s.temporalClient.ExecuteWorkflow(
 		ctx,
 		workflowOptions,
@@ -1709,6 +1705,7 @@ func (s *service) triggerPipeline(
 				HeaderAuthorization:  resource.GetRequestSingleHeader(ctx, "authorization"),
 				ExpiryRule:           triggerParams.expiryRule,
 			},
+			Streaming: isStreaming,
 			Mode:      mgmtpb.Mode_MODE_SYNC,
 			WorkerUID: s.workerUID,
 			Recipe:    triggerParams.recipe,
@@ -1780,6 +1777,7 @@ func (s *service) triggerAsyncPipeline(ctx context.Context, params triggerParams
 		return nil, err
 	}
 
+	isStreaming := resource.GetRequestSingleHeader(ctx, constant.HeaderAccept) == "text/event-stream"
 	we, err := s.temporalClient.ExecuteWorkflow(
 		ctx,
 		workflowOptions,
@@ -1798,6 +1796,7 @@ func (s *service) triggerAsyncPipeline(ctx context.Context, params triggerParams
 				HeaderAuthorization:  resource.GetRequestSingleHeader(ctx, "authorization"),
 				ExpiryRule:           params.expiryRule,
 			},
+			Streaming: isStreaming,
 			Mode:      mgmtpb.Mode_MODE_ASYNC,
 			WorkerUID: s.workerUID,
 			Recipe:    params.recipe,

--- a/pkg/service/pipeline_test.go
+++ b/pkg/service/pipeline_test.go
@@ -133,7 +133,7 @@ type serviceConfig struct {
 	mgmtPrivateServiceClient     mgmtpb.MgmtPrivateServiceClient
 	minioClient                  minio.Client
 	componentStore               *componentstore.Store
-	memory                       memory.Store
+	memory                       *memory.Store
 	workerUID                    uuid.UUID
 	retentionHandler             MetadataRetentionHandler
 	binaryFetcher                external.BinaryFetcher

--- a/pkg/service/pipeline_test.go
+++ b/pkg/service/pipeline_test.go
@@ -85,7 +85,7 @@ func TestService_UpdateNamespacePipelineByID(t *testing.T) {
 			converter:                converter,
 			mgmtPrivateServiceClient: mgmtPrivateClient,
 			componentStore:           compStore,
-			memory:                   memory.NewStore(nil),
+			memory:                   memory.NewStore(nil, nil),
 			workerUID:                workerUID,
 		},
 	)

--- a/pkg/service/pipeline_test.go
+++ b/pkg/service/pipeline_test.go
@@ -85,7 +85,7 @@ func TestService_UpdateNamespacePipelineByID(t *testing.T) {
 			converter:                converter,
 			mgmtPrivateServiceClient: mgmtPrivateClient,
 			componentStore:           compStore,
-			memory:                   memory.NewMemoryStore(nil),
+			memory:                   memory.NewStore(nil),
 			workerUID:                workerUID,
 		},
 	)
@@ -133,7 +133,7 @@ type serviceConfig struct {
 	mgmtPrivateServiceClient     mgmtpb.MgmtPrivateServiceClient
 	minioClient                  minio.Client
 	componentStore               *componentstore.Store
-	memory                       memory.MemoryStore
+	memory                       memory.Store
 	workerUID                    uuid.UUID
 	retentionHandler             MetadataRetentionHandler
 	binaryFetcher                external.BinaryFetcher

--- a/pkg/service/webhook.go
+++ b/pkg/service/webhook.go
@@ -276,7 +276,7 @@ type initEventWorkflowParams struct {
 
 func (s *service) initEventWorkflow(ctx context.Context, params initEventWorkflowParams) error {
 
-	wfm, err := s.memory.NewWorkflowMemory(ctx, params.pipelineTriggerUID.String(), nil, 1)
+	wfm, err := s.memory.NewWorkflowMemory(ctx, params.pipelineTriggerUID.String(), 1)
 	if err != nil {
 		return err
 	}

--- a/pkg/worker/io.go
+++ b/pkg/worker/io.go
@@ -14,7 +14,7 @@ import (
 )
 
 type setupReader struct {
-	memoryStore       memory.MemoryStore
+	memoryStore       memory.Store
 	workflowID        string
 	compID            string
 	processedBatchIDs []int
@@ -46,14 +46,14 @@ func (s *setupReader) Read(ctx context.Context) (setups []*structpb.Struct, err 
 }
 
 type inputReader struct {
-	memoryStore   memory.MemoryStore
+	memoryStore   memory.Store
 	workflowID    string
 	compID        string
 	originalIdx   int
 	binaryFetcher external.BinaryFetcher
 }
 
-func newInputReader(memoryStore memory.MemoryStore, workflowID string, compID string, originalIdx int, binaryFetcher external.BinaryFetcher) *inputReader {
+func newInputReader(memoryStore memory.Store, workflowID string, compID string, originalIdx int, binaryFetcher external.BinaryFetcher) *inputReader {
 	return &inputReader{
 		memoryStore:   memoryStore,
 		workflowID:    workflowID,
@@ -120,14 +120,14 @@ func (i *inputReader) ReadData(ctx context.Context, input any) (err error) {
 }
 
 type outputWriter struct {
-	memoryStore memory.MemoryStore
+	memoryStore memory.Store
 	workflowID  string
 	compID      string
 	originalIdx int
 	streaming   bool
 }
 
-func newOutputWriter(memoryStore memory.MemoryStore, workflowID string, compID string, originalIdx int, streaming bool) *outputWriter {
+func newOutputWriter(memoryStore memory.Store, workflowID string, compID string, originalIdx int, streaming bool) *outputWriter {
 	return &outputWriter{
 		memoryStore: memoryStore,
 		workflowID:  workflowID,
@@ -192,7 +192,7 @@ func (o *outputWriter) write(ctx context.Context, val format.Value) (err error) 
 }
 
 type errorHandler struct {
-	memoryStore memory.MemoryStore
+	memoryStore memory.Store
 	workflowID  string
 	compID      string
 	originalIdx int
@@ -202,7 +202,7 @@ type errorHandler struct {
 	parentOriginalIdx *int
 }
 
-func newErrorHandler(memoryStore memory.MemoryStore, workflowID string, compID string, originalIdx int, parentWorkflowID *string, parentCompID *string, parentOriginalIdx *int) *errorHandler {
+func newErrorHandler(memoryStore memory.Store, workflowID string, compID string, originalIdx int, parentWorkflowID *string, parentCompID *string, parentOriginalIdx *int) *errorHandler {
 	return &errorHandler{
 		memoryStore:       memoryStore,
 		workflowID:        workflowID,

--- a/pkg/worker/io.go
+++ b/pkg/worker/io.go
@@ -14,7 +14,7 @@ import (
 )
 
 type setupReader struct {
-	memoryStore       memory.Store
+	memoryStore       *memory.Store
 	workflowID        string
 	compID            string
 	processedBatchIDs []int
@@ -46,14 +46,14 @@ func (s *setupReader) Read(ctx context.Context) (setups []*structpb.Struct, err 
 }
 
 type inputReader struct {
-	memoryStore   memory.Store
+	memoryStore   *memory.Store
 	workflowID    string
 	compID        string
 	originalIdx   int
 	binaryFetcher external.BinaryFetcher
 }
 
-func newInputReader(memoryStore memory.Store, workflowID string, compID string, originalIdx int, binaryFetcher external.BinaryFetcher) *inputReader {
+func newInputReader(memoryStore *memory.Store, workflowID string, compID string, originalIdx int, binaryFetcher external.BinaryFetcher) *inputReader {
 	return &inputReader{
 		memoryStore:   memoryStore,
 		workflowID:    workflowID,
@@ -120,14 +120,14 @@ func (i *inputReader) ReadData(ctx context.Context, input any) (err error) {
 }
 
 type outputWriter struct {
-	memoryStore memory.Store
+	memoryStore *memory.Store
 	workflowID  string
 	compID      string
 	originalIdx int
 	streaming   bool
 }
 
-func newOutputWriter(memoryStore memory.Store, workflowID string, compID string, originalIdx int, streaming bool) *outputWriter {
+func newOutputWriter(memoryStore *memory.Store, workflowID string, compID string, originalIdx int, streaming bool) *outputWriter {
 	return &outputWriter{
 		memoryStore: memoryStore,
 		workflowID:  workflowID,
@@ -192,7 +192,7 @@ func (o *outputWriter) write(ctx context.Context, val format.Value) (err error) 
 }
 
 type errorHandler struct {
-	memoryStore memory.Store
+	memoryStore *memory.Store
 	workflowID  string
 	compID      string
 	originalIdx int
@@ -202,7 +202,7 @@ type errorHandler struct {
 	parentOriginalIdx *int
 }
 
-func newErrorHandler(memoryStore memory.Store, workflowID string, compID string, originalIdx int, parentWorkflowID *string, parentCompID *string, parentOriginalIdx *int) *errorHandler {
+func newErrorHandler(memoryStore *memory.Store, workflowID string, compID string, originalIdx int, parentWorkflowID *string, parentCompID *string, parentOriginalIdx *int) *errorHandler {
 	return &errorHandler{
 		memoryStore:       memoryStore,
 		workflowID:        workflowID,

--- a/pkg/worker/main.go
+++ b/pkg/worker/main.go
@@ -30,7 +30,7 @@ type Worker interface {
 	TriggerPipelineWorkflow(workflow.Context, *TriggerPipelineWorkflowParam) error
 	SchedulePipelineWorkflow(workflow.Context, *scheduler.SchedulePipelineWorkflowParam) error
 
-	LoadWorkflowMemory(_ context.Context, userUID uuid.UUID, workflowID string) error
+	LoadWorkflowMemory(context.Context, LoadWorkflowMemoryActivityParam) error
 	ComponentActivity(context.Context, *ComponentActivityParam) error
 	OutputActivity(context.Context, *ComponentActivityParam) error
 	PreIteratorActivity(context.Context, *PreIteratorActivityParam) ([]ChildPipelineTriggerParams, error)

--- a/pkg/worker/main.go
+++ b/pkg/worker/main.go
@@ -55,7 +55,7 @@ type WorkerConfig struct {
 	InfluxDBWriteClient          api.WriteAPI
 	Component                    *componentstore.Store
 	MinioClient                  minio.Client
-	MemoryStore                  memory.Store
+	MemoryStore                  *memory.Store
 	WorkerUID                    uuid.UUID
 	ArtifactPublicServiceClient  artifactpb.ArtifactPublicServiceClient
 	ArtifactPrivateServiceClient artifactpb.ArtifactPrivateServiceClient
@@ -71,7 +71,7 @@ type worker struct {
 	component                    *componentstore.Store
 	minioClient                  minio.Client
 	log                          *zap.Logger
-	memoryStore                  memory.Store
+	memoryStore                  *memory.Store
 	workerUID                    uuid.UUID
 	artifactPublicServiceClient  artifactpb.ArtifactPublicServiceClient
 	artifactPrivateServiceClient artifactpb.ArtifactPrivateServiceClient

--- a/pkg/worker/main.go
+++ b/pkg/worker/main.go
@@ -30,6 +30,7 @@ type Worker interface {
 	TriggerPipelineWorkflow(workflow.Context, *TriggerPipelineWorkflowParam) error
 	SchedulePipelineWorkflow(workflow.Context, *scheduler.SchedulePipelineWorkflowParam) error
 
+	LoadWorkflowMemory(_ context.Context, userUID uuid.UUID, workflowID string) error
 	ComponentActivity(context.Context, *ComponentActivityParam) error
 	OutputActivity(context.Context, *ComponentActivityParam) error
 	PreIteratorActivity(context.Context, *PreIteratorActivityParam) ([]ChildPipelineTriggerParams, error)

--- a/pkg/worker/main.go
+++ b/pkg/worker/main.go
@@ -55,7 +55,7 @@ type WorkerConfig struct {
 	InfluxDBWriteClient          api.WriteAPI
 	Component                    *componentstore.Store
 	MinioClient                  minio.Client
-	MemoryStore                  memory.MemoryStore
+	MemoryStore                  memory.Store
 	WorkerUID                    uuid.UUID
 	ArtifactPublicServiceClient  artifactpb.ArtifactPublicServiceClient
 	ArtifactPrivateServiceClient artifactpb.ArtifactPrivateServiceClient
@@ -71,7 +71,7 @@ type worker struct {
 	component                    *componentstore.Store
 	minioClient                  minio.Client
 	log                          *zap.Logger
-	memoryStore                  memory.MemoryStore
+	memoryStore                  memory.Store
 	workerUID                    uuid.UUID
 	artifactPublicServiceClient  artifactpb.ArtifactPublicServiceClient
 	artifactPrivateServiceClient artifactpb.ArtifactPrivateServiceClient

--- a/pkg/worker/workflow.go
+++ b/pkg/worker/workflow.go
@@ -919,7 +919,7 @@ func (w *worker) PostIteratorActivity(ctx context.Context, param *PostIteratorAc
 // preTriggerErr returns a function that handles errors that happen during the
 // trigger workflow setup, i.e., before the components start to be executed.
 // If the trigger is streamed, it will send an event to halt the execution.
-func (w *worker) preTriggerErr(ctx context.Context, workflowID string, wfm memory.WorkflowMemory) func(error) error {
+func (w *worker) preTriggerErr(ctx context.Context, workflowID string, wfm *memory.WorkflowMemory) func(error) error {
 	return func(err error) error {
 		if msg := errmsg.Message(err); msg != "" {
 			err = temporal.NewApplicationErrorWithCause(msg, preTriggerErrorType, err)
@@ -1025,7 +1025,7 @@ func (w *worker) loadConnectionFromComponent(
 // the connection value is overwritten.
 func (w *worker) mergeInputConnections(
 	ctx context.Context,
-	wfm memory.WorkflowMemory,
+	wfm *memory.WorkflowMemory,
 	idx int,
 	requesterUID uuid.UUID,
 	pipelineConnections data.Map,
@@ -1312,7 +1312,7 @@ func (w *worker) IncreasePipelineTriggerCountActivity(ctx context.Context, sv re
 
 // processCondition processes the conditions of a batch, returning the batch
 // IDs that should be processed.
-func (w *worker) processCondition(ctx context.Context, wfm memory.WorkflowMemory, id string, upstreamIDs []string, condition string) ([]int, error) {
+func (w *worker) processCondition(ctx context.Context, wfm *memory.WorkflowMemory, id string, upstreamIDs []string, condition string) ([]int, error) {
 	processedIDs := make([]int, 0, wfm.GetBatchSize())
 
 	for idx := range wfm.GetBatchSize() {
@@ -1396,7 +1396,7 @@ func (w *worker) pipelineTriggerDataPoint(workflowID string, sysVars recipe.Syst
 // componentActivityError transforms an error with (potentially) an end-user
 // message into a Temporal application error. Temporal clients can extract the
 // message and propagate it to the end user.
-func componentActivityError(ctx context.Context, wfm memory.WorkflowMemory, err error, errType, componentID string) error {
+func componentActivityError(ctx context.Context, wfm *memory.WorkflowMemory, err error, errType, componentID string) error {
 	if wfm == nil {
 		return fmt.Errorf("workflow memory is empty")
 	}

--- a/pkg/worker/workflow.go
+++ b/pkg/worker/workflow.go
@@ -1237,7 +1237,7 @@ func (w *worker) SendStartedEventActivity(ctx context.Context, workflowID string
 	return nil
 }
 
-// PostTriggerActivity copy the trigger memory from MemoryStore to Redis.
+// PostTriggerActivity copies the trigger memory to Redis.
 func (w *worker) PostTriggerActivity(ctx context.Context, param *PostTriggerActivityParam) error {
 
 	logger, _ := logger.GetZapLogger(ctx)

--- a/pkg/worker/workflow.go
+++ b/pkg/worker/workflow.go
@@ -776,7 +776,7 @@ func (w *worker) PreIteratorActivity(ctx context.Context, param *PreIteratorActi
 			}
 		}
 
-		childWFM, err := w.memoryStore.NewWorkflowMemory(ctx, childWorkflowID, param.IteratorRecipe, len(indexes))
+		childWFM, err := w.memoryStore.NewWorkflowMemory(ctx, childWorkflowID, len(indexes))
 		if err != nil {
 			return nil, componentActivityError(ctx, wfm, err, preIteratorActivityErrorType, param.ID)
 		}

--- a/pkg/worker/workflow.go
+++ b/pkg/worker/workflow.go
@@ -1247,9 +1247,8 @@ func (w *worker) SendStartedEventActivity(ctx context.Context, workflowID string
 	return nil
 }
 
-// PostTriggerActivity copies the trigger memory to Redis.
+// PostTriggerActivity commits the workflow memory and copies it to Redis.
 func (w *worker) PostTriggerActivity(ctx context.Context, param *PostTriggerActivityParam) error {
-
 	logger, _ := logger.GetZapLogger(ctx)
 	logger.Info("PostTriggerActivity started")
 
@@ -1301,6 +1300,10 @@ func (w *worker) PostTriggerActivity(ctx context.Context, param *PostTriggerActi
 				return temporal.NewApplicationErrorWithCause("sending event", postTriggerActivityErrorType, err)
 			}
 		}
+	}
+
+	if err := w.memoryStore.CommitWorkflowData(ctx, param.SystemVariables.PipelineUserUID, wfm); err != nil {
+		return temporal.NewApplicationErrorWithCause("committing workflow memory", postTriggerActivityErrorType, err)
 	}
 
 	logger.Info("PostTriggerActivity completed")

--- a/pkg/worker/workflow.go
+++ b/pkg/worker/workflow.go
@@ -122,11 +122,6 @@ type InitComponentsActivityParam struct {
 	Recipe          *datamodel.Recipe
 }
 
-type LoadDAGDataActivityResult struct {
-	Recipe    *datamodel.Recipe
-	BatchSize int
-}
-
 type PostTriggerActivityParam struct {
 	WorkflowID      string
 	SystemVariables recipe.SystemVariables


### PR DESCRIPTION
Because

- We're communicating the workflow memory information between the temporal clients and workers through an in-memory structure.
- This forces us to run the worker in the same process as the client.

This commit

- Stores and reads the workflow memory as a MinIO blob to decouple client and worker.
