### PR TITLE
ci(docker): add GitHub fallback for ffmpeg installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,21 @@ RUN apt-get update && apt-get install -y \
 
 # Install FFmpeg Static Build
 RUN FFMPEG_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") && \
-    wget https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-${FFMPEG_ARCH}-static.tar.xz && \
+    (wget --timeout=30 --tries=3 https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-${FFMPEG_ARCH}-static.tar.xz || \
+    (echo "Primary source failed, trying GitHub fallback..." && \
+      if [ "$FFMPEG_ARCH" = "amd64" ]; then \
+          wget https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz -O ffmpeg-release-${FFMPEG_ARCH}-static.tar.xz; \
+      else \
+          wget https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linuxarm64-gpl.tar.xz -O ffmpeg-release-${FFMPEG_ARCH}-static.tar.xz; \
+      fi)) && \
     tar xvf ffmpeg-release-${FFMPEG_ARCH}-static.tar.xz && \
-    mv ffmpeg-*-static/ffmpeg /usr/local/bin/ && \
-    mv ffmpeg-*-static/ffprobe /usr/local/bin/ && \
+    if [ -d ffmpeg-*-static ]; then \
+        mv ffmpeg-*-static/ffmpeg /usr/local/bin/ && \
+        mv ffmpeg-*-static/ffprobe /usr/local/bin/; \
+    else \
+        mv ffmpeg-*/bin/ffmpeg /usr/local/bin/ && \
+        mv ffmpeg-*/bin/ffprobe /usr/local/bin/; \
+    fi && \
     rm -rf ffmpeg-*
 
 # Install ONNX Runtime (latest release)

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -34,12 +34,23 @@ RUN apt update && \
     /opt/venv/bin/pip install pdfplumber mistral-common tokenizers docling==2.18.0 && \
     rm -rf /var/lib/apt/lists/*
 
-# Install FFmpeg Static Build
+# Install FFmpeg Static Build with GitHub fallback
 RUN FFMPEG_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") && \
-    wget https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-${FFMPEG_ARCH}-static.tar.xz && \
+    (wget --timeout=30 --tries=3 https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-${FFMPEG_ARCH}-static.tar.xz || \
+    (echo "Primary source failed, trying GitHub fallback..." && \
+      if [ "$FFMPEG_ARCH" = "amd64" ]; then \
+          wget https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz -O ffmpeg-release-${FFMPEG_ARCH}-static.tar.xz; \
+      else \
+          wget https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linuxarm64-gpl.tar.xz -O ffmpeg-release-${FFMPEG_ARCH}-static.tar.xz; \
+      fi)) && \
     tar xvf ffmpeg-release-${FFMPEG_ARCH}-static.tar.xz && \
-    mv ffmpeg-*-static/ffmpeg /usr/local/bin/ && \
-    mv ffmpeg-*-static/ffprobe /usr/local/bin/ && \
+    if [ -d ffmpeg-*-static ]; then \
+        mv ffmpeg-*-static/ffmpeg /usr/local/bin/ && \
+        mv ffmpeg-*-static/ffprobe /usr/local/bin/; \
+    else \
+        mv ffmpeg-*/bin/ffmpeg /usr/local/bin/ && \
+        mv ffmpeg-*/bin/ffprobe /usr/local/bin/; \
+    fi && \
     rm -rf ffmpeg-*
 
 # Install ONNX Runtime (latest release)


### PR DESCRIPTION
Because

- The primary ffmpeg download source (johnvansickle.com) frequently experiences connection timeouts and download failures
- Build failures occur when the primary source is unavailable, blocking development and deployment workflows

This commit

- Adds GitHub BtbN/FFmpeg-Builds as a fallback source for ffmpeg static builds
- Implements timeout and retry logic (30 seconds, 3 attempts) for the primary source
- Handles different directory structures between johnvansickle and GitHub builds
- Supports both amd64 and arm64 architectures for both sources
- Provides clear error messaging when falling back to the secondary source
- Updates both Dockerfile and Dockerfile.dev for consistency