### PR TITLE
ci(workflows): add workflow_dispatch event

### DIFF
--- a/.github/workflows/sync-component-docs.yml
+++ b/.github/workflows/sync-component-docs.yml
@@ -1,7 +1,7 @@
 name: Sync component docs
 
 on:
-  workflow_call:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -13,6 +13,14 @@ on:
     types: [published]
 
 jobs:
+  sync-manual:
+    name: Sync component docs (manual trigger)
+    if: github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/sync-component-docs-reusable.yml
+    with:
+      target_branch: v0-dev
+      commit_message: "triggered by manual workflow dispatch"
+    secrets: inherit
   sync-dev:
     name: Dev
     if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
Because

- `workflow_dispatch` is useful to manually trigger to generate `v0-dev` component documentation

This commit

- add the event
