### PR TITLE
ci(gitignore): ignore .cursor folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,6 @@ protogen-go
 .air.toml
 tmp
 .idea
+
+# Cursor related files and folders
+.cursor/


### PR DESCRIPTION
This commit

- add `.cursor/` folder to ignore.
