### PR TITLE
ci(workflows): adopt short commit hash for service version

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,12 @@
 name: Coverage
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   codecov:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -2,7 +2,11 @@ name: golangci-lint
 
 on:
   push:
+    branches:
+      - main
   pull_request:
+    branches:
+      - main
 
 permissions:
   contents: read

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -44,6 +44,25 @@ jobs:
           username: drop@instill-ai.com
           password: ${{ secrets.botDockerHubPassword }}
 
+      - name: Set short commit SHA
+        if: github.ref == 'refs/heads/main'
+        run: |
+          echo "COMMIT_SHORT_SHA=${GITHUB_SHA:0:7}" >> $GITHUB_ENV
+
+      - name: Build and push amd64 (latest)
+        if: github.ref == 'refs/heads/main'
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64
+          context: .
+          push: true
+          build-args: |
+            SERVICE_NAME=${{ env.SERVICE_NAME }}
+            SERVICE_VERSION=${{ env.COMMIT_SHORT_SHA }}
+          tags: instill/pipeline-backend:latest-amd64
+          cache-from: type=registry,ref=instill/pipeline-backend:buildcache
+          cache-to: type=registry,ref=instill/pipeline-backend:buildcache,mode=max
+
       - name: Set Versions
         if: github.event_name == 'release' || startsWith(github.ref, 'refs/tags/')
         uses: actions/github-script@v6
@@ -55,20 +74,6 @@ jobs:
             core.setOutput('tag', tag)
             core.setOutput('no_v_tag', no_v_tag)
 
-      - name: Build and push amd64 (latest)
-        if: github.ref == 'refs/heads/main'
-        uses: docker/build-push-action@v6
-        with:
-          platforms: linux/amd64
-          context: .
-          push: true
-          build-args: |
-            SERVICE_NAME=pipeline-backend
-            SERVICE_VERSION=${{ github.sha }}
-          tags: instill/pipeline-backend:latest-amd64
-          cache-from: type=registry,ref=instill/pipeline-backend:buildcache
-          cache-to: type=registry,ref=instill/pipeline-backend:buildcache,mode=max
-
       - name: Build and push amd64 (rc/release)
         if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'release'
         uses: docker/build-push-action@v6
@@ -77,7 +82,7 @@ jobs:
           context: .
           push: true
           build-args: |
-            SERVICE_NAME=pipeline-backend
+            SERVICE_NAME=${{ env.SERVICE_NAME }}
             SERVICE_VERSION=${{ steps.set_version.outputs.no_v_tag }}
           tags: instill/pipeline-backend:${{ steps.set_version.outputs.no_v_tag }}-amd64
           cache-from: type=registry,ref=instill/pipeline-backend:buildcache
@@ -114,6 +119,25 @@ jobs:
           username: dropletbot
           password: ${{ secrets.botDockerHubPassword }}
 
+      - name: Set short commit SHA
+        if: github.ref == 'refs/heads/main'
+        run: |
+          echo "COMMIT_SHORT_SHA=${GITHUB_SHA:0:7}" >> $GITHUB_ENV
+
+      - name: Build and push arm64 (latest)
+        if: github.ref == 'refs/heads/main'
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/arm64
+          context: .
+          push: true
+          build-args: |
+            SERVICE_NAME=${{ env.SERVICE_NAME }}
+            SERVICE_VERSION=${{ env.COMMIT_SHORT_SHA }}
+          tags: instill/pipeline-backend:latest-arm64
+          cache-from: type=registry,ref=instill/pipeline-backend:buildcache
+          cache-to: type=registry,ref=instill/pipeline-backend:buildcache,mode=max
+
       - name: Set Versions
         if: github.event_name == 'release' || startsWith(github.ref, 'refs/tags/')
         uses: actions/github-script@v6
@@ -125,20 +149,6 @@ jobs:
             core.setOutput('tag', tag)
             core.setOutput('no_v_tag', no_v_tag)
 
-      - name: Build and push arm64 (latest)
-        if: github.ref == 'refs/heads/main'
-        uses: docker/build-push-action@v6
-        with:
-          platforms: linux/arm64
-          context: .
-          push: true
-          build-args: |
-            SERVICE_NAME=pipeline-backend
-            SERVICE_VERSION=${{ github.sha }}
-          tags: instill/pipeline-backend:latest-arm64
-          cache-from: type=registry,ref=instill/pipeline-backend:buildcache
-          cache-to: type=registry,ref=instill/pipeline-backend:buildcache,mode=max
-
       - name: Build and push arm64 (rc/release)
         if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'release'
         uses: docker/build-push-action@v6
@@ -147,7 +157,7 @@ jobs:
           context: .
           push: true
           build-args: |
-            SERVICE_NAME=pipeline-backend
+            SERVICE_NAME=${{ env.SERVICE_NAME }}
             SERVICE_VERSION=${{ steps.set_version.outputs.no_v_tag }}
           tags: instill/pipeline-backend:${{ steps.set_version.outputs.no_v_tag }}-arm64
           cache-from: type=registry,ref=instill/pipeline-backend:buildcache

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -9,14 +9,8 @@ on:
       - main
 
 jobs:
