### PR TITLE
fix(run): return correct total duration

### DIFF
--- a/pkg/datamodel/runlogging.go
+++ b/pkg/datamodel/runlogging.go
@@ -70,7 +70,6 @@ type PipelineRun struct {
 	PipelineVersion        string    `gorm:"type:varchar(255)" json:"pipeline-version"`                                // Pipeline version used in the run
 	Status                 RunStatus `gorm:"type:valid_trigger_status;index" json:"status"`                            // Current status of the run (e.g., Running, Completed, Failed)
 	Source                 RunSource `gorm:"type:valid_trigger_source" json:"source"`                                  // Origin of the run (e.g., Web click, API)
-	TotalDuration          null.Int  `gorm:"type:bigint" json:"total-duration"`                                        // Time taken to complete the run in nanoseconds
 	RunnerUID              uuid.UUID `gorm:"type:uuid" json:"runner-uid"`                                              // Identity of the user who initiated the run
 	RequesterUID           uuid.UUID `gorm:"type:uuid" json:"requester-uid"`                                           // Namespace used for the run, which is the requester
 	Inputs                 JSONB     `gorm:"type:jsonb" json:"inputs"`                                                 // Input files for the run
@@ -89,7 +88,6 @@ type ComponentRun struct {
 	PipelineTriggerUID     uuid.UUID   `gorm:"type:uuid;primaryKey;index" json:"pipeline-trigger-uid"`                   // Links to the parent PipelineRun
 	ComponentID            string      `gorm:"type:varchar(255);primaryKey" json:"component-id"`                         // Unique identifier for each pipeline component
 	Status                 RunStatus   `gorm:"type:varchar(50);index" json:"status"`                                     // Completion status of the component (e.g., Completed, Errored)
-	TotalDuration          null.Int    `gorm:"type:bigint" json:"total-duration"`                                        // Time taken to execute the component in nanoseconds
 	StartedTime            time.Time   `gorm:"type:timestamp with time zone;index" json:"started-time"`                  // Time when the component started execution
 	CompletedTime          null.Time   `gorm:"type:timestamp with time zone;index" json:"completed-time"`                // Time when the component finished execution
 	BlobDataExpirationTime null.Time   `gorm:"type:timestamp with time zone" json:"blob-data-expiration-time,omitempty"` // Time when the blob data (e.g. input or recipe) will expire.

--- a/pkg/db/migration/000041_drop_total_duration.down.sql
+++ b/pkg/db/migration/000041_drop_total_duration.down.sql
@@ -1,0 +1,10 @@
+BEGIN
+
+ALTER TABLE pipeline_run ADD COLUMN IF NOT EXISTS total_duration BIGINT DEFAULT 0;
+COMMENT ON COLUMN pipeline_run.total_duration IS 'in milliseconds';
+
+ALTER TABLE component_run ADD COLUMN IF NOT EXISTS total_duration BIGINT DEFAULT 0;
+COMMENT ON COLUMN component_run.total_duration IS 'in milliseconds';
+
+COMMIT;
+

--- a/pkg/db/migration/000041_drop_total_duration.up.sql
+++ b/pkg/db/migration/000041_drop_total_duration.up.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+ALTER TABLE component_run DROP COLUMN IF EXISTS total_duration;
+ALTER TABLE pipeline_run DROP COLUMN IF EXISTS total_duration;
+
+COMMIT;
+

--- a/pkg/db/migration/migration.go
+++ b/pkg/db/migration/migration.go
@@ -27,7 +27,7 @@ import (
 )
 
 // TargetSchemaVersion determines the database schema version.
-const TargetSchemaVersion uint = 40
+const TargetSchemaVersion uint = 41
 
 type migration interface {
 	Migrate() error

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -1855,13 +1855,7 @@ func (s *service) triggerAsyncPipeline(ctx context.Context, params triggerParams
 			}
 			logger.Error(fmt.Sprintf("unable to execute workflow: %s", err.Error()))
 
-			run, repoErr := s.repository.GetPipelineRunByUID(subCtx, uuid.FromStringOrNil(params.pipelineTriggerID))
-			if repoErr != nil {
-				logger.Error("failed to log pipeline run error", zap.Error(err), zap.Error(repoErr))
-				return
-			}
-
-			s.logPipelineRunError(subCtx, params.pipelineTriggerID, err, run.StartedTime)
+			s.logPipelineRunError(subCtx, params.pipelineTriggerID, err)
 			return
 		}
 	})
