### PR TITLE
chore(dep): bump up usage-client version

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -36,7 +36,13 @@ backend with your local changes.
 ```shell
 cd $MY_WORKSPACE
 git clone https://github.com/instill-ai/instill-core && cd instill-core
-make latest PROFILE=api-gateway,mgmt,model,artifact,console
+make latest
+```
+
+#### Remove the containers to avoid conflicts
+
+```shell
+docker rm -f pipeline-backend pipeline-backend-worker
 ```
 
 #### Building the development container

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -72,7 +72,6 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Set short commit SHA
-        if: github.ref == 'refs/heads/main'
         run: |
           echo "COMMIT_SHORT_SHA=${GITHUB_SHA:0:7}" >> $GITHUB_ENV
 

--- a/go.mod
+++ b/go.mod
@@ -45,8 +45,8 @@ require (
 	github.com/h2non/filetype v1.1.3
 	github.com/iancoleman/strcase v0.3.0
 	github.com/influxdata/influxdb-client-go/v2 v2.14.0
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250612083230-80e6987e5d61
-	github.com/instill-ai/usage-client v0.3.0-alpha.0.20250313022849-49504d982f18
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250626141501-c8e22cc2e0b6
+	github.com/instill-ai/usage-client v0.4.0
 	github.com/instill-ai/x v0.8.0-alpha.0.20250522164415-9172edd336bb
 	github.com/itchyny/gojq v0.12.17
 	github.com/jackc/pgconn v1.14.3

--- a/go.sum
+++ b/go.sum
@@ -460,10 +460,10 @@ github.com/influxdata/influxdb-client-go/v2 v2.14.0 h1:AjbBfJuq+QoaXNcrova8smSjw
 github.com/influxdata/influxdb-client-go/v2 v2.14.0/go.mod h1:Ahpm3QXKMJslpXl3IftVLVezreAUtBOTZssDrjZEFHI=
 github.com/influxdata/line-protocol v0.0.0-20210922203350-b1ad95c89adf h1:7JTmneyiNEwVBOHSjoMxiWAqB992atOeepeFYegn5RU=
 github.com/influxdata/line-protocol v0.0.0-20210922203350-b1ad95c89adf/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250612083230-80e6987e5d61 h1:wA9YlKStdlutjW/QxlTZApNFJXRivFvlqsUiwKz4MlQ=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250612083230-80e6987e5d61/go.mod h1:bCnBosofpaUxKBuTTJM3/I3thAK37kvfBnKByjnLsl4=
-github.com/instill-ai/usage-client v0.3.0-alpha.0.20250313022849-49504d982f18 h1:RFdRDODY4qMTTIcKm4TBMpYhxDGFCql6HQ7oocA+WeQ=
-github.com/instill-ai/usage-client v0.3.0-alpha.0.20250313022849-49504d982f18/go.mod h1:/B+Irg9TYBlP+X79GZ+yvPxFvC+7fbRL7APNGiJlDSk=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250626141501-c8e22cc2e0b6 h1:5o4fBRte53mNXcjengF2TtlGaY4vUiM49iWT2KoOa5Q=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250626141501-c8e22cc2e0b6/go.mod h1:bCnBosofpaUxKBuTTJM3/I3thAK37kvfBnKByjnLsl4=
+github.com/instill-ai/usage-client v0.4.0 h1:xf1hAlO4a8lZwZzz9bprZOJqU3ghIcIsavUUB7UURyg=
+github.com/instill-ai/usage-client v0.4.0/go.mod h1:zZ9LRoXps2u63ARYPAbR2YvqTib3dWJLObZn+9YqhF0=
 github.com/instill-ai/x v0.8.0-alpha.0.20250522164415-9172edd336bb h1:lrHTet3MB9ctNTvY/H8qcyiHd1vdTRqzUMkGsh5/Pp8=
 github.com/instill-ai/x v0.8.0-alpha.0.20250522164415-9172edd336bb/go.mod h1:uzCqJuS/AuCPiY8HhzQpz7I3L5pJfIZZNw/euT6SfHE=
 github.com/itchyny/gojq v0.12.17 h1:8av8eGduDb5+rvEdaOO+zQUjA04MS0m3Ps8HiD+fceg=


### PR DESCRIPTION
Because

- usage-client has a a new version to adopt the latest services

This commit

- bumps up the usage-client version
- updates contributing guidline