### PR TITLE
fix(compogen): remove redundant escape characters

### DIFF
--- a/pkg/component/ai/anthropic/v0/README.mdx
+++ b/pkg/component/ai/anthropic/v0/README.mdx
@@ -61,7 +61,7 @@ Anthropic's text generation models (often called generative pre-trained transfor
 | Prompt (required) | `prompt` | string | The prompt text. |
 | System Message | `system-message` | string | The system message helps set the behavior of the assistant. For example, you can modify the personality of the assistant or provide specific instructions about how it should behave throughout the conversation. By default, the model's behavior is set using a generic message as "You are a helpful assistant.". |
 | Prompt Images | `prompt-images` | array[string] | The prompt images (Note: The prompt images will be injected in the order they are provided to the 'prompt' message. Anthropic doesn't support sending images via image-url, use this field instead). |
-| [Chat History](#text-generation-chat-chat-history) | `chat-history` | array[object] | Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: \{"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"\}. |
+| [Chat History](#text-generation-chat-chat-history) | `chat-history` | array[object] | Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: {"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"}. |
 | Seed | `seed` | integer | The seed (Note: Not supported by Anthropic Models). |
 | Temperature | `temperature` | number | The temperature for sampling. |
 | Top K | `top-k` | integer | Top k for sampling. |
@@ -74,7 +74,7 @@ Anthropic's text generation models (often called generative pre-trained transfor
 
 <h4 id="text-generation-chat-chat-history">Chat History</h4>
 
-Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: \{"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"\}.
+Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: {"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"}.
 
 <div class="markdown-col-no-wrap" data-col-1 data-col-2>
 

--- a/pkg/component/ai/cohere/v0/README.mdx
+++ b/pkg/component/ai/cohere/v0/README.mdx
@@ -64,7 +64,7 @@ Cohere's text generation models (often called generative pre-trained transformer
 | System Message | `system-message` | string | The system message helps set the behavior of the assistant. For example, you can modify the personality of the assistant or provide specific instructions about how it should behave throughout the conversation. By default, the model's behavior is using a generic message as "You are a helpful assistant.". |
 | Documents | `documents` | array[string] | The documents to be used for the model, for optimal performance, the length of each document should be less than 300 words. |
 | Prompt Images | `prompt-images` | array[string] | The prompt images (Note: As for 2024-06-24 Cohere models are not multimodal, so images will be ignored.). |
-| [Chat History](#text-generation-chat-chat-history) | `chat-history` | array[object] | Incorporate external chat history, specifically previous messages within the conversation. Each message should adhere to the format: : \{"role": "The message role, i.e. `USER` or `CHATBOT`", "content": "message content"\}. |
+| [Chat History](#text-generation-chat-chat-history) | `chat-history` | array[object] | Incorporate external chat history, specifically previous messages within the conversation. Each message should adhere to the format: : {"role": "The message role, i.e. `USER` or `CHATBOT`", "content": "message content"}. |
 | Seed | `seed` | integer | The seed (default=42). |
 | Temperature | `temperature` | number | The temperature for sampling (default=0.7). |
 | Top K | `top-k` | integer | Top k for sampling (default=10). |
@@ -77,7 +77,7 @@ Cohere's text generation models (often called generative pre-trained transformer
 
 <h4 id="text-generation-chat-chat-history">Chat History</h4>
 
-Incorporate external chat history, specifically previous messages within the conversation. Each message should adhere to the format: : \{"role": "The message role, i.e. `USER` or `CHATBOT`", "content": "message content"\}.
+Incorporate external chat history, specifically previous messages within the conversation. Each message should adhere to the format: : {"role": "The message role, i.e. `USER` or `CHATBOT`", "content": "message content"}.
 
 <div class="markdown-col-no-wrap" data-col-1 data-col-2>
 

--- a/pkg/component/ai/fireworksai/v0/README.mdx
+++ b/pkg/component/ai/fireworksai/v0/README.mdx
@@ -62,7 +62,7 @@ Fireworks AI's text generation models (often called generative pre-trained trans
 | Prompt (required) | `prompt` | string | The prompt text. |
 | System Message | `system-message` | string | The system message helps set the behavior of the assistant. For example, you can modify the personality of the assistant or provide specific instructions about how it should behave throughout the conversation. By default, the model's behavior is set using a generic message as "You are a helpful assistant.". |
 | Prompt Images | `prompt-images` | array[string] | The prompt images (Note: According to Fireworks AI documentation on 2024-07-24, the total number of images included in a single API request should not exceed 30, and all the images should be smaller than 5MB in size). |
-| [Chat History](#text-generation-chat-chat-history) | `chat-history` | array[object] | 'Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: : \{"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"\}.' |
+| [Chat History](#text-generation-chat-chat-history) | `chat-history` | array[object] | 'Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: : {"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"}.' |
 | Seed | `seed` | integer | The seed. |
 | Temperature | `temperature` | number | The temperature for sampling. |
 | Top K | `top-k` | integer | Integer to define the top tokens considered within the sample operation to create new text. |
@@ -76,7 +76,7 @@ Fireworks AI's text generation models (often called generative pre-trained trans
 
 <h4 id="text-generation-chat-chat-history">Chat History</h4>
 
-'Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: : \{"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"\}.'
+'Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: : {"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"}.'
 
 <div class="markdown-col-no-wrap" data-col-1 data-col-2>
 

--- a/pkg/component/ai/groq/v0/README.mdx
+++ b/pkg/component/ai/groq/v0/README.mdx
@@ -61,7 +61,7 @@ Groq serves open source text generation models (often called generative pre-trai
 | Prompt (required) | `prompt` | string | The prompt text. |
 | System Message | `system-message` | string | The system message helps set the behavior of the assistant. For example, you can modify the personality of the assistant or provide specific instructions about how it should behave throughout the conversation. By default, the model's behavior is set using a generic message as "You are a helpful assistant.". |
 | Prompt Images | `prompt-images` | array[string] | The prompt images (Note: Only a subset of OSS models support image inputs). |
-| [Chat History](#text-generation-chat-chat-history) | `chat-history` | array[object] | Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: \{"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"\}. |
+| [Chat History](#text-generation-chat-chat-history) | `chat-history` | array[object] | Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: {"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"}. |
 | Seed | `seed` | integer | The seed. |
 | Temperature | `temperature` | number | The temperature for sampling. |
 | Top K | `top-k` | integer | Integer to define the top tokens considered within the sample operation to create new text. |
@@ -76,7 +76,7 @@ Groq serves open source text generation models (often called generative pre-trai
 
 <h4 id="text-generation-chat-chat-history">Chat History</h4>
 
-Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: \{"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"\}.
+Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: {"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"}.
 
 <div class="markdown-col-no-wrap" data-col-1 data-col-2>
 

--- a/pkg/component/ai/instillmodel/v0/README.mdx
+++ b/pkg/component/ai/instillmodel/v0/README.mdx
@@ -374,7 +374,7 @@ Generate texts from input text prompts and chat history.
 | Prompt (required) | `prompt` | string | The prompt text. |
 | System Message | `system-message` | string | The system message helps set the behavior of the assistant. For example, you can modify the personality of the assistant or provide specific instructions about how it should behave throughout the conversation. By default, the model's behavior is using a generic message as "You are a helpful assistant.". |
 | Prompt Images | `prompt-images` | array[string] | The prompt images. |
-| [Chat History](#text-generation-chat-chat-history) | `chat-history` | array[object] | Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: \{"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"\}. |
+| [Chat History](#text-generation-chat-chat-history) | `chat-history` | array[object] | Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: {"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"}. |
 | Seed | `seed` | integer | The seed. |
 | Temperature | `temperature` | number | The temperature for sampling. |
 | Max New Tokens | `max-new-tokens` | integer | The maximum number of tokens for model to generate. |
@@ -386,7 +386,7 @@ Generate texts from input text prompts and chat history.
 
 <h4 id="text-generation-chat-chat-history">Chat History</h4>
 
-Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: \{"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"\}.
+Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: {"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"}.
 
 <div class="markdown-col-no-wrap" data-col-1 data-col-2>
 
@@ -472,7 +472,7 @@ Answer questions based on a prompt and an image.
 | Prompt (required) | `prompt` | string | The prompt text. |
 | System Message | `system-message` | string | The system message helps set the behavior of the assistant. For example, you can modify the personality of the assistant or provide specific instructions about how it should behave throughout the conversation. By default, the model's behavior is using a generic message as "You are a helpful assistant.". |
 | Prompt Images | `prompt-images` | array[string] | The prompt images. |
-| [Chat History](#visual-question-answering-chat-history) | `chat-history` | array[object] | Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: \{"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"\}. |
+| [Chat History](#visual-question-answering-chat-history) | `chat-history` | array[object] | Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: {"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"}. |
 | Seed | `seed` | integer | The seed. |
 | Temperature | `temperature` | number | The temperature for sampling. |
 | Max New Tokens | `max-new-tokens` | integer | The maximum number of tokens for model to generate. |
@@ -484,7 +484,7 @@ Answer questions based on a prompt and an image.
 
 <h4 id="visual-question-answering-chat-history">Chat History</h4>
 
-Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: \{"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"\}.
+Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: {"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"}.
 
 <div class="markdown-col-no-wrap" data-col-1 data-col-2>
 
@@ -540,7 +540,7 @@ Generate texts from input text prompts and chat history.
 | Prompt (required) | `prompt` | string | The prompt text. |
 | System Message | `system-message` | string | The system message helps set the behavior of the assistant. For example, you can modify the personality of the assistant or provide specific instructions about how it should behave throughout the conversation. By default, the model's behavior is using a generic message as "You are a helpful assistant.". |
 | Prompt Images | `prompt-images` | array[string] | The prompt images. |
-| [Chat History](#chat-chat-history) | `chat-history` | array[object] | Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: \{"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"\}. |
+| [Chat History](#chat-chat-history) | `chat-history` | array[object] | Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: {"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"}. |
 | Seed | `seed` | integer | The seed. |
 | Temperature | `temperature` | number | The temperature for sampling. |
 | Max New Tokens | `max-new-tokens` | integer | The maximum number of tokens for model to generate. |
@@ -552,7 +552,7 @@ Generate texts from input text prompts and chat history.
 
 <h4 id="chat-chat-history">Chat History</h4>
 
-Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: \{"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"\}.
+Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: {"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"}.
 
 <div class="markdown-col-no-wrap" data-col-1 data-col-2>
 

--- a/pkg/component/ai/mistralai/v0/README.mdx
+++ b/pkg/component/ai/mistralai/v0/README.mdx
@@ -62,7 +62,7 @@ Mistral AI's text generation models (often called generative pre-trained transfo
 | Prompt (required) | `prompt` | string | The prompt text. |
 | System Message | `system-message` | string | The system message helps set the behavior of the assistant. For example, you can modify the personality of the assistant or provide specific instructions about how it should behave throughout the conversation. By default, the model's behavior is set using a generic message as "You are a helpful assistant.". |
 | Prompt Images | `prompt-images` | array[string] | The prompt images (Note: The Mistral models are not trained to process images, thus images will be omitted). |
-| [Chat History](#text-generation-chat-chat-history) | `chat-history` | array[object] | Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: \{"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"\}. |
+| [Chat History](#text-generation-chat-chat-history) | `chat-history` | array[object] | Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: {"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"}. |
 | Seed | `seed` | integer | The seed. |
 | Temperature | `temperature` | number | The temperature for sampling. |
 | Top K | `top-k` | integer | Integer to define the top tokens considered within the sample operation to create new text (Note: The Mistral models does not support top-k sampling). |
@@ -77,7 +77,7 @@ Mistral AI's text generation models (often called generative pre-trained transfo
 
 <h4 id="text-generation-chat-chat-history">Chat History</h4>
 
-Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: \{"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"\}.
+Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: {"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"}.
 
 <div class="markdown-col-no-wrap" data-col-1 data-col-2>
 

--- a/pkg/component/ai/ollama/v0/README.mdx
+++ b/pkg/component/ai/ollama/v0/README.mdx
@@ -63,7 +63,7 @@ Open-source large language models (OSS LLMs) are artificial intelligence models 
 | Prompt (required) | `prompt` | string | The prompt text. |
 | System Message | `system-message` | string | The system message helps set the behavior of the assistant. For example, you can modify the personality of the assistant or provide specific instructions about how it should behave throughout the conversation. By default, the model's behavior is set using a generic message as "You are a helpful assistant.". |
 | Prompt Images | `prompt-images` | array[string] | The prompt images. |
-| [Chat History](#text-generation-chat-chat-history) | `chat-history` | array[object] | Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: \{"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"\}. |
+| [Chat History](#text-generation-chat-chat-history) | `chat-history` | array[object] | Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: {"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"}. |
 | Seed | `seed` | integer | The seed. |
 | Temperature | `temperature` | number | The temperature for sampling. |
 | Top K | `top-k` | integer | Top k for sampling. |
@@ -76,7 +76,7 @@ Open-source large language models (OSS LLMs) are artificial intelligence models 
 
 <h4 id="text-generation-chat-chat-history">Chat History</h4>
 
-Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: \{"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"\}.
+Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: {"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"}.
 
 <div class="markdown-col-no-wrap" data-col-1 data-col-2>
 

--- a/pkg/component/ai/openai/v0/README.mdx
+++ b/pkg/component/ai/openai/v0/README.mdx
@@ -66,7 +66,7 @@ OpenAI's text generation models (often called generative pre-trained transformer
 | Prompt (required) | `prompt` | string | The prompt text. |
 | System Message | `system-message` | string | The system message helps set the behavior of the assistant. For example, you can modify the personality of the assistant or provide specific instructions about how it should behave throughout the conversation. By default, the model's behavior is using a generic message as "You are a helpful assistant.". |
 | Image | `images` | array[string] | The images. |
-| [Chat History](#text-generation-chat-history) | `chat-history` | array[object] | Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format \{"role": "The message role, i.e. ''system'', ''user'' or ''assistant''", "content": "message content"\}. |
+| [Chat History](#text-generation-chat-history) | `chat-history` | array[object] | Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format {"role": "The message role, i.e. ''system'', ''user'' or ''assistant''", "content": "message content"}. |
 | Temperature | `temperature` | number | What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic. We generally recommend altering this or `top-p` but not both. |
 | N | `n` | integer | How many chat completion choices to generate for each input message. Note that you will be charged based on the number of generated tokens across all of the choices. Keep `n` as `1` to minimize costs. |
 | Max Tokens | `max-tokens` | integer | The maximum number of tokens that can be generated in the chat completion. The total length of input tokens and generated tokens is limited by the model's context length. |
@@ -87,7 +87,7 @@ OpenAI's text generation models (often called generative pre-trained transformer
 
 <h4 id="text-generation-chat-history">Chat History</h4>
 
-Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format \{"role": "The message role, i.e. ''system'', ''user'' or ''assistant''", "content": "message content"\}.
+Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format {"role": "The message role, i.e. ''system'', ''user'' or ''assistant''", "content": "message content"}.
 
 <div class="markdown-col-no-wrap" data-col-1 data-col-2>
 

--- a/pkg/component/data/elasticsearch/v0/README.mdx
+++ b/pkg/component/data/elasticsearch/v0/README.mdx
@@ -277,7 +277,7 @@ Create an index in Elasticsearch
 | :--- | :--- | :--- | :--- |
 | Task ID (required) | `task` | string | `TASK_CREATE_INDEX` |
 | Index Name (required) | `index-name` | string | Name of the Elasticsearch index. |
-| Mappings | `mappings` | object | Index mappings which starts with \{"mappings":\{"properties"\}\} field, please refer to [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/dense-vector.html) for vector search and [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-types.html) for other mappings. |
+| Mappings | `mappings` | object | Index mappings which starts with {"mappings":{"properties"}} field, please refer to [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/dense-vector.html) for vector search and [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-types.html) for other mappings. |
 </div>
 
 

--- a/pkg/component/data/sql/v0/README.mdx
+++ b/pkg/component/data/sql/v0/README.mdx
@@ -242,7 +242,7 @@ Create a table in the database
 | :--- | :--- | :--- | :--- |
 | Task ID (required) | `task` | string | `TASK_CREATE_TABLE` |
 | Table Name (required) | `table-name` | string | The table name in the database to be created. |
-| Columns (required) | `columns-structure` | object | The columns structure to be created in the table, json with value string, e.g \{"name": "VARCHAR(255)", "age": "INT not null"\}. |
+| Columns (required) | `columns-structure` | object | The columns structure to be created in the table, json with value string, e.g {"name": "VARCHAR(255)", "age": "INT not null"}. |
 </div>
 
 

--- a/pkg/component/generic/collection/v0/README.mdx
+++ b/pkg/component/generic/collection/v0/README.mdx
@@ -58,7 +58,7 @@ Append values to create or extend an array, or add key-value pairs to an object.
 
 | Output | Field ID | Type | Description |
 | :--- | :--- | :--- | :--- |
-| Data | `data` | any | The resulting data structure after the append operation. Will be either an array (if input was array or primitive) or an object (if input was object). Examples: [1,2,3], \{"name": "John", "age": 25\}, or ["hello","world"]. |
+| Data | `data` | any | The resulting data structure after the append operation. Will be either an array (if input was array or primitive) or an object (if input was object). Examples: [1,2,3], {"name": "John", "age": 25}, or ["hello","world"]. |
 </div>
 
 
@@ -98,7 +98,7 @@ Concatenate multiple arrays or merge multiple objects into a single collection.
 | Input | Field ID | Type | Description |
 | :--- | :--- | :--- | :--- |
 | Task ID (required) | `task` | string | `TASK_CONCAT` |
-| Data (required) | `data` | array[any] | An array of arrays or objects to be concatenated/merged. For arrays: `[[1, 2], [3, 4]]` becomes `[1, 2, 3, 4]`. For objects: `[\{"a": 1\}, \{"b": 2\}]` becomes `\{"a": 1, "b": 2\}`. Later values override earlier ones for objects. |
+| Data (required) | `data` | array[any] | An array of arrays or objects to be concatenated/merged. For arrays: `[[1, 2], [3, 4]]` becomes `[1, 2, 3, 4]`. For objects: `[{"a": 1}, {"b": 2}]` becomes `{"a": 1, "b": 2}`. Later values override earlier ones for objects. |
 </div>
 
 
@@ -123,7 +123,7 @@ Find elements that exist in the first array or object but not in any of the othe
 | Input | Field ID | Type | Description |
 | :--- | :--- | :--- | :--- |
 | Task ID (required) | `task` | string | `TASK_DIFFERENCE` |
-| Data (required) | `data` | array[any] | An array of arrays or objects to find the difference. The first element is compared against all subsequent elements. For example, given arrays `[[1, 2, 3], [2, 3, 4], [3, 4, 5]]`, the result will be `[1]`. For objects, given `[\{"a": 1, "b": 2\}, \{"b": 2, "c": 3\}]`, the result will be `\{"a": 1\}`. |
+| Data (required) | `data` | array[any] | An array of arrays or objects to find the difference. The first element is compared against all subsequent elements. For example, given arrays `[[1, 2, 3], [2, 3, 4], [3, 4, 5]]`, the result will be `[1]`. For objects, given `[{"a": 1, "b": 2}, {"b": 2, "c": 3}]`, the result will be `{"a": 1}`. |
 </div>
 
 
@@ -148,7 +148,7 @@ Find common elements that exist in all input arrays or objects.
 | Input | Field ID | Type | Description |
 | :--- | :--- | :--- | :--- |
 | Task ID (required) | `task` | string | `TASK_INTERSECTION` |
-| Data (required) | `data` | array[any] | An array of arrays or objects to find common elements. For arrays: given `[[1, 2, 3], [2, 3, 4]]`, the result will be `[2, 3]`. For objects: given `[\{"a": 1, "b": 2\}, \{"b": 2, "c": 3\}]`, the result will be `\{"b": 2\}`. |
+| Data (required) | `data` | array[any] | An array of arrays or objects to find common elements. For arrays: given `[[1, 2, 3], [2, 3, 4]]`, the result will be `[2, 3]`. For objects: given `[{"a": 1, "b": 2}, {"b": 2, "c": 3}]`, the result will be `{"b": 2}`. |
 </div>
 
 
@@ -199,7 +199,7 @@ Find elements that exist in exactly one of the input arrays or objects, but not 
 | Input | Field ID | Type | Description |
 | :--- | :--- | :--- | :--- |
 | Task ID (required) | `task` | string | `TASK_SYMMETRIC_DIFFERENCE` |
-| Data (required) | `data` | array[any] | An array of arrays or objects to find symmetric difference. For arrays: given `[[1, 2], [2, 3]]`, the result will be `[1, 3]`. For objects: given `[\{"a": 1, "b": 2\}, \{"b": 2, "c": 3\}]`, the result will be `\{"a": 1, "c": 3\}`. |
+| Data (required) | `data` | array[any] | An array of arrays or objects to find symmetric difference. For arrays: given `[[1, 2], [2, 3]]`, the result will be `[1, 3]`. For objects: given `[{"a": 1, "b": 2}, {"b": 2, "c": 3}]`, the result will be `{"a": 1, "c": 3}`. |
 </div>
 
 
@@ -224,7 +224,7 @@ Find unique elements that exist in any of the input arrays or objects.
 | Input | Field ID | Type | Description |
 | :--- | :--- | :--- | :--- |
 | Task ID (required) | `task` | string | `TASK_UNION` |
-| Data (required) | `data` | array[any] | An array of arrays or objects to find unique elements. For arrays: given `[[1, 2], [2, 3]]`, the result will be `[1, 2, 3]`. For objects: given `[\{"a": 1, "b": 2\}, \{"b": 2, "c": 3\}]`, the result will be `\{"a": 1, "b": 2, "c": 3\}`. |
+| Data (required) | `data` | array[any] | An array of arrays or objects to find unique elements. For arrays: given `[[1, 2], [2, 3]]`, the result will be `[1, 2, 3]`. For objects: given `[{"a": 1, "b": 2}, {"b": 2, "c": 3}]`, the result will be `{"a": 1, "b": 2, "c": 3}`. |
 </div>
 
 

--- a/pkg/component/tools/compogen/pkg/gen/readme.go
+++ b/pkg/component/tools/compogen/pkg/gen/readme.go
@@ -159,12 +159,6 @@ func (g *READMEGenerator) parseTasks(configDir string) (map[string]task, error) 
 	return tasks, nil
 }
 
-// This is used to build the cURL examples for Instill Core and Cloud.
-type host struct {
-	Name string
-	URL  string
-}
-
 // Generate creates a MDX file with the component documentation from the
 // component schema.
 func (g *READMEGenerator) Generate() error {
@@ -192,12 +186,6 @@ func (g *READMEGenerator) Generate() error {
 		"anchorTaskObject":         anchorTaskObject,
 		"insertHeaderByObjectKey":  insertHeaderByObjectKey,
 		"insertHeaderByConstValue": insertHeaderByConstValue,
-		"hosts": func() []host {
-			return []host{
-				{Name: "Instill-Cloud", URL: "https://api.instill-ai.com"},
-				{Name: "Instill-Core", URL: "http://localhost:8080"},
-			}
-		},
 	}).Parse(readmeTmpl)
 	if err != nil {
 		return err
@@ -388,6 +376,11 @@ func parseResourceProperties(o *objectSchema) []resourceProperty {
 		return cmp.Compare(i.ID, j.ID)
 	})
 
+	// Ensure all descriptions are processed (handles $ref resolved properties)
+	for i := range props {
+		props[i].replaceDescription()
+	}
+
 	return props
 }
 
@@ -544,8 +537,6 @@ func (rt *readmeTask) parseOneOfsProperties(properties map[string]property) {
 		}
 		rt.parseOneOfsProperties(op.Properties)
 	}
-
-	return
 }
 
 func (sc *setupConfig) parseOneOfProperties(properties map[string]property) {
@@ -701,8 +692,6 @@ func (prop *property) replaceDescription() {
 		prop.Description = strings.ReplaceAll(prop.Description, "}}", "}}`")
 	} else {
 		prop.Description = strings.ReplaceAll(prop.Description, "\n", " ")
-		prop.Description = strings.ReplaceAll(prop.Description, "{", "\\{")
-		prop.Description = strings.ReplaceAll(prop.Description, "}", "\\}")
 	}
 }
 


### PR DESCRIPTION
Because

- `compogen` had a wrong curly bracket logic to escape causing the final rendered result showing redundant backslash.

This commit

- remove the character replacement calls.
