### PR TITLE
chore(data,component,gemini): improve error msg

### DIFF
--- a/pkg/component/ai/gemini/v0/main.go
+++ b/pkg/component/ai/gemini/v0/main.go
@@ -78,7 +78,7 @@ func (c *component) CreateExecution(x base.ComponentExecution) (base.IExecution,
 
 	switch x.Task {
 	case ChatTask:
-		e.execute = e.textGeneration
+		e.execute = e.chat
 	default:
 		return nil, fmt.Errorf("unsupported task")
 	}

--- a/pkg/component/ai/gemini/v0/task_chat.go
+++ b/pkg/component/ai/gemini/v0/task_chat.go
@@ -15,7 +15,7 @@ import (
 	"github.com/instill-ai/pipeline-backend/pkg/data"
 )
 
-func (e *execution) textGeneration(ctx context.Context, job *base.Job) error {
+func (e *execution) chat(ctx context.Context, job *base.Job) error {
 	// Read input
 	in := TaskChatInput{}
 	if err := job.Input.ReadData(ctx, &in); err != nil {

--- a/pkg/data/struct.go
+++ b/pkg/data/struct.go
@@ -279,6 +279,8 @@ func (u *Unmarshaler) unmarshalString(ctx context.Context, v format.String, fiel
 				field.Set(reflect.ValueOf(f))
 				return nil
 			}
+			// If URL creation fails, return a helpful error message
+			return fmt.Errorf("cannot unmarshal string into %v: expected valid URL, not base64 string: %w", field.Type(), err)
 		case reflect.TypeOf(v), reflect.TypeOf((*format.String)(nil)).Elem():
 			field.Set(reflect.ValueOf(v))
 		case reflect.TypeOf((*format.Value)(nil)).Elem():


### PR DESCRIPTION
Because
- When a user assigns `:base64` to a variable but the field expects format.Image or format.Document, no error is raised.
- The conversion logic incorrectly assumes the value is a URL string and attempts to download the blob file.

This commit
- Adds error reporting when `:base64` is used in a field that expects format.Image or format.Document.
- Prevents silent failures by making the validation explicit.
- Corrects wrong task function name of Gemini `TASK_CHAT`