### PR TITLE
fix(service): handle null JSON metadata in pipeline conversion

### DIFF
--- a/pkg/service/convert.go
+++ b/pkg/service/convert.go
@@ -641,12 +641,17 @@ func (c *converter) ConvertPipelineToPB(ctx context.Context, dbPipelineOrigin *d
 
 	if view > pipelinepb.Pipeline_VIEW_BASIC {
 		if dbPipeline.Metadata != nil {
-			str := structpb.Struct{}
-			err := str.UnmarshalJSON(dbPipeline.Metadata)
-			if err != nil {
-				logger.Error(err.Error())
+
+			// Check if metadata is not null JSON value
+			if string(dbPipeline.Metadata) != "null" {
+				str := structpb.Struct{}
+				err := str.UnmarshalJSON(dbPipeline.Metadata)
+				if err != nil {
+					logger.Error(err.Error())
+				} else {
+					pbPipeline.Metadata = &str
+				}
 			}
-			pbPipeline.Metadata = &str
 		}
 	}
 
@@ -813,12 +818,16 @@ func (c *converter) ConvertPipelineReleaseToPB(ctx context.Context, dbPipeline *
 
 	if view > pipelinepb.Pipeline_VIEW_BASIC {
 		if dbPipelineRelease.Metadata != nil {
-			str := structpb.Struct{}
-			err := str.UnmarshalJSON(dbPipelineRelease.Metadata)
-			if err != nil {
-				logger.Error(err.Error())
+			// Check if metadata is not null JSON value
+			if string(dbPipelineRelease.Metadata) != "null" {
+				str := structpb.Struct{}
+				err := str.UnmarshalJSON(dbPipelineRelease.Metadata)
+				if err != nil {
+					logger.Error(err.Error())
+				} else {
+					pbPipelineRelease.Metadata = &str
+				}
 			}
-			pbPipelineRelease.Metadata = &str
 		}
 	}
 

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -1452,6 +1452,7 @@ func (s *service) CreateNamespacePipelineRelease(ctx context.Context, ns resourc
 	if dbPipelineReleaseToCreate.RecipeYAML == "" {
 		dbPipelineReleaseToCreate.RecipeYAML = dbPipeline.RecipeYAML
 	}
+
 	if dbPipelineReleaseToCreate.Metadata == nil {
 		dbPipelineReleaseToCreate.Metadata = dbPipeline.Metadata
 	}


### PR DESCRIPTION
Because

- The pipeline conversion service was encountering protobuf syntax errors when trying to unmarshal JSON metadata fields containing the literal value `"null"`
- `structpb.Struct` expects a JSON object `{}` but cannot handle JSON `null` values, causing parsing failures with error: `"proto: syntax error (line 1:1): unexpected token null"`
- Legacy database records or direct database manipulation could result in NULL metadata values being stored as the JSON literal `"null"`

This commit

- Adds null value checks before attempting to unmarshal metadata in both `ConvertPipelineToPB` and `ConvertPipelineReleaseToPB` functions
- Prevents protobuf parsing errors by skipping unmarshaling when metadata contains the JSON literal `"null"`
- Ensures metadata is only set on the protobuf object when valid JSON objects are successfully unmarshaled
- Maintains backward compatibility while gracefully handling edge cases with null metadata values

The fix ensures robust handling of metadata fields across different scenarios:
- NULL database values (handled by skipping null literals)
- Empty metadata (handled by existing nil checks) 
- Valid JSON objects (unmarshaled successfully as before)