### PR TITLE
fix(component): fix missing propagation of original request header instill-artifact component

### DIFF
--- a/pkg/component/data/instillartifact/v0/client.go
+++ b/pkg/component/data/instillartifact/v0/client.go
@@ -49,6 +49,11 @@ func getRequestMetadata(vars map[string]any) metadata.MD {
 		"Instill-Auth-Type", "user",
 	)
 
+	originalHeader := util.GetOriginalHeader(vars)
+	for k, v := range originalHeader {
+		md.Set(k, v.(string))
+	}
+
 	if requester := util.GetInstillRequesterUID(vars); requester != "" {
 		md.Set("Instill-Requester-Uid", requester)
 	}

--- a/pkg/component/internal/util/helper.go
+++ b/pkg/component/internal/util/helper.go
@@ -215,6 +215,13 @@ func GetInstillRequesterUID(vars map[string]any) string {
 	return vars["__PIPELINE_REQUESTER_UID"].(string)
 }
 
+func GetOriginalHeader(vars map[string]any) map[string]any {
+	if v, ok := vars["__ORIGINAL_HEADER"]; ok {
+		return v.(map[string]any)
+	}
+	return nil
+}
+
 func ConvertDataFrameToMarkdownTable(rows [][]string) string {
 	var sb strings.Builder
 

--- a/pkg/recipe/variable.go
+++ b/pkg/recipe/variable.go
@@ -50,6 +50,9 @@ type SystemVariables struct {
 	MgmtBackend         string `json:"__MGMT_BACKEND"`
 	ArtifactBackend     string `json:"__ARTIFACT_BACKEND"`
 	AgentBackend        string `json:"__AGENT_BACKEND"`
+
+	// OriginalHeader contains the original context header from the request.
+	OriginalHeader map[string]string `json:"__ORIGINAL_HEADER"`
 }
 
 // TODO: GenerateSystemVariables will be refactored for better code structure.


### PR DESCRIPTION
Because

- We need to propagate headers with the `instill-` prefix to the instill-artifact component.

This commit

- Fixes missing propagation of original request header instill-artifact component