### PR TITLE
fix(component,artifact): remove duplicated connection close

### DIFF
--- a/pkg/component/data/instillartifact/v0/task_get_chunks_metadata.go
+++ b/pkg/component/data/instillartifact/v0/task_get_chunks_metadata.go
@@ -21,9 +21,7 @@ func (e *execution) getChunksMetadata(input *structpb.Struct) (*structpb.Struct,
 		return nil, fmt.Errorf("failed to convert input to struct: %w", err)
 	}
 
-	artifactClient, connection := e.client, e.connection
-
-	defer connection.Close()
+	artifactClient := e.client
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()

--- a/pkg/component/data/instillartifact/v0/task_get_file_in_markdown.go
+++ b/pkg/component/data/instillartifact/v0/task_get_file_in_markdown.go
@@ -21,9 +21,7 @@ func (e *execution) getFileInMarkdown(input *structpb.Struct) (*structpb.Struct,
 		return nil, fmt.Errorf("failed to convert input to struct: %w", err)
 	}
 
-	artifactClient, connection := e.client, e.connection
-
-	defer connection.Close()
+	artifactClient := e.client
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()

--- a/pkg/component/data/instillartifact/v0/task_get_files_metadata.go
+++ b/pkg/component/data/instillartifact/v0/task_get_files_metadata.go
@@ -22,9 +22,7 @@ func (e *execution) getFilesMetadata(input *structpb.Struct) (*structpb.Struct, 
 		return nil, fmt.Errorf("failed to convert input to struct: %w", err)
 	}
 
-	artifactClient, connection := e.client, e.connection
-
-	defer connection.Close()
+	artifactClient := e.client
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()

--- a/pkg/component/data/instillartifact/v0/task_match_files_status.go
+++ b/pkg/component/data/instillartifact/v0/task_match_files_status.go
@@ -21,9 +21,7 @@ func (e *execution) matchFileStatus(input *structpb.Struct) (*structpb.Struct, e
 		return nil, fmt.Errorf("failed to convert input to struct: %w", err)
 	}
 
-	artifactClient, connection := e.client, e.connection
-
-	defer connection.Close()
+	artifactClient := e.client
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()

--- a/pkg/component/data/instillartifact/v0/task_query.go
+++ b/pkg/component/data/instillartifact/v0/task_query.go
@@ -21,9 +21,7 @@ func (e *execution) query(input *structpb.Struct) (*structpb.Struct, error) {
 		return nil, fmt.Errorf("failed to convert input to struct: %w", err)
 	}
 
-	artifactClient, connection := e.client, e.connection
-
-	defer connection.Close()
+	artifactClient := e.client
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()

--- a/pkg/component/data/instillartifact/v0/task_search_chunks.go
+++ b/pkg/component/data/instillartifact/v0/task_search_chunks.go
@@ -21,9 +21,7 @@ func (e *execution) searchChunks(input *structpb.Struct) (*structpb.Struct, erro
 		return nil, fmt.Errorf("failed to convert input to struct: %w", err)
 	}
 
-	artifactClient, connection := e.client, e.connection
-
-	defer connection.Close()
+	artifactClient := e.client
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()

--- a/pkg/component/data/instillartifact/v0/task_sync_files.go
+++ b/pkg/component/data/instillartifact/v0/task_sync_files.go
@@ -53,9 +53,7 @@ func (e *execution) syncFiles(input *structpb.Struct) (*structpb.Struct, error) 
 		return nil, fmt.Errorf("convert input to struct: %w", err)
 	}
 
-	artifactClient, connection := e.client, e.connection
-
-	defer connection.Close()
+	artifactClient := e.client
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()

--- a/pkg/component/data/instillartifact/v0/task_upload_files.go
+++ b/pkg/component/data/instillartifact/v0/task_upload_files.go
@@ -29,8 +29,7 @@ func (e *execution) uploadFiles(input *structpb.Struct) (*structpb.Struct, error
 		return nil, fmt.Errorf("number of files and file names do not match")
 	}
 
-	artifactClient, connection := e.client, e.connection
-	defer connection.Close()
+	artifactClient := e.client
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()


### PR DESCRIPTION
Because

- connection is close before execution completed.

This commit

- remove duplicated connection close.
