### PR TITLE
refactor(component,generic,http): move test functions to test files and improve code legibility

### DIFF
--- a/pkg/component/generic/http/v0/main.go
+++ b/pkg/component/generic/http/v0/main.go
@@ -83,21 +83,6 @@ func Init(bc base.Component) *component {
 	return comp
 }
 
-// InitForTest creates a component instance for testing with configurable validation
-// whitelist: URLs to allow (nil/empty = allow all external URLs)
-// allowLocalhost: whether to allow localhost/127.x.x.x URLs
-func InitForTest(bc base.Component, whitelist []string, allowLocalhost bool) *component {
-	c := &component{
-		Component:    bc,
-		urlValidator: NewTestURLValidator(whitelist, allowLocalhost),
-	}
-	err := c.LoadDefinition(definitionYAML, setupYAML, tasksYAML, nil, nil)
-	if err != nil {
-		panic(err)
-	}
-	return c
-}
-
 func (c *component) CreateExecution(x base.ComponentExecution) (base.IExecution, error) {
 
 	// We may have different url in batch.

--- a/pkg/component/generic/http/v0/validator.go
+++ b/pkg/component/generic/http/v0/validator.go
@@ -28,15 +28,6 @@ func NewURLValidator() URLValidator {
 	return &urlValidator{allowPrivateIPs: false}
 }
 
-// NewTestURLValidator creates a validator for testing
-func NewTestURLValidator(whitelistedEndpoints []string, allowLocalhost bool) URLValidator {
-	return &urlValidator{
-		whitelistedEndpoints: whitelistedEndpoints,
-		allowLocalhost:       allowLocalhost,
-		allowPrivateIPs:      true, // Test mode allows external URLs by default
-	}
-}
-
 // ValidateInput implements the consolidated validation logic
 func (v *urlValidator) ValidateInput(input *httpInput) error {
 	if input == nil {


### PR DESCRIPTION
Because

- PR #1121 comments requested moving test-specific functions out of production code to improve code organization
- Nested if-else structures in test code reduced readability and could be simplified with early returns

This commit

- Moves `NewTestURLValidator` from `validator.go` to `validator_test.go` to keep test utilities in test files
- Moves `InitForTest` from `main.go` to `validator_test.go` to separate test-specific component initialization from production code
- Refactors nested if-else structure in validator test (lines 90-99) using early returns to improve code legibility
- Removes test functions from production code, reducing binary size and improving maintainability