### PR TITLE
feat(component,ai,gemini): add image generation support

### DIFF
--- a/pkg/component/ai/gemini/v0/config/tasks.yaml
+++ b/pkg/component/ai/gemini/v0/config/tasks.yaml
@@ -1556,19 +1556,22 @@ TASK_CHAT:
           ID of the model to use.
           The value is one of the following:
             `gemini-2.5-pro`: Optimized for enhanced thinking and reasoning, multimodal understanding, advanced coding, and more.
-            `gemini-2.5-flash`: Optimized for Adaptive thinking, cost efficiency.
-            `gemini-2.0-flash-lite`: Optimized for Most cost-efficient model supporting high throughput.
+            `gemini-2.5-flash`: Optimized for adaptive thinking, cost efficiency.
+            `gemini-2.5-flash-lite`: Optimized for most cost-efficient model supporting high throughput.
+            `gemini-2.5-flash-image-preview`: Optimized for precise, conversational image generation and editing.
         type: string
         enum:
           - gemini-2.5-pro
           - gemini-2.5-flash
-          - gemini-2.0-flash-lite
+          - gemini-2.5-flash-lite
+          - gemini-2.5-flash-image-preview
         default: gemini-2.5-flash
         instillCredentialMap:
           values:
             - gemini-2.5-pro
             - gemini-2.5-flash
-            - gemini-2.0-flash-lite
+            - gemini-2.5-flash-lite
+            - gemini-2.5-flash-image-preview
           targets:
             - setup.api-key
       stream:
@@ -1709,20 +1712,31 @@ TASK_CHAT:
         title: Texts
         description: >-
           Simplified text output extracted from candidates. Each string represents the concatenated text content  from the corresponding candidate's parts,
-          including thought processes when `include-thoughts` is enabled.  This field provides easy access to the generated text without needing to traverse
+          including thought processes when `include-thoughts` is enabled. This field provides easy access to the generated text without needing to traverse
           the candidate structure.  Updated in real-time during streaming.
         type: array
         items:
           type: string
-      usage:
+      images:
         uiOrder: 1
+        title: Images
+        description: >-
+          Images output extracted and converted from candidates. This field provides easy access to the generated images as base64-encoded strings.
+          The original binary data is removed from the candidates field to prevent raw binary exposure in JSON output.  This field is only available when
+          the model supports image generation.
+        type: array
+        items:
+          title: Image
+          type: image/webp
+      usage:
+        uiOrder: 2
         title: Usage
         description: >-
           Token usage statistics: prompt tokens, completion tokens, total tokens, etc.
         type: object
         additionalProperties: true
       candidates:
-        uiOrder: 2
+        uiOrder: 3
         title: Candidates
         description: >-
           Complete candidate objects from the model containing rich metadata and structured content.  Each candidate includes safety ratings, finish reason,
@@ -1732,18 +1746,18 @@ TASK_CHAT:
         items:
           $ref: "#/$defs/candidate"
       usage-metadata:
-        uiOrder: 3
+        uiOrder: 4
         $ref: "#/$defs/usage-metadata"
       prompt-feedback:
-        uiOrder: 4
+        uiOrder: 5
         $ref: "#/$defs/prompt-feedback"
       model-version:
-        uiOrder: 5
+        uiOrder: 6
         title: Model Version
         description: The model version used to generate the response.
         type: string
       response-id:
-        uiOrder: 6
+        uiOrder: 7
         title: Response ID
         description: Identifier for this response.
         type: string

--- a/pkg/component/ai/gemini/v0/io.go
+++ b/pkg/component/ai/gemini/v0/io.go
@@ -59,8 +59,9 @@ func (t TaskChatInput) GetSystemInstruction() *genai.Content { return t.SystemIn
 // TaskChatOutput is the output for the TASK_CHAT task.
 type TaskChatOutput struct {
 	// Flattened chat output properties
-	Texts []string       `instill:"texts"`
-	Usage map[string]any `instill:"usage"`
+	Texts  []string       `instill:"texts"`
+	Images []format.Image `instill:"images"`
+	Usage  map[string]any `instill:"usage"`
 
 	// Use genai types directly with instill tags
 	Candidates     []*genai.Candidate                           `instill:"candidates"`


### PR DESCRIPTION
Because

- The Gemini component lacked support for image generation using the `gemini-2.5-flash-image-preview` model
- Generated images were being exposed as raw binary data arrays in the `candidates` field instead of being properly extracted to the `images` field
- Image processing was duplicated and inefficient in streaming responses, processing the same images multiple times

This commit

- Adds image generation capability to the Gemini component by extracting images from `genai.GenerateContentResponse`
- Extracts generated images from API responses and converts them to `format.Image` objects in the `Images` output field
- Cleans up raw binary `InlineData` from candidates after image extraction to prevent JSON exposure of binary data
- Optimizes streaming responses by deferring image processing to final response only, eliminating duplicate processing
- Updates component configuration documentation to clarify the relationship between `images` field and `candidates` field