### PR TITLE
fix(worker): use pipeline server host in pipeline client

### DIFF
--- a/pkg/external/external.go
+++ b/pkg/external/external.go
@@ -45,7 +45,16 @@ func InitPipelinePublicServiceClient(ctx context.Context) (pipelinepb.PipelinePu
 		clientDialOpts = grpc.WithTransportCredentials(insecure.NewCredentials())
 	}
 
-	clientConn, err := grpc.NewClient(fmt.Sprintf(":%v", config.Config.Server.PublicPort), clientDialOpts, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(constant.MaxPayloadSize), grpc.MaxCallSendMsgSize(constant.MaxPayloadSize)))
+	// We need to specify the host because several parts of the code (e.g.
+	// worker) might be deployed in a separate container.
+	clientConn, err := grpc.NewClient(
+		fmt.Sprintf("%v:%v", config.Config.Server.InstanceID, config.Config.Server.PublicPort),
+		clientDialOpts,
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(constant.MaxPayloadSize),
+			grpc.MaxCallSendMsgSize(constant.MaxPayloadSize),
+		),
+	)
 	if err != nil {
 		logger.Error(err.Error())
 		return nil, nil


### PR DESCRIPTION
Because

- The worker needs to make requests to the pipeline server, but this process might be run in a separate container.

This commit

- Uses the server's instance ID in the configuration to connect to the pipeline server.
