### PR TITLE
feat(temporal): remove Temporal namespace initialization

### DIFF
--- a/cmd/init/main.go
+++ b/cmd/init/main.go
@@ -2,32 +2,16 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log"
-	"strconv"
-	"strings"
-	"time"
 
 	"github.com/redis/go-redis/v9"
-	"go.opentelemetry.io/otel"
-	"go.temporal.io/api/workflowservice/v1"
-	"go.temporal.io/sdk/contrib/opentelemetry"
-	"go.temporal.io/sdk/interceptor"
-	"go.uber.org/zap"
-	"google.golang.org/protobuf/types/known/durationpb"
-
-	temporalclient "go.temporal.io/sdk/client"
 
 	"github.com/instill-ai/pipeline-backend/cmd/init/definitionupdater"
 	"github.com/instill-ai/pipeline-backend/config"
 	"github.com/instill-ai/pipeline-backend/pkg/repository"
-	"github.com/instill-ai/x/temporal"
 
 	database "github.com/instill-ai/pipeline-backend/pkg/db"
-	logx "github.com/instill-ai/x/log"
 )
-
-var serviceName = "pipeline-backend-init"
 
 func main() {
 
@@ -52,75 +36,4 @@ func main() {
 		log.Fatal(err)
 	}
 
-	logger, _ := logx.GetZapLogger(ctx)
-
-	// Initialize Temporal client
-	temporalClientOptions, err := temporal.ClientOptions(config.Config.Temporal, logger)
-	if err != nil {
-		logger.Fatal("Unable to build Temporal client options", zap.Error(err))
-	}
-
-	// Only add interceptor if tracing is enabled
-	if config.Config.OTELCollector.Enable {
-		temporalTracingInterceptor, err := opentelemetry.NewTracingInterceptor(opentelemetry.TracerOptions{
-			Tracer:            otel.Tracer(serviceName),
-			TextMapPropagator: otel.GetTextMapPropagator(),
-		})
-		if err != nil {
-			logger.Fatal("Unable to create temporal tracing interceptor", zap.Error(err))
-		}
-		temporalClientOptions.Interceptors = []interceptor.ClientInterceptor{temporalTracingInterceptor}
-	}
-
-	temporalClient, err := temporalclient.Dial(temporalClientOptions)
-	if err != nil {
-		logger.Fatal("Unable to create Temporal client", zap.Error(err))
-	}
-	// for only local temporal cluster
-	if config.Config.Temporal.ServerRootCA == "" && config.Config.Temporal.ClientCert == "" && config.Config.Temporal.ClientKey == "" {
-		initTemporalNamespace(ctx, temporalClient)
-	}
-
-}
-
-func initTemporalNamespace(ctx context.Context, client temporalclient.Client) {
-	logger, _ := logx.GetZapLogger(ctx)
-
-	resp, err := client.WorkflowService().ListNamespaces(ctx, &workflowservice.ListNamespacesRequest{})
-	if err != nil {
-		logger.Fatal(fmt.Sprintf("Unable to list namespaces: %s", err))
-	}
-
-	found := false
-	for _, n := range resp.GetNamespaces() {
-		if n.NamespaceInfo.Name == config.Config.Temporal.Namespace {
-			found = true
-		}
-	}
-
-	if !found {
-		if _, err := client.WorkflowService().RegisterNamespace(ctx,
-			&workflowservice.RegisterNamespaceRequest{
-				Namespace: config.Config.Temporal.Namespace,
-				WorkflowExecutionRetentionPeriod: func() *durationpb.Duration {
-					// Check if the string ends with "d" for day.
-					s := config.Config.Temporal.Retention
-					if strings.HasSuffix(s, "d") {
-						// Parse the number of days.
-						days, err := strconv.Atoi(s[:len(s)-1])
-						if err != nil {
-							logger.Fatal(fmt.Sprintf("Unable to parse retention period in day: %s", err))
-						}
-						// Convert days to hours and then to a duration.
-						t := time.Hour * 24 * time.Duration(days)
-						return durationpb.New(t)
-					}
-					logger.Fatal(fmt.Sprintf("Unable to parse retention period in day: %s", err))
-					return nil
-				}(),
-			},
-		); err != nil {
-			logger.Fatal(fmt.Sprintf("Unable to register namespace: %s", err))
-		}
-	}
 }

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -48,13 +48,10 @@ otelcollector:
   port: 4317
 temporal:
   hostport: temporal:7233
-  namespace: model-backend
+  namespace: instill-core
   retention: 1d
   metricsport: 8096
-  servername:
-  serverrootca:
-  clientcert:
-  clientkey:
+  apikey:
   insecureskipverify:
 mgmtbackend:
   host: mgmt-backend

--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/influxdata/influxdb-client-go/v2 v2.14.0
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250707160902-77023eb2f033
 	github.com/instill-ai/usage-client v0.4.0
-	github.com/instill-ai/x v0.9.0-alpha
+	github.com/instill-ai/x v0.9.0-alpha.0.20250804063509-85de2fb234cc
 	github.com/itchyny/gojq v0.12.17
 	github.com/jackc/pgx/v5 v5.7.5
 	github.com/jmoiron/sqlx v1.4.0
