### PR TITLE
fix(cmd): move Temporal namespace creation to cmd/init

### DIFF
--- a/cmd/init/main.go
+++ b/cmd/init/main.go
@@ -2,17 +2,32 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/redis/go-redis/v9"
+	"go.opentelemetry.io/otel"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/sdk/contrib/opentelemetry"
+	"go.temporal.io/sdk/interceptor"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	temporalclient "go.temporal.io/sdk/client"
 
 	"github.com/instill-ai/pipeline-backend/cmd/init/definitionupdater"
-
 	"github.com/instill-ai/pipeline-backend/config"
 	"github.com/instill-ai/pipeline-backend/pkg/repository"
+	"github.com/instill-ai/x/temporal"
 
 	database "github.com/instill-ai/pipeline-backend/pkg/db"
+	logx "github.com/instill-ai/x/log"
 )
+
+var serviceName = "pipeline-backend-init"
 
 func main() {
 
@@ -37,4 +52,75 @@ func main() {
 		log.Fatal(err)
 	}
 
+	logger, _ := logx.GetZapLogger(ctx)
+
+	// Initialize Temporal client
+	temporalClientOptions, err := temporal.ClientOptions(config.Config.Temporal, logger)
+	if err != nil {
+		logger.Fatal("Unable to build Temporal client options", zap.Error(err))
+	}
+
+	// Only add interceptor if tracing is enabled
+	if config.Config.OTELCollector.Enable {
+		temporalTracingInterceptor, err := opentelemetry.NewTracingInterceptor(opentelemetry.TracerOptions{
+			Tracer:            otel.Tracer(serviceName),
+			TextMapPropagator: otel.GetTextMapPropagator(),
+		})
+		if err != nil {
+			logger.Fatal("Unable to create temporal tracing interceptor", zap.Error(err))
+		}
+		temporalClientOptions.Interceptors = []interceptor.ClientInterceptor{temporalTracingInterceptor}
+	}
+
+	temporalClient, err := temporalclient.Dial(temporalClientOptions)
+	if err != nil {
+		logger.Fatal("Unable to create Temporal client", zap.Error(err))
+	}
+	// for only local temporal cluster
+	if config.Config.Temporal.ServerRootCA == "" && config.Config.Temporal.ClientCert == "" && config.Config.Temporal.ClientKey == "" {
+		initTemporalNamespace(ctx, temporalClient)
+	}
+
+}
+
+func initTemporalNamespace(ctx context.Context, client temporalclient.Client) {
+	logger, _ := logx.GetZapLogger(ctx)
+
+	resp, err := client.WorkflowService().ListNamespaces(ctx, &workflowservice.ListNamespacesRequest{})
+	if err != nil {
+		logger.Fatal(fmt.Sprintf("Unable to list namespaces: %s", err))
+	}
+
+	found := false
+	for _, n := range resp.GetNamespaces() {
+		if n.NamespaceInfo.Name == config.Config.Temporal.Namespace {
+			found = true
+		}
+	}
+
+	if !found {
+		if _, err := client.WorkflowService().RegisterNamespace(ctx,
+			&workflowservice.RegisterNamespaceRequest{
+				Namespace: config.Config.Temporal.Namespace,
+				WorkflowExecutionRetentionPeriod: func() *durationpb.Duration {
+					// Check if the string ends with "d" for day.
+					s := config.Config.Temporal.Retention
+					if strings.HasSuffix(s, "d") {
+						// Parse the number of days.
+						days, err := strconv.Atoi(s[:len(s)-1])
+						if err != nil {
+							logger.Fatal(fmt.Sprintf("Unable to parse retention period in day: %s", err))
+						}
+						// Convert days to hours and then to a duration.
+						t := time.Hour * 24 * time.Duration(days)
+						return durationpb.New(t)
+					}
+					logger.Fatal(fmt.Sprintf("Unable to parse retention period in day: %s", err))
+					return nil
+				}(),
+			},
+		); err != nil {
+			logger.Fatal(fmt.Sprintf("Unable to register namespace: %s", err))
+		}
+	}
 }

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -6,19 +6,15 @@ import (
 	"log"
 	"os"
 	"os/signal"
-	"strconv"
-	"strings"
 	"syscall"
 	"time"
 
 	"github.com/redis/go-redis/v9"
 	"go.opentelemetry.io/otel"
-	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/contrib/opentelemetry"
 	"go.temporal.io/sdk/interceptor"
 	"go.temporal.io/sdk/worker"
 	"go.uber.org/zap"
-	"google.golang.org/protobuf/types/known/durationpb"
 	"gorm.io/gorm"
 
 	grpczap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
@@ -89,11 +85,6 @@ func main() {
 	pipelinePublicServiceClient, artifactPublicServiceClient, artifactPrivateServiceClient,
 		redisClient, db, minIOClient, minIOFileGetter, temporalClient, timeseries, closeClients := newClients(ctx, logger)
 	defer closeClients()
-
-	// for only local temporal cluster
-	if config.Config.Temporal.ServerRootCA == "" && config.Config.Temporal.ClientCert == "" && config.Config.Temporal.ClientKey == "" {
-		initTemporalNamespace(ctx, temporalClient)
-	}
 
 	// Keep NewArtifactBinaryFetcher as requested
 	binaryFetcher := external.NewArtifactBinaryFetcher(artifactPrivateServiceClient, minIOFileGetter)
@@ -323,46 +314,4 @@ func newClients(ctx context.Context, logger *zap.Logger) (
 
 	return pipelinePublicServiceClient, artifactPublicServiceClient, artifactPrivateServiceClient,
 		redisClient, db, minIOClient, minIOFileGetter, temporalClient, timeseries, closer
-}
-
-func initTemporalNamespace(ctx context.Context, client temporalclient.Client) {
-	logger, _ := logx.GetZapLogger(ctx)
-
-	resp, err := client.WorkflowService().ListNamespaces(ctx, &workflowservice.ListNamespacesRequest{})
-	if err != nil {
-		logger.Fatal(fmt.Sprintf("Unable to list namespaces: %s", err))
-	}
-
-	found := false
-	for _, n := range resp.GetNamespaces() {
-		if n.NamespaceInfo.Name == config.Config.Temporal.Namespace {
-			found = true
-		}
-	}
-
-	if !found {
-		if _, err := client.WorkflowService().RegisterNamespace(ctx,
-			&workflowservice.RegisterNamespaceRequest{
-				Namespace: config.Config.Temporal.Namespace,
-				WorkflowExecutionRetentionPeriod: func() *durationpb.Duration {
-					// Check if the string ends with "d" for day.
-					s := config.Config.Temporal.Retention
-					if strings.HasSuffix(s, "d") {
-						// Parse the number of days.
-						days, err := strconv.Atoi(s[:len(s)-1])
-						if err != nil {
-							logger.Fatal(fmt.Sprintf("Unable to parse retention period in day: %s", err))
-						}
-						// Convert days to hours and then to a duration.
-						t := time.Hour * 24 * time.Duration(days)
-						return durationpb.New(t)
-					}
-					logger.Fatal(fmt.Sprintf("Unable to parse retention period in day: %s", err))
-					return nil
-				}(),
-			},
-		); err != nil {
-			logger.Fatal(fmt.Sprintf("Unable to register namespace: %s", err))
-		}
-	}
 }


### PR DESCRIPTION
Because

- the Temporal namespace needs to be created before both `cmd/main` and `cmd/worker`.

This commit

- moves Temporal namespace creation to cmd/init