-  build-push-image:
-    if: github.ref == 'refs/heads/main'
-    name: Build and push image
-    uses: instill-ai/pipeline-backend/.github/workflows/images.yml@main
-    secrets: inherit
-  pr-head:
-    if: github.event_name == 'pull_request'
-    name: PR head branch
+  integration-test:
+    name: Integration test
     runs-on: ubuntu-latest
     steps:
       - name: Maximize build space
@@ -77,14 +71,19 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Set short commit SHA
+        if: github.ref == 'refs/heads/main'
+        run: |
+          echo "COMMIT_SHORT_SHA=${GITHUB_SHA:0:7}" >> $GITHUB_ENV
+
       - name: Build image
         uses: docker/build-push-action@v6
         with:
           context: pipeline-backend
           load: true
           build-args: |
-            SERVICE_NAME=pipeline-backend
-            SERVICE_VERSION=${{ github.sha }}
+            SERVICE_NAME=${{ env.SERVICE_NAME }}
+            SERVICE_VERSION=${{ env.COMMIT_SHORT_SHA }}
           tags: instill/pipeline-backend:latest
           cache-from: |
             type=registry,ref=instill/pipeline-backend:buildcache
@@ -94,7 +93,7 @@ jobs:
       - name: Launch Instill Core CE (latest)
         working-directory: instill-core
         run: |
-          make latest EDITION=local-ce:test ENV_SECRETS_COMPONENT=.env.secrets.component.test
+          make latest EDITION=docker-ce:test ENV_SECRETS_COMPONENT=.env.secrets.component.test
 
       - name: Run integration-test
         working-directory: pipeline-backend

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,37 +37,35 @@ ENV C_INCLUDE_PATH=${ONNXRUNTIME_ROOT_PATH}/include
 ENV LD_RUN_PATH=${ONNXRUNTIME_ROOT_PATH}/lib
 ENV LIBRARY_PATH=${ONNXRUNTIME_ROOT_PATH}/lib
 
-WORKDIR /src
-
-COPY go.mod go.sum ./
-RUN go mod download
-COPY . .
+WORKDIR /build
 
 ARG SERVICE_NAME SERVICE_VERSION TARGETOS TARGETARCH
-RUN --mount=target=. \
+
+RUN --mount=type=bind,target=. \
+    --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    --mount=type=cache,target=/go/pkg \
     GOOS=$TARGETOS GOARCH=$TARGETARCH \
     go build -ldflags "-w -X main.version=${SERVICE_VERSION} -X main.serviceName=${SERVICE_NAME}" \
     -tags=ocr,onnx -o /${SERVICE_NAME} ./cmd/main
 
-RUN --mount=target=. \
+RUN --mount=type=bind,target=. \
+    --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    --mount=type=cache,target=/go/pkg \
     GOOS=$TARGETOS GOARCH=$TARGETARCH \
+    go mod download && \
     go build -ldflags "-w -X main.version=${SERVICE_VERSION} -X main.serviceName=${SERVICE_NAME}-worker" \
     -tags=ocr,onnx -o /${SERVICE_NAME}-worker ./cmd/worker
 
-RUN --mount=target=. \
+RUN --mount=type=bind,target=. \
+    --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    --mount=type=cache,target=/go/pkg \
     GOOS=$TARGETOS GOARCH=$TARGETARCH \
     go build -ldflags "-w -X main.version=${SERVICE_VERSION} -X main.serviceName=${SERVICE_NAME}-migrate" \
     -tags=ocr,onnx -o /${SERVICE_NAME}-migrate ./cmd/migration
 
-RUN --mount=target=. \
+RUN --mount=type=bind,target=. \
+    --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    --mount=type=cache,target=/go/pkg \
     GOOS=$TARGETOS GOARCH=$TARGETARCH \
     go build -ldflags "-w -X main.version=${SERVICE_VERSION} -X main.serviceName=${SERVICE_NAME}-init" \
     -tags=ocr,onnx -o /${SERVICE_NAME}-init ./cmd/init
@@ -117,14 +115,14 @@ ENV BASE_DOCLING_PATH=/home/nobody
 RUN mkdir -p ${BASE_DOCLING_PATH}/.EasyOCR/model && chown -R nobody:nogroup ${BASE_DOCLING_PATH}
 
 RUN apt update && \
-    apt install -y wget unzip && \
+    apt install -y unzip && \
     wget https://github.com/JaidedAI/EasyOCR/releases/download/v1.3/latin_g2.zip && \
     unzip latin_g2.zip -d ${BASE_DOCLING_PATH}/.EasyOCR/model/ && \
     rm latin_g2.zip && \
     wget https://github.com/JaidedAI/EasyOCR/releases/download/pre-v1.1.6/craft_mlt_25k.zip && \
     unzip craft_mlt_25k.zip -d ${BASE_DOCLING_PATH}/.EasyOCR/model/ && \
     rm craft_mlt_25k.zip && \
