### PR TITLE
chore(http): block internal endpoints in HTTP component.

### DIFF
--- a/pkg/component/generic/http/v0/README.mdx
+++ b/pkg/component/generic/http/v0/README.mdx
@@ -112,7 +112,7 @@ Send a HTTP GET request.
 | Input | Field ID | Type | Description |
 | :--- | :--- | :--- | :--- |
 | Task ID (required) | `task` | string | `TASK_GET` |
-| Endpoint URL (required) | `endpoint-url` | string | The API endpoint url. |
+| Endpoint URL (required) | `endpoint-url` | string | The API endpoint URL. It must be a valid URI reference and point to an external IP address. If the URL resolves to an internal or private IP, the component will throw an error. |
 | Body | `output-body-schema` | string | The request body. |
 | Header | `header` | json | The HTTP header of the response. It must be an object whose values are arrays of strings. |
 </div>
@@ -141,7 +141,7 @@ Send a HTTP POST request.
 | Input | Field ID | Type | Description |
 | :--- | :--- | :--- | :--- |
 | Task ID (required) | `task` | string | `TASK_POST` |
-| Endpoint URL (required) | `endpoint-url` | string | The API endpoint url. |
+| Endpoint URL (required) | `endpoint-url` | string | The API endpoint URL. It must be a valid URI reference and point to an external IP address. If the URL resolves to an internal or private IP, the component will throw an error. |
 | Body | `body` | any | The request body. |
 | Body | `output-body-schema` | string | The JSON schema of output body. |
 | Header | `header` | json | The HTTP header of the response. It must be an object whose values are arrays of strings. |
@@ -171,7 +171,7 @@ Send a HTTP PATCH request.
 | Input | Field ID | Type | Description |
 | :--- | :--- | :--- | :--- |
 | Task ID (required) | `task` | string | `TASK_PATCH` |
-| Endpoint URL (required) | `endpoint-url` | string | The API endpoint url. |
+| Endpoint URL (required) | `endpoint-url` | string | The API endpoint URL. It must be a valid URI reference and point to an external IP address. If the URL resolves to an internal or private IP, the component will throw an error. |
 | Body | `body` | any | The request body. |
 | Body | `output-body-schema` | string | The JSON schema of output body. |
 | Header | `header` | json | The HTTP header of the response. It must be an object whose values are arrays of strings. |
@@ -201,7 +201,7 @@ Send a HTTP PUT request.
 | Input | Field ID | Type | Description |
 | :--- | :--- | :--- | :--- |
 | Task ID (required) | `task` | string | `TASK_PUT` |
-| Endpoint URL (required) | `endpoint-url` | string | The API endpoint url. |
+| Endpoint URL (required) | `endpoint-url` | string | The API endpoint URL. It must be a valid URI reference and point to an external IP address. If the URL resolves to an internal or private IP, the component will throw an error. |
 | Body | `body` | any | The request body. |
 | Body | `output-body-schema` | string | The JSON schema of output body. |
 | Header | `header` | json | The HTTP header of the response. It must be an object whose values are arrays of strings. |
@@ -231,7 +231,7 @@ Send a HTTP DELETE request.
 | Input | Field ID | Type | Description |
 | :--- | :--- | :--- | :--- |
 | Task ID (required) | `task` | string | `TASK_DELETE` |
-| Endpoint URL (required) | `endpoint-url` | string | The API endpoint url. |
+| Endpoint URL (required) | `endpoint-url` | string | The API endpoint URL. It must be a valid URI reference and point to an external IP address. If the URL resolves to an internal or private IP, the component will throw an error. |
 | Body | `body` | any | The request body. |
 | Body | `output-body-schema` | string | The JSON schema of output body. |
 | Header | `header` | json | The HTTP header of the response. It must be an object whose values are arrays of strings. |
@@ -261,7 +261,7 @@ Send a HTTP HEAD request.
 | Input | Field ID | Type | Description |
 | :--- | :--- | :--- | :--- |
 | Task ID (required) | `task` | string | `TASK_HEAD` |
