### PR TITLE
fix(component,http): fix incorrect marshaling in the request body

### DIFF
--- a/pkg/component/generic/http/v0/main.go
+++ b/pkg/component/generic/http/v0/main.go
@@ -153,7 +153,11 @@ func (e *execution) executeHTTP(ctx context.Context, job *base.Job) error {
 	// An API error is a valid output in this component.
 	req := e.client.R()
 	if in.Body != nil {
-		req.SetBody(in.Body.String())
+		jsonValue, err := in.Body.ToJSONValue()
+		if err != nil {
+			return fmt.Errorf("failed to convert body to JSON value: %w", err)
+		}
+		req.SetBody(jsonValue)
 	}
 
 	resp, err := req.Execute(taskMethod[e.Task], in.EndpointURL)


### PR DESCRIPTION
Because

- We used String() to set the object as the HTTP request body, but the String() function doesn’t produce the same result as JSON marshaling in some cases.

This commit

- Fixes incorrect marshaling in the request body.