### PR TITLE
fix(document): make Python scripts fail silently on document-to-markdown conversion

### DIFF
--- a/pkg/component/operator/document/v0/transformer/execution/docling_pdf_to_md_converter.py
+++ b/pkg/component/operator/document/v0/transformer/execution/docling_pdf_to_md_converter.py
@@ -13,9 +13,15 @@ from docling.datamodel.pipeline_options import PdfPipelineOptions
 from docling_core.types.doc import ImageRefMode, PictureItem
 
 if __name__ == "__main__":
-    # Capture warnings and errors. These are printed to stderr by default, which
-    # will prevent clients from unmarshalling the response.
+    # Capture all stderr output and logging warnings/errors
+    stderr_capture = StringIO()
     conversion_logs = StringIO()
+
+    # Redirect stderr to capture all stderr output
+    original_stderr = sys.stderr
+    sys.stderr = stderr_capture
+
+    # Set up logging to capture warnings and errors
     log_handler = logging.StreamHandler(conversion_logs)
     log_handler.setLevel(logging.WARNING)
 
@@ -25,31 +31,31 @@ if __name__ == "__main__":
     # Add the handler to capture warnings/errors
     logging.getLogger().addHandler(log_handler)
 
-    json_str = sys.stdin.buffer.read().decode('utf-8')
-    params = json.loads(json_str)
-    display_image_tag = params["display-image-tag"]
-    display_all_page_image = params["display-all-page-image"]
-    pdf_string = params["PDF"]
-    if ("resolution" in params and
-            params["resolution"] != 0 and
-            params["resolution"] is not None):
-        resolution = params["resolution"]
-    else:
-        resolution = 300
-    decoded_bytes = base64.b64decode(pdf_string)
-    pdf_file_obj = BytesIO(decoded_bytes)
-
-    # Convert resolution DPI to image resolution scale
-    image_resolution_scale = resolution / 72.0
-
-    # Initialize variables
-    images = []
-    all_page_images = []
-    page_numbers_with_images = []
-    elements = []
-    errors = []
-
     try:
+        json_str = sys.stdin.buffer.read().decode('utf-8')
+        params = json.loads(json_str)
+        display_image_tag = params["display-image-tag"]
+        display_all_page_image = params["display-all-page-image"]
+        pdf_string = params["PDF"]
+        if ("resolution" in params and
+                params["resolution"] != 0 and
+                params["resolution"] is not None):
+            resolution = params["resolution"]
+        else:
+            resolution = 300
+        decoded_bytes = base64.b64decode(pdf_string)
+        pdf_file_obj = BytesIO(decoded_bytes)
+
+        # Convert resolution DPI to image resolution scale
+        image_resolution_scale = resolution / 72.0
+
+        # Initialize variables
+        images = []
+        all_page_images = []
+        page_numbers_with_images = []
+        elements = []
+        errors = []
+
         # Configure the pipeline options
         # The model artifacts should be prefetched and stored in a location
         # through the `DOCLING_ARTIFACTS_PATH` variable.
@@ -113,6 +119,15 @@ if __name__ == "__main__":
                 if page_no in page_numbers_with_images:
                     all_page_images.append(str(page.image.uri))
 
+        # Combine all captured output
+        all_logs = []
+        stderr_content = stderr_capture.getvalue().strip()
+        if stderr_content:
+            all_logs.extend(stderr_content.splitlines())
+        log_content = conversion_logs.getvalue().strip()
+        if log_content:
+            all_logs.extend(log_content.splitlines())
+
         # Collate the output
         output = {
             "body": result,
@@ -121,8 +136,14 @@ if __name__ == "__main__":
             "all_page_images": all_page_images,
             "display_all_page_image": display_all_page_image,
             "markdowns": markdown_pages,
-            "logs": conversion_logs.getvalue().splitlines(),
+            "logs": all_logs,
         }
+
+        # Restore original stderr for the final output
+        sys.stderr = original_stderr
         print(json.dumps(output))
+
     except Exception as e:
+        # Restore original stderr before printing error
+        sys.stderr = original_stderr
         print(json.dumps({"system_error": str(e)}), file=sys.stderr)

--- a/pkg/component/operator/document/v0/transformer/markdowntransformer.go
+++ b/pkg/component/operator/document/v0/transformer/markdowntransformer.go
@@ -132,7 +132,17 @@ func (t *pdfToMarkdownTransformer) transform() (converterOutput, error) {
 	}
 
 	if output.SystemError != "" {
-		return output, fmt.Errorf("converting PDF to Markdown: %s", output.SystemError)
+		// There are documents that will fail to be converted to MD. Usually,
+		// the document-to-markdwon task is a step in a pipeline to obtain an
+		// approximate result or to feed it into other components that will
+		// refine it. In most cases, we don't want this failure to stop the
+		// execution of the pipeline, so we continue with a blank result.
+		//
+		// TODO jvallesm: INS-8156 implements a failover mechanism so pipeline
+		// recipes can determine if a component failure is fatal or not. When
+		// that's implemented, we should return an error here instead of
+		// continuing.
+		t.logger.Error("Failed to convert PDF to Markdown. Continuing with empty result.", zap.String("systemError", output.SystemError))
 	}
 
 	if len(output.Logs) > 0 {

--- a/pkg/component/operator/document/v0/transformer/markdowntransformer.go
+++ b/pkg/component/operator/document/v0/transformer/markdowntransformer.go
@@ -114,7 +114,8 @@ func (t *pdfToMarkdownTransformer) transform() (converterOutput, error) {
 		errChan <- nil
 	}()
 
-	outputBytes, err := cmdRunner.Output()
+	outputBytes, err := cmdRunner.CombinedOutput()
+
 	benchmarkLog = benchmarkLog.With(zap.Time("convert", time.Now()))
 	if err != nil {
 		errorStr := string(outputBytes)


### PR DESCRIPTION
Because

- `pdfplumber` when converting certain files
- `docling` printed unstructured information to `stderr` outside of the logging system

This commit

- Makes `pdfplumber` silently fail so other components can continue the execution
- Improves the python scripts to capture all the `stderr` information.