### PR TITLE
fix(document): fix the document cannot be converted to an image

### DIFF
--- a/pkg/component/internal/util/helper.go
+++ b/pkg/component/internal/util/helper.go
@@ -300,7 +300,7 @@ func ExecutePythonCode(pythonCode string, params map[string]interface{}) ([]byte
 		errChan <- nil
 	}()
 
-	outputBytes, err := cmdRunner.CombinedOutput()
+	outputBytes, err := cmdRunner.Output()
 
 	if err != nil {
 		errorStr := string(outputBytes)


### PR DESCRIPTION
Because:

- We use `CombinedOutput()` to get the output of the Python script, which contains both `stdout` and `stderr`. Some libraries print warnings or other messages in `stderr`, causing Go to retrieve incorrect results.

This commit:

- Fetches the data only from `stdout`.