### PR TITLE
fix(data): remove duplicate dot in generated filenames

### DIFF
--- a/pkg/data/file.go
+++ b/pkg/data/file.go
@@ -51,7 +51,7 @@ func NewFileFromBytes(b []byte, contentType, filename string) (bin *fileData, er
 
 	if filename == "" {
 		fileUID, _ := uuid.NewV4()
-		filename = fmt.Sprintf("%s.%s", fileUID, strings.ToLower(mimetype.Detect(b).Extension()))
+		filename = fmt.Sprintf("%s%s", fileUID, strings.ToLower(mimetype.Detect(b).Extension()))
 	}
 
 	f := &fileData{


### PR DESCRIPTION
## Because

- Generated filenames had double dots (e.g., `uuid..flac` instead of `uuid.flac`)
- The `mimetype.Detect(b).Extension()` method already returns file extensions with a leading dot
- The format string `"%s.%s"` was adding an extra dot before the extension

## This commit

- Fixes the filename generation in `NewFileFromBytes` function by removing the extra dot from the format string
- Changes `fmt.Sprintf("%s.%s", fileUID, extension)` to `fmt.Sprintf("%s%s", fileUID, extension)`
- Ensures generated filenames have correct format like `uuid.flac` instead of `uuid..flac`