### PR TITLE
fix(component,openai): resize the image before sending to OpenAI

### DIFF
--- a/pkg/component/ai/openai/v0/main.go
+++ b/pkg/component/ai/openai/v0/main.go
@@ -187,19 +187,14 @@ func (e *execution) worker(ctx context.Context, client *httpclient.Client, job *
 		userContents := []Content{}
 		userContents = append(userContents, Content{Type: "text", Text: &inputStruct.Prompt})
 		for _, image := range inputStruct.Images {
-			if image.Height().Integer() > 8192 || image.Width().Integer() > 8192 {
-				// Calculate new dimensions maintaining aspect ratio with max length 8192
-				ratio := float64(image.Width().Integer()) / float64(image.Height().Integer())
-				var newWidth, newHeight int
 
-				if image.Width().Integer() > image.Height().Integer() {
-					newWidth = 8192
-					newHeight = int(float64(newWidth) / ratio)
-				} else {
-					newHeight = 8192
-					newWidth = int(float64(newHeight) * ratio)
-				}
+			width := image.Width().Integer()
+			height := image.Height().Integer()
 
+			newWidth, newHeight := resizeImage(width, height)
+
+			// Only resize if dimensions changed
+			if newWidth != width || newHeight != height {
 				image, err = image.Resize(newWidth, newHeight)
 				if err != nil {
 					job.Error.Error(ctx, err)

--- a/pkg/component/ai/openai/v0/preprocess.go
+++ b/pkg/component/ai/openai/v0/preprocess.go
@@ -1,0 +1,38 @@
+package openai
+
+func resizeImage(width, height int) (int, int) {
+	// Resize image to match OpenAI's model requirements.
+	// OpenAI requires images to:
+	// 1. Scale to fit in a 2048px x 2048px square, maintaining original aspect ratio
+	// 2. Scale so that the image's shortest side is 768px long
+	// We pre-resize to reduce payload size and improve performance.
+	// Reference: https://platform.openai.com/docs/guides/images-vision#gpt-4o-gpt-4-1-gpt-4o-mini-cua-and-o-series-except-o4-mini
+	// First, ensure the image fits within 2048px x 2048px square
+	maxDimension := 2048
+	if width > maxDimension || height > maxDimension {
+		ratio := float64(width) / float64(height)
+		if width > height {
+			width = maxDimension
+			height = int(float64(width) / ratio)
+		} else {
+			height = maxDimension
+			width = int(float64(height) * ratio)
+		}
+	}
+
+	// Then, ensure the shortest side is exactly 768px
+	minDimension := 768
+	if width != minDimension && height != minDimension {
+		ratio := float64(width) / float64(height)
+		if width < height {
+			// Width is shorter side
+			width = minDimension
+			height = int(float64(width) / ratio)
+		} else {
+			// Height is shorter side
+			height = minDimension
+			width = int(float64(height) * ratio)
+		}
+	}
+	return width, height
+}

--- a/pkg/component/ai/openai/v0/preprocess_test.go
+++ b/pkg/component/ai/openai/v0/preprocess_test.go
@@ -1,0 +1,77 @@
+package openai
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestResizeImage(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name           string
+		inputWidth     int
+		inputHeight    int
+		expectedWidth  int
+		expectedHeight int
+	}{
+		{
+			name:           "image already within bounds",
+			inputWidth:     1024,
+			inputHeight:    768,
+			expectedWidth:  1024,
+			expectedHeight: 768,
+		},
+		{
+			name:           "image too large, width is larger",
+			inputWidth:     3000,
+			inputHeight:    2000,
+			expectedWidth:  1152,
+			expectedHeight: 768,
+		},
+		{
+			name:           "image too large, height is larger",
+			inputWidth:     2000,
+			inputHeight:    3000,
+			expectedWidth:  768,
+			expectedHeight: 1152,
+		},
+		{
+			name:           "image needs shortest side scaling, width is shorter",
+			inputWidth:     512,
+			inputHeight:    1024,
+			expectedWidth:  768,
+			expectedHeight: 1536,
+		},
+		{
+			name:           "image needs shortest side scaling, height is shorter",
+			inputWidth:     1024,
+			inputHeight:    512,
+			expectedWidth:  1536,
+			expectedHeight: 768,
+		},
+		{
+			name:           "square image",
+			inputWidth:     1000,
+			inputHeight:    1000,
+			expectedWidth:  768,
+			expectedHeight: 768,
+		},
+		{
+			name:           "very large square image",
+			inputWidth:     5000,
+			inputHeight:    5000,
+			expectedWidth:  768,
+			expectedHeight: 768,
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			width, height := resizeImage(tt.inputWidth, tt.inputHeight)
+			c.Assert(width, qt.Equals, tt.expectedWidth)
+			c.Assert(height, qt.Equals, tt.expectedHeight)
+		})
+	}
+}


### PR DESCRIPTION
Because

- OpenAI downsizes images before processing them, there’s no need to send large images.

This commit

- Resizes the image before sending it to OpenAI.