@@ -82,8 +82,8 @@ require (
 	go.einride.tech/aip v0.70.2
 	go.mongodb.org/mongo-driver v1.17.3
 	go.opentelemetry.io/otel v1.37.0
-	go.temporal.io/api v1.49.1
-	go.temporal.io/sdk v1.34.0
+	go.temporal.io/api v1.51.0
+	go.temporal.io/sdk v1.35.0
 	go.temporal.io/sdk/contrib/opentelemetry v0.6.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/exp v0.0.0-20250506013437-ce4c2cf36ca6

--- a/go.sum
+++ b/go.sum
@@ -464,8 +464,8 @@ github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250707160902-77023eb2f033 h1:
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250707160902-77023eb2f033/go.mod h1:bCnBosofpaUxKBuTTJM3/I3thAK37kvfBnKByjnLsl4=
 github.com/instill-ai/usage-client v0.4.0 h1:xf1hAlO4a8lZwZzz9bprZOJqU3ghIcIsavUUB7UURyg=
 github.com/instill-ai/usage-client v0.4.0/go.mod h1:zZ9LRoXps2u63ARYPAbR2YvqTib3dWJLObZn+9YqhF0=
-github.com/instill-ai/x v0.9.0-alpha h1:J11sJNMe39GAQ69tPy7OWV/hBD39oyF+4wHB1fKiwvw=
-github.com/instill-ai/x v0.9.0-alpha/go.mod h1:vAzbuQ7HAWdQkkpDq9mvWjSXQEJZSgJhguN6NhpLTUk=
+github.com/instill-ai/x v0.9.0-alpha.0.20250804063509-85de2fb234cc h1:rzg5semefqYy7AuYBAJp16P96c6fs9r3Y1d7OeSrGk4=
+github.com/instill-ai/x v0.9.0-alpha.0.20250804063509-85de2fb234cc/go.mod h1:OaBzHZhIBfrngDMxWbyTPSd1gILO2vrndi5z/tFpCSk=
 github.com/itchyny/gojq v0.12.17 h1:8av8eGduDb5+rvEdaOO+zQUjA04MS0m3Ps8HiD+fceg=
 github.com/itchyny/gojq v0.12.17/go.mod h1:WBrEMkgAfAGO1LUcGOckBl5O726KPp+OlkKug0I/FEY=
 github.com/itchyny/timefmt-go v0.1.6 h1:ia3s54iciXDdzWzwaVKXZPbiXzxxnv1SPGFfM/myJ5Q=
@@ -935,11 +935,11 @@ go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqe
 go.opentelemetry.io/proto/otlp v1.7.0 h1:jX1VolD6nHuFzOYso2E73H85i92Mv8JQYk0K9vz09os=
 go.opentelemetry.io/proto/otlp v1.7.0/go.mod h1:fSKjH6YJ7HDlwzltzyMj036AJ3ejJLCgCSHGj4efDDo=
 go.temporal.io/api v1.5.0/go.mod h1:BqKxEJJYdxb5dqf0ODfzfMxh8UEQ5L3zKS51FiIYYkA=
-go.temporal.io/api v1.49.1 h1:CdiIohibamF4YP9k261DjrzPVnuomRoh1iC//gZ1puA=
-go.temporal.io/api v1.49.1/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
+go.temporal.io/api v1.51.0 h1:9+e14GrIa7nWoWoudqj/PSwm33yYjV+u8TAR9If7s/g=
+go.temporal.io/api v1.51.0/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
 go.temporal.io/sdk v1.12.0/go.mod h1:lSp3lH1lI0TyOsus0arnO3FYvjVXBZGi/G7DjnAnm6o=
-go.temporal.io/sdk v1.34.0 h1:VLg/h6ny7GvLFVoQPqz2NcC93V9yXboQwblkRvZ1cZE=
-go.temporal.io/sdk v1.34.0/go.mod h1:iE4U5vFrH3asOhqpBBphpj9zNtw8btp8+MSaf5A0D3w=
+go.temporal.io/sdk v1.35.0 h1:lRNAQ5As9rLgYa7HBvnmKyzxLcdElTuoFJ0FXM/AsLQ=
+go.temporal.io/sdk v1.35.0/go.mod h1:1q5MuLc2MEJ4lneZTHJzpVebW2oZnyxoIOWX3oFVebw=
 go.temporal.io/sdk/contrib/opentelemetry v0.6.0 h1:rNBArDj5iTUkcMwKocUShoAW59o6HdS7Nq4CTp4ldj8=
 go.temporal.io/sdk/contrib/opentelemetry v0.6.0/go.mod h1:Lem8VrE2ks8P+FYcRM3UphPoBr+tfM3v/Kaf0qStzSg=
 go.temporal.io/sdk/contrib/tally v0.2.0 h1:XnTJIQcjOv+WuCJ1u8Ve2nq+s2H4i/fys34MnWDRrOo=


### PR DESCRIPTION
Because

- The Temporal namespace will now be initialized when the Temporal service starts.
Ref: https://github.com/instill-ai/instill-core/pull/1352
- We now use the shared `instill-core` namespace across all services.

This commit

- Removes Temporal namespace initialization
- Adopts the latest `x/temporal` package to support API key authentication for connecting to Temporal Cloud