### PR TITLE
fix(compogen): escape curly braces for readme.com compatibility

### DIFF
--- a/pkg/component/ai/anthropic/v0/README.mdx
+++ b/pkg/component/ai/anthropic/v0/README.mdx
@@ -52,7 +52,7 @@ Anthropic's text generation models (often called generative pre-trained transfor
 | Prompt (required) | `prompt` | string | The prompt text. |
 | System Message | `system-message` | string | The system message helps set the behavior of the assistant. For example, you can modify the personality of the assistant or provide specific instructions about how it should behave throughout the conversation. By default, the model's behavior is set using a generic message as "You are a helpful assistant.". |
 | Prompt Images | `prompt-images` | array[string] | The prompt images (Note: The prompt images will be injected in the order they are provided to the 'prompt' message. Anthropic doesn't support sending images via image-url, use this field instead). |
-| [Chat History](#text-generation-chat-chat-history) | `chat-history` | array[object] | Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: {"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"}. |
+| [Chat History](#text-generation-chat-chat-history) | `chat-history` | array[object] | Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: `{"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"}`. |
 | Seed | `seed` | integer | The seed (Note: Not supported by Anthropic Models). |
 | Temperature | `temperature` | number | The temperature for sampling. |
 | Top K | `top-k` | integer | Top k for sampling. |
@@ -64,7 +64,7 @@ Anthropic's text generation models (often called generative pre-trained transfor
 
 <h4 id="text-generation-chat-chat-history">Chat History</h4>
 
-Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: {"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"}.
+Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: `{"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"}`.
 
 
 <div class="markdown-col-no-wrap" data-col-1 data-col-2>

--- a/pkg/component/ai/cohere/v0/README.mdx
+++ b/pkg/component/ai/cohere/v0/README.mdx
@@ -55,7 +55,7 @@ Cohere's text generation models (often called generative pre-trained transformer
 | System Message | `system-message` | string | The system message helps set the behavior of the assistant. For example, you can modify the personality of the assistant or provide specific instructions about how it should behave throughout the conversation. By default, the model's behavior is using a generic message as "You are a helpful assistant.". |
 | Documents | `documents` | array[string] | The documents to be used for the model, for optimal performance, the length of each document should be less than 300 words. |
 | Prompt Images | `prompt-images` | array[string] | The prompt images (Note: As for 2024-06-24 Cohere models are not multimodal, so images will be ignored.). |
-| [Chat History](#text-generation-chat-chat-history) | `chat-history` | array[object] | Incorporate external chat history, specifically previous messages within the conversation. Each message should adhere to the format: : {"role": "The message role, i.e. `USER` or `CHATBOT`", "content": "message content"}. |
+| [Chat History](#text-generation-chat-chat-history) | `chat-history` | array[object] | Incorporate external chat history, specifically previous messages within the conversation. Each message should adhere to the format: : `{"role": "The message role, i.e. `USER` or `CHATBOT`", "content": "message content"}`. |
 | Seed | `seed` | integer | The seed (default=42). |
 | Temperature | `temperature` | number | The temperature for sampling (default=0.7). |
 | Top K | `top-k` | integer | Top k for sampling (default=10). |
@@ -67,7 +67,7 @@ Cohere's text generation models (often called generative pre-trained transformer
 
 <h4 id="text-generation-chat-chat-history">Chat History</h4>
 
-Incorporate external chat history, specifically previous messages within the conversation. Each message should adhere to the format: : {"role": "The message role, i.e. `USER` or `CHATBOT`", "content": "message content"}.
+Incorporate external chat history, specifically previous messages within the conversation. Each message should adhere to the format: : `{"role": "The message role, i.e. `USER` or `CHATBOT`", "content": "message content"}`.
 
 
 <div class="markdown-col-no-wrap" data-col-1 data-col-2>

--- a/pkg/component/ai/fireworksai/v0/README.mdx
+++ b/pkg/component/ai/fireworksai/v0/README.mdx
@@ -53,7 +53,7 @@ Fireworks AI's text generation models (often called generative pre-trained trans
 | Prompt (required) | `prompt` | string | The prompt text. |
 | System Message | `system-message` | string | The system message helps set the behavior of the assistant. For example, you can modify the personality of the assistant or provide specific instructions about how it should behave throughout the conversation. By default, the model's behavior is set using a generic message as "You are a helpful assistant.". |
 | Prompt Images | `prompt-images` | array[string] | The prompt images (Note: According to Fireworks AI documentation on 2024-07-24, the total number of images included in a single API request should not exceed 30, and all the images should be smaller than 5MB in size). |
-| [Chat History](#text-generation-chat-chat-history) | `chat-history` | array[object] | 'Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: : {"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"}.' |
+| [Chat History](#text-generation-chat-chat-history) | `chat-history` | array[object] | 'Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: : `{"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"}`.' |
 | Seed | `seed` | integer | The seed. |
 | Temperature | `temperature` | number | The temperature for sampling. |
 | Top K | `top-k` | integer | Integer to define the top tokens considered within the sample operation to create new text. |
@@ -66,7 +66,7 @@ Fireworks AI's text generation models (often called generative pre-trained trans
 
 <h4 id="text-generation-chat-chat-history">Chat History</h4>
 
-'Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: : {"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"}.'
+'Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: : `{"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"}`.'
 
 
 <div class="markdown-col-no-wrap" data-col-1 data-col-2>

--- a/pkg/component/ai/gemini/v0/README.mdx
+++ b/pkg/component/ai/gemini/v0/README.mdx
@@ -49,7 +49,7 @@ Gemini's multimodal models understand text and images. They generate text output
 | Input | Field ID | Type | Description |
 | :--- | :--- | :--- | :--- |
 | Task ID (required) | `task` | string | `TASK_CHAT` |
-| Model (required) | `model` | string | ID of the model to use. The value is one of the following:   `gemini-2.5-pro`: Optimized for enhanced thinking and reasoning, multimodal understanding, advanced coding, and more.   `gemini-2.5-flash`: Optimized for Adaptive thinking, cost efficiency.   `gemini-2.0-flash-lite`: Optimized for Most cost-efficient model supporting high throughput. <br/><details><summary><strong>Enum values</strong></summary><ul><li>`gemini-2.5-pro`</li><li>`gemini-2.5-flash`</li><li>`gemini-2.0-flash-lite`</li></ul></details> |
+| Model (required) | `model` | string | ID of the model to use. The value is one of the following:   `gemini-2.5-pro`: Optimized for enhanced thinking and reasoning, multimodal understanding, advanced coding, and more.   `gemini-2.5-flash`: Optimized for adaptive thinking, cost efficiency.   `gemini-2.5-flash-lite`: Optimized for most cost-efficient model supporting high throughput.   `gemini-2.5-flash-image-preview`: Optimized for precise, conversational image generation and editing. <br/><details><summary><strong>Enum values</strong></summary><ul><li>`gemini-2.5-pro`</li><li>`gemini-2.5-flash`</li><li>`gemini-2.5-flash-lite`</li><li>`gemini-2.5-flash-image-preview`</li></ul></details> |
 | Stream | `stream` | boolean | Whether to incrementally stream the response using server-sent events (SSE). |
 | Prompt | `prompt` | string | The main text instruction or query for the model. |
 | Images | `images` | array[string] | URI references or base64 content of input images. |
@@ -69,7 +69,7 @@ Gemini's multimodal models understand text and images. They generate text output
 | [Safety Settings](#chat-safety-settings) | `safety-settings` | array[object] | Safety settings for content filtering. |
 | [System Instruction](#chat-system-instruction) | `system-instruction` | object | A system instruction to guide the model behavior. |
 | [Generation Config](#chat-generation-config) | `generation-config` | object | Generation configuration for the request. |
-| Cached Content | `cached-content` | string | The name of a cached content to use as context. Format: cachedContents/{cachedContent}. |
+| Cached Content | `cached-content` | string | The name of a cached content to use as context. Format: cachedContents/\{cachedContent\}. |
 
 </div>
 <details>
@@ -518,7 +518,8 @@ Config for thinking features.
 
 | Output | Field ID | Type | Description |
 | :--- | :--- | :--- | :--- |
-| Texts (optional) | `texts` | array[string] | Simplified text output extracted from candidates. Each string represents the concatenated text content  from the corresponding candidate's parts, including thought processes when `include-thoughts` is enabled.  This field provides easy access to the generated text without needing to traverse the candidate structure.  Updated in real-time during streaming. |
+| Texts (optional) | `texts` | array[string] | Simplified text output extracted from candidates. Each string represents the concatenated text content  from the corresponding candidate's parts, including thought processes when `include-thoughts` is enabled. This field provides easy access to the generated text without needing to traverse the candidate structure.  Updated in real-time during streaming. |
+| Images (optional) | `images` | array[image/webp] | Images output extracted and converted from candidates. This field provides easy access to the generated images as base64-encoded strings. The original binary data is removed from the candidates field to prevent raw binary exposure in JSON output.  This field is only available when the model supports image generation. |
 | Usage (optional) | `usage` | object | Token usage statistics: prompt tokens, completion tokens, total tokens, etc. |
 | [Candidates](#chat-candidates) (optional) | `candidates` | array[object] | Complete candidate objects from the model containing rich metadata and structured content.  Each candidate includes safety ratings, finish reason, token counts, citations, content parts  (including thought processes when include-thoughts is enabled), and other detailed information.  This provides full access to all response data beyond just text. Updated incrementally during  streaming with accumulated content and latest metadata. |
 | [Usage Metadata](#chat-usage-metadata) (optional) | `usage-metadata` | object | Metadata on the generation request's token usage. |
@@ -924,7 +925,7 @@ Context caching allows you to cache input tokens and reference them in subsequen
 | Task ID (required) | `task` | string | `TASK_CACHE` |
 | Operation (required) | `operation` | string | The cache operation to perform. The value is one of the following:   `create`: Create a new cached content.   `list`: List all cached contents.   `get`: Retrieve a specific cached content.   `update`: Update an existing cached content (only expiration time can be updated).   `delete`: Delete a cached content. <br/><details><summary><strong>Enum values</strong></summary><ul><li>`create`</li><li>`list`</li><li>`get`</li><li>`update`</li><li>`delete`</li></ul></details> |
 | Model (required) | `model` | string | ID of the model to use for caching. Required for create operations. The model is immutable after creation. The value is one of the following:   `gemini-2.5-pro`: Optimized for enhanced thinking and reasoning, multimodal understanding, advanced coding, and more.   `gemini-2.5-flash`: Optimized for Adaptive thinking, cost efficiency.   `gemini-2.0-flash-lite`: Optimized for Most cost-efficient model supporting high throughput. <br/><details><summary><strong>Enum values</strong></summary><ul><li>`gemini-2.5-pro`</li><li>`gemini-2.5-flash`</li><li>`gemini-2.0-flash-lite`</li></ul></details> |
-| Cache Name | `cache-name` | string | [**GET**, **UPDATE**, **DELETE**] The name of the cached content for get, update, or delete operations.  Format: cachedContents/{cachedContent}. Required for get, update, and delete operations. |
+| Cache Name | `cache-name` | string | [**GET**, **UPDATE**, **DELETE**] The name of the cached content for get, update, or delete operations.  Format: cachedContents/\{cachedContent\}. Required for get, update, and delete operations. |
 | Prompt | `prompt` | string | [**CREATE**] The main text instruction or query to be cached for create operations. |
 | Images | `images` | array[string] | [**CREATE**] URI references or base64 content of input images to be cached for create operations. |
 | Audio | `audio` | array[string] | [**CREATE**] URI references or base64 content of input audio to be cached for create operations. |
@@ -1252,7 +1253,7 @@ Configuration for specifying function calling behavior.
 | Display Name | `display-name` | string | Optional. The user-provided name of the cached content. |
 | Expire Time | `expire-time` | string | Expiration time of the cached content in RFC3339 format. |
 | Model | `model` | string | The name of the Model to use for cached content. |
-| Name | `name` | string | The resource name referring to the cached content. Format: cachedContents/{cachedContent} |
+| Name | `name` | string | The resource name referring to the cached content. Format: cachedContents/\{cachedContent\} |
 | Update Time | `update-time` | string | Last update time of the cached content in RFC3339 format. |
 | [Usage Metadata](#cache-usage-metadata) | `usage-metadata` | object | Token usage statistics for the cached content. |
 
@@ -1282,7 +1283,7 @@ Configuration for specifying function calling behavior.
 | Display Name | `display-name` | string | Optional. The user-provided name of the cached content. |
 | Expire Time | `expire-time` | string | Expiration time of the cached content in RFC3339 format. |
 | Model | `model` | string | The name of the Model to use for cached content. |
-| Name | `name` | string | The resource name referring to the cached content. Format: cachedContents/{cachedContent} |
+| Name | `name` | string | The resource name referring to the cached content. Format: cachedContents/\{cachedContent\} |
 | Update Time | `update-time` | string | Last update time of the cached content in RFC3339 format. |
 | [Usage Metadata](#cache-usage-metadata) | `usage-metadata` | object | Token usage statistics for the cached content. |
 

--- a/pkg/component/ai/groq/v0/README.mdx
+++ b/pkg/component/ai/groq/v0/README.mdx
@@ -52,7 +52,7 @@ Groq serves open source text generation models (often called generative pre-trai
 | Prompt (required) | `prompt` | string | The prompt text. |
 | System Message | `system-message` | string | The system message helps set the behavior of the assistant. For example, you can modify the personality of the assistant or provide specific instructions about how it should behave throughout the conversation. By default, the model's behavior is set using a generic message as "You are a helpful assistant.". |
 | Prompt Images | `prompt-images` | array[string] | The prompt images (Note: Only a subset of OSS models support image inputs). |
-| [Chat History](#text-generation-chat-chat-history) | `chat-history` | array[object] | Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: {"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"}. |
+| [Chat History](#text-generation-chat-chat-history) | `chat-history` | array[object] | Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: `{"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"}`. |
 | Seed | `seed` | integer | The seed. |
 | Temperature | `temperature` | number | The temperature for sampling. |
 | Top K | `top-k` | integer | Integer to define the top tokens considered within the sample operation to create new text. |
@@ -66,7 +66,7 @@ Groq serves open source text generation models (often called generative pre-trai
 
 <h4 id="text-generation-chat-chat-history">Chat History</h4>
 
-Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: {"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"}.
+Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: `{"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"}`.
 
 
 <div class="markdown-col-no-wrap" data-col-1 data-col-2>

--- a/pkg/component/ai/instillmodel/v0/README.mdx
+++ b/pkg/component/ai/instillmodel/v0/README.mdx
@@ -365,7 +365,7 @@ Generate texts from input text prompts and chat history.
 | Prompt (required) | `prompt` | string | The prompt text. |
 | System Message | `system-message` | string | The system message helps set the behavior of the assistant. For example, you can modify the personality of the assistant or provide specific instructions about how it should behave throughout the conversation. By default, the model's behavior is using a generic message as "You are a helpful assistant.". |
 | Prompt Images | `prompt-images` | array[string] | The prompt images. |
-| [Chat History](#text-generation-chat-chat-history) | `chat-history` | array[object] | Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: {"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"}. |
+| [Chat History](#text-generation-chat-chat-history) | `chat-history` | array[object] | Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: `{"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"}`. |
 | Seed | `seed` | integer | The seed. |
 | Temperature | `temperature` | number | The temperature for sampling. |
 | Max New Tokens | `max-new-tokens` | integer | The maximum number of tokens for model to generate. |
@@ -376,7 +376,7 @@ Generate texts from input text prompts and chat history.
 
 <h4 id="text-generation-chat-chat-history">Chat History</h4>
 
-Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: {"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"}.
+Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: `{"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"}`.
 
 
 <div class="markdown-col-no-wrap" data-col-1 data-col-2>
@@ -460,7 +460,7 @@ Answer questions based on a prompt and an image.
 | Prompt (required) | `prompt` | string | The prompt text. |
 | System Message | `system-message` | string | The system message helps set the behavior of the assistant. For example, you can modify the personality of the assistant or provide specific instructions about how it should behave throughout the conversation. By default, the model's behavior is using a generic message as "You are a helpful assistant.". |
 | Prompt Images | `prompt-images` | array[string] | The prompt images. |
-| [Chat History](#visual-question-answering-chat-history) | `chat-history` | array[object] | Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: {"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"}. |
+| [Chat History](#visual-question-answering-chat-history) | `chat-history` | array[object] | Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: `{"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"}`. |
 | Seed | `seed` | integer | The seed. |
 | Temperature | `temperature` | number | The temperature for sampling. |
 | Max New Tokens | `max-new-tokens` | integer | The maximum number of tokens for model to generate. |
@@ -471,7 +471,7 @@ Answer questions based on a prompt and an image.
 
 <h4 id="visual-question-answering-chat-history">Chat History</h4>
 
-Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: {"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"}.
+Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: `{"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"}`.
 
 
 <div class="markdown-col-no-wrap" data-col-1 data-col-2>
@@ -528,7 +528,7 @@ Generate texts from input text prompts and chat history.
 | Prompt (required) | `prompt` | string | The prompt text. |
 | System Message | `system-message` | string | The system message helps set the behavior of the assistant. For example, you can modify the personality of the assistant or provide specific instructions about how it should behave throughout the conversation. By default, the model's behavior is using a generic message as "You are a helpful assistant.". |
 | Prompt Images | `prompt-images` | array[string] | The prompt images. |
-| [Chat History](#chat-chat-history) | `chat-history` | array[object] | Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: {"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"}. |
+| [Chat History](#chat-chat-history) | `chat-history` | array[object] | Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: `{"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"}`. |
 | Seed | `seed` | integer | The seed. |
 | Temperature | `temperature` | number | The temperature for sampling. |
 | Max New Tokens | `max-new-tokens` | integer | The maximum number of tokens for model to generate. |
@@ -539,7 +539,7 @@ Generate texts from input text prompts and chat history.
 
 <h4 id="chat-chat-history">Chat History</h4>
 
-Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: {"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"}.
+Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: `{"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"}`.
 
 
 <div class="markdown-col-no-wrap" data-col-1 data-col-2>

--- a/pkg/component/ai/mistralai/v0/README.mdx
+++ b/pkg/component/ai/mistralai/v0/README.mdx
@@ -53,7 +53,7 @@ Mistral AI's text generation models (often called generative pre-trained transfo
 | Prompt (required) | `prompt` | string | The prompt text. |
 | System Message | `system-message` | string | The system message helps set the behavior of the assistant. For example, you can modify the personality of the assistant or provide specific instructions about how it should behave throughout the conversation. By default, the model's behavior is set using a generic message as "You are a helpful assistant.". |
 | Prompt Images | `prompt-images` | array[string] | The prompt images (Note: The Mistral models are not trained to process images, thus images will be omitted). |
-| [Chat History](#text-generation-chat-chat-history) | `chat-history` | array[object] | Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: {"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"}. |
+| [Chat History](#text-generation-chat-chat-history) | `chat-history` | array[object] | Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: `{"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"}`. |
 | Seed | `seed` | integer | The seed. |
 | Temperature | `temperature` | number | The temperature for sampling. |
 | Top K | `top-k` | integer | Integer to define the top tokens considered within the sample operation to create new text (Note: The Mistral models does not support top-k sampling). |
@@ -67,7 +67,7 @@ Mistral AI's text generation models (often called generative pre-trained transfo
 
 <h4 id="text-generation-chat-chat-history">Chat History</h4>
 
-Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: {"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"}.
+Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: `{"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"}`.
 
 
 <div class="markdown-col-no-wrap" data-col-1 data-col-2>

--- a/pkg/component/ai/ollama/v0/README.mdx
+++ b/pkg/component/ai/ollama/v0/README.mdx
@@ -54,7 +54,7 @@ Open-source large language models (OSS LLMs) are artificial intelligence models 
 | Prompt (required) | `prompt` | string | The prompt text. |
 | System Message | `system-message` | string | The system message helps set the behavior of the assistant. For example, you can modify the personality of the assistant or provide specific instructions about how it should behave throughout the conversation. By default, the model's behavior is set using a generic message as "You are a helpful assistant.". |
 | Prompt Images | `prompt-images` | array[string] | The prompt images. |
-| [Chat History](#text-generation-chat-chat-history) | `chat-history` | array[object] | Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: {"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"}. |
+| [Chat History](#text-generation-chat-chat-history) | `chat-history` | array[object] | Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: `{"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"}`. |
 | Seed | `seed` | integer | The seed. |
 | Temperature | `temperature` | number | The temperature for sampling. |
 | Top K | `top-k` | integer | Top k for sampling. |
@@ -66,7 +66,7 @@ Open-source large language models (OSS LLMs) are artificial intelligence models 
 
 <h4 id="text-generation-chat-chat-history">Chat History</h4>
 
-Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: {"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"}.
+Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: `{"role": "The message role, i.e. `system`, `user` or `assistant`", "content": "message content"}`.
 
 
 <div class="markdown-col-no-wrap" data-col-1 data-col-2>

--- a/pkg/component/ai/openai/v0/README.mdx
+++ b/pkg/component/ai/openai/v0/README.mdx
@@ -57,7 +57,7 @@ OpenAI's text generation models (often called generative pre-trained transformer
 | Prompt (required) | `prompt` | string | The prompt text. |
 | System Message | `system-message` | string | The system message helps set the behavior of the assistant. For example, you can modify the personality of the assistant or provide specific instructions about how it should behave throughout the conversation. By default, the model's behavior is using a generic message as "You are a helpful assistant.". |
 | Image | `images` | array[string] | The images. |
-| [Chat History](#text-generation-chat-history) | `chat-history` | array[object] | Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format {"role": "The message role, i.e. ''system'', ''user'' or ''assistant''", "content": "message content"}. |
+| [Chat History](#text-generation-chat-history) | `chat-history` | array[object] | Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format `{"role": "The message role, i.e. ''system'', ''user'' or ''assistant''", "content": "message content"}`. |
 | Temperature | `temperature` | number | What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic. We generally recommend altering this or `top-p` but not both. |
 | N | `n` | integer | How many chat completion choices to generate for each input message. Note that you will be charged based on the number of generated tokens across all of the choices. Keep `n` as `1` to minimize costs. |
 | Max Tokens | `max-tokens` | integer | The maximum number of tokens that can be generated in the chat completion. The total length of input tokens and generated tokens is limited by the model's context length. |
@@ -77,7 +77,7 @@ OpenAI's text generation models (often called generative pre-trained transformer
 
 <h4 id="text-generation-chat-history">Chat History</h4>
 
-Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format {"role": "The message role, i.e. ''system'', ''user'' or ''assistant''", "content": "message content"}.
+Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format `{"role": "The message role, i.e. ''system'', ''user'' or ''assistant''", "content": "message content"}`.
 
 
 <div class="markdown-col-no-wrap" data-col-1 data-col-2>

--- a/pkg/component/data/elasticsearch/v0/README.mdx
+++ b/pkg/component/data/elasticsearch/v0/README.mdx
@@ -256,7 +256,7 @@ Create an index in Elasticsearch
 | :--- | :--- | :--- | :--- |
 | Task ID (required) | `task` | string | `TASK_CREATE_INDEX` |
 | Index Name (required) | `index-name` | string | Name of the Elasticsearch index. |
-| Mappings | `mappings` | object | Index mappings which starts with {"mappings":{"properties"}} field, please refer to [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/dense-vector.html) for vector search and [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-types.html) for other mappings. |
+| Mappings | `mappings` | object | Index mappings which starts with `{"mappings": {"properties"}}` field, please refer to [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/dense-vector.html) for vector search and [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-types.html) for other mappings. |
 
 </div>
 

--- a/pkg/component/data/elasticsearch/v0/config/tasks.yaml
+++ b/pkg/component/data/elasticsearch/v0/config/tasks.yaml
@@ -458,7 +458,7 @@ TASK_CREATE_INDEX:
         title: Index Name
       mappings:
         description: >-
-          Index mappings which starts with {"mappings":{"properties"}} field, please refer to [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/dense-vector.html)
+          Index mappings which starts with {"mappings": {"properties"}} field, please refer to [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/dense-vector.html)
           for vector search and [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-types.html) for other mappings.
         type: object
         uiOrder: 1

--- a/pkg/component/data/sql/v0/README.mdx
+++ b/pkg/component/data/sql/v0/README.mdx
@@ -218,7 +218,7 @@ Create a table in the database
 | :--- | :--- | :--- | :--- |
 | Task ID (required) | `task` | string | `TASK_CREATE_TABLE` |
 | Table Name (required) | `table-name` | string | The table name in the database to be created. |
-| Columns (required) | `columns-structure` | object | The columns structure to be created in the table, json with value string, e.g {"name": "VARCHAR(255)", "age": "INT not null"}. |
+| Columns (required) | `columns-structure` | object | The columns structure to be created in the table, json with value string, e.g `{"name": "VARCHAR(255)", "age": "INT not null"}`. |
 
 </div>
 

--- a/pkg/component/generic/collection/v0/README.mdx
+++ b/pkg/component/generic/collection/v0/README.mdx
@@ -47,7 +47,7 @@ Append values to create or extend an array, or add key-value pairs to an object.
 
 | Output | Field ID | Type | Description |
 | :--- | :--- | :--- | :--- |
-| Data | `data` | any | The resulting data structure after the append operation. Will be either an array (if input was array or primitive) or an object (if input was object). Examples: [1,2,3], {"name": "John", "age": 25}, or ["hello","world"]. |
+| Data | `data` | any | The resulting data structure after the append operation. Will be either an array (if input was array or primitive) or an object (if input was object). Examples: [1,2,3], `{"name": "John", "age": 25}`, or ["hello","world"]. |
 
 </div>
 

--- a/pkg/component/tools/compogen/cmd/testdata/readme-component2.txt
+++ b/pkg/component/tools/compogen/cmd/testdata/readme-component2.txt
@@ -217,7 +217,7 @@ This task is dummier than `TASK_DUMMY`.
 | Output | Field ID | Type | Description |
 | :--- | :--- | :--- | :--- |
 | Elementum | `elementum` | string | Tellus elementum sagittis vitae et |
-| [Atem](#dummier-atem) | `atem` | object | This object should comply witht he format {"tortor": "something", "arcu": "something else"} |
+| [Atem](#dummier-atem) | `atem` | object | This object should comply witht he format `{"tortor": "something", "arcu": "something else"}` |
 | Nullam Non | `nullam_non` | number | Id faucibus nisl tincidunt eget nullam non |
 | Errors (optional) | `errors` | array[string] | Error messages, if any, during the dummy process |
 | Meta (optional) | `context` | any | Free-form metadata |

--- a/pkg/component/tools/compogen/pkg/gen/readme_test.go
+++ b/pkg/component/tools/compogen/pkg/gen/readme_test.go
@@ -74,3 +74,106 @@ func TestTitleCase(t *testing.T) {
 		})
 	}
 }
+
+func TestEscapeCurlyBracesForReadme(t *testing.T) {
+	c := qt.New(t)
+
+	testcases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "single curly braces should be escaped",
+			in:   "Format: cachedContents/{cachedContent}",
+			want: "Format: cachedContents/\\{cachedContent\\}",
+		},
+		{
+			name: "template variables should be wrapped in backticks",
+			in:   "Use {{variable_name}} in templates",
+			want: "Use `{{variable_name}}` in templates",
+		},
+		{
+			name: "JSON examples should be wrapped in backticks",
+			in:   `This object should comply with the format {"tortor": "something", "arcu": "something else"}`,
+			want: "This object should comply with the format `{\"tortor\": \"something\", \"arcu\": \"something else\"}`",
+		},
+		{
+			name: "mixed JSON and variable placeholders",
+			in:   `Use format {"key": "value"} with {placeholder}`,
+			want: "Use format `{\"key\": \"value\"}` with \\{placeholder\\}",
+		},
+		{
+			name: "already escaped braces should not be double-escaped",
+			in:   "Already escaped \\{item\\} should stay",
+			want: "Already escaped \\{item\\} should stay",
+		},
+		{
+			name: "template variables already in backticks should not be re-processed",
+			in:   "Already processed `{{var}}` template",
+			want: "Already processed `{{var}}` template",
+		},
+		{
+			name: "empty string",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "no braces",
+			in:   "Plain text without braces",
+			want: "Plain text without braces",
+		},
+		{
+			name: "multiple single braces",
+			in:   "First {item1} and second {item2}",
+			want: "First \\{item1\\} and second \\{item2\\}",
+		},
+		{
+			name: "complex example from Gemini",
+			in:   "The name of a cached content to use as context. Format: cachedContents/{cachedContent}.",
+			want: "The name of a cached content to use as context. Format: cachedContents/\\{cachedContent\\}.",
+		},
+		{
+			name: "SmartLead template variable explanation",
+			in:   "You can use {{variable_name}} in your email templates",
+			want: "You can use `{{variable_name}}` in your email templates",
+		},
+		{
+			name: "hyphenated identifiers",
+			in:   "Use {cache-name} for the cache identifier",
+			want: "Use \\{cache-name\\} for the cache identifier",
+		},
+		{
+			name: "underscore identifiers",
+			in:   "Reference {snake_case} variables",
+			want: "Reference \\{snake_case\\} variables",
+		},
+		{
+			name: "JSON array with objects",
+			in:   `Input: [{"a": 1}, {"b": 2}]`,
+			want: "Input: `[{\"a\": 1}, {\"b\": 2}]`",
+		},
+		{
+			name: "simple JSON object",
+			in:   `Config: {"name": "John", "age": 25}`,
+			want: "Config: `{\"name\": \"John\", \"age\": 25}`",
+		},
+		{
+			name: "complex JSON with nested quotes and backticks should be wrapped",
+			in:   "Format: {\"role\": \"The message role, i.e. `system`, `user` or `assistant`\", \"content\": \"message content\"}",
+			want: "Format: `{\"role\": \"The message role, i.e. `system`, `user` or `assistant`\", \"content\": \"message content\"}`",
+		},
+		{
+			name: "nested JSON objects should be wrapped",
+			in:   "starts with {\"mappings\": {\"properties\"}} field",
+			want: "starts with `{\"mappings\": {\"properties\"}}` field",
+		},
+	}
+
+	for _, tc := range testcases {
+		c.Run(tc.name, func(c *qt.C) {
+			got := escapeCurlyBracesForReadme(tc.in)
+			c.Check(got, qt.Equals, tc.want)
+		})
+	}
+}


### PR DESCRIPTION
Because

- `readme.com` treats `{variable}` as variable placeholders, causing parsing errors and display issues in component documentation
- JSON examples like `{"key": "value"}` and nested JSON objects like `{"mappings": {"properties"}}` were not being properly formatted for `readme.com` as well
- Go template variables `{{variable}}` needed special handling to display correctly
- The existing escaping logic was incomplete and couldn't handle complex nested JSON structures

This commit

- Implements comprehensive curly brace escaping for README.io compatibility in the compogen tool
- Wraps JSON objects and arrays in backticks (e.g., `{"key": "value"}`) for proper code formatting
- Preserves Go template syntax by wrapping `{{variable}}` in backticks
- Escapes variable placeholders like `{placeholder}` to `\{placeholder\}` to prevent README.io variable resolution
- Adds balanced brace matching algorithm to handle nested JSON structures correctly
- Refactors complex escaping logic into smaller, maintainable functions with single responsibilities
- Includes comprehensive unit tests covering all escaping scenarios
- Updates integration tests to verify end-to-end functionality
- Fixes MDX parsing errors that were occurring in generated component documentation