### PR TITLE
refactor(component,ai.gemini): standardize file api timeout and use n…

### DIFF
--- a/pkg/component/ai/gemini/v0/common.go
+++ b/pkg/component/ai/gemini/v0/common.go
@@ -415,6 +415,9 @@ func extractSystemMessage(in SystemMessageInput) string {
 // MaxInlineSize is the 20MB threshold for determining when to use File API based on total request size
 const MaxInlineSize = 20 * 1024 * 1024
 
+// FileAPITimeout is the timeout for File API operations (upload and processing)
+const FileAPITimeout = 300 * time.Second
+
 // uploadedFile represents a file that was uploaded and needs to be waited for
 type uploadedFile struct {
 	name     string
@@ -672,7 +675,7 @@ func (e *execution) processImagePartsWithTotalSize(ctx context.Context, client *
 		}
 
 		// Process using File API decision based on total request size
-		part, fileName, err := e.processMediaFile(ctx, client, binary.ByteArray(), contentType, 0, 60*time.Second, useFileAPI)
+		part, fileName, err := e.processMediaFile(ctx, client, binary.ByteArray(), contentType, 0, FileAPITimeout, useFileAPI)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to process image: %w", err)
 		}
@@ -722,7 +725,7 @@ func (e *execution) processAudioPartsWithTotalSize(ctx context.Context, client *
 		}
 
 		// Process using File API decision based on total request size
-		part, fileName, err := e.processMediaFile(ctx, client, binary.ByteArray(), contentType, 0, 60*time.Second, useFileAPI)
+		part, fileName, err := e.processMediaFile(ctx, client, binary.ByteArray(), contentType, 0, FileAPITimeout, useFileAPI)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to process audio: %w", err)
 		}
@@ -772,7 +775,7 @@ func (e *execution) processVideoPartsWithTotalSize(ctx context.Context, client *
 		}
 
 		// Use File API based on decision (longer timeout for videos)
-		part, fileName, err := e.processMediaFile(ctx, client, binary.ByteArray(), contentType, 0, 120*time.Second, useFileAPI)
+		part, fileName, err := e.processMediaFile(ctx, client, binary.ByteArray(), contentType, 0, FileAPITimeout, useFileAPI)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to process video: %w", err)
 		}
@@ -831,7 +834,7 @@ func (e *execution) processDocumentPartsWithTotalSize(ctx context.Context, clien
 			}
 
 			// Process using File API decision based on total request size
-			part, fileName, err := e.processMediaFile(ctx, client, binary.ByteArray(), "application/pdf", 0, 60*time.Second, useFileAPI)
+			part, fileName, err := e.processMediaFile(ctx, client, binary.ByteArray(), "application/pdf", 0, FileAPITimeout, useFileAPI)
 			if err != nil {
 				return nil, nil, fmt.Errorf("failed to process PDF: %w", err)
 			}

--- a/pkg/component/ai/gemini/v0/io.go
+++ b/pkg/component/ai/gemini/v0/io.go
@@ -139,5 +139,5 @@ type TaskTextEmbeddingsInput struct {
 
 // TaskTextEmbeddingsOutput is the output for the TASK_TEXT_EMBEDDINGS task.
 type TaskTextEmbeddingsOutput struct {
-	Embedding []float64 `instill:"embedding"`
+	Embedding *genai.ContentEmbedding `instill:"embedding"`
 }

--- a/pkg/component/ai/gemini/v0/task_text_embeddings.go
+++ b/pkg/component/ai/gemini/v0/task_text_embeddings.go
@@ -57,15 +57,9 @@ func (e *execution) textEmbeddings(ctx context.Context, job *base.Job) error {
 		return nil
 	}
 
-	// Convert from []float32 to []float64 for consistency with other components
-	embeddingFloat64 := make([]float64, len(embedding.Values))
-	for i, v := range embedding.Values {
-		embeddingFloat64[i] = float64(v)
-	}
-
-	// Prepare output
+	// Prepare output using the genai ContentEmbedding directly
 	output := TaskTextEmbeddingsOutput{
-		Embedding: embeddingFloat64,
+		Embedding: embedding,
 	}
 
 	// Write output


### PR DESCRIPTION
Because

- File API timeouts were inconsistent across different media types (60s for images/audio/documents, 120s for videos)
- The text embeddings output was being manually converted from the native `ContentEmbedding` type to `[]float64`, losing metadata and requiring unnecessary type conversion
- Inconsistent timeouts could cause issues with large file uploads that need more processing time

This commit

- Introduces `FileAPITimeout` constant (300 seconds) to standardize File API operation timeouts across all media types (images, audio, videos, documents)
- Changes `TaskTextEmbeddingsOutput.Embedding` type from `[]float64` to `*genai.ContentEmbedding` to preserve the native Gemini API structure
- Removes unnecessary float32-to-float64 conversion loop in `textEmbeddings()` execution function
- Adds `TASK_BATCH` placeholder in tasks.yaml for future batch processing support
- Fixes trailing whitespace in definition.yaml