### PR TITLE
fix(component,audio): fix wrong instill type

### DIFF
--- a/pkg/component/operator/audio/v0/config/tasks.yaml
+++ b/pkg/component/operator/audio/v0/config/tasks.yaml
@@ -93,7 +93,7 @@ TASK_SEGMENT:
         description: A list of segmented audio data.
         uiOrder: 0
         items:
-          type: string
+          type: audio
         title: Audios
         type: array
     required:


### PR DESCRIPTION
Because

- the Instill Type for audio output was not correct.

This commit

- fixes wrong instill type
