### PR TITLE
ci(workflows): adopt loarger runner for coverage test

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   codecov:
     name: codecov
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-4core-amd64
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Because

- The unit tests are getting resource consuming especially for the component tests.

This commit

- update coverage workflow to use a larger runner.
