### PR TITLE
fix(usage): treat input rendering error as fatal

### DIFF
--- a/pkg/component/ai/instillmodel/v0/main_test.go
+++ b/pkg/component/ai/instillmodel/v0/main_test.go
@@ -145,7 +145,7 @@ func TestExecution_Execute(t *testing.T) {
 
 		// Create mock job
 		input, _ := structpb.NewStruct(map[string]any{
-			"model-name": "test-model",
+			"model-name": "namespace/test-model/v0.1.0",
 			"prompt":     "test prompt",
 		})
 

--- a/pkg/component/base/executionwrapper_test.go
+++ b/pkg/component/base/executionwrapper_test.go
@@ -85,7 +85,7 @@ func TestExecutionWrapper_Execute(t *testing.T) {
 			name:     "nok - check error",
 			in:       inputValid,
 			checkErr: fmt.Errorf("foo"),
-			wantErr:  "foo",
+			wantErr:  ".*foo",
 		},
 		// {
 		// 	name:    "nok - invalid output",

--- a/pkg/component/internal/util/helper.go
+++ b/pkg/component/internal/util/helper.go
@@ -198,6 +198,7 @@ func StripProtocolFromURL(url string) string {
 	if index > 0 {
 		return url[strings.Index(url, "://")+3:]
 	}
+
 	return url
 }
 
@@ -205,20 +206,30 @@ func GetHeaderAuthorization(vars map[string]any) string {
 	if v, ok := vars["__PIPELINE_HEADER_AUTHORIZATION"]; ok {
 		return v.(string)
 	}
+
 	return ""
 }
 func GetInstillUserUID(vars map[string]any) string {
-	return vars["__PIPELINE_USER_UID"].(string)
+	if v, ok := vars["__PIPELINE_USER_UID"]; ok {
+		return v.(string)
+	}
+
+	return ""
 }
 
 func GetInstillRequesterUID(vars map[string]any) string {
-	return vars["__PIPELINE_REQUESTER_UID"].(string)
+	if v, ok := vars["__PIPELINE_REQUESTER_UID"]; ok {
+		return v.(string)
+	}
+
+	return ""
 }
 
 func GetOriginalHeader(vars map[string]any) map[string]any {
 	if v, ok := vars["__ORIGINAL_HEADER"]; ok {
 		return v.(map[string]any)
 	}
+
 	return nil
 }
 

--- a/pkg/worker/io.go
+++ b/pkg/worker/io.go
@@ -35,7 +35,7 @@ func (s *setupReader) Read(ctx context.Context) (setups []*structpb.Struct, err 
 		}
 		setupVal, err := recipe.Render(ctx, setupTemplate, batchIdx, wfm, false)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("rendering setup: %w", err)
 		}
 		setup, err := setupVal.ToStructValue()
 		if err != nil {
@@ -81,7 +81,7 @@ func (i *inputReader) read(ctx context.Context) (inputVal format.Value, err erro
 
 	inputVal, err = recipe.Render(ctx, inputTemplate, i.originalIdx, wfm, false)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("reading input template: %w", err)
 	}
 
 	if err = wfm.SetComponentData(ctx, i.originalIdx, i.compID, memory.ComponentDataInput, inputVal); err != nil {


### PR DESCRIPTION
Because

- Usage handler error produces a misleading error when the input data
  fails to be rendered.

This commit

- Fixes INS-8583
- Passes only the valid inputs to the usage checker.
- Returns a fatal error if no valid inputs could be rendered.
