### PR TITLE
fix(iterator): always initialize pipeline output template

### DIFF
--- a/pkg/memory/store.go
+++ b/pkg/memory/store.go
@@ -43,10 +43,11 @@ func (s *Store) NewWorkflowMemory(_ context.Context, workflowID string, batchSiz
 	wfmData := make([]format.Value, batchSize)
 	for idx := range batchSize {
 		m := data.Map{
-			string(PipelineVariable):   data.Map{},
-			string(PipelineSecret):     data.Map{},
-			string(PipelineConnection): data.Map{},
-			string(PipelineOutput):     data.Map{},
+			string(PipelineVariable):       data.Map{},
+			string(PipelineSecret):         data.Map{},
+			string(PipelineConnection):     data.Map{},
+			string(PipelineOutput):         data.Map{},
+			string(PipelineOutputTemplate): data.Map{},
 		}
 
 		wfmData[idx] = m

--- a/pkg/memory/workflow.go
+++ b/pkg/memory/workflow.go
@@ -274,6 +274,11 @@ func (wfm *WorkflowMemory) SetPipelineData(ctx context.Context, batchIdx int, t 
 	if !wfm.streaming {
 		return nil
 	}
+
+	if t != PipelineOutput {
+		return nil
+	}
+
 	// TODO: simplify struct conversion
 	s, err := value.ToStructValue()
 	if err != nil {
@@ -287,10 +292,6 @@ func (wfm *WorkflowMemory) SetPipelineData(ctx context.Context, batchIdx int, t 
 	err = json.Unmarshal(b, &data)
 	if err != nil {
 		return err
-	}
-
-	if t != PipelineOutput {
-		return nil
 	}
 
 	event := pubsub.Event{

--- a/pkg/worker/io.go
+++ b/pkg/worker/io.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"fmt"
 
 	"google.golang.org/protobuf/types/known/structpb"
 
@@ -165,26 +166,26 @@ func (o *outputWriter) Write(ctx context.Context, output *structpb.Struct) (err 
 func (o *outputWriter) write(ctx context.Context, val format.Value) (err error) {
 	wfm, err := o.memoryStore.GetWorkflowMemory(ctx, o.workflowID)
 	if err != nil {
-		return err
+		return fmt.Errorf("getting workflow memory: %w", err)
 	}
 
 	if err := wfm.SetComponentData(ctx, o.originalIdx, o.compID, memory.ComponentDataOutput, val); err != nil {
-		return err
+		return fmt.Errorf("setting component output data: %w", err)
 	}
 
 	if o.streaming {
 		outputTemplate, err := wfm.Get(ctx, o.originalIdx, string(memory.PipelineOutputTemplate))
 		if err != nil {
-			return err
+			return fmt.Errorf("getting output template: %w", err)
 		}
 
 		output, err := recipe.Render(ctx, outputTemplate, o.originalIdx, wfm, true)
 		if err != nil {
-			return err
+			return fmt.Errorf("rendering output template: %w", err)
 		}
 		err = wfm.SetPipelineData(ctx, o.originalIdx, memory.PipelineOutput, output)
 		if err != nil {
-			return err
+			return fmt.Errorf("setting pipeline output data: %w", err)
 		}
 	}
 


### PR DESCRIPTION
Because

- Streamed executions with iterators failed because the `_output` key
  wasn't set in the iterator's child workflow memory. This is
  initialized on `InitComponentsActivity`, which is run only on parent
  workflows.

This commit

- Intializes this field on workflow memory creation. `ComponentActivity`
  will use it to update the (child) pipeline output at the end of the
  sub-component execution.
