### PR TITLE
feat(temporal): propagate request metadata to Temporal headers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250327024010-44cf729ab567
 	github.com/instill-ai/usage-client v0.3.0-alpha.0.20250313022849-49504d982f18
-	github.com/instill-ai/x v0.8.0-alpha.0.20250522141741-d2571d735e5c
+	github.com/instill-ai/x v0.8.0-alpha.0.20250522155757-17600f269ec8
 	github.com/itchyny/gojq v0.12.14
 	github.com/jackc/pgconn v1.14.3
 	github.com/jackc/pgx/v5 v5.5.5

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250327024010-44cf729ab567
 	github.com/instill-ai/usage-client v0.3.0-alpha.0.20250313022849-49504d982f18
-	github.com/instill-ai/x v0.8.0-alpha.0.20250522155757-17600f269ec8
+	github.com/instill-ai/x v0.8.0-alpha.0.20250522164415-9172edd336bb
 	github.com/itchyny/gojq v0.12.14
 	github.com/jackc/pgconn v1.14.3
 	github.com/jackc/pgx/v5 v5.5.5

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250327024010-44cf729ab567
 	github.com/instill-ai/usage-client v0.3.0-alpha.0.20250313022849-49504d982f18
-	github.com/instill-ai/x v0.8.0-alpha
+	github.com/instill-ai/x v0.8.0-alpha.0.20250522141741-d2571d735e5c
 	github.com/itchyny/gojq v0.12.14
 	github.com/jackc/pgconn v1.14.3
 	github.com/jackc/pgx/v5 v5.5.5

--- a/go.sum
+++ b/go.sum
@@ -953,6 +953,10 @@ github.com/instill-ai/usage-client v0.3.0-alpha.0.20250313022849-49504d982f18 h1
 github.com/instill-ai/usage-client v0.3.0-alpha.0.20250313022849-49504d982f18/go.mod h1:/B+Irg9TYBlP+X79GZ+yvPxFvC+7fbRL7APNGiJlDSk=
 github.com/instill-ai/x v0.8.0-alpha h1:GJl8QATrtH7Vc9zeMARhxuAqsTShQoY3GiKwLQdu/l8=
 github.com/instill-ai/x v0.8.0-alpha/go.mod h1:l6xECxln5VQz7tSafeDWSdCN1sKizzVamHxlMMGenzg=
+github.com/instill-ai/x v0.8.0-alpha.0.20250522111731-55c0b3cae328 h1:gJdJzWEdxc3RNxYr27Y68imG+gKvGTXOAEpdTVqtW2A=
+github.com/instill-ai/x v0.8.0-alpha.0.20250522111731-55c0b3cae328/go.mod h1:uzCqJuS/AuCPiY8HhzQpz7I3L5pJfIZZNw/euT6SfHE=
+github.com/instill-ai/x v0.8.0-alpha.0.20250522141741-d2571d735e5c h1:/QrfuEpN6B3+bu9vUqJd0Ft07cH49C9Fstx6FntQ/hA=
+github.com/instill-ai/x v0.8.0-alpha.0.20250522141741-d2571d735e5c/go.mod h1:uzCqJuS/AuCPiY8HhzQpz7I3L5pJfIZZNw/euT6SfHE=
 github.com/intel/goresctrl v0.2.0/go.mod h1:+CZdzouYFn5EsxgqAQTEzMfwKwuc0fVdMrT9FCCAVRQ=
 github.com/itchyny/gojq v0.12.14 h1:6k8vVtsrhQSYgSGg827AD+PVVaB1NLXEdX+dda2oZCc=
 github.com/itchyny/gojq v0.12.14/go.mod h1:y1G7oO7XkcR1LPZO59KyoCRy08T3j9vDYRV0GgYSS+s=

--- a/go.sum
+++ b/go.sum
@@ -951,8 +951,8 @@ github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250327024010-44cf729ab567 h1:
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250327024010-44cf729ab567/go.mod h1:FuQL8siq3GgUFUlvKUKmLv3bgHxEVPeNfOZWQKRdPg0=
 github.com/instill-ai/usage-client v0.3.0-alpha.0.20250313022849-49504d982f18 h1:RFdRDODY4qMTTIcKm4TBMpYhxDGFCql6HQ7oocA+WeQ=
 github.com/instill-ai/usage-client v0.3.0-alpha.0.20250313022849-49504d982f18/go.mod h1:/B+Irg9TYBlP+X79GZ+yvPxFvC+7fbRL7APNGiJlDSk=
