### PR TITLE
fix(component,ai,gemini): add operation validation for cache task

### DIFF
--- a/pkg/component/ai/gemini/v0/task_cache.go
+++ b/pkg/component/ai/gemini/v0/task_cache.go
@@ -17,6 +17,13 @@ func (e *execution) cache(ctx context.Context, job *base.Job) error {
 		return nil
 	}
 
+	// Check if operation is specified
+	if in.Operation == "" {
+		err := fmt.Errorf("caching operation is not specified")
+		job.Error.Error(ctx, err)
+		return nil
+	}
+
 	// Create Gemini client
 	client, err := e.createGeminiClient(ctx)
 	if err != nil {


### PR DESCRIPTION
Because

- The cache task was missing validation for the required `operation` field, which could lead to runtime errors or unexpected behavior when users don't specify which cache operation to perform

This commit

- Adds validation to check if the `operation` field is specified before proceeding with cache operations