-| Endpoint URL (required) | `endpoint-url` | string | The API endpoint url. |
+| Endpoint URL (required) | `endpoint-url` | string | The API endpoint URL. It must be a valid URI reference and point to an external IP address. If the URL resolves to an internal or private IP, the component will throw an error. |
 | Body | `output-body-schema` | string | The request body. |
 | Header | `header` | json | The HTTP header of the response. It must be an object whose values are arrays of strings. |
 </div>
@@ -290,7 +290,7 @@ Send a HTTP OPTIONS request.
 | Input | Field ID | Type | Description |
 | :--- | :--- | :--- | :--- |
 | Task ID (required) | `task` | string | `TASK_OPTIONS` |
-| Endpoint URL (required) | `endpoint-url` | string | The API endpoint url. |
+| Endpoint URL (required) | `endpoint-url` | string | The API endpoint URL. It must be a valid URI reference and point to an external IP address. If the URL resolves to an internal or private IP, the component will throw an error. |
 | Body | `body` | any | The request body. |
 | Body | `output-body-schema` | string | The JSON schema of output body. |
 | Header | `header` | json | The HTTP header of the response. It must be an object whose values are arrays of strings. |

--- a/pkg/component/generic/http/v0/component_test.go
+++ b/pkg/component/generic/http/v0/component_test.go
@@ -22,22 +22,6 @@ const (
 	authValue = "321"
 )
 
-var testAuth = map[authType]map[string]any{
-	noAuthType: {},
-	basicAuthType: {
-		"username": username,
-		"password": password,
-	},
-	bearerTokenType: {
-		"token": token,
-	},
-	apiKeyType: {
-		"auth-location": string(query),
-		"key":           authKey,
-		"value":         authValue,
-	},
-}
-
 func TestComponent(t *testing.T) {
 	c := qt.New(t)
 	c.Parallel()
@@ -351,7 +335,19 @@ func TestComponent(t *testing.T) {
 }
 
 func cfg(atype authType) *structpb.Struct {
-	auth := testAuth[atype]
+	auth := map[string]any{}
+	switch atype {
+	case basicAuthType:
+		auth["username"] = username
+		auth["password"] = password
+	case bearerTokenType:
+		auth["token"] = token
+	case apiKeyType:
+		auth["auth-location"] = string(query)
+		auth["key"] = authKey
+		auth["value"] = authValue
+	}
+
 	auth["auth-type"] = string(atype)
 	setup, _ := structpb.NewStruct(map[string]any{
 		"authentication": auth,

--- a/pkg/component/generic/http/v0/config/tasks.yaml
+++ b/pkg/component/generic/http/v0/config/tasks.yaml
@@ -11,10 +11,13 @@ $defs:
         required: []
         title: Body
       endpoint-url:
-        description: The API endpoint url.
+        title: Endpoint URL
+        description: |-
+          The API endpoint URL. It must be a valid URI reference and point to
+          an external IP address. If the URL resolves to an internal or private
+          IP, the component will throw an error.
         type: string
         uiOrder: 0
-        title: Endpoint Url
       output-body-schema:
         description: The JSON schema of output body.
         type: string
@@ -45,10 +48,13 @@ $defs:
     uiOrder: 0
     properties:
       endpoint-url:
-        description: The API endpoint url.
+        title: Endpoint URL
+        description: |-
+          The API endpoint URL. It must be a valid URI reference and point to
+          an external IP address. If the URL resolves to an internal or private
+          IP, the component will throw an error.
         type: string
         uiOrder: 0
-        title: Endpoint Url
       output-body-schema:
         description: The request body.
         type: string


### PR DESCRIPTION
Because

- The internal network of an Instill Core deployment is exposed through
  the `http` component.

This commit

- Blocks the endpoints resolved to internal IP ranges.
- Reworks coverage of the component to use an external URL for testing.