-github.com/instill-ai/x v0.8.0-alpha.0.20250522155757-17600f269ec8 h1:Oc1jXMnmEooV7xKkaA2K1BupZu7mE11HgHNvju9lKrk=
-github.com/instill-ai/x v0.8.0-alpha.0.20250522155757-17600f269ec8/go.mod h1:uzCqJuS/AuCPiY8HhzQpz7I3L5pJfIZZNw/euT6SfHE=
+github.com/instill-ai/x v0.8.0-alpha.0.20250522164415-9172edd336bb h1:lrHTet3MB9ctNTvY/H8qcyiHd1vdTRqzUMkGsh5/Pp8=
+github.com/instill-ai/x v0.8.0-alpha.0.20250522164415-9172edd336bb/go.mod h1:uzCqJuS/AuCPiY8HhzQpz7I3L5pJfIZZNw/euT6SfHE=
 github.com/intel/goresctrl v0.2.0/go.mod h1:+CZdzouYFn5EsxgqAQTEzMfwKwuc0fVdMrT9FCCAVRQ=
 github.com/itchyny/gojq v0.12.14 h1:6k8vVtsrhQSYgSGg827AD+PVVaB1NLXEdX+dda2oZCc=
 github.com/itchyny/gojq v0.12.14/go.mod h1:y1G7oO7XkcR1LPZO59KyoCRy08T3j9vDYRV0GgYSS+s=

--- a/go.sum
+++ b/go.sum
@@ -951,12 +951,8 @@ github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250327024010-44cf729ab567 h1:
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250327024010-44cf729ab567/go.mod h1:FuQL8siq3GgUFUlvKUKmLv3bgHxEVPeNfOZWQKRdPg0=
 github.com/instill-ai/usage-client v0.3.0-alpha.0.20250313022849-49504d982f18 h1:RFdRDODY4qMTTIcKm4TBMpYhxDGFCql6HQ7oocA+WeQ=
 github.com/instill-ai/usage-client v0.3.0-alpha.0.20250313022849-49504d982f18/go.mod h1:/B+Irg9TYBlP+X79GZ+yvPxFvC+7fbRL7APNGiJlDSk=
-github.com/instill-ai/x v0.8.0-alpha h1:GJl8QATrtH7Vc9zeMARhxuAqsTShQoY3GiKwLQdu/l8=
-github.com/instill-ai/x v0.8.0-alpha/go.mod h1:l6xECxln5VQz7tSafeDWSdCN1sKizzVamHxlMMGenzg=
-github.com/instill-ai/x v0.8.0-alpha.0.20250522111731-55c0b3cae328 h1:gJdJzWEdxc3RNxYr27Y68imG+gKvGTXOAEpdTVqtW2A=
-github.com/instill-ai/x v0.8.0-alpha.0.20250522111731-55c0b3cae328/go.mod h1:uzCqJuS/AuCPiY8HhzQpz7I3L5pJfIZZNw/euT6SfHE=
-github.com/instill-ai/x v0.8.0-alpha.0.20250522141741-d2571d735e5c h1:/QrfuEpN6B3+bu9vUqJd0Ft07cH49C9Fstx6FntQ/hA=
-github.com/instill-ai/x v0.8.0-alpha.0.20250522141741-d2571d735e5c/go.mod h1:uzCqJuS/AuCPiY8HhzQpz7I3L5pJfIZZNw/euT6SfHE=
+github.com/instill-ai/x v0.8.0-alpha.0.20250522155757-17600f269ec8 h1:Oc1jXMnmEooV7xKkaA2K1BupZu7mE11HgHNvju9lKrk=
+github.com/instill-ai/x v0.8.0-alpha.0.20250522155757-17600f269ec8/go.mod h1:uzCqJuS/AuCPiY8HhzQpz7I3L5pJfIZZNw/euT6SfHE=
 github.com/intel/goresctrl v0.2.0/go.mod h1:+CZdzouYFn5EsxgqAQTEzMfwKwuc0fVdMrT9FCCAVRQ=
 github.com/itchyny/gojq v0.12.14 h1:6k8vVtsrhQSYgSGg827AD+PVVaB1NLXEdX+dda2oZCc=
 github.com/itchyny/gojq v0.12.14/go.mod h1:y1G7oO7XkcR1LPZO59KyoCRy08T3j9vDYRV0GgYSS+s=