@@ -2006,7 +2000,7 @@ func (s *service) TriggerNamespacePipelineByID(ctx context.Context, ns resource.
 		return nil, nil, fmt.Errorf("fetching requester namespace: %w", err)
 	}
 
-	pipelineRun := s.logPipelineRunStart(ctx, logPipelineRunStartParams{
+	_ = s.logPipelineRunStart(ctx, logPipelineRunStartParams{
 		pipelineTriggerID: pipelineTriggerID,
 		pipelineUID:       pipelineUID,
 		pipelineReleaseID: defaultPipelineReleaseID,
@@ -2015,7 +2009,7 @@ func (s *service) TriggerNamespacePipelineByID(ctx context.Context, ns resource.
 	})
 	defer func() {
 		if err != nil {
-			s.logPipelineRunError(ctx, pipelineTriggerID, err, pipelineRun.StartedTime)
+			s.logPipelineRunError(ctx, pipelineTriggerID, err)
 		}
 	}()
 
@@ -2064,7 +2058,7 @@ func (s *service) TriggerAsyncNamespacePipelineByID(ctx context.Context, ns reso
 		return nil, fmt.Errorf("fetching requester namespace: %w", err)
 	}
 
-	pipelineRun := s.logPipelineRunStart(ctx, logPipelineRunStartParams{
+	_ = s.logPipelineRunStart(ctx, logPipelineRunStartParams{
 		pipelineTriggerID: pipelineTriggerID,
 		pipelineUID:       dbPipeline.UID,
 		pipelineReleaseID: defaultPipelineReleaseID,
@@ -2073,7 +2067,7 @@ func (s *service) TriggerAsyncNamespacePipelineByID(ctx context.Context, ns reso
 	})
 	defer func() {
 		if err != nil {
-			s.logPipelineRunError(ctx, pipelineTriggerID, err, pipelineRun.StartedTime)
+			s.logPipelineRunError(ctx, pipelineTriggerID, err)
 		}
 	}()
 
@@ -2126,7 +2120,7 @@ func (s *service) TriggerNamespacePipelineReleaseByID(ctx context.Context, ns re
 		return nil, nil, err
 	}
 
-	pipelineRun := s.logPipelineRunStart(ctx, logPipelineRunStartParams{
+	_ = s.logPipelineRunStart(ctx, logPipelineRunStartParams{
 		pipelineTriggerID: pipelineTriggerID,
 		pipelineUID:       pipelineUID,
 		pipelineReleaseID: dbPipelineRelease.ID,
@@ -2135,7 +2129,7 @@ func (s *service) TriggerNamespacePipelineReleaseByID(ctx context.Context, ns re
 	})
 	defer func() {
 		if err != nil {
-			s.logPipelineRunError(ctx, pipelineTriggerID, err, pipelineRun.StartedTime)
+			s.logPipelineRunError(ctx, pipelineTriggerID, err)
 		}
 	}()
 
@@ -2191,7 +2185,7 @@ func (s *service) TriggerAsyncNamespacePipelineReleaseByID(ctx context.Context, 
 		return nil, err
 	}
 
-	pipelineRun := s.logPipelineRunStart(ctx, logPipelineRunStartParams{
+	_ = s.logPipelineRunStart(ctx, logPipelineRunStartParams{
 		pipelineTriggerID: pipelineTriggerID,
 		pipelineUID:       pipelineUID,
 		pipelineReleaseID: dbPipelineRelease.ID,
@@ -2200,7 +2194,7 @@ func (s *service) TriggerAsyncNamespacePipelineReleaseByID(ctx context.Context, 
 	})
 	defer func() {
 		if err != nil {
-			s.logPipelineRunError(ctx, pipelineTriggerID, err, pipelineRun.StartedTime)
+			s.logPipelineRunError(ctx, pipelineTriggerID, err)
 		}
 	}()
 

--- a/pkg/service/pipelinerun.go
+++ b/pkg/service/pipelinerun.go
@@ -57,12 +57,11 @@ func (s *service) logPipelineRunStart(ctx context.Context, params logPipelineRun
 	return pipelineRun
 }
 
-func (s *service) logPipelineRunError(ctx context.Context, pipelineTriggerID string, err error, startedTime time.Time) {
+func (s *service) logPipelineRunError(ctx context.Context, pipelineTriggerID string, err error) {
 	now := time.Now()
 	pipelineRunUpdates := &datamodel.PipelineRun{
 		Error:         null.StringFrom(err.Error()),
 		Status:        datamodel.RunStatus(runpb.RunStatus_RUN_STATUS_FAILED),
-		TotalDuration: null.IntFrom(now.Sub(startedTime).Milliseconds()),
 		CompletedTime: null.TimeFrom(now),
 	}
 

--- a/pkg/service/pipelinerun_test.go
+++ b/pkg/service/pipelinerun_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/gojuno/minimock/v3"
 	"go.einride.tech/aip/filtering"
 	"google.golang.org/grpc/metadata"
-	"gopkg.in/guregu/null.v4"
 	"gorm.io/gorm"
 
 	qt "github.com/frankban/quicktest"
@@ -211,7 +210,6 @@ func TestService_ListPipelineRuns(t *testing.T) {
 				RunnerUID:          testCase.runner,
 				RequesterUID:       testCase.runNamespace,
 				StartedTime:        time.Now(),
-				TotalDuration:      null.IntFrom(42),
 			}
 
 			err = repo.UpsertPipelineRun(ctx, pipelineRun)
@@ -428,7 +426,6 @@ func TestService_ListPipelineRuns_OrgResource(t *testing.T) {
 				RunnerUID:          testCase.runner,
 				RequesterUID:       testCase.runNamespace,
 				StartedTime:        time.Now(),
-				TotalDuration:      null.IntFrom(42),
 				Components:         nil,
 			}
 
@@ -520,7 +517,6 @@ func TestService_ListPipelineRunsByRequester(t *testing.T) {
 		RunnerUID:          ownerUID,
 		RequesterUID:       ownerNamespace,
 		StartedTime:        time.Now(),
-		TotalDuration:      null.IntFrom(42),
 		Components:         nil,
 	}
 
@@ -548,7 +544,6 @@ func TestService_ListPipelineRunsByRequester(t *testing.T) {
 		RunnerUID:          ownerUID,
 		RequesterUID:       uuid.Must(uuid.NewV4()),
 		StartedTime:        time.Now(),
-		TotalDuration:      null.IntFrom(42),
 		Components:         nil,
 	}
 

--- a/pkg/service/utils.go
+++ b/pkg/service/utils.go
@@ -136,12 +136,11 @@ func (s *service) convertPipelineRunToPB(run datamodel.PipelineRun) (*pipelinepb
 		Error:               run.Error.Ptr(),
 	}
 
-	if run.TotalDuration.Valid {
-		totalDuration := int32(run.TotalDuration.Int64)
-		result.TotalDuration = &totalDuration
-	}
 	if run.CompletedTime.Valid {
+		totalDuration := int32(run.CompletedTime.Time.Sub(run.StartedTime).Milliseconds())
+
 		result.CompleteTime = timestamppb.New(run.CompletedTime.Time)
+		result.TotalDuration = &totalDuration
 	}
 	if run.BlobDataExpirationTime.Valid {
 		result.BlobDataExpirationTime = timestamppb.New(run.BlobDataExpirationTime.Time)
@@ -159,12 +158,11 @@ func (s *service) convertComponentRunToPB(run datamodel.ComponentRun) (*pipeline
 		Error:          run.Error.Ptr(),
 	}
 
-	if run.TotalDuration.Valid {
-		totalDuration := int32(run.TotalDuration.Int64)
-		result.TotalDuration = &totalDuration
-	}
 	if run.CompletedTime.Valid {
+		totalDuration := int32(run.CompletedTime.Time.Sub(run.StartedTime))
+
 		result.CompleteTime = timestamppb.New(run.CompletedTime.Time)
+		result.TotalDuration = &totalDuration
 	}
 	if run.BlobDataExpirationTime.Valid {
 		result.BlobDataExpirationTime = timestamppb.New(run.BlobDataExpirationTime.Time)

--- a/pkg/service/webhook.go
+++ b/pkg/service/webhook.go
@@ -168,7 +168,7 @@ func (s *service) DispatchPipelineWebhookEvent(ctx context.Context, params Dispa
 			}
 
 			if runOn.ReleaseUID == uuid.Nil {
-				pipelineRun := s.logPipelineRunStart(ctx, logPipelineRunStartParams{
+				_ = s.logPipelineRunStart(ctx, logPipelineRunStartParams{
 					pipelineTriggerID: pipelineTriggerID.String(),
 					pipelineUID:       loadPipelineResult.pipeline.UID,
 					pipelineReleaseID: defaultPipelineReleaseID,
@@ -177,7 +177,7 @@ func (s *service) DispatchPipelineWebhookEvent(ctx context.Context, params Dispa
 				})
 				defer func() {
 					if err != nil {
-						s.logPipelineRunError(ctx, pipelineTriggerID.String(), err, pipelineRun.StartedTime)
+						s.logPipelineRunError(ctx, pipelineTriggerID.String(), err)
 					}
 				}()
 				_, err = s.triggerAsyncPipeline(ctx, triggerParams{
@@ -194,7 +194,7 @@ func (s *service) DispatchPipelineWebhookEvent(ctx context.Context, params Dispa
 					return DispatchPipelineWebhookEventResult{}, err
 				}
 			} else {
-				pipelineRun := s.logPipelineRunStart(ctx, logPipelineRunStartParams{
+				_ = s.logPipelineRunStart(ctx, logPipelineRunStartParams{
 					pipelineTriggerID: pipelineTriggerID.String(),
 					pipelineUID:       loadPipelineResult.pipeline.UID,
 					pipelineReleaseID: loadPipelineResult.release.ID,
@@ -203,7 +203,7 @@ func (s *service) DispatchPipelineWebhookEvent(ctx context.Context, params Dispa
 				})
 				defer func() {
 					if err != nil {
-						s.logPipelineRunError(ctx, pipelineTriggerID.String(), err, pipelineRun.StartedTime)
+						s.logPipelineRunError(ctx, pipelineTriggerID.String(), err)
 					}
 				}()
 				_, err = s.triggerAsyncPipeline(ctx, triggerParams{

--- a/pkg/worker/workflow.go
+++ b/pkg/worker/workflow.go
@@ -277,6 +277,7 @@ func (w *worker) TriggerPipelineWorkflow(ctx workflow.Context, param *TriggerPip
 		return err
 	}
 
+	startTime := time.Now()
 	errs := []error{}
 	componentRunFutures := []workflow.Future{}
 	componentRunFailed := false
@@ -446,7 +447,6 @@ groupLoop:
 		}
 	}
 
-	startTime := time.Now()
 	duration := time.Since(startTime)
 	if isParentPipeline {
 		if err := workflow.ExecuteActivity(ctx, w.OutputActivity, &ComponentActivityParam{
@@ -476,7 +476,7 @@ groupLoop:
 		}
 
 		dataPoint := w.pipelineTriggerDataPoint(workflowID, param.SystemVariables, param.Mode)
-		dataPoint.TriggerTime = startTime.Format(time.RFC3339Nano)
+		dataPoint.TriggerTime = time.Now().Format(time.RFC3339Nano)
 		dataPoint.ComputeTimeDuration = duration.Seconds()
 		dataPoint.Status = mgmtpb.Status_STATUS_COMPLETED
 
@@ -502,7 +502,6 @@ groupLoop:
 		PipelineRun: &datamodel.PipelineRun{
 			CompletedTime: null.TimeFrom(time.Now()),
 			Status:        datamodel.RunStatus(runpb.RunStatus_RUN_STATUS_COMPLETED),
-			TotalDuration: null.IntFrom(duration.Milliseconds()),
 		},
 	}
 	if componentRunFailed {
@@ -563,7 +562,6 @@ func (w *worker) ComponentActivity(ctx context.Context, param *ComponentActivity
 		componentRun := &datamodel.ComponentRun{
 			Status:        datamodel.RunStatus(runpb.RunStatus_RUN_STATUS_COMPLETED),
 			CompletedTime: null.TimeFrom(time.Now()),
-			TotalDuration: null.IntFrom(time.Since(startTime).Milliseconds()),
 		}
 
 		if err != nil {


### PR DESCRIPTION
Because

- The total duration of a pipeline / component run was set only on
  failed states.
- Total duration is redundant with started / completed timestamps, which
  are always set.

This commit

- Removes the total duration column in the database
- Computes the total duration in the API as the time diff between the
  completed and started timestamps
