### PR TITLE
fix(usage): add missing error filtering for users/admin

### DIFF
--- a/pkg/usage/usage.go
+++ b/pkg/usage/usage.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
+	"github.com/gofrs/uuid"
 	"github.com/redis/go-redis/v9"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -41,10 +43,15 @@ func NewUsage(ctx context.Context, r repository.Repository, m mgmtpb.MgmtPrivate
 	logger, _ := logx.GetZapLogger(ctx)
 
 	var defaultOwnerUID string
-	if resp, err := m.GetUserAdmin(ctx, &mgmtpb.GetUserAdminRequest{UserId: constant.DefaultUserID}); err == nil {
-		defaultOwnerUID = resp.GetUser().GetUid()
+	if user, err := m.GetUserAdmin(ctx, &mgmtpb.GetUserAdminRequest{UserId: constant.DefaultUserID}); err == nil {
+		defaultOwnerUID = user.GetUser().GetUid()
+	} else if strings.Contains(err.Error(), "users/admin") {
+		// Only Instill Core CE has the default user "admin"
+		logger.Debug(fmt.Sprintf("error getting default user: %v, use a zero uuid as default owner uid", err))
+		defaultOwnerUID = uuid.Nil.String()
 	} else {
 		logger.Error(err.Error())
+		return nil
 	}
 
 	reporter, err := usageclient.InitReporter(ctx, usc, usagepb.Session_SERVICE_PIPELINE, config.Config.Server.Edition, serviceVersion, defaultOwnerUID)
@@ -219,6 +226,10 @@ func (u *usage) StartReporter(ctx context.Context) {
 	var defaultOwnerUID string
 	if resp, err := u.mgmtPrivateServiceClient.GetUserAdmin(ctx, &mgmtpb.GetUserAdminRequest{UserId: constant.DefaultUserID}); err == nil {
 		defaultOwnerUID = resp.GetUser().GetUid()
+	} else if strings.Contains(err.Error(), "users/admin") {
+		// Only Instill Core CE has the default user "admin"
+		logger.Debug(fmt.Sprintf("error getting default user: %v, use a zero uuid as default owner uid", err))
+		defaultOwnerUID = uuid.Nil.String()
 	} else {
 		logger.Error(err.Error())
 		return
@@ -243,6 +254,10 @@ func (u *usage) TriggerSingleReporter(ctx context.Context) {
 	var defaultOwnerUID string
 	if resp, err := u.mgmtPrivateServiceClient.GetUserAdmin(ctx, &mgmtpb.GetUserAdminRequest{UserId: constant.DefaultUserID}); err == nil {
 		defaultOwnerUID = resp.GetUser().GetUid()
+	} else if strings.Contains(err.Error(), "users/admin") {
+		// Only Instill Core CE has the default user "admin"
+		logger.Debug(fmt.Sprintf("error getting default user: %v, use a zero uuid as default owner uid", err))
+		defaultOwnerUID = uuid.Nil.String()
 	} else {
 		logger.Error(err.Error())
 		return


### PR DESCRIPTION
Because

- The `TriggerSingleReporter` method was missing the same error filtering logic that exists in `NewUsage` and `StartReporter` methods
- When `GetUserAdmin` fails with "users/admin" error, it should be treated as a debug message rather than an error since only Instill Core CE has the default "admin" user
- Without this filtering, false alarm errors were being logged when the admin user doesn't exist in other Instill editions

This commit

- Adds the same error filtering pattern to `TriggerSingleReporter` that already exists in `NewUsage` and `StartReporter`
- Changes the error handling to check if the error contains "users/admin" and treats it as a debug log instead of an error log
- Ensures consistent error handling across all three methods when dealing with the default admin user lookup
- Prevents false alarm error logs in Instill editions that don't have the default admin user