### PR TITLE
fix(component,document): fix the wrong python script output parsing

### DIFF
--- a/pkg/component/operator/document/v0/transformer/markdowntransformer.go
+++ b/pkg/component/operator/document/v0/transformer/markdowntransformer.go
@@ -114,7 +114,7 @@ func (t *pdfToMarkdownTransformer) transform() (converterOutput, error) {
 		errChan <- nil
 	}()
 
-	outputBytes, err := cmdRunner.CombinedOutput()
+	outputBytes, err := cmdRunner.Output()
 	benchmarkLog = benchmarkLog.With(zap.Time("convert", time.Now()))
 	if err != nil {
 		errorStr := string(outputBytes)


### PR DESCRIPTION
Because

- the stderr pipe output pollute the output parsing

This commit

- fix the wrong python script output parsing
