### PR TITLE
feat(http): add header parameter in HTTP component

### DIFF
--- a/pkg/component/generic/http/v0/README.mdx
+++ b/pkg/component/generic/http/v0/README.mdx
@@ -114,6 +114,7 @@ Send a HTTP GET request.
 | Task ID (required) | `task` | string | `TASK_GET` |
 | Endpoint URL (required) | `endpoint-url` | string | The API endpoint url. |
 | Body | `output-body-schema` | string | The request body. |
+| Header | `header` | json | The HTTP header of the response. It must be an object whose values are arrays of strings. |
 </div>
 
 
@@ -143,6 +144,7 @@ Send a HTTP POST request.
 | Endpoint URL (required) | `endpoint-url` | string | The API endpoint url. |
 | Body | `body` | any | The request body. |
 | Body | `output-body-schema` | string | The JSON schema of output body. |
+| Header | `header` | json | The HTTP header of the response. It must be an object whose values are arrays of strings. |
 </div>
 
 
@@ -172,6 +174,7 @@ Send a HTTP PATCH request.
 | Endpoint URL (required) | `endpoint-url` | string | The API endpoint url. |
 | Body | `body` | any | The request body. |
 | Body | `output-body-schema` | string | The JSON schema of output body. |
+| Header | `header` | json | The HTTP header of the response. It must be an object whose values are arrays of strings. |
 </div>
 
 
@@ -201,6 +204,7 @@ Send a HTTP PUT request.
 | Endpoint URL (required) | `endpoint-url` | string | The API endpoint url. |
 | Body | `body` | any | The request body. |
 | Body | `output-body-schema` | string | The JSON schema of output body. |
+| Header | `header` | json | The HTTP header of the response. It must be an object whose values are arrays of strings. |
 </div>
 
 
@@ -230,6 +234,7 @@ Send a HTTP DELETE request.
 | Endpoint URL (required) | `endpoint-url` | string | The API endpoint url. |
 | Body | `body` | any | The request body. |
 | Body | `output-body-schema` | string | The JSON schema of output body. |
+| Header | `header` | json | The HTTP header of the response. It must be an object whose values are arrays of strings. |
 </div>
 
 
@@ -258,6 +263,7 @@ Send a HTTP HEAD request.
 | Task ID (required) | `task` | string | `TASK_HEAD` |
 | Endpoint URL (required) | `endpoint-url` | string | The API endpoint url. |
 | Body | `output-body-schema` | string | The request body. |
+| Header | `header` | json | The HTTP header of the response. It must be an object whose values are arrays of strings. |
 </div>
 
 
@@ -287,6 +293,7 @@ Send a HTTP OPTIONS request.
 | Endpoint URL (required) | `endpoint-url` | string | The API endpoint url. |
 | Body | `body` | any | The request body. |
 | Body | `output-body-schema` | string | The JSON schema of output body. |
+| Header | `header` | json | The HTTP header of the response. It must be an object whose values are arrays of strings. |
 </div>
 
 

--- a/pkg/component/generic/http/v0/config/tasks.yaml
+++ b/pkg/component/generic/http/v0/config/tasks.yaml
@@ -19,10 +19,24 @@ $defs:
         description: The JSON schema of output body.
         type: string
         shortDescription: The JSON schema of output body
-        uiOrder: 1
+        uiOrder: 2
         order: 2
         required: []
         title: Body
+      header:
+        description: |-
+          The HTTP header of the response. It must be an object whose values
+          are arrays of strings.
+        uiOrder: 3
+        order: 3
+        required: []
+        title: Header
+        type: json
+        example:
+          Instill-Header-One:
+            - foo
+          Instill-Header-Two:
+            - bar
     required:
       - endpoint-url
     title: Input
@@ -45,19 +59,18 @@ $defs:
         title: Body
       header:
         description: |-
-          The request HTTP headers. It must be an object where the values are
-          an array of strings.
+          The HTTP header of the response. It must be an object whose values
+          are arrays of strings.
         uiOrder: 2
         order: 2
         required: []
         title: Header
         type: json
         example:
-          Extra-Header-One:
-            - myHeaderValue
-          Extra-Header-Two:
-            - val1
-            - val2
+          Instill-Header-One:
+            - foo
+          Instill-Header-Two:
+            - bar
     required:
       - endpoint-url
     title: Input Without Body

--- a/pkg/component/generic/http/v0/io.go
+++ b/pkg/component/generic/http/v0/io.go
@@ -1,15 +1,19 @@
 package http
 
-import "github.com/instill-ai/pipeline-backend/pkg/data/format"
+import (
+	"net/http"
+
+	"github.com/instill-ai/pipeline-backend/pkg/data/format"
+)
 
 type httpInput struct {
-	EndpointURL string              `instill:"endpoint-url"`
-	Header      map[string][]string `instill:"header"`
-	Body        format.Value        `instill:"body"`
+	EndpointURL string       `instill:"endpoint-url"`
+	Header      http.Header  `instill:"header"`
+	Body        format.Value `instill:"body"`
 }
 
 type httpOutput struct {
-	Header     map[string][]string `instill:"header"`
-	Body       format.Value        `instill:"body"`
-	StatusCode int                 `instill:"status-code"`
+	Header     http.Header  `instill:"header"`
+	Body       format.Value `instill:"body"`
+	StatusCode int          `instill:"status-code"`
 }

--- a/pkg/component/generic/http/v0/main.go
+++ b/pkg/component/generic/http/v0/main.go
@@ -160,6 +160,10 @@ func (e *execution) executeHTTP(ctx context.Context, job *base.Job) error {
 		req.SetBody(jsonValue)
 	}
 
+	for k, h := range in.Header {
+		req.SetHeader(k, strings.Join(h, ","))
+	}
+
 	resp, err := req.Execute(taskMethod[e.Task], in.EndpointURL)
 	if err != nil {
 		return fmt.Errorf("executing HTTP request: %w", err)


### PR DESCRIPTION
This commit

- Adds a `header` parameter to the HTTP component in order to pass custom
  headers in requests.