-    apt remove -y wget unzip && \
+    apt remove -y unzip && \
     apt autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 
@@ -135,22 +133,24 @@ RUN /opt/venv/bin/python import_artifacts.py && rm import_artifacts.py
 
 USER nobody:nogroup
 
-ARG SERVICE_NAME
+ARG SERVICE_NAME SERVICE_VERSION
 
 ENV HOME=${BASE_DOCLING_PATH}
 WORKDIR /${SERVICE_NAME}
 
 ENV GODEBUG=tlsrsakex=1
 
-COPY --from=build --chown=nobody:nogroup /src/config ./config
-COPY --from=build --chown=nobody:nogroup /src/release-please ./release-please
-COPY --from=build --chown=nobody:nogroup /src/pkg/db/migration ./pkg/db/migration
-
 COPY --from=build --chown=nobody:nogroup /${SERVICE_NAME}-migrate ./
 COPY --from=build --chown=nobody:nogroup /${SERVICE_NAME}-init ./
 COPY --from=build --chown=nobody:nogroup /${SERVICE_NAME}-worker ./
 COPY --from=build --chown=nobody:nogroup /${SERVICE_NAME} ./
 
+COPY --chown=nobody:nogroup ./config ./config
+COPY --chown=nobody:nogroup ./pkg/db/migration ./pkg/db/migration
+
 # Set up ONNX model and environment variable
 COPY --chown=nobody:nogroup ./pkg/component/resources/onnx/silero_vad.onnx /${SERVICE_NAME}/pkg/component/resources/onnx/silero_vad.onnx
 ENV ONNX_MODEL_FOLDER_PATH=/${SERVICE_NAME}/pkg/component/resources/onnx
+
+ENV SERVICE_NAME=${SERVICE_NAME}
+ENV SERVICE_VERSION=${SERVICE_VERSION}

--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -57,11 +57,13 @@ import (
 const gracefulShutdownWaitPeriod = 15 * time.Second
 const gracefulShutdownTimeout = 60 * time.Minute
 
-var propagator propagation.TextMapPropagator
+var (
+	// These variables might be overridden at buildtime.
+	serviceVersion = "dev"
+	serviceName    = "pipeline-backend"
 
-// These variables might be overridden at buildtime.
-var version = "dev"
-var serviceName = "pipeline-backend"
+	propagator propagation.TextMapPropagator
+)
 
 func grpcHandlerFunc(grpcServer *grpc.Server, gwHandler http.Handler) http.Handler {
 	return h2c.NewHandler(
@@ -212,7 +214,7 @@ func main() {
 		Logger: logger,
 		AppInfo: minio.AppInfo{
 			Name:    serviceName,
-			Version: version,
+			Version: serviceVersion,
 		},
 	}
 	minIOFileGetter, err := minio.NewFileGetter(minIOParams)
@@ -325,7 +327,7 @@ func main() {
 			logger.Info("try to start usage reporter")
 			go func() {
 				for {
-					usg = usage.NewUsage(ctx, repo, mgmtPrivateServiceClient, redisClient, usageServiceClient)
+					usg = usage.NewUsage(ctx, repo, mgmtPrivateServiceClient, redisClient, usageServiceClient, serviceVersion)
 					if usg != nil {
 						usg.StartReporter(ctx)
 						logger.Info("usage reporter started")

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -38,9 +38,11 @@ import (
 const gracefulShutdownWaitPeriod = 15 * time.Second
 const gracefulShutdownTimeout = 60 * time.Minute
 
-// These variables might be overridden at buildtime.
-var version = "dev"
-var serviceName = "pipeline-backend-worker"
+var (
+	// These variables might be overridden at buildtime.
+	serviceVersion = "dev"
+	serviceName    = "pipeline-backend-worker"
+)
 
 func main() {
 	if err := config.Init(config.ParseConfigFlag()); err != nil {
@@ -82,7 +84,7 @@ func main() {
 		Logger: logger,
 		AppInfo: minio.AppInfo{
 			Name:    serviceName,
-			Version: version,
+			Version: serviceVersion,
 		},
 	}
 	minIOFileGetter, err := minio.NewFileGetter(minIOParams)

--- a/config/config.go
+++ b/config/config.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	EditionLocalCE      = "local-ce:dev"
+	EditionLocalCE      = "docker-ce:dev"
 	EditionCloudDev     = "cloud:dev"
 	EditionCloudStaging = "cloud:staging"
 	EditionCloudProd    = "cloud"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -4,7 +4,7 @@ server:
   https:
     cert:
     key:
-  edition: local-ce:dev
+  edition: docker-ce:dev
   usage:
     enabled: true
     tlsenabled: true


### PR DESCRIPTION
Because

- the service version for the repo commit head at the moment is tagged using the long commit hash. We'd like to keep it short. 

This commit

- update the build-time versioning logic.
