### PR TITLE
fix(component-run): set component status when execution failed

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -89,10 +89,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Get short SHA
-        id: short-sha
-        run: echo "SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
-
       - name: Build image
         uses: docker/build-push-action@v6
         with:
@@ -101,7 +97,7 @@ jobs:
           build-args: |
             SERVICE_NAME=pipeline-backend
             SERVICE_VERSION=${{ steps.short-sha.outputs.SHORT_SHA }}
-          tags: instill/pipeline-backend:${{ steps.short-sha.outputs.SHORT_SHA }}
+          tags: instill/pipeline-backend:latest
           cache-from: |
             type=registry,ref=instill/pipeline-backend:buildcache
           cache-to: |

--- a/integration-test/pipeline/grpc-pipeline-private.js
+++ b/integration-test/pipeline/grpc-pipeline-private.js
@@ -48,7 +48,7 @@ export function CheckList(data) {
     for (var i = 0; i < numPipelines; i++) {
       reqBodies[i] = Object.assign(
         {
-          id: randomString(10),
+          id: constant.dbIDPrefix + randomString(10),
           description: randomString(50),
         },
         constant.simplePipelineWithYAMLRecipe
@@ -229,7 +229,7 @@ export function CheckLookUp(data) {
 
     var reqBody = Object.assign(
       {
-        id: randomString(10),
+        id: constant.dbIDPrefix + randomString(10),
       },
       constant.simplePipelineWithYAMLRecipe
     );

--- a/integration-test/pipeline/grpc-pipeline-public-with-jwt.js
+++ b/integration-test/pipeline/grpc-pipeline-public-with-jwt.js
@@ -17,7 +17,7 @@ export function CheckCreate(data) {
 
       var reqBody = Object.assign(
         {
-          id: randomString(32),
+          id: constant.dbIDPrefix + randomString(10),
           description: randomString(50),
         },
         constant.simplePipelineWithYAMLRecipe
@@ -77,7 +77,7 @@ export function CheckGet(data) {
 
     var reqBody = Object.assign(
       {
-        id: randomString(10),
+        id: constant.dbIDPrefix + randomString(10),
         description: randomString(50),
       },
       constant.simplePipelineWithYAMLRecipe
@@ -143,7 +143,7 @@ export function CheckUpdate(data) {
 
       var reqBody = Object.assign(
         {
-          id: randomString(10),
+          id: constant.dbIDPrefix + randomString(10),
         },
         constant.simplePipelineWithYAMLRecipe
       );
@@ -217,7 +217,7 @@ export function CheckRename(data) {
 
       var reqBody = Object.assign(
         {
-          id: randomString(10),
+          id: constant.dbIDPrefix + randomString(10),
         },
         constant.simplePipelineWithYAMLRecipe
       );
@@ -288,7 +288,7 @@ export function CheckLookUp(data) {
 
       var reqBody = Object.assign(
         {
-          id: randomString(10),
+          id: constant.dbIDPrefix + randomString(10),
         },
         constant.simplePipelineWithYAMLRecipe
       );

--- a/integration-test/pipeline/grpc-pipeline-public.js
+++ b/integration-test/pipeline/grpc-pipeline-public.js
@@ -17,7 +17,7 @@ export function CheckCreate(data) {
 
     var reqBody = Object.assign(
       {
-        id: randomString(32),
+        id: constant.dbIDPrefix + randomString(10),
         description: randomString(50),
       },
       constant.simplePipelineWithYAMLRecipe
@@ -163,7 +163,7 @@ export function CheckCreate(data) {
       }
     );
 
-    reqBody.id = randomString(40);
+    reqBody.id = constant.dbIDPrefix + randomString(40);
     check(
       client.invoke(
         "pipeline.pipeline.v1beta.PipelinePublicService/CreateUserPipeline",
@@ -243,7 +243,7 @@ export function CheckList(data) {
     for (var i = 0; i < numPipelines; i++) {
       reqBodies[i] = Object.assign(
         {
-          id: randomString(10),
+          id: constant.dbIDPrefix + randomString(10),
           description: randomString(50),
         },
         constant.simplePipelineWithYAMLRecipe
@@ -430,7 +430,7 @@ export function CheckGet(data) {
 
     var reqBody = Object.assign(
       {
-        id: randomString(10),
+        id: constant.dbIDPrefix + randomString(10),
         description: randomString(50),
       },
       constant.simplePipelineWithYAMLRecipe
@@ -536,7 +536,7 @@ export function CheckUpdate(data) {
 
     var reqBody = Object.assign(
       {
-        id: randomString(10),
+        id: constant.dbIDPrefix + randomString(10),
       },
       constant.simplePipelineWithYAMLRecipe
     );
@@ -696,7 +696,7 @@ export function CheckRename(data) {
 
     var reqBody = Object.assign(
       {
-        id: randomString(10),
+        id: constant.dbIDPrefix + randomString(10),
       },
       constant.simplePipelineWithYAMLRecipe
     );
@@ -767,7 +767,7 @@ export function CheckLookUp(data) {
 
     var reqBody = Object.assign(
       {
-        id: randomString(10),
+        id: constant.dbIDPrefix + randomString(10),
       },
       constant.simplePipelineWithYAMLRecipe
     );

--- a/integration-test/pipeline/grpc-trigger-async.js
+++ b/integration-test/pipeline/grpc-trigger-async.js
@@ -19,7 +19,7 @@ export function CheckTrigger(data) {
 
       var reqBody = Object.assign(
         {
-          id: randomString(10),
+          id: constant.dbIDPrefix + randomString(10),
           description: randomString(50),
         },
         constant.simplePipelineWithYAMLRecipe
@@ -85,7 +85,7 @@ export function CheckTrigger(data) {
 
       var reqBody = Object.assign(
         {
-          id: randomString(10),
+          id: constant.dbIDPrefix + randomString(10),
           description: randomString(50),
         },
         constant.simplePipelineWithYAMLRecipe

--- a/integration-test/pipeline/grpc-trigger.js
+++ b/integration-test/pipeline/grpc-trigger.js
@@ -18,7 +18,7 @@ export function CheckTrigger(data) {
 
       var reqGRPC = Object.assign(
         {
-          id: randomString(10),
+          id: constant.dbIDPrefix + randomString(10),
           description: randomString(50),
         },
         constant.simplePipelineWithYAMLRecipe
@@ -84,7 +84,7 @@ export function CheckTrigger(data) {
 
       var reqGRPC = Object.assign(
         {
-          id: randomString(10),
+          id: constant.dbIDPrefix + randomString(10),
           description: randomString(50),
         },
         constant.simplePipelineWithYAMLRecipe

--- a/integration-test/pipeline/grpc.js
+++ b/integration-test/pipeline/grpc.js
@@ -143,9 +143,10 @@ export function teardown(data) {
     client.close();
   });
 
-  client.connect(constant.pipelineGRPCPublicHost, {
-    plaintext: true,
-  });
+  group("Integration API: Delete data created by this test", () => {
+    var q = `DELETE FROM pipeline WHERE id LIKE '${constant.dbIDPrefix}%';`;
+    constant.db.exec(q);
 
-  client.close();
+    constant.db.close();
+  });
 }

--- a/integration-test/pipeline/rest-pipeline-private.js
+++ b/integration-test/pipeline/rest-pipeline-private.js
@@ -30,7 +30,7 @@ export function CheckList(data) {
     for (var i = 0; i < numPipelines; i++) {
       reqBodies[i] = Object.assign(
         {
-          id: randomString(10),
+          id: constant.dbIDPrefix + randomString(10),
           description: randomString(50),
         },
         constant.simplePipelineWithYAMLRecipe
@@ -198,7 +198,7 @@ export function CheckLookUp(data) {
   group("Pipelines API: Look up a pipeline by uid by admin", () => {
     var reqBody = Object.assign(
       {
-        id: randomString(10),
+        id: constant.dbIDPrefix + randomString(10),
       },
       constant.simplePipelineWithYAMLRecipe
     );

--- a/integration-test/pipeline/rest-pipeline-public-with-jwt.js
+++ b/integration-test/pipeline/rest-pipeline-public-with-jwt.js
@@ -12,7 +12,7 @@ export function CheckCreate(data) {
     () => {
       var reqBody = Object.assign(
         {
-          id: randomString(32),
+          id: constant.dbIDPrefix + randomString(10),
           description: randomString(50),
         },
         constant.simplePipelineWithYAMLRecipe
@@ -57,7 +57,7 @@ export function CheckGet(data) {
   group(`Pipelines API: Get a pipeline [with random "Instill-User-Uid" header]`, () => {
     var reqBody = Object.assign(
       {
-        id: randomString(10),
+        id: constant.dbIDPrefix + randomString(10),
         description: randomString(50),
       },
       constant.simplePipelineWithYAMLRecipe
@@ -113,7 +113,7 @@ export function CheckUpdate(data) {
     () => {
       var reqBody = Object.assign(
         {
-          id: randomString(10),
+          id: constant.dbIDPrefix + randomString(10),
         },
         constant.simplePipelineWithYAMLRecipe
       );
@@ -173,7 +173,7 @@ export function CheckRename(data) {
   group(
     `Pipelines API: Rename a pipeline [with random "Instill-User-Uid" header]`,
     () => {
-      var id = randomString(10);
+      var id = constant.dbIDPrefix + randomString(10);
       var reqBody = Object.assign(
         {
           id: id,
@@ -196,7 +196,7 @@ export function CheckRename(data) {
           r.json().pipeline.name === `${constant.namespace}/pipelines/${reqBody.id}`,
       });
 
-      reqBody.new_pipeline_id = randomString(10);
+      reqBody.new_pipeline_id = constant.dbIDPrefix + randomString(10);
 
       // Cannot rename a pipeline of a non-exist user
       check(
@@ -236,7 +236,7 @@ export function CheckLookUp(data) {
     () => {
       var reqBody = Object.assign(
         {
-          id: randomString(10),
+          id: constant.dbIDPrefix + randomString(10),
         },
         constant.simplePipelineWithYAMLRecipe
       );

--- a/integration-test/pipeline/rest-pipeline-public.js
+++ b/integration-test/pipeline/rest-pipeline-public.js
@@ -12,7 +12,7 @@ export function CheckCreate(data) {
 
     var reqBody = Object.assign(
       {
-        id: randomString(32),
+        id: constant.dbIDPrefix + randomString(10),
         description: randomString(50),
       },
       constant.simplePipelineWithYAMLRecipe
@@ -155,7 +155,7 @@ export function CheckCreate(data) {
       }
     );
 
-    reqBody.id = randomString(40);
+    reqBody.id = constant.dbIDPrefix + randomString(40);
     check(
       http.request(
         "POST",
@@ -219,7 +219,7 @@ export function CheckList(data) {
     for (var i = 0; i < numPipelines; i++) {
       reqBodies[i] = Object.assign(
         {
-          id: randomString(10),
+          id: constant.dbIDPrefix + randomString(10),
           description: randomString(50),
         },
         constant.simplePipelineWithYAMLRecipe
@@ -390,7 +390,7 @@ export function CheckGet(data) {
   group("Pipelines API: Get a pipeline", () => {
     var reqBody = Object.assign(
       {
-        id: randomString(10),
+        id: constant.dbIDPrefix + randomString(10),
         description: randomString(50),
       },
       constant.simplePipelineWithYAMLRecipe
@@ -483,7 +483,7 @@ export function CheckUpdate(data) {
   group("Pipelines API: Update a pipeline", () => {
     var reqBody = Object.assign(
       {
-        id: randomString(10),
+        id: constant.dbIDPrefix + randomString(10),
       },
       constant.simplePipelineWithYAMLRecipe
     );
@@ -574,7 +574,7 @@ export function CheckUpdate(data) {
       }
     );
 
-    reqBodyUpdate.id = randomString(10);
+    reqBodyUpdate.id = constant.dbIDPrefix + randomString(10);
     check(
       http.request(
         "PATCH",
@@ -636,7 +636,7 @@ export function CheckRename(data) {
   group("Pipelines API: Rename a pipeline", () => {
     var reqBody = Object.assign(
       {
-        id: randomString(10),
+        id: constant.dbIDPrefix + randomString(10),
       },
       constant.simplePipelineWithYAMLRecipe
     );
@@ -655,7 +655,7 @@ export function CheckRename(data) {
         r.json().pipeline.name === `${constant.namespace}/pipelines/${reqBody.id}`,
     });
 
-    reqBody.new_pipeline_id = randomString(10);
+    reqBody.new_pipeline_id = constant.dbIDPrefix + randomString(10);
 
     check(
       http.request(
@@ -697,7 +697,7 @@ export function CheckLookUp(data) {
   group("Pipelines API: Look up a pipeline by uid", () => {
     var reqBody = Object.assign(
       {
-        id: randomString(10),
+        id: constant.dbIDPrefix + randomString(10),
       },
       constant.simplePipelineWithYAMLRecipe
     );

--- a/integration-test/pipeline/rest-trigger-async.js
+++ b/integration-test/pipeline/rest-trigger-async.js
@@ -13,7 +13,7 @@ export function CheckTrigger(data) {
 
     var reqBody = Object.assign(
       {
-        id: randomString(10),
+        id: constant.dbIDPrefix + randomString(10),
         description: randomString(50),
       },
       constant.simplePipelineWithYAMLRecipe
@@ -40,7 +40,7 @@ export function CheckTrigger(data) {
 
     var reqBody = Object.assign(
       {
-        id: randomString(10),
+        id: constant.dbIDPrefix + randomString(10),
         description: randomString(50),
       },
       constant.simplePipelineWithYAMLRecipe

--- a/integration-test/pipeline/rest-trigger.js
+++ b/integration-test/pipeline/rest-trigger.js
@@ -44,7 +44,7 @@ export function CheckTrigger(data) {
   group("Pipelines API: Trigger a pipeline", () => {
     var reqHTTP = Object.assign(
       {
-        id: randomString(10),
+        id: constant.dbIDPrefix + randomString(10),
         description: randomString(50),
       },
       constant.simplePipelineWithYAMLRecipe
@@ -66,7 +66,7 @@ export function CheckTrigger(data) {
   group("Pipelines API: Trigger a pipeline with YAML recipe", () => {
     var reqHTTP = Object.assign(
       {
-        id: randomString(10),
+        id: constant.dbIDPrefix + randomString(10),
         description: randomString(50),
       },
       constant.simplePipelineWithYAMLRecipe

--- a/integration-test/pipeline/rest-trigger.js
+++ b/integration-test/pipeline/rest-trigger.js
@@ -29,18 +29,17 @@ component:
     task: TASK_SEND_EMAIL
 `;
 
+var collectionPath = `/v1beta/namespaces/${constant.defaultUsername}/pipelines`;
+
+function resourcePath(id) {
+  return `${collectionPath}/${id}`;
+}
+
+function triggerPath(id) {
+  return resourcePath(id) + "/trigger";
+}
 
 export function CheckTrigger(data) {
-  var collectionPath = `/v1beta/namespaces/${constant.defaultUsername}/pipelines`;
-
-  function resourcePath(id) {
-    return `${collectionPath}/${id}`;
-  }
-
-  function triggerPath(id) {
-    return resourcePath(id) + "/trigger";
-  }
-
   group("Pipelines API: Trigger a pipeline", () => {
     var reqHTTP = Object.assign(
       {
@@ -137,5 +136,161 @@ export function CheckTrigger(data) {
     check(http.request("DELETE", pipelinePublicHost + resourcePath(reqInvalid.id), null, data.header), {
       [`DELETE ${resourcePath(reqInvalid.id)} response status 204`]: (r) => r.status === 204,
     });
+  });
+}
+
+const breakableRecipe = `
+version: v1.0-alpha
+variable:
+  jota:
+    type: json
+component:
+  jq:
+    type: json
+    task: TASK_JQ
+    input:
+      jq-filter: '.foo'
+      json-value: \${variable.jota}
+output:
+  out:
+    value: \${jq.output.results[0]}
+`;
+
+export function CheckPipelineRuns(data) {
+  group("Pipelines API: View pipeline and component runs", () => {
+    const creationReq = {
+      id: constant.dbIDPrefix + randomString(10),
+      description: randomString(50),
+      rawRecipe: breakableRecipe,
+    };
+
+    // Create pipeline
+    check(
+      http.request(
+        "POST",
+        pipelinePublicHost + collectionPath,
+        JSON.stringify(creationReq),
+        data.header
+      ),
+      {
+        [`POST ${collectionPath} (${creationReq.id}) response status is 201 (HTTP pipeline)`]: (r) =>
+          r.status === 201,
+      }
+    );
+
+    // Trigger pipeline with error
+    const nokPayload = JSON.stringify({
+      data: [
+        {
+          variable: {},
+        },
+      ],
+    });
+
+    const nokResp = http.request(
+      "POST",
+      pipelinePublicHost + triggerPath(creationReq.id),
+      nokPayload,
+      data.header
+    );
+    check(nokResp, {
+      [`POST ${triggerPath(creationReq.id)} (NOK) response status is 200`]: (r) =>
+        r.status === 200,
+      [`POST ${triggerPath(creationReq.id)} (NOK) returns error status`]: (r) =>
+        r.json().metadata.traces.jq.statuses[0] === "STATUS_ERROR",
+    });
+
+    // Successfully trigger pipeline
+    const okPayload = JSON.stringify({
+      data: [
+        {
+          variable: {
+            jota: { foo: "bar" },
+          },
+        },
+      ],
+    });
+
+    const okResp = http.request(
+      "POST",
+      pipelinePublicHost + triggerPath(creationReq.id),
+      okPayload,
+      data.header
+    );
+    check(okResp, {
+      [`POST ${triggerPath(creationReq.id)} (OK) response status is 200`]: (r) =>
+        r.status === 200,
+      [`POST ${triggerPath(creationReq.id)} (OK) contains result`]: (r) =>
+        r.json().outputs[0].out === "bar",
+      [`POST ${triggerPath(creationReq.id)} (OK) returns successful status`]: (r) =>
+        r.json().metadata.traces.jq.statuses[0] === "STATUS_COMPLETED",
+    });
+
+    const pipelineRuns = http.request(
+      "GET",
+      pipelinePublicHost + resourcePath(creationReq.id) + "/runs",
+      null,
+      data.header
+    );
+    check(pipelineRuns, {
+      [`GET ${resourcePath(creationReq.id)}/runs response status is 200`]: (r) =>
+        r.status === 200,
+      [`GET ${resourcePath(creationReq.id)}/runs contains runs`]: (r) =>
+        r.json().pipelineRuns.length === 2,
+      [`GET ${resourcePath(creationReq.id)}/runs has a successful run`]: (r) =>
+        r.json().pipelineRuns[0].status === "RUN_STATUS_COMPLETED",
+      [`GET ${resourcePath(creationReq.id)}/runs has a failed run`]: (r) =>
+        r.json().pipelineRuns[1].status === "RUN_STATUS_FAILED",
+    });
+
+    const okPipelineRunUID = pipelineRuns.json().pipelineRuns[0].pipelineRunUid;
+
+    const okComponentRuns = http.request(
+      "GET",
+      `${pipelinePublicHost}/v1beta/pipeline-runs/${okPipelineRunUID}/component-runs`,
+      null,
+      data.header
+    );
+    check(okComponentRuns, {
+      [`GET /v1beta/pipeline-runs/${okPipelineRunUID}/component-runs response status is 200`]: (r) =>
+        r.status === 200,
+      [`GET /v1beta/pipeline-runs/${okPipelineRunUID}/component-runs contains component runs`]: (r) =>
+        r.json().componentRuns.length === 1,
+      [`GET /v1beta/pipeline-runs/${okPipelineRunUID}/component-runs matches the component ID`]: (r) =>
+        r.json().componentRuns[0].componentId === "jq",
+      [`GET /v1beta/pipeline-runs/${okPipelineRunUID}/component-runs has a successful component run`]: (r) =>
+        r.json().componentRuns[0].status === "RUN_STATUS_COMPLETED",
+    });
+
+    const nokPipelineRunUID = pipelineRuns.json().pipelineRuns[1].pipelineRunUid;
+    const nokComponentRuns = http.request(
+      "GET",
+      `${pipelinePublicHost}/v1beta/pipeline-runs/${nokPipelineRunUID}/component-runs`,
+      null,
+      data.header
+    );
+    check(nokComponentRuns, {
+      [`GET /v1beta/pipeline-runs/${nokPipelineRunUID}/component-runs response status is 200`]: (r) =>
+        r.status === 200,
+      [`GET /v1beta/pipeline-runs/${nokPipelineRunUID}/component-runs contains component runs`]: (r) =>
+        r.json().componentRuns.length === 1,
+      [`GET /v1beta/pipeline-runs/${nokPipelineRunUID}/component-runs matches the component ID`]: (r) =>
+        r.json().componentRuns[0].componentId === "jq",
+      [`GET /v1beta/pipeline-runs/${nokPipelineRunUID}/component-runs has a failed component run`]: (r) =>
+        r.json().componentRuns[0].status === "RUN_STATUS_FAILED",
+    });
+
+    check(
+      http.request(
+        "DELETE",
+        pipelinePublicHost + resourcePath(creationReq.id),
+        null,
+        data.header
+      ),
+      {
+        [`DELETE ${resourcePath(creationReq.id)} response status 204`]: (r) =>
+          r.status === 204,
+      }
+    );
   });
 }

--- a/integration-test/pipeline/rest.js
+++ b/integration-test/pipeline/rest.js
@@ -103,7 +103,7 @@ export function teardown(data) {
     }
   });
 
-  group("Integration API: Delete all connections created by this test", () => {
+  group("Integration API: Delete data created by this test", () => {
     var q = `DELETE FROM connection WHERE id LIKE '${constant.dbIDPrefix}%';`;
     constant.db.exec(q);
 

--- a/integration-test/pipeline/rest.js
+++ b/integration-test/pipeline/rest.js
@@ -86,6 +86,7 @@ export default function (data) {
   pipelinePublic.CheckLookUp(data);
 
   trigger.CheckTrigger(data);
+  trigger.CheckPipelineRuns(data);
   triggerAsync.CheckTrigger(data);
 
   componentDefinition.CheckList(data);

--- a/pkg/handler/pipeline.go
+++ b/pkg/handler/pipeline.go
@@ -1000,6 +1000,7 @@ func (h *PublicHandler) TriggerNamespacePipeline(ctx context.Context, req *pb.Tr
 		return nil, err
 	}
 
+	// TODO: it would be useful to return the trigger UID here.
 	return &pb.TriggerNamespacePipelineResponse{Outputs: outputs, Metadata: metadata}, nil
 }
 

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -1967,6 +1967,11 @@ func (s *service) TriggerNamespacePipelineByID(ctx context.Context, ns resource.
 	if err != nil {
 		return nil, nil, errdomain.ErrNotFound
 	}
+
+	if dbPipeline.Recipe == nil {
+		return nil, nil, fmt.Errorf("pipeline must have a valid recipe in order to be triggered")
+	}
+
 	pipelineUID := dbPipeline.UID
 
 	requesterUID, userUID := resourcex.GetRequesterUIDAndUserUID(ctx)


### PR DESCRIPTION
Because

- When a component failed to execute, the pipeline status was FAILED but
  the component status wasn't

This commit

- Sets the error correctly in the component activity so the deferred
  cleanup function that updates the component run can capture the
  execution status.