--- a/pkg/acl/acl.go
+++ b/pkg/acl/acl.go
@@ -17,7 +17,9 @@ import (
 	"github.com/instill-ai/pipeline-backend/config"
 	"github.com/instill-ai/pipeline-backend/pkg/constant"
 	"github.com/instill-ai/pipeline-backend/pkg/datamodel"
-	"github.com/instill-ai/pipeline-backend/pkg/resource"
+	"github.com/instill-ai/x/resource"
+
+	constantx "github.com/instill-ai/x/constant"
 )
 
 type ACLClientInterface interface {
@@ -99,7 +101,7 @@ func InitOpenFGAClient(ctx context.Context, host string, port int) (openfga.Open
 }
 
 func (c *ACLClient) getClient(ctx context.Context, mode Mode) openfga.OpenFGAServiceClient {
-	userUID := resource.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey)
+	userUID := resource.GetRequestSingleHeader(ctx, constantx.HeaderUserUIDKey)
 
 	if mode == WriteMode {
 		// To solve the read-after-write inconsistency problem,
@@ -317,14 +319,14 @@ func (c *ACLClient) CheckPermission(ctx context.Context, objectType string, obje
 		return true, nil
 	}
 
-	userType := resource.GetRequestSingleHeader(ctx, constant.HeaderAuthTypeKey)
+	userType := resource.GetRequestSingleHeader(ctx, constantx.HeaderAuthTypeKey)
 
 	var userUID string
 	switch userType {
 	case "user":
-		userUID = resource.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey)
+		userUID = resource.GetRequestSingleHeader(ctx, constantx.HeaderUserUIDKey)
 	default:
-		userUID = resource.GetRequestSingleHeader(ctx, constant.HeaderVisitorUIDKey)
+		userUID = resource.GetRequestSingleHeader(ctx, constantx.HeaderVisitorUIDKey)
 	}
 
 	data, err := c.getClient(ctx, ReadMode).Check(ctx, &openfga.CheckRequest{
@@ -366,13 +368,13 @@ func (c *ACLClient) CheckPublicExecutable(ctx context.Context, objectType string
 
 func (c *ACLClient) ListPermissions(ctx context.Context, objectType string, role string, isPublic bool) ([]uuid.UUID, error) {
 
-	userType := resource.GetRequestSingleHeader(ctx, constant.HeaderAuthTypeKey)
+	userType := resource.GetRequestSingleHeader(ctx, constantx.HeaderAuthTypeKey)
 	var userUIDStr string
 	if userType == "user" {
-		userUIDStr = resource.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey)
+		userUIDStr = resource.GetRequestSingleHeader(ctx, constantx.HeaderUserUIDKey)
 
 	} else {
-		userUIDStr = resource.GetRequestSingleHeader(ctx, constant.HeaderVisitorUIDKey)
+		userUIDStr = resource.GetRequestSingleHeader(ctx, constantx.HeaderVisitorUIDKey)
 	}
 
 	if isPublic {

--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -15,18 +15,6 @@ const MaxPayloadSize = 1024 * 1024 * 256
 const DefaultUserID string = "admin"
 
 const (
-	// HeaderUserUIDKey is the context key for the authenticated user.
-	HeaderUserUIDKey = "Instill-User-Uid"
-	// HeaderRequesterUIDKey is the context key for the requester. An
-	// authenticated user can use different namespaces (e.g. an organization
-	// they belong to) to make requests, as long as they have permissions.
-	HeaderRequesterUIDKey = "Instill-Requester-Uid"
-	// HeaderVisitorUIDKey is the context key for the visitor UID when requests
-	// are made without authentication.
-	HeaderVisitorUIDKey = "Instill-Visitor-Uid"
-	// HeaderAuthTypeKey is the context key the authentication type (user or
-	// visitor).
-	HeaderAuthTypeKey     = "Instill-Auth-Type"
 	HeaderInstillCodeKey  = "Instill-Share-Code"
 	HeaderReturnTracesKey = "Instill-Return-Traces"
 
@@ -37,8 +25,6 @@ const (
 	// bypass standard authorization checks since they represent trusted
 	// internal traffic.
 	HeaderServiceKey = "Instill-Service"
-
-	HeaderUserAgentKey = "Instill-User-Agent"
 
 	HeaderAccept           = "Accept"
 	HeaderValueEventStream = "text/event-stream"
@@ -52,8 +38,6 @@ const (
 	SegInput      = "input"
 	SegOutput     = "output"
 )
-
-const ContentTypeJSON = "application/json"
 
 // GlobalSecretKey can be used to reference a global secret in the
 // configuration of a component (i.e, ${secrets.INSTILL_SECRET}).

--- a/pkg/external/external.go
+++ b/pkg/external/external.go
@@ -20,12 +20,12 @@ import (
 	"github.com/instill-ai/pipeline-backend/pkg/constant"
 	"github.com/instill-ai/pipeline-backend/pkg/logger"
 	"github.com/instill-ai/x/minio"
+	"github.com/instill-ai/x/resource"
 
 	artifactpb "github.com/instill-ai/protogen-go/artifact/artifact/v1alpha"
 	mgmtpb "github.com/instill-ai/protogen-go/core/mgmt/v1beta"
 	usagepb "github.com/instill-ai/protogen-go/core/usage/v1beta"
 	pipelinepb "github.com/instill-ai/protogen-go/pipeline/pipeline/v1beta"
-	resourcex "github.com/instill-ai/x/resource"
 )
 
 // InitPipelinePublicServiceClient initialises a PipelineServiceClient instance
@@ -312,7 +312,7 @@ func (f *artifactBinaryFetcher) fetchFromBlobStorage(ctx context.Context, urlUID
 	// If we want a full audit of the MinIO actions (or if we want to check
 	// object permissions), we need to update the signature to pass the user
 	// UID explicitly.
-	_, userUID := resourcex.GetRequesterUIDAndUserUID(ctx)
+	_, userUID := resource.GetRequesterUIDAndUserUID(ctx)
 	b, _, err = f.fileGetter.GetFile(ctx, minio.GetFileParams{
 		BucketName: bucketName,
 		Path:       objectPath,

--- a/pkg/handler/pipeline.go
+++ b/pkg/handler/pipeline.go
@@ -29,6 +29,7 @@ import (
 	errdomain "github.com/instill-ai/pipeline-backend/pkg/errors"
 	customotel "github.com/instill-ai/pipeline-backend/pkg/logger/otel"
 	pb "github.com/instill-ai/protogen-go/pipeline/pipeline/v1beta"
+	resourcex "github.com/instill-ai/x/resource"
 )
 
 func (h *PrivateHandler) ListPipelinesAdmin(ctx context.Context, req *pb.ListPipelinesAdminRequest) (*pb.ListPipelinesAdminResponse, error) {
@@ -947,7 +948,7 @@ func (h *PublicHandler) preTriggerNamespacePipeline(ctx context.Context, req Tri
 	// if err != nil {
 	// 	return ns, nil, id, nil, false, status.Error(codes.FailedPrecondition, fmt.Sprintf("[Pipeline Recipe Error] %+v", err.Error()))
 	// }
-	returnTraces := resource.GetRequestSingleHeader(ctx, constant.HeaderReturnTracesKey) == "true"
+	returnTraces := resourcex.GetRequestSingleHeader(ctx, constant.HeaderReturnTracesKey) == "true"
 
 	return ns, id, pbPipeline, returnTraces, nil
 
@@ -1698,7 +1699,7 @@ func (h *PublicHandler) preTriggerNamespacePipelineRelease(ctx context.Context, 
 	if err != nil {
 		return ns, "", nil, nil, false, err
 	}
-	returnTraces := resource.GetRequestSingleHeader(ctx, constant.HeaderReturnTracesKey) == "true"
+	returnTraces := resourcex.GetRequestSingleHeader(ctx, constant.HeaderReturnTracesKey) == "true"
 
 	return ns, req.GetReleaseId(), pbPipeline, pbPipelineRelease, returnTraces, nil
 

--- a/pkg/handler/utils.go
+++ b/pkg/handler/utils.go
@@ -4,8 +4,10 @@ import (
 	"context"
 
 	"github.com/instill-ai/pipeline-backend/pkg/constant"
-	"github.com/instill-ai/pipeline-backend/pkg/resource"
 	"github.com/instill-ai/pipeline-backend/pkg/service"
+	"github.com/instill-ai/x/resource"
+
+	constantx "github.com/instill-ai/x/constant"
 )
 
 func authenticateUser(ctx context.Context, allowVisitor bool) error {
@@ -13,8 +15,8 @@ func authenticateUser(ctx context.Context, allowVisitor bool) error {
 		return nil
 	}
 
-	if resource.GetRequestSingleHeader(ctx, constant.HeaderAuthTypeKey) == "user" {
-		if resource.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey) == "" {
+	if resource.GetRequestSingleHeader(ctx, constantx.HeaderAuthTypeKey) == "user" {
+		if resource.GetRequestSingleHeader(ctx, constantx.HeaderUserUIDKey) == "" {
 			return service.ErrUnauthenticated
 		}
 		return nil
@@ -24,7 +26,7 @@ func authenticateUser(ctx context.Context, allowVisitor bool) error {
 		return service.ErrUnauthenticated
 	}
 
-	if resource.GetRequestSingleHeader(ctx, constant.HeaderVisitorUIDKey) == "" {
+	if resource.GetRequestSingleHeader(ctx, constantx.HeaderVisitorUIDKey) == "" {
 		return service.ErrUnauthenticated
 	}
 

--- a/pkg/logger/otel/const.go
+++ b/pkg/logger/otel/const.go
@@ -6,9 +6,9 @@ import (
 
 	"go.opentelemetry.io/otel/trace"
 
-	"github.com/instill-ai/pipeline-backend/pkg/constant"
-	"github.com/instill-ai/pipeline-backend/pkg/resource"
 	"github.com/instill-ai/pipeline-backend/pkg/utils"
+	"github.com/instill-ai/x/constant"
+	"github.com/instill-ai/x/resource"
 )
 
 type Option func(l logMessage) logMessage

--- a/pkg/recipe/variable.go
+++ b/pkg/recipe/variable.go
@@ -8,10 +8,11 @@ import (
 	"github.com/gofrs/uuid"
 
 	"github.com/instill-ai/pipeline-backend/config"
-	"github.com/instill-ai/pipeline-backend/pkg/constant"
 	"github.com/instill-ai/pipeline-backend/pkg/resource"
+	"github.com/instill-ai/x/constant"
+	"github.com/instill-ai/x/minio"
 
-	miniox "github.com/instill-ai/x/minio"
+	resourcex "github.com/instill-ai/x/resource"
 )
 
 // SystemVariables contain information about a pipeline trigger.
@@ -42,7 +43,7 @@ type SystemVariables struct {
 
 	// ExpiryRule defines the tag and object expiration for the blob storage
 	// associated to the pipeline run data (e.g. recipe, input, output).
-	ExpiryRule miniox.ExpiryRule `json:"__EXPIRY_RULE"`
+	ExpiryRule minio.ExpiryRule `json:"__EXPIRY_RULE"`
 
 	HeaderAuthorization string `json:"__PIPELINE_HEADER_AUTHORIZATION"`
 	ModelBackend        string `json:"__MODEL_BACKEND"`
@@ -58,10 +59,10 @@ type SystemVariables struct {
 // the context and instance configuration.
 func GenerateSystemVariables(ctx context.Context, sysVar SystemVariables) (map[string]any, error) {
 	if sysVar.PipelineUserUID.IsNil() {
-		sysVar.PipelineUserUID = uuid.FromStringOrNil(resource.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey))
+		sysVar.PipelineUserUID = uuid.FromStringOrNil(resourcex.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey))
 	}
 	if sysVar.HeaderAuthorization == "" {
-		sysVar.HeaderAuthorization = resource.GetRequestSingleHeader(ctx, "Authorization")
+		sysVar.HeaderAuthorization = resourcex.GetRequestSingleHeader(ctx, "Authorization")
 	}
 	if sysVar.ModelBackend == "" {
 		sysVar.ModelBackend = fmt.Sprintf("%s:%d", config.Config.ModelBackend.Host, config.Config.ModelBackend.PublicPort)

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -29,6 +29,8 @@ import (
 
 	errdomain "github.com/instill-ai/pipeline-backend/pkg/errors"
 	pb "github.com/instill-ai/protogen-go/pipeline/pipeline/v1beta"
+	constantx "github.com/instill-ai/x/constant"
+	resourcex "github.com/instill-ai/x/resource"
 )
 
 // TODO: in the repository, we'd better use uid as our function params
@@ -190,7 +192,7 @@ func (r *repository) GetHubStats(uidAllowList []uuid.UUID) (*datamodel.HubStats,
 func (r *repository) CheckPinnedUser(ctx context.Context, db *gorm.DB, table string) *gorm.DB {
 	db = db.WithContext(ctx)
 
-	userUID := resource.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey)
+	userUID := resourcex.GetRequestSingleHeader(ctx, constantx.HeaderUserUIDKey)
 	if userUID == "" {
 		return db
 	}
@@ -206,7 +208,7 @@ func (r *repository) CheckPinnedUser(ctx context.Context, db *gorm.DB, table str
 // period to ensure that the data is synchronized from the primary DB to the
 // replica DB.
 func (r *repository) PinUser(ctx context.Context, table string) {
-	userUID := resource.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey)
+	userUID := resourcex.GetRequestSingleHeader(ctx, constantx.HeaderUserUIDKey)
 	if userUID == "" {
 		return
 	}

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -1,33 +1,13 @@
 package resource
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
 	"github.com/gofrs/uuid"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
-
-// ExtractFromMetadata extracts context metadata given a key
-func ExtractFromMetadata(ctx context.Context, key string) ([]string, bool) {
-	data, ok := metadata.FromIncomingContext(ctx)
-	if !ok {
-		return []string{}, false
-	}
-	return data[strings.ToLower(key)], true
-}
-
-// GetRequestSingleHeader get a request header, the header has to be single-value HTTP header
-func GetRequestSingleHeader(ctx context.Context, header string) string {
-	metaHeader := metadata.ValueFromIncomingContext(ctx, strings.ToLower(header))
-	if len(metaHeader) != 1 {
-		return ""
-	}
-	return metaHeader[0]
-}
 
 // GetRscNameID returns the resource ID given a resource name
 func GetRscNameID(path string) (string, error) {

--- a/pkg/service/convert.go
+++ b/pkg/service/convert.go
@@ -44,6 +44,8 @@ import (
 	errdomain "github.com/instill-ai/pipeline-backend/pkg/errors"
 	mgmtpb "github.com/instill-ai/protogen-go/core/mgmt/v1beta"
 	pb "github.com/instill-ai/protogen-go/pipeline/pipeline/v1beta"
+	constantx "github.com/instill-ai/x/constant"
+	resourcex "github.com/instill-ai/x/resource"
 )
 
 type Converter interface {
@@ -513,7 +515,7 @@ func (c *converter) ConvertPipelineToPB(ctx context.Context, dbPipelineOrigin *d
 
 	ownerName := fmt.Sprintf("%s/%s", dbPipeline.NamespaceType, dbPipeline.NamespaceID)
 
-	ctxUserUID := resource.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey)
+	ctxUserUID := resourcex.GetRequestSingleHeader(ctx, constantx.HeaderUserUIDKey)
 
 	if view == pb.Pipeline_VIEW_FULL {
 		if err := c.IncludeDetailInRecipe(ctx, dbPipeline.Owner, dbPipeline.Recipe, useDynamicDef); err != nil {

--- a/pkg/service/integration.go
+++ b/pkg/service/integration.go
@@ -23,13 +23,13 @@ import (
 	fieldmaskutil "github.com/mennanov/fieldmask-utils"
 
 	"github.com/instill-ai/pipeline-backend/config"
-	"github.com/instill-ai/pipeline-backend/pkg/constant"
 	"github.com/instill-ai/pipeline-backend/pkg/datamodel"
 	"github.com/instill-ai/pipeline-backend/pkg/recipe"
 	"github.com/instill-ai/pipeline-backend/pkg/repository"
-	"github.com/instill-ai/pipeline-backend/pkg/resource"
 	"github.com/instill-ai/x/checkfield"
+	"github.com/instill-ai/x/constant"
 	"github.com/instill-ai/x/errmsg"
+	"github.com/instill-ai/x/resource"
 
 	errdomain "github.com/instill-ai/pipeline-backend/pkg/errors"
 	mgmtpb "github.com/instill-ai/protogen-go/core/mgmt/v1beta"

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -43,6 +43,7 @@ import (
 	mgmtpb "github.com/instill-ai/protogen-go/core/mgmt/v1beta"
 	pipelinepb "github.com/instill-ai/protogen-go/pipeline/pipeline/v1beta"
 	resourcex "github.com/instill-ai/x/resource"
+	temporalx "github.com/instill-ai/x/temporal"
 )
 
 var preserveTags = []string{"featured", "feature"}
@@ -1691,8 +1692,9 @@ func (s *service) triggerPipeline(
 	}
 
 	isStreaming := resource.GetRequestSingleHeader(ctx, constant.HeaderAccept) == "text/event-stream"
+
 	we, err := s.temporalClient.ExecuteWorkflow(
-		ctx,
+		temporalx.PropagateMetadata(ctx),
 		workflowOptions,
 		"TriggerPipelineWorkflow",
 		&worker.TriggerPipelineWorkflowParam{
@@ -1786,8 +1788,9 @@ func (s *service) triggerAsyncPipeline(ctx context.Context, params triggerParams
 	}
 
 	isStreaming := resource.GetRequestSingleHeader(ctx, constant.HeaderAccept) == "text/event-stream"
+
 	we, err := s.temporalClient.ExecuteWorkflow(
-		ctx,
+		temporalx.PropagateMetadata(ctx),
 		workflowOptions,
 		"TriggerPipelineWorkflow",
 		&worker.TriggerPipelineWorkflowParam{

--- a/pkg/service/pipelinerun.go
+++ b/pkg/service/pipelinerun.go
@@ -12,16 +12,15 @@ import (
 	"go.uber.org/zap"
 	"gopkg.in/guregu/null.v4"
 
-	"github.com/instill-ai/pipeline-backend/pkg/constant"
 	"github.com/instill-ai/pipeline-backend/pkg/datamodel"
 	"github.com/instill-ai/pipeline-backend/pkg/repository"
-	"github.com/instill-ai/pipeline-backend/pkg/resource"
+	"github.com/instill-ai/x/constant"
+	"github.com/instill-ai/x/minio"
+	"github.com/instill-ai/x/resource"
 
 	runpb "github.com/instill-ai/protogen-go/common/run/v1alpha"
 	mgmtpb "github.com/instill-ai/protogen-go/core/mgmt/v1beta"
 	pb "github.com/instill-ai/protogen-go/pipeline/pipeline/v1beta"
-	miniox "github.com/instill-ai/x/minio"
-	resourcex "github.com/instill-ai/x/resource"
 )
 
 const defaultPipelineReleaseID = "latest"
@@ -83,7 +82,7 @@ func (s *service) ListPipelineRuns(ctx context.Context, req *pb.ListPipelineRuns
 		return nil, err
 	}
 
-	requesterUID, userUID := resourcex.GetRequesterUIDAndUserUID(ctx)
+	requesterUID, userUID := resource.GetRequesterUIDAndUserUID(ctx)
 	page := s.pageInRange(req.GetPage())
 	pageSize := s.pageSizeInRange(req.GetPageSize())
 
@@ -197,7 +196,7 @@ func (s *service) ListPipelineRuns(ctx context.Context, req *pb.ListPipelineRuns
 func (s *service) ListComponentRuns(ctx context.Context, req *pb.ListComponentRunsRequest, filter filtering.Filter) (*pb.ListComponentRunsResponse, error) {
 	page := s.pageInRange(req.GetPage())
 	pageSize := s.pageSizeInRange(req.GetPageSize())
-	requesterUID, userUID := resourcex.GetRequesterUIDAndUserUID(ctx)
+	requesterUID, userUID := resource.GetRequesterUIDAndUserUID(ctx)
 
 	orderBy, err := ordering.ParseOrderBy(req)
 	if err != nil {
@@ -386,7 +385,7 @@ func (s *service) ListPipelineRunsByRequester(ctx context.Context, req *pb.ListP
 
 type uploadPipelineRunInputsToMinioParam struct {
 	pipelineTriggerID string
-	expiryRule        miniox.ExpiryRule
+	expiryRule        minio.ExpiryRule
 	pipelineData      []map[string]any
 }
 
@@ -399,9 +398,9 @@ func (s *service) uploadPipelineRunInputsToMinio(ctx context.Context, param uplo
 		zap.Any("pipelineData", param.pipelineData),
 	)
 
-	_, userUID := resourcex.GetRequesterUIDAndUserUID(ctx)
+	_, userUID := resource.GetRequesterUIDAndUserUID(ctx)
 	url, objectInfo, err := minioClient.WithLogger(s.log).
-		UploadFile(ctx, &miniox.UploadFileParam{
+		UploadFile(ctx, &minio.UploadFileParam{
 			UserUID:       userUID,
 			FilePath:      objectName,
 			FileContent:   param.pipelineData,

--- a/pkg/service/pipelinerun_test.go
+++ b/pkg/service/pipelinerun_test.go
@@ -21,16 +21,16 @@ import (
 	qt "github.com/frankban/quicktest"
 
 	"github.com/instill-ai/pipeline-backend/config"
-	"github.com/instill-ai/pipeline-backend/pkg/constant"
 	"github.com/instill-ai/pipeline-backend/pkg/datamodel"
 	"github.com/instill-ai/pipeline-backend/pkg/mock"
 	"github.com/instill-ai/pipeline-backend/pkg/repository"
+	"github.com/instill-ai/x/constant"
 
 	database "github.com/instill-ai/pipeline-backend/pkg/db"
 	runpb "github.com/instill-ai/protogen-go/common/run/v1alpha"
 	mgmtpb "github.com/instill-ai/protogen-go/core/mgmt/v1beta"
 	pb "github.com/instill-ai/protogen-go/pipeline/pipeline/v1beta"
-	mockx "github.com/instill-ai/x/mock"
+	miniomock "github.com/instill-ai/x/mock"
 )
 
 var db *gorm.DB
@@ -166,7 +166,7 @@ func TestService_ListPipelineRuns(t *testing.T) {
 		Owner: nil,
 	}, nil)
 
-	mockMinio := mockx.NewMinioIMock(mc)
+	mockMinio := miniomock.NewClientMock(mc)
 	mockMinio.GetFilesByPathsMock.Return(nil, fmt.Errorf("some errors"))
 
 	for i, testCase := range testCases {
@@ -378,7 +378,7 @@ func TestService_ListPipelineRuns_OrgResource(t *testing.T) {
 		Owner: nil,
 	}, nil)
 
-	mockMinio := mockx.NewMinioIMock(mc)
+	mockMinio := miniomock.NewClientMock(mc)
 	mockMinio.GetFilesByPathsMock.Return(nil, fmt.Errorf("some error happens"))
 
 	for i, testCase := range testCases {
@@ -482,7 +482,7 @@ func TestService_ListPipelineRunsByRequester(t *testing.T) {
 		Owner: nil,
 	}, nil)
 
-	mockMinio := mockx.NewMinioIMock(mc)
+	mockMinio := miniomock.NewClientMock(mc)
 
 	tx := db.Begin()
 	c.Cleanup(func() { tx.Rollback() })

--- a/pkg/service/utils.go
+++ b/pkg/service/utils.go
@@ -12,7 +12,6 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/instill-ai/pipeline-backend/pkg/constant"
 	"github.com/instill-ai/pipeline-backend/pkg/datamodel"
 	"github.com/instill-ai/pipeline-backend/pkg/resource"
 
@@ -20,6 +19,8 @@ import (
 	runpb "github.com/instill-ai/protogen-go/common/run/v1alpha"
 	mgmtpb "github.com/instill-ai/protogen-go/core/mgmt/v1beta"
 	pipelinepb "github.com/instill-ai/protogen-go/pipeline/pipeline/v1beta"
+	constantx "github.com/instill-ai/x/constant"
+	resourcex "github.com/instill-ai/x/resource"
 )
 
 const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
@@ -50,7 +51,7 @@ func (s *service) checkNamespacePermission(ctx context.Context, ns resource.Name
 			return errdomain.ErrUnauthorized
 		}
 	} else {
-		if ns.NsUID != uuid.FromStringOrNil(resource.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey)) {
+		if ns.NsUID != uuid.FromStringOrNil(resourcex.GetRequestSingleHeader(ctx, constantx.HeaderUserUIDKey)) {
 			return errdomain.ErrUnauthorized
 		}
 	}
@@ -59,7 +60,7 @@ func (s *service) checkNamespacePermission(ctx context.Context, ns resource.Name
 
 func (s *service) GetCtxUserNamespace(ctx context.Context) (resource.Namespace, error) {
 
-	uid := uuid.FromStringOrNil(resource.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey))
+	uid := uuid.FromStringOrNil(resourcex.GetRequestSingleHeader(ctx, constantx.HeaderUserUIDKey))
 	resp, err := s.mgmtPrivateServiceClient.CheckNamespaceByUIDAdmin(ctx, &mgmtpb.CheckNamespaceByUIDAdminRequest{
 		Uid: uid.String(),
 	})

--- a/pkg/worker/minioactivity.go
+++ b/pkg/worker/minioactivity.go
@@ -12,12 +12,11 @@ import (
 	"gopkg.in/guregu/null.v4"
 
 	"github.com/gofrs/uuid"
-	"github.com/instill-ai/pipeline-backend/pkg/constant"
 	"github.com/instill-ai/pipeline-backend/pkg/datamodel"
 	"github.com/instill-ai/pipeline-backend/pkg/memory"
 	"github.com/instill-ai/pipeline-backend/pkg/utils"
-
-	miniox "github.com/instill-ai/x/minio"
+	"github.com/instill-ai/x/constant"
+	"github.com/instill-ai/x/minio"
 )
 
 // UploadRecipeToMinIOParam contains the information to upload a pipeline
@@ -45,7 +44,7 @@ func (w *worker) UploadRecipeToMinIOActivity(ctx context.Context, param UploadRe
 
 	url, minioObjectInfo, err := w.minioClient.WithLogger(log).UploadFileBytes(
 		ctx,
-		&miniox.UploadFileBytesParam{
+		&minio.UploadFileBytesParam{
 			UserUID:       param.Metadata.UserUID,
 			FilePath:      fmt.Sprintf("pipeline-runs/recipe/%s.json", param.Metadata.PipelineTriggerID),
 			FileBytes:     b,
@@ -111,7 +110,7 @@ func (w *worker) UploadOutputsToMinIOActivity(ctx context.Context, param *MinIOU
 
 	url, objectInfo, err := w.minioClient.WithLogger(log).UploadFile(
 		ctx,
-		&miniox.UploadFileParam{
+		&minio.UploadFileParam{
 			UserUID:       param.UserUID,
 			FilePath:      objectName,
 			FileContent:   outputStructs,
@@ -187,7 +186,7 @@ func (w *worker) UploadComponentInputsActivity(ctx context.Context, param *Compo
 
 	url, objectInfo, err := w.minioClient.WithLogger(log).UploadFile(
 		ctx,
-		&miniox.UploadFileParam{
+		&minio.UploadFileParam{
 			UserUID:       param.SystemVariables.PipelineUserUID,
 			FilePath:      objectName,
 			FileContent:   compInputs,
@@ -268,7 +267,7 @@ func (w *worker) UploadComponentOutputsActivity(ctx context.Context, param *Comp
 
 	url, objectInfo, err := w.minioClient.WithLogger(log).UploadFile(
 		ctx,
-		&miniox.UploadFileParam{
+		&minio.UploadFileParam{
 			UserUID:       param.SystemVariables.PipelineUserUID,
 			FilePath:      objectName,
 			FileContent:   compOutputs,


### PR DESCRIPTION
This commit

- Uses the latest `instill-ai/x/temporal` to propagate the gRPC metadata
  in requests to the Temporal workflows and activities